### PR TITLE
fix(allocator): map coreboot Table regions to AcpiMemoryNvs

### DIFF
--- a/src/coreboot/memory.rs
+++ b/src/coreboot/memory.rs
@@ -41,7 +41,9 @@ impl MemoryType {
             MemoryType::AcpiReclaimable => efi::ACPI_RECLAIM_MEMORY,
             MemoryType::AcpiNvs => efi::ACPI_MEMORY_NVS,
             MemoryType::Unusable => efi::UNUSABLE_MEMORY,
-            MemoryType::Table => efi::BOOT_SERVICES_DATA,
+            // Coreboot's Table type includes cbmem regions that must persist
+            // after boot for Linux kernel modules (cbmem, memconsole, etc.)
+            MemoryType::Table => efi::ACPI_MEMORY_NVS,
         }
     }
 }

--- a/src/efi/allocator.rs
+++ b/src/efi/allocator.rs
@@ -110,7 +110,12 @@ fn cb_to_efi_memory_type(cb_type: CbMemoryType) -> MemoryType {
         CbMemoryType::AcpiReclaimable => MemoryType::AcpiReclaimMemory,
         CbMemoryType::AcpiNvs => MemoryType::AcpiMemoryNvs,
         CbMemoryType::Unusable => MemoryType::UnusableMemory,
-        CbMemoryType::Table => MemoryType::BootServicesData,
+        // Coreboot's Table type includes cbmem regions (console, SMBIOS, etc.)
+        // that Linux kernel modules need to access after boot. Using AcpiMemoryNvs
+        // ensures these regions are preserved and not reclaimed as usable RAM.
+        // BootServicesData would be incorrect because it gets converted to
+        // ConventionalMemory at ExitBootServices, causing memremap failures.
+        CbMemoryType::Table => MemoryType::AcpiMemoryNvs,
     }
 }
 


### PR DESCRIPTION
Coreboot's Table memory type (16) includes cbmem regions containing the
console, SMBIOS tables, and other data that Linux kernel modules need to
access after boot. Previously these were mapped to BootServicesData,
which gets reclaimed as ConventionalMemory at ExitBootServices.

This caused Linux's cbmem driver to fail with 'memremap attempted on
mixed range' warnings because the kernel saw the memory as usable RAM
while the driver expected reserved firmware data.

Using AcpiMemoryNvs ensures these regions persist after boot and are
properly marked as firmware-owned memory.