### PR TITLE
Add xHCI phantom port detection and device path-based image loading

### DIFF
--- a/src/drivers/ahci/mod.rs
+++ b/src/drivers/ahci/mod.rs
@@ -1411,14 +1411,14 @@ pub fn store_global_device(controller_index: usize, port_index: usize) -> bool {
 ///
 /// The LBA is interpreted as a device block LBA (in terms of the device's native
 /// sector size - 512 bytes for SATA, 2048 bytes for SATAPI/CD-ROM).
-pub fn global_read_sector(lba: u64, buffer: &mut [u8]) -> Result<(), ()> {
+pub fn global_read_sectors(lba: u64, buffer: &mut [u8]) -> Result<(), ()> {
     let (controller_index, port_index) = match GLOBAL_AHCI_DEVICE.lock().as_ref() {
         Some(ptr) => unsafe {
             let device = &*ptr.0;
             (device.controller_index, device.port_index)
         },
         None => {
-            log::error!("global_read_sector: no AHCI device stored");
+            log::error!("global_read_sectors: no AHCI device stored");
             return Err(());
         }
     };
@@ -1427,7 +1427,7 @@ pub fn global_read_sector(lba: u64, buffer: &mut [u8]) -> Result<(), ()> {
         Some(c) => c,
         None => {
             log::error!(
-                "global_read_sector: no AHCI controller at index {}",
+                "global_read_sectors: no AHCI controller at index {}",
                 controller_index
             );
             return Err(());
@@ -1445,7 +1445,7 @@ pub fn global_read_sector(lba: u64, buffer: &mut [u8]) -> Result<(), ()> {
     controller
         .read_sectors(port_index, lba, num_sectors, buffer.as_mut_ptr())
         .map_err(|e| {
-            log::error!("global_read_sector: read failed at LBA {}: {:?}", lba, e);
+            log::error!("global_read_sectors: read failed at LBA {}: {:?}", lba, e);
         })
 }
 

--- a/src/drivers/block.rs
+++ b/src/drivers/block.rs
@@ -313,10 +313,10 @@ impl BlockDevice for UsbBlockDevice {
     }
 
     fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError> {
-        // Read all sectors in a single call — global_read_sector now supports
+        // Read all sectors in a single call — global_read_sectors supports
         // multi-sector reads by inferring sector count from buffer size.
         let total_bytes = count as usize * self.info.block_size as usize;
-        usb::mass_storage::global_read_sector(lba, &mut buffer[..total_bytes])
+        usb::mass_storage::global_read_sectors(lba, &mut buffer[..total_bytes])
             .map_err(|()| BlockError::DeviceError)
     }
 }

--- a/src/drivers/block.rs
+++ b/src/drivers/block.rs
@@ -313,23 +313,11 @@ impl BlockDevice for UsbBlockDevice {
     }
 
     fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError> {
-        // Get the USB controller and mass storage device, then read
-        // This uses the global USB mass storage read function
-        usb::mass_storage::global_read_sector(lba, buffer).map_err(|()| BlockError::DeviceError)?;
-
-        // Handle multi-block reads by reading sectors one at a time
-        // (global_read_sector handles single sectors)
-        if count > 1 {
-            let block_size = self.info.block_size as usize;
-            for i in 1..count {
-                let offset = i as usize * block_size;
-                let sector_lba = lba + i as u64;
-                usb::mass_storage::global_read_sector(sector_lba, &mut buffer[offset..])
-                    .map_err(|()| BlockError::DeviceError)?;
-            }
-        }
-
-        Ok(())
+        // Read all sectors in a single call — global_read_sector now supports
+        // multi-sector reads by inferring sector count from buffer size.
+        let total_bytes = count as usize * self.info.block_size as usize;
+        usb::mass_storage::global_read_sector(lba, &mut buffer[..total_bytes])
+            .map_err(|()| BlockError::DeviceError)
     }
 }
 

--- a/src/drivers/sdhci/mod.rs
+++ b/src/drivers/sdhci/mod.rs
@@ -1015,13 +1015,18 @@ impl SdhciController {
         Ok(())
     }
 
-    /// Read a single sector (convenience method)
+    /// Read one or more sectors into a buffer
+    ///
+    /// The number of sectors to read is inferred from the buffer size.
+    /// If the buffer is larger than one sector, multiple sectors are read
+    /// in a single operation for performance.
     pub fn read_sector(&mut self, lba: u64, buffer: &mut [u8]) -> Result<(), SdhciError> {
         if buffer.len() < SD_BLOCK_SIZE as usize {
             return Err(SdhciError::InvalidParameter);
         }
 
-        self.read_sectors(lba, 1, buffer.as_mut_ptr())
+        let num_sectors = (buffer.len() / SD_BLOCK_SIZE as usize).max(1) as u32;
+        self.read_sectors(lba, num_sectors, buffer.as_mut_ptr())
     }
 
     /// Get the number of blocks on the card

--- a/src/drivers/storage.rs
+++ b/src/drivers/storage.rs
@@ -101,7 +101,7 @@ pub fn read_sectors(device_id: u32, lba: u64, buffer: &mut [u8]) -> Result<(), (
     match device.device_type {
         StorageType::Usb { slot_id: _ } => {
             // Use the global USB read function
-            crate::drivers::usb::mass_storage::global_read_sector(lba, buffer)
+            crate::drivers::usb::mass_storage::global_read_sectors(lba, buffer)
         }
         StorageType::Nvme {
             controller_id,
@@ -120,12 +120,12 @@ pub fn read_sectors(device_id: u32, lba: u64, buffer: &mut [u8]) -> Result<(), (
             controller_id: _,
             port: _,
         } => {
-            // Use global_read_sector which handles sector size translation for SATAPI
-            crate::drivers::ahci::global_read_sector(lba, buffer)
+            // Use global_read_sectors which handles sector size translation for SATAPI
+            crate::drivers::ahci::global_read_sectors(lba, buffer)
         }
         StorageType::Sdhci { controller_id: _ } => {
-            // Use global_read_sector for SDHCI
-            crate::drivers::sdhci::global_read_sector(lba, buffer)
+            // Use global_read_sectors for SDHCI
+            crate::drivers::sdhci::global_read_sectors(lba, buffer)
         }
     }
 }

--- a/src/drivers/usb/controller.rs
+++ b/src/drivers/usb/controller.rs
@@ -714,6 +714,8 @@ pub struct DeviceInfo {
     pub device_class: u8,
     /// Is this a mass storage device?
     pub is_mass_storage: bool,
+    /// Mass storage interface number (for BOT reset recovery)
+    pub mass_storage_interface: u8,
     /// Is this a HID device?
     pub is_hid: bool,
     /// Is this a keyboard?
@@ -745,6 +747,8 @@ pub struct UsbDevice {
     pub config_info: ConfigurationInfo,
     /// Is mass storage device
     pub is_mass_storage: bool,
+    /// Mass storage interface number (for BOT reset recovery)
+    pub mass_storage_interface: u8,
     /// Is HID keyboard
     pub is_hid_keyboard: bool,
     /// Is USB hub
@@ -779,6 +783,7 @@ impl UsbDevice {
             device_desc: DeviceDescriptor::default(),
             config_info: ConfigurationInfo::default(),
             is_mass_storage: false,
+            mass_storage_interface: 0,
             is_hid_keyboard: false,
             is_hub: false,
             num_hub_ports: 0,
@@ -810,6 +815,7 @@ impl UsbDevice {
             product_id: self.device_desc.product_id,
             device_class: self.device_desc.device_class,
             is_mass_storage: self.is_mass_storage,
+            mass_storage_interface: self.mass_storage_interface,
             is_hid: self.is_hid_keyboard,
             is_keyboard: self.is_hid_keyboard,
             is_hub: self.is_hub,
@@ -1206,9 +1212,10 @@ where
     for iface in &device.config_info.interfaces[..device.config_info.num_interfaces] {
         if iface.is_mass_storage() {
             device.is_mass_storage = true;
+            device.mass_storage_interface = iface.interface_number;
             device.bulk_in = iface.find_bulk_in().cloned();
             device.bulk_out = iface.find_bulk_out().cloned();
-            log::info!("    Mass Storage interface");
+            log::info!("    Mass Storage interface {}", iface.interface_number);
         } else if iface.is_hid_keyboard() {
             device.is_hid_keyboard = true;
             device.interrupt_in = iface.find_interrupt_in().cloned();

--- a/src/drivers/usb/ehci.rs
+++ b/src/drivers/usb/ehci.rs
@@ -1657,6 +1657,7 @@ impl UsbController for EhciController {
             product_id: d.device_desc.product_id,
             device_class: d.device_desc.device_class,
             is_mass_storage: d.is_mass_storage,
+            mass_storage_interface: d.mass_storage_interface,
             is_hid: d.is_hid_keyboard,
             is_keyboard: d.is_hid_keyboard,
             is_hub: d.is_hub,

--- a/src/drivers/usb/mass_storage.rs
+++ b/src/drivers/usb/mass_storage.rs
@@ -1056,7 +1056,7 @@ pub fn get_global_device() -> Option<&'static mut UsbMassStorage> {
 /// This function can be used as the read callback for the SimpleFileSystem protocol.
 /// It uses the stored controller pointer directly to avoid lock contention.
 /// Supports reading multiple sectors in a single SCSI command for performance.
-pub fn global_read_sector(lba: u64, buffer: &mut [u8]) -> Result<(), ()> {
+pub fn global_read_sectors(lba: u64, buffer: &mut [u8]) -> Result<(), ()> {
     log::trace!("USB mass storage: read LBA {}", lba);
 
     // Get the device and controller pointers (release lock immediately)

--- a/src/drivers/usb/mod.rs
+++ b/src/drivers/usb/mod.rs
@@ -425,6 +425,9 @@ impl UsbController for XhciController {
             XhciError::Timeout => self::controller::UsbError::Timeout,
             XhciError::StallError => self::controller::UsbError::Stall,
             XhciError::DeviceNotFound => self::controller::UsbError::DeviceNotFound,
+            XhciError::TransferFailed(cc) if cc == xhci_regs::TRB_CC_BABBLE_DETECTED => {
+                self::controller::UsbError::Babble
+            }
             _ => self::controller::UsbError::TransactionError,
         })
     }
@@ -441,6 +444,9 @@ impl UsbController for XhciController {
             XhciError::Timeout => self::controller::UsbError::Timeout,
             XhciError::StallError => self::controller::UsbError::Stall,
             XhciError::DeviceNotFound => self::controller::UsbError::DeviceNotFound,
+            XhciError::TransferFailed(cc) if cc == xhci_regs::TRB_CC_BABBLE_DETECTED => {
+                self::controller::UsbError::Babble
+            }
             _ => self::controller::UsbError::TransactionError,
         })
     }
@@ -486,6 +492,7 @@ impl UsbController for XhciController {
             product_id: slot.device_desc.product_id,
             device_class: slot.device_desc.device_class,
             is_mass_storage: slot.is_mass_storage,
+            mass_storage_interface: slot.mass_storage_interface,
             is_hid: slot.is_hid_keyboard || slot.device_desc.device_class == 0x03,
             is_keyboard: slot.is_hid_keyboard,
             is_hub: slot.device_desc.device_class == 0x09,

--- a/src/drivers/usb/mod.rs
+++ b/src/drivers/usb/mod.rs
@@ -469,7 +469,7 @@ impl UsbController for XhciController {
 
     fn find_hid_keyboard(&self) -> Option<u8> {
         // Check all slots for HID keyboard devices
-        (0..4u8).find(|&slot_id| {
+        (0..xhci::MAX_SLOTS as u8).find(|&slot_id| {
             self.get_slot(slot_id)
                 .map(|slot| slot.is_hid_keyboard)
                 .unwrap_or(false)

--- a/src/drivers/usb/mod.rs
+++ b/src/drivers/usb/mod.rs
@@ -380,7 +380,7 @@ where
 /// Get a raw pointer to a controller
 ///
 /// This is useful when you need to store the controller pointer for later use,
-/// such as in global_read_sector. The pointer remains valid for the entire boot
+/// such as in global_read_sectors. The pointer remains valid for the entire boot
 /// process since controllers are allocated via efi::allocate_pages and never freed.
 ///
 /// # Safety

--- a/src/drivers/usb/ohci.rs
+++ b/src/drivers/usb/ohci.rs
@@ -998,6 +998,7 @@ impl UsbController for OhciController {
             product_id: d.device_desc.product_id,
             device_class: d.device_desc.device_class,
             is_mass_storage: d.is_mass_storage,
+            mass_storage_interface: d.mass_storage_interface,
             is_hid: d.is_hid_keyboard,
             is_keyboard: d.is_hid_keyboard,
             is_hub: d.is_hub,

--- a/src/drivers/usb/uhci.rs
+++ b/src/drivers/usb/uhci.rs
@@ -930,6 +930,7 @@ impl UsbController for UhciController {
             product_id: d.device_desc.product_id,
             device_class: d.device_desc.device_class,
             is_mass_storage: d.is_mass_storage,
+            mass_storage_interface: d.mass_storage_interface,
             is_hid: d.is_hid_keyboard,
             is_keyboard: d.is_hid_keyboard,
             is_hub: d.is_hub,

--- a/src/drivers/usb/xhci_regs.rs
+++ b/src/drivers/usb/xhci_regs.rs
@@ -515,5 +515,13 @@ pub const PORTSC_PR: u32 = 1 << 4;
 pub const PORTSC_PP: u32 = 1 << 9;
 /// Port Speed Mask (bits 10-13)
 pub const PORTSC_SPEED_MASK: u32 = 0xF << 10;
+/// Port Link State Mask (bits 5-8)
+pub const PORTSC_PLS_MASK: u32 = 0xF << 5;
+/// Port Link State: U0 (link is up and operational)
+pub const PORTSC_PLS_U0: u32 = 0 << 5;
+/// Port Link State: RxDetect (looking for device, not connected)
+pub const PORTSC_PLS_RXDETECT: u32 = 5 << 5;
+/// Port Link State: Polling (link training in progress)
+pub const PORTSC_PLS_POLLING: u32 = 7 << 5;
 /// Port Reset Change
 pub const PORTSC_PRC: u32 = 1 << 21;

--- a/src/drivers/usb/xhci_regs.rs
+++ b/src/drivers/usb/xhci_regs.rs
@@ -389,8 +389,85 @@ pub const TRB_CC_USB_TRANSACTION_ERROR: u32 = 4;
 pub const TRB_CC_TRB_ERROR: u32 = 5;
 /// Stall Error
 pub const TRB_CC_STALL_ERROR: u32 = 6;
+/// Resource Error
+pub const TRB_CC_RESOURCE_ERROR: u32 = 7;
+/// Bandwidth Error
+pub const TRB_CC_BANDWIDTH_ERROR: u32 = 8;
+/// No Slots Available
+pub const TRB_CC_NO_SLOTS: u32 = 9;
+/// Invalid Stream Type
+pub const TRB_CC_INVALID_STREAM_TYPE: u32 = 10;
+/// Slot Not Enabled
+pub const TRB_CC_SLOT_NOT_ENABLED: u32 = 11;
+/// Endpoint Not Enabled
+pub const TRB_CC_EP_NOT_ENABLED: u32 = 12;
 /// Short Packet
 pub const TRB_CC_SHORT_PACKET: u32 = 13;
+/// Ring Underrun
+pub const TRB_CC_RING_UNDERRUN: u32 = 14;
+/// Ring Overrun
+pub const TRB_CC_RING_OVERRUN: u32 = 15;
+/// VF Event Ring Full Error
+pub const TRB_CC_VF_EVENT_RING_FULL: u32 = 16;
+/// Parameter Error
+pub const TRB_CC_PARAMETER_ERROR: u32 = 17;
+/// Bandwidth Overrun Error
+pub const TRB_CC_BW_OVERRUN: u32 = 18;
+/// Context State Error
+pub const TRB_CC_CONTEXT_STATE_ERROR: u32 = 19;
+/// No Ping Response Error
+pub const TRB_CC_NO_PING_RESPONSE: u32 = 20;
+/// Event Ring Full Error
+pub const TRB_CC_EVENT_RING_FULL: u32 = 21;
+/// Incompatible Device Error
+pub const TRB_CC_INCOMPATIBLE_DEVICE: u32 = 22;
+/// Missed Service Error
+pub const TRB_CC_MISSED_SERVICE: u32 = 23;
+/// Command Ring Stopped
+pub const TRB_CC_COMMAND_RING_STOPPED: u32 = 24;
+/// Command Aborted
+pub const TRB_CC_COMMAND_ABORTED: u32 = 25;
+/// Stopped
+pub const TRB_CC_STOPPED: u32 = 26;
+/// Stopped - Length Invalid
+pub const TRB_CC_STOPPED_LENGTH_INVALID: u32 = 27;
+/// Stopped - Short Packet
+pub const TRB_CC_STOPPED_SHORT_PACKET: u32 = 28;
+
+/// Convert completion code to string for debugging
+pub fn trb_cc_name(cc: u32) -> &'static str {
+    match cc {
+        TRB_CC_SUCCESS => "SUCCESS",
+        TRB_CC_DATA_BUFFER_ERROR => "DATA_BUFFER_ERROR",
+        TRB_CC_BABBLE_DETECTED => "BABBLE_DETECTED",
+        TRB_CC_USB_TRANSACTION_ERROR => "USB_TRANSACTION_ERROR",
+        TRB_CC_TRB_ERROR => "TRB_ERROR",
+        TRB_CC_STALL_ERROR => "STALL_ERROR",
+        TRB_CC_RESOURCE_ERROR => "RESOURCE_ERROR",
+        TRB_CC_BANDWIDTH_ERROR => "BANDWIDTH_ERROR",
+        TRB_CC_NO_SLOTS => "NO_SLOTS",
+        TRB_CC_INVALID_STREAM_TYPE => "INVALID_STREAM_TYPE",
+        TRB_CC_SLOT_NOT_ENABLED => "SLOT_NOT_ENABLED",
+        TRB_CC_EP_NOT_ENABLED => "EP_NOT_ENABLED",
+        TRB_CC_SHORT_PACKET => "SHORT_PACKET",
+        TRB_CC_RING_UNDERRUN => "RING_UNDERRUN",
+        TRB_CC_RING_OVERRUN => "RING_OVERRUN",
+        TRB_CC_VF_EVENT_RING_FULL => "VF_EVENT_RING_FULL",
+        TRB_CC_PARAMETER_ERROR => "PARAMETER_ERROR",
+        TRB_CC_BW_OVERRUN => "BW_OVERRUN",
+        TRB_CC_CONTEXT_STATE_ERROR => "CONTEXT_STATE_ERROR",
+        TRB_CC_NO_PING_RESPONSE => "NO_PING_RESPONSE",
+        TRB_CC_EVENT_RING_FULL => "EVENT_RING_FULL",
+        TRB_CC_INCOMPATIBLE_DEVICE => "INCOMPATIBLE_DEVICE",
+        TRB_CC_MISSED_SERVICE => "MISSED_SERVICE",
+        TRB_CC_COMMAND_RING_STOPPED => "COMMAND_RING_STOPPED",
+        TRB_CC_COMMAND_ABORTED => "COMMAND_ABORTED",
+        TRB_CC_STOPPED => "STOPPED",
+        TRB_CC_STOPPED_LENGTH_INVALID => "STOPPED_LENGTH_INVALID",
+        TRB_CC_STOPPED_SHORT_PACKET => "STOPPED_SHORT_PACKET",
+        _ => "UNKNOWN",
+    }
+}
 
 // ============================================================================
 // Extended Capability IDs
@@ -421,8 +498,17 @@ pub const USBLEGSUP_OS_OWNED: u32 = 1 << 24;
 // ============================================================================
 
 /// All status change bits that can be cleared by writing 1
+/// CSC(17), PEC(18), WRC(19), OCC(20), PRC(21), PLC(22), CEC(23)
 pub const PORTSC_CHANGE_MASK: u32 =
     (1 << 17) | (1 << 18) | (1 << 19) | (1 << 20) | (1 << 21) | (1 << 22) | (1 << 23);
+
+/// Read/Write bits that should be preserved when writing to PORTSC
+/// PP(9), PIC(14:15), WCE(25), WDE(26), WOE(27)
+/// Note: PED(1) is RW1C, PR(4) is RW1S, WPR(31) is RW1S - don't preserve these!
+/// Note: LWS(16) is intentionally excluded - setting it triggers a link state
+/// write strobe which would cause unintended link state changes. Only set LWS
+/// when deliberately changing the Port Link State (PLS) field.
+pub const PORTSC_RW_MASK: u32 = (1 << 9) | (3 << 14) | (1 << 25) | (1 << 26) | (1 << 27);
 
 // ============================================================================
 // Capability Register Offsets
@@ -525,3 +611,7 @@ pub const PORTSC_PLS_RXDETECT: u32 = 5 << 5;
 pub const PORTSC_PLS_POLLING: u32 = 7 << 5;
 /// Port Reset Change
 pub const PORTSC_PRC: u32 = 1 << 21;
+/// Warm Port Reset Change (USB3 only)
+pub const PORTSC_WRC: u32 = 1 << 19;
+/// Warm Port Reset (USB3 only)
+pub const PORTSC_WPR: u32 = 1 << 31;

--- a/src/efi/allocator.rs
+++ b/src/efi/allocator.rs
@@ -523,7 +523,9 @@ impl MemoryAllocator {
             // Change the type back to conventional memory
             self.entries[idx].memory_type = MemoryType::ConventionalMemory as u32;
             self.map_key += 1;
-            self.merge_entries();
+            // Don't merge here - merging should only happen at ExitBootServices
+            // to keep the memory map clean for the OS. Merging during normal
+            // operation breaks subsequent free_pages calls that need exact matches.
             efi::Status::SUCCESS
         } else {
             efi::Status::NOT_FOUND
@@ -831,7 +833,8 @@ impl MemoryAllocator {
 
         self.map_key += 1;
         self.sort_entries();
-        self.merge_entries(); // Consolidate to reduce fragmentation
+        // Don't merge here - merging breaks subsequent free_pages calls
+        // that need exact matches. Merge only at ExitBootServices.
         true
     }
 
@@ -929,7 +932,8 @@ impl MemoryAllocator {
 
         self.map_key += 1;
         self.sort_entries();
-        self.merge_entries(); // Always merge after carving to reduce fragmentation
+        // Don't merge here - merging breaks subsequent free_pages calls
+        // that need exact matches. Merge only at ExitBootServices.
 
         Ok(())
     }

--- a/src/efi/boot_services.rs
+++ b/src/efi/boot_services.rs
@@ -880,6 +880,9 @@ fn load_image_from_device_path(
     log::info!("BS.LoadImage: Loading from device path: {}", path_display);
 
     // Find a handle with SimpleFileSystem protocol
+    // TODO: This always uses the first SFS handle found. The UEFI spec requires
+    // matching the device path against handles' device paths to find the correct
+    // volume. On multi-disk systems, this could load from the wrong disk.
     let sfs_handle = find_handle_with_protocol(&SIMPLE_FILE_SYSTEM_GUID).ok_or_else(|| {
         log::error!("BS.LoadImage: No SimpleFileSystem handle found");
         Status::NOT_FOUND

--- a/src/efi/boot_services.rs
+++ b/src/efi/boot_services.rs
@@ -10,6 +10,7 @@
 
 use super::allocator::{self, AllocateType, MemoryDescriptor, MemoryType};
 use super::protocols::loaded_image::{LOADED_IMAGE_PROTOCOL_GUID, create_loaded_image_protocol};
+use super::protocols::simple_file_system::SIMPLE_FILE_SYSTEM_GUID;
 use super::system_table;
 use crate::pe;
 use crate::state::{
@@ -18,7 +19,16 @@ use crate::state::{
 };
 use core::ffi::c_void;
 use r_efi::efi::{self, Boolean, Guid, Handle, Status, SystemTable, TableHeader, Tpl};
-use r_efi::protocols::device_path::Protocol as DevicePathProtocol;
+use r_efi::protocols::device_path::{self, Media, Protocol as DevicePathProtocol};
+use r_efi::protocols::file::Protocol as FileProtocol;
+use r_efi::protocols::simple_file_system::Protocol as SimpleFileSystemProtocol;
+
+/// Device path type for Media
+const DEVICE_PATH_TYPE_MEDIA: u8 = device_path::TYPE_MEDIA;
+/// Device path subtype for File Path
+const DEVICE_PATH_SUBTYPE_FILE_PATH: u8 = Media::SUBTYPE_FILE_PATH;
+/// Device path type for End
+const DEVICE_PATH_TYPE_END: u8 = device_path::TYPE_END;
 
 /// Boot Services signature "BOOTSERV"
 const EFI_BOOT_SERVICES_SIGNATURE: u64 = 0x56524553544F4F42;
@@ -663,10 +673,17 @@ extern "efiapi" fn locate_handle(
         .map(|entry| entry.handle)
         .collect();
 
+    // Check for no matches FIRST, before buffer size checks
+    if matching.is_empty() {
+        log::debug!("  -> NOT_FOUND (no handles with this protocol)");
+        return Status::NOT_FOUND;
+    }
+
     let required_size = matching.len() * core::mem::size_of::<Handle>();
 
     if buffer.is_null() || unsafe { *buffer_size } < required_size {
         unsafe { *buffer_size = required_size };
+        log::debug!("  -> BUFFER_TOO_SMALL (need {} bytes)", required_size);
         return Status::BUFFER_TOO_SMALL;
     }
 
@@ -675,14 +692,8 @@ extern "efiapi" fn locate_handle(
     dest.copy_from_slice(&matching[..]);
     unsafe { *buffer_size = required_size };
 
-    if matching.is_empty() {
-        log::info!("  -> NOT_FOUND");
-        Status::NOT_FOUND
-    } else {
-        log::info!("  -> found {} handles: {:?}", matching.len(), &matching[..]);
-        log::info!("  -> returning from LocateHandle");
-        Status::SUCCESS
-    }
+    log::debug!("  -> found {} handles: {:?}", matching.len(), &matching[..]);
+    Status::SUCCESS
 }
 
 extern "efiapi" fn locate_device_path(
@@ -776,6 +787,244 @@ extern "efiapi" fn install_configuration_table(guid: *mut Guid, table: *mut c_vo
 // Image Functions
 // ============================================================================
 
+/// Extract file path string from a device path
+///
+/// Walks the device path nodes looking for a Media File Path node,
+/// then extracts the UTF-16 path string from it.
+///
+/// # Arguments
+/// * `device_path` - The device path to parse
+///
+/// # Returns
+/// A tuple of (file_path_utf16, length_in_u16_chars) or None if no file path found
+fn extract_file_path_from_device_path(
+    device_path: *mut DevicePathProtocol,
+) -> Option<(*const u16, usize)> {
+    if device_path.is_null() {
+        return None;
+    }
+
+    let mut current = device_path;
+
+    unsafe {
+        loop {
+            let node_type = (*current).r#type;
+            let node_subtype = (*current).sub_type;
+            let node_length =
+                u16::from_le_bytes([(*current).length[0], (*current).length[1]]) as usize;
+
+            // Check for end of device path
+            if node_type == DEVICE_PATH_TYPE_END {
+                break;
+            }
+
+            // Check for file path node
+            if node_type == DEVICE_PATH_TYPE_MEDIA && node_subtype == DEVICE_PATH_SUBTYPE_FILE_PATH
+            {
+                // File path node: header (4 bytes) + UTF-16 path
+                if node_length > 4 {
+                    let path_ptr = (current as *const u8).add(4) as *const u16;
+                    let path_len = (node_length - 4) / 2; // Convert bytes to UTF-16 chars
+                    return Some((path_ptr, path_len));
+                }
+            }
+
+            // Move to next node
+            if node_length < 4 {
+                break; // Invalid length
+            }
+            current = (current as *const u8).add(node_length) as *mut DevicePathProtocol;
+        }
+    }
+
+    None
+}
+
+/// Load an image from a device path
+///
+/// This function is called when LoadImage is invoked with source_buffer=NULL.
+/// It parses the device path to find the file path, locates the SimpleFileSystem
+/// protocol, opens and reads the file, then returns the data.
+///
+/// # Arguments
+/// * `device_path` - The device path containing a file path node
+///
+/// # Returns
+/// A tuple of (buffer_ptr, buffer_size, device_handle) on success, or an error status
+fn load_image_from_device_path(
+    device_path: *mut DevicePathProtocol,
+) -> Result<(*mut c_void, usize, Handle), Status> {
+    // Extract the file path from the device path
+    let (path_ptr, path_len) =
+        extract_file_path_from_device_path(device_path).ok_or_else(|| {
+            log::error!("BS.LoadImage: No file path found in device path");
+            Status::INVALID_PARAMETER
+        })?;
+
+    // Log the file path for debugging
+    let mut path_str = [0u8; 256];
+    let mut str_len = 0;
+    unsafe {
+        for i in 0..path_len {
+            let c = *path_ptr.add(i);
+            if c == 0 {
+                break;
+            }
+            if str_len < path_str.len() - 1 && c < 128 {
+                path_str[str_len] = c as u8;
+                str_len += 1;
+            }
+        }
+    }
+    let path_display = core::str::from_utf8(&path_str[..str_len]).unwrap_or("<invalid>");
+    log::info!("BS.LoadImage: Loading from device path: {}", path_display);
+
+    // Find a handle with SimpleFileSystem protocol
+    let sfs_handle = find_handle_with_protocol(&SIMPLE_FILE_SYSTEM_GUID).ok_or_else(|| {
+        log::error!("BS.LoadImage: No SimpleFileSystem handle found");
+        Status::NOT_FOUND
+    })?;
+
+    // Get the SimpleFileSystem protocol
+    let mut sfs_interface: *mut c_void = core::ptr::null_mut();
+    let status = open_protocol(
+        sfs_handle,
+        &SIMPLE_FILE_SYSTEM_GUID as *const Guid as *mut Guid,
+        &mut sfs_interface,
+        core::ptr::null_mut(),
+        core::ptr::null_mut(),
+        efi::OPEN_PROTOCOL_BY_HANDLE_PROTOCOL,
+    );
+
+    if status != Status::SUCCESS || sfs_interface.is_null() {
+        log::error!(
+            "BS.LoadImage: Failed to get SimpleFileSystem protocol: {:?}",
+            status
+        );
+        return Err(status);
+    }
+
+    let sfs = sfs_interface as *mut SimpleFileSystemProtocol;
+
+    // Open the volume (root directory)
+    let mut root: *mut FileProtocol = core::ptr::null_mut();
+    let status = unsafe { ((*sfs).open_volume)(sfs, &mut root) };
+
+    if status != Status::SUCCESS || root.is_null() {
+        log::error!("BS.LoadImage: Failed to open volume: {:?}", status);
+        return Err(status);
+    }
+
+    // Open the file
+    let mut file: *mut FileProtocol = core::ptr::null_mut();
+    let status = unsafe {
+        ((*root).open)(
+            root,
+            &mut file,
+            path_ptr as *mut u16,
+            r_efi::protocols::file::MODE_READ,
+            0,
+        )
+    };
+
+    if status != Status::SUCCESS || file.is_null() {
+        log::error!("BS.LoadImage: Failed to open file: {:?}", status);
+        unsafe { ((*root).close)(root) };
+        return Err(status);
+    }
+
+    // Get file size using GetInfo
+    let mut info_buffer = [0u8; 256];
+    let mut info_size = info_buffer.len();
+
+    let status = unsafe {
+        ((*file).get_info)(
+            file,
+            &r_efi::protocols::file::INFO_ID as *const Guid as *mut Guid,
+            &mut info_size,
+            info_buffer.as_mut_ptr() as *mut c_void,
+        )
+    };
+
+    if status != Status::SUCCESS || info_size < 16 {
+        log::error!(
+            "BS.LoadImage: Failed to get file info: {:?}, info_size={}",
+            status,
+            info_size
+        );
+        unsafe {
+            ((*file).close)(file);
+            ((*root).close)(root);
+        }
+        return Err(Status::DEVICE_ERROR);
+    }
+
+    // EFI_FILE_INFO starts with Size (8 bytes) then FileSize (8 bytes)
+    let file_size = u64::from_le_bytes(info_buffer[8..16].try_into().unwrap_or([0; 8]));
+    log::debug!("BS.LoadImage: File size = {} bytes", file_size);
+
+    if file_size == 0 || file_size > 256 * 1024 * 1024 {
+        // Sanity check: reject empty files or files > 256MB
+        log::error!("BS.LoadImage: Invalid file size: {}", file_size);
+        unsafe {
+            ((*file).close)(file);
+            ((*root).close)(root);
+        }
+        return Err(Status::INVALID_PARAMETER);
+    }
+
+    // Allocate buffer for the file
+    let buffer = match allocator::allocate_pool(MemoryType::BootServicesData, file_size as usize) {
+        Ok(ptr) => ptr,
+        Err(status) => {
+            log::error!("BS.LoadImage: Failed to allocate {} bytes", file_size);
+            unsafe {
+                ((*file).close)(file);
+                ((*root).close)(root);
+            }
+            return Err(status);
+        }
+    };
+
+    // Read the file
+    let mut read_size = file_size as usize;
+    let status = unsafe { ((*file).read)(file, &mut read_size, buffer as *mut c_void) };
+
+    // Close file handles
+    unsafe {
+        ((*file).close)(file);
+        ((*root).close)(root);
+    }
+
+    if status != Status::SUCCESS {
+        log::error!("BS.LoadImage: Failed to read file: {:?}", status);
+        let _ = allocator::free_pool(buffer);
+        return Err(status);
+    }
+
+    log::info!(
+        "BS.LoadImage: Successfully loaded {} bytes from device path",
+        read_size
+    );
+
+    Ok((buffer as *mut c_void, read_size, sfs_handle))
+}
+
+/// Find a handle that has a specific protocol installed
+fn find_handle_with_protocol(protocol_guid: &Guid) -> Option<Handle> {
+    let efi_state = state::efi();
+
+    for entry in &efi_state.handles[..efi_state.handle_count] {
+        for proto in &entry.protocols[..entry.protocol_count] {
+            if proto.guid == *protocol_guid {
+                return Some(entry.handle);
+            }
+        }
+    }
+
+    None
+}
+
 extern "efiapi" fn load_image(
     boot_policy: Boolean,
     parent_image_handle: Handle,
@@ -799,14 +1048,35 @@ extern "efiapi" fn load_image(
         return Status::INVALID_PARAMETER;
     }
 
-    // We only support loading from a memory buffer currently
-    if source_buffer.is_null() || source_size == 0 {
-        log::error!("BS.LoadImage: source_buffer is NULL or size is 0");
+    // Determine the source: either from buffer or from device path
+    // Also track the device handle if loading from device path
+    let (data_ptr, data_size, allocated_buffer, loaded_from_device): (
+        *mut c_void,
+        usize,
+        bool,
+        Option<Handle>,
+    ) = if !source_buffer.is_null() && source_size > 0 {
+        // Load from provided buffer
+        (source_buffer, source_size, false, None)
+    } else if !device_path.is_null() {
+        // Load from device path
+        match load_image_from_device_path(device_path) {
+            Ok((ptr, size, dev_handle)) => (ptr, size, true, Some(dev_handle)),
+            Err(status) => {
+                log::error!(
+                    "BS.LoadImage: Failed to load from device path: {:?}",
+                    status
+                );
+                return status;
+            }
+        }
+    } else {
+        log::error!("BS.LoadImage: No source buffer and no device path provided");
         return Status::INVALID_PARAMETER;
-    }
+    };
 
     // Create a slice from the source buffer
-    let data = unsafe { core::slice::from_raw_parts(source_buffer as *const u8, source_size) };
+    let data = unsafe { core::slice::from_raw_parts(data_ptr as *const u8, data_size) };
 
     // Secure Boot verification (if enabled)
     if super::auth::is_secure_boot_enabled() {
@@ -818,11 +1088,17 @@ extern "efiapi" fn load_image(
             Ok(false) => {
                 log::error!("BS.LoadImage: Secure Boot verification FAILED - image not authorized");
                 crate::display_secure_boot_error();
+                if allocated_buffer {
+                    let _ = allocator::free_pool(data_ptr as *mut u8);
+                }
                 return Status::SECURITY_VIOLATION;
             }
             Err(e) => {
                 log::error!("BS.LoadImage: Secure Boot verification error: {:?}", e);
                 crate::display_secure_boot_error();
+                if allocated_buffer {
+                    let _ = allocator::free_pool(data_ptr as *mut u8);
+                }
                 return Status::SECURITY_VIOLATION;
             }
         }
@@ -833,9 +1109,18 @@ extern "efiapi" fn load_image(
         Ok(img) => img,
         Err(status) => {
             log::error!("BS.LoadImage: Failed to load PE image: {:?}", status);
+            // Free the temporary buffer if we allocated it
+            if allocated_buffer {
+                let _ = allocator::free_pool(data_ptr as *mut u8);
+            }
             return status;
         }
     };
+
+    // Free the temporary buffer now that PE is loaded (it makes its own copy)
+    if allocated_buffer {
+        let _ = allocator::free_pool(data_ptr as *mut u8);
+    }
 
     log::debug!(
         "BS.LoadImage: PE loaded at {:#x}, entry={:#x}, size={:#x}",
@@ -855,8 +1140,10 @@ extern "efiapi" fn load_image(
     };
 
     // Create LoadedImageProtocol for this image
-    // Get the parent's device handle if available
-    let device_handle = get_device_handle_from_parent(parent_image_handle);
+    // Use the device handle from loading if we loaded from device path,
+    // otherwise try to get it from the parent
+    let device_handle =
+        loaded_from_device.unwrap_or_else(|| get_device_handle_from_parent(parent_image_handle));
 
     let system_table = super::get_system_table();
     let loaded_image_protocol = create_loaded_image_protocol(
@@ -1251,12 +1538,49 @@ extern "efiapi" fn open_protocol(
 }
 
 extern "efiapi" fn close_protocol(
-    _handle: Handle,
-    _protocol: *mut Guid,
+    handle: Handle,
+    protocol: *mut Guid,
     _agent_handle: Handle,
     _controller_handle: Handle,
 ) -> Status {
-    Status::UNSUPPORTED
+    let guid = if protocol.is_null() {
+        log::debug!("BS.CloseProtocol: protocol is NULL");
+        return Status::INVALID_PARAMETER;
+    } else {
+        unsafe { *protocol }
+    };
+
+    log::debug!(
+        "BS.CloseProtocol(handle={:?}, protocol={})",
+        handle,
+        GuidFmt(guid)
+    );
+
+    if handle.is_null() {
+        log::debug!("  -> INVALID_PARAMETER (handle is NULL)");
+        return Status::INVALID_PARAMETER;
+    }
+
+    // Verify the handle exists and has this protocol
+    let efi_state = state::efi();
+    let handle_exists = efi_state.handles[..efi_state.handle_count]
+        .iter()
+        .any(|entry| {
+            entry.handle == handle
+                && entry.protocols[..entry.protocol_count]
+                    .iter()
+                    .any(|p| p.guid == guid)
+        });
+
+    if !handle_exists {
+        log::debug!("  -> NOT_FOUND");
+        return Status::NOT_FOUND;
+    }
+
+    // In our simple implementation, we don't track open protocol usage,
+    // so close is effectively a no-op but we return SUCCESS
+    log::debug!("  -> SUCCESS");
+    Status::SUCCESS
 }
 
 extern "efiapi" fn open_protocol_information(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,7 +605,7 @@ fn boot_uefi_entry(entry: &menu::BootEntry) {
             use drivers::storage::{self, StorageType};
 
             // Get the controller pointer directly (no lock needed for the boot phase
-            // since global_read_sector stores the pointer)
+            // since global_read_sectors stores the pointer)
             let controller_ptr = match drivers::usb::get_controller_ptr(controller_id) {
                 Some(ptr) => ptr,
                 None => {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -589,6 +589,12 @@ fn discover_usb_entries(menu: &mut BootMenu) {
         let device_created = usb::with_controller(controller_id, |controller| {
             match UsbMassStorage::new(controller, device_addr) {
                 Ok(usb_device) => {
+                    // Skip devices with no media (e.g., card reader without card)
+                    if usb_device.num_blocks == 0 {
+                        log::info!("USB Mass Storage: no media present, skipping");
+                        return false;
+                    }
+
                     // Store device globally WITH controller pointer so global_read_sector can use it directly
                     // This avoids lock contention since we store the pointer, not just the ID
                     // SAFETY: controller_ptr is obtained from get_controller_ptr and is valid

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -595,7 +595,7 @@ fn discover_usb_entries(menu: &mut BootMenu) {
                         return false;
                     }
 
-                    // Store device globally WITH controller pointer so global_read_sector can use it directly
+                    // Store device globally WITH controller pointer so global_read_sectors can use it directly
                     // This avoids lock contention since we store the pointer, not just the ID
                     // SAFETY: controller_ptr is obtained from get_controller_ptr and is valid
                     unsafe {


### PR DESCRIPTION
This PR improves USB device enumeration and adds support for loading EFI images from file paths.

Key changes:

**xHCI driver improvements:**
- Add Port Link State (PLS) detection to identify phantom USB ports (e.g., Thunderbolt controller internal ports)
- Wait up to 50ms for link training before attempting device enumeration
- Skip ports where the link doesn't reach U0 state or returns to RxDetect
- Verify link state after port reset to avoid enumerating non-existent devices
- Add constants for PLS states (U0, RxDetect, Polling)

**EFI Boot Services enhancements:**
- Implement device path-based image loading in `LoadImage()` when source buffer is NULL
- Add `extract_file_path_from_device_path()` to parse file paths from device paths
- Add `load_image_from_device_path()` to load files via SimpleFileSystem protocol
- Implement `CloseProtocol()` to properly handle protocol close requests
- Fix `LocateHandle()` to return NOT_FOUND before BUFFER_TOO_SMALL when no handles match
- Properly track device handles for loaded images

**Memory allocator fix:**
- Disable automatic memory map merging during `allocate_pages()`/`free_pages()` operations
- Merging is now only performed at `ExitBootServices()` to prevent breaking exact-match lookups needed for freeing pages