### PR TITLE
fix(efi): invalidate coreboot framebuffer at ExitBootServices

### DIFF
--- a/src/coreboot/mod.rs
+++ b/src/coreboot/mod.rs
@@ -27,6 +27,13 @@ pub fn store_framebuffer(fb: FramebufferInfo) {
     });
 }
 
+/// Store the coreboot framebuffer record address for later invalidation
+pub fn store_framebuffer_record_addr(addr: u64) {
+    crate::state::with_drivers_mut(|drivers| {
+        drivers.coreboot_fb_record_addr = Some(addr);
+    });
+}
+
 /// Get access to the global framebuffer info
 ///
 /// Returns a clone of the framebuffer info if available.
@@ -75,4 +82,52 @@ pub fn store_boot_media(boot_media: BootMediaInfo) {
 /// This includes the FMAP offset which can be used to locate flash regions.
 pub fn get_boot_media() -> Option<BootMediaInfo> {
     crate::state::try_get().and_then(|state| state.drivers.boot_media.clone())
+}
+
+/// Invalidate the coreboot framebuffer record in the coreboot tables.
+///
+/// This should be called at ExitBootServices to prevent a race condition
+/// where Linux tries to use both the coreboot framebuffer (via simplefb)
+/// and the EFI framebuffer (via efifb). By changing the record tag to
+/// CB_TAG_UNUSED (0x0000), Linux will ignore the coreboot framebuffer
+/// and only use the EFI GOP framebuffer.
+///
+/// # Safety
+///
+/// This function modifies memory in the coreboot tables area. It must only
+/// be called when it's safe to modify that memory (at ExitBootServices).
+pub unsafe fn invalidate_framebuffer_record() {
+    let addr = crate::state::try_get().and_then(|state| state.drivers.coreboot_fb_record_addr);
+
+    if let Some(record_addr) = addr {
+        // The tag is the first 4 bytes of the record (u32)
+        // Change it from CB_TAG_FRAMEBUFFER (0x0012) to CB_TAG_UNUSED (0x0000)
+        //
+        // Coreboot table records are aligned to LB_ENTRY_ALIGN (4 bytes), so this is safe.
+        debug_assert!(
+            record_addr % 4 == 0,
+            "Coreboot framebuffer record address {:#x} not 4-byte aligned",
+            record_addr
+        );
+        let tag_ptr = record_addr as *mut u32;
+        let old_tag = tag_ptr.read_volatile();
+
+        if old_tag == tables::tags::CB_TAG_FRAMEBUFFER {
+            tag_ptr.write_volatile(tables::tags::CB_TAG_UNUSED);
+            log::info!(
+                "Invalidated coreboot framebuffer record at {:#x} (tag: {:#x} -> {:#x})",
+                record_addr,
+                old_tag,
+                tables::tags::CB_TAG_UNUSED
+            );
+        } else {
+            log::warn!(
+                "Coreboot framebuffer record at {:#x} has unexpected tag {:#x}, not invalidating",
+                record_addr,
+                old_tag
+            );
+        }
+    } else {
+        log::debug!("No coreboot framebuffer record to invalidate");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,12 @@ pub fn init(coreboot_table_ptr: u64) {
         coreboot::store_framebuffer(fb.clone());
     }
 
+    // Store the coreboot framebuffer record address so we can invalidate it
+    // at ExitBootServices to prevent a race between Linux's simplefb and efifb
+    if let Some(addr) = cb_info.framebuffer_record_addr {
+        coreboot::store_framebuffer_record_addr(addr);
+    }
+
     // Store SMMSTORE v2 info globally for variable persistence
     if let Some(ref smmstore) = cb_info.smmstorev2 {
         coreboot::store_smmstorev2(smmstore.clone());

--- a/src/state.rs
+++ b/src/state.rs
@@ -139,11 +139,7 @@ pub fn try_get() -> Option<&'static FirmwareState> {
 #[inline]
 pub fn try_get_mut_ptr() -> Option<*mut FirmwareState> {
     let ptr = STATE_PTR.load(Ordering::Acquire);
-    if ptr.is_null() {
-        None
-    } else {
-        Some(ptr)
-    }
+    if ptr.is_null() { None } else { Some(ptr) }
 }
 
 // ============================================================================

--- a/src/state.rs
+++ b/src/state.rs
@@ -139,7 +139,11 @@ pub fn try_get() -> Option<&'static FirmwareState> {
 #[inline]
 pub fn try_get_mut_ptr() -> Option<*mut FirmwareState> {
     let ptr = STATE_PTR.load(Ordering::Acquire);
-    if ptr.is_null() { None } else { Some(ptr) }
+    if ptr.is_null() {
+        None
+    } else {
+        Some(ptr)
+    }
 }
 
 // ============================================================================
@@ -499,6 +503,11 @@ pub struct DriverState {
     /// Global framebuffer info (from coreboot)
     pub framebuffer: Option<FramebufferInfo>,
 
+    /// Address of the coreboot framebuffer record in the coreboot tables.
+    /// This is stored so we can invalidate it at ExitBootServices to prevent
+    /// Linux from trying to use both the coreboot framebuffer and the EFI GOP.
+    pub coreboot_fb_record_addr: Option<u64>,
+
     /// SMMSTORE v2 info (from coreboot tables)
     ///
     /// Contains information for accessing UEFI variable storage through
@@ -531,6 +540,7 @@ impl DriverState {
             serial_port: None,
             keyboard: KeyboardState::new(),
             framebuffer: None,
+            coreboot_fb_record_addr: None,
             smmstorev2: None,
             spi_flash: None,
             boot_media: None,


### PR DESCRIPTION
Prevent race condition between Linux's simplefb (coreboot) and efifb
(EFI GOP) drivers by changing the coreboot framebuffer record tag from
CB_TAG_FRAMEBUFFER to CB_TAG_UNUSED at ExitBootServices time.

- Store framebuffer record address during coreboot table parsing
- Add invalidate_framebuffer_record() to modify the tag in-place
- Call invalidation during ExitBootServices cleanup