### PR TITLE
Add CBFS payload support with decompression and trampoline relocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,12 @@ dependencies = [
  "der",
  "heapless",
  "log",
+ "lz4_flex",
+ "lzma-rust2",
  "postcard",
  "r-efi",
  "rsa",
+ "ruzstd",
  "serde",
  "sha2",
  "signature",
@@ -264,6 +267,18 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lz4_flex"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 
 [[package]]
 name = "num-bigint-dig"
@@ -437,6 +452,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ruzstd"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,11 @@ spki = { version = "0.7", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 postcard = { version = "1.0", default-features = false, features = ["alloc"] }
 
+# Decompression for CBFS payloads (all no_std compatible)
+lz4_flex = { version = "0.12", default-features = false }
+ruzstd = { version = "0.8", default-features = false }
+lzma-rust2 = { version = "0.15.7", default-features = false }
+
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = "0.15"
 

--- a/src/arch/x86_64/entry.rs
+++ b/src/arch/x86_64/entry.rs
@@ -180,16 +180,17 @@ long_mode_start:
     mov gs, ax
     mov ss, ax
 
-    // Set up stack
-    lea rsp, [rip + _stack_top]
-
-    // Zero BSS
+    // Zero all NOLOAD sections (BSS, stack, deferred_buffer) before using stack
+    // They are contiguous: _bss_start to _deferred_buffer_end
     lea rdi, [rip + _bss_start]
-    lea rcx, [rip + _bss_end]
+    lea rcx, [rip + _deferred_buffer_end]
     sub rcx, rdi
-    shr rcx, 3
+    shr rcx, 3                    // Convert bytes to qwords
     xor rax, rax
     rep stosq
+
+    // Set up stack (now pointing to zeroed memory)
+    lea rsp, [rip + _stack_top]
 
     // Enable SSE
     mov rax, cr0

--- a/src/coreboot/cbfs.rs
+++ b/src/coreboot/cbfs.rs
@@ -698,7 +698,7 @@ impl Cbfs {
         );
 
         // Allocate bounce buffer for decompression
-        let mut bounce_buffer = trampoline::allocate_bounce_buffer(file.decompressed_size as usize)
+        let bounce_buffer = trampoline::allocate_bounce_buffer(file.decompressed_size as usize)
             .ok_or_else(|| {
                 log::error!("CBFS: failed to allocate bounce buffer");
                 CbfsError::AllocationFailed
@@ -711,7 +711,7 @@ impl Cbfs {
         );
 
         // Decompress to bounce buffer
-        let decompressed_size = self.read(file, &mut bounce_buffer)?;
+        let decompressed_size = self.read(file, bounce_buffer)?;
 
         // Calculate BSS size
         let bss_size = (load_info.mem_size as usize).saturating_sub(decompressed_size);

--- a/src/coreboot/cbfs.rs
+++ b/src/coreboot/cbfs.rs
@@ -1,0 +1,1657 @@
+//! CBFS (Coreboot File System) parsing
+//!
+//! This module provides read-only access to files stored in CBFS.
+//! CBFS location is obtained from coreboot's `LB_TAG_BOOT_MEDIA_PARAMS`
+//! table entry, which provides the exact offset and size in flash.
+//!
+//! On x86, the SPI flash is memory-mapped at the end of the 4GB address space,
+//! so we can directly read CBFS contents from memory.
+//!
+//! # References
+//!
+//! - coreboot/src/commonlib/bsd/include/commonlib/bsd/cbfs_serialized.h
+//! - coreboot/payloads/libpayload/libcbfs/cbfs.c
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::mem::size_of;
+use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
+
+/// CBFS file magic: "LARCHIVE"
+pub const CBFS_FILE_MAGIC: &[u8; 8] = b"LARCHIVE";
+
+/// CBFS header magic: 0x4F524243 ("ORBC" in big-endian)
+pub const CBFS_HEADER_MAGIC: u32 = 0x4F524243;
+
+/// CBFS file alignment (all files are aligned to this boundary)
+pub const CBFS_ALIGNMENT: usize = 64;
+
+/// Maximum metadata size (filename + attributes)
+pub const CBFS_METADATA_MAX_SIZE: usize = 256;
+
+/// CBFS compression types
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum CbfsCompression {
+    None = 0,
+    Lzma = 1,
+    Lz4 = 2,
+    Zstd = 3,
+}
+
+impl CbfsCompression {
+    fn from_be(value: u32) -> Self {
+        match u32::from_be(value) {
+            0 => Self::None,
+            1 => Self::Lzma,
+            2 => Self::Lz4,
+            3 => Self::Zstd,
+            _ => Self::None,
+        }
+    }
+}
+
+/// CBFS file types
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum CbfsType {
+    Deleted = 0x00000000,
+    Null = 0xffffffff,
+    Bootblock = 0x01,
+    CbfsHeader = 0x02,
+    LegacyStage = 0x10,
+    Stage = 0x11,
+    Self_ = 0x20,
+    FitPayload = 0x21,
+    OptionRom = 0x30,
+    BootSplash = 0x40,
+    Raw = 0x50,
+    Vsa = 0x51,
+    Mbi = 0x52,
+    Microcode = 0x53,
+    IntelFit = 0x54,
+    Fsp = 0x60,
+    Mrc = 0x61,
+    Mma = 0x62,
+    Efi = 0x63,
+    Struct = 0x70,
+    AmdFw = 0x80,
+    CmosDefault = 0xaa,
+    Spd = 0xab,
+    MrcCache = 0xac,
+    CmosLayout = 0x01aa,
+    Unknown(u32),
+}
+
+impl CbfsType {
+    fn from_be(value: u32) -> Self {
+        match u32::from_be(value) {
+            0x00000000 => Self::Deleted,
+            0xffffffff => Self::Null,
+            0x01 => Self::Bootblock,
+            0x02 => Self::CbfsHeader,
+            0x10 => Self::LegacyStage,
+            0x11 => Self::Stage,
+            0x20 => Self::Self_,
+            0x21 => Self::FitPayload,
+            0x30 => Self::OptionRom,
+            0x40 => Self::BootSplash,
+            0x50 => Self::Raw,
+            0x51 => Self::Vsa,
+            0x52 => Self::Mbi,
+            0x53 => Self::Microcode,
+            0x54 => Self::IntelFit,
+            0x60 => Self::Fsp,
+            0x61 => Self::Mrc,
+            0x62 => Self::Mma,
+            0x63 => Self::Efi,
+            0x70 => Self::Struct,
+            0x80 => Self::AmdFw,
+            0xaa => Self::CmosDefault,
+            0xab => Self::Spd,
+            0xac => Self::MrcCache,
+            0x01aa => Self::CmosLayout,
+            v => Self::Unknown(v),
+        }
+    }
+}
+
+/// CBFS file attribute tags
+#[allow(dead_code)]
+mod attr_tags {
+    pub const UNUSED: u32 = 0;
+    pub const UNUSED2: u32 = 0xffffffff;
+    pub const COMPRESSION: u32 = 0x42435a4c; // "BCZL" in BE
+    pub const HASH: u32 = 0x68736148; // "hsaH" in BE
+    pub const POSITION: u32 = 0x42435350; // "BCSP" in BE
+    pub const ALIGNMENT: u32 = 0x42434c41; // "BCLA" in BE
+    pub const IBB: u32 = 0x32494242; // "2IBB" in BE
+    pub const PADDING: u32 = 0x47444150; // "GNDP" in BE
+    pub const STAGEHEADER: u32 = 0x53746748; // "StgH" in BE
+}
+
+/// CBFS file header (on-disk format, all fields big-endian)
+///
+/// Layout in flash:
+/// ```text
+/// [CbfsFileHeader]     <- offset 0
+/// [filename string]    <- offset sizeof(CbfsFileHeader)
+/// [attributes]         <- offset attributes_offset (if non-zero)
+/// [file data]          <- offset `offset` field
+/// ```
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Debug, Clone, Copy)]
+pub struct CbfsFileHeader {
+    /// Magic: "LARCHIVE"
+    pub magic: [u8; 8],
+    /// Length of file data (big-endian)
+    pub len: u32,
+    /// File type (big-endian)
+    pub type_: u32,
+    /// Offset to attributes from start of header, 0 if none (big-endian)
+    pub attributes_offset: u32,
+    /// Offset to file data from start of header (big-endian)
+    pub offset: u32,
+    // filename follows (variable length, null-terminated)
+}
+
+/// CBFS file attribute header
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Debug, Clone, Copy)]
+pub struct CbfsFileAttribute {
+    /// Attribute tag (big-endian)
+    pub tag: u32,
+    /// Total attribute length including header (big-endian)
+    pub len: u32,
+    // attribute data follows
+}
+
+/// CBFS compression attribute
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Debug, Clone, Copy)]
+pub struct CbfsAttrCompression {
+    /// Tag: CBFS_FILE_ATTR_TAG_COMPRESSION
+    pub tag: u32,
+    /// Length of this attribute
+    pub len: u32,
+    /// Compression algorithm (big-endian)
+    pub compression: u32,
+    /// Decompressed size (big-endian)
+    pub decompressed_size: u32,
+}
+
+/// CBFS stage header attribute (for stages like ramstage, postcar)
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Debug, Clone, Copy)]
+pub struct CbfsAttrStageHeader {
+    /// Tag: CBFS_FILE_ATTR_TAG_STAGEHEADER
+    pub tag: u32,
+    /// Length of this attribute
+    pub len: u32,
+    /// Memory address to load the code to (big-endian)
+    pub loadaddr: u64,
+    /// Offset of entry point from loadaddr (big-endian)
+    pub entry_offset: u32,
+    /// Total length (including BSS) in memory (big-endian)
+    pub memlen: u32,
+}
+
+/// CBFS payload segment header (for self-extracting payloads)
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Debug, Clone, Copy)]
+pub struct CbfsPayloadSegment {
+    /// Segment type (CODE, DATA, BSS, ENTRY, PARAMS)
+    pub seg_type: u32,
+    /// Compression algorithm (big-endian)
+    pub compression: u32,
+    /// Offset of segment data within payload (big-endian)
+    pub offset: u32,
+    /// Memory address to load this segment (big-endian)
+    pub load_addr: u64,
+    /// Length of compressed data (big-endian)
+    pub len: u32,
+    /// Length in memory after decompression (big-endian)
+    pub mem_len: u32,
+}
+
+/// Payload segment types
+#[allow(dead_code)]
+mod payload_segment_types {
+    pub const CODE: u32 = 0x434F4445; // "CODE" in BE
+    pub const DATA: u32 = 0x44415441; // "DATA" in BE
+    pub const BSS: u32 = 0x42535320; // "BSS " in BE
+    pub const PARAMS: u32 = 0x50415241; // "PARA" in BE
+    pub const ENTRY: u32 = 0x454E5452; // "ENTR" in BE
+}
+
+/// Information about a CBFS file
+#[derive(Debug, Clone)]
+pub struct CbfsFileInfo {
+    /// File name
+    pub name: String,
+    /// File type
+    pub file_type: CbfsType,
+    /// Compression algorithm
+    pub compression: CbfsCompression,
+    /// Compressed size (size on flash)
+    pub compressed_size: u32,
+    /// Decompressed size (actual data size)
+    pub decompressed_size: u32,
+    /// Host memory address where file data starts
+    pub data_addr: u64,
+    /// Flash offset where file data starts
+    pub flash_offset: u64,
+    /// Stage/payload load information (if available)
+    pub load_info: Option<CbfsLoadInfo>,
+}
+
+/// Load information for stages and payloads
+#[derive(Debug, Clone, Copy)]
+pub struct CbfsLoadInfo {
+    /// Memory address to load the code to
+    pub load_addr: u64,
+    /// Entry point address (load_addr + entry_offset)
+    pub entry_point: u64,
+    /// Total memory size needed (including BSS)
+    pub mem_size: u32,
+}
+
+/// CBFS access handle
+///
+/// Provides access to CBFS contents using information from coreboot tables.
+#[derive(Debug)]
+pub struct Cbfs {
+    /// Base host address of CBFS region
+    cbfs_host_base: u64,
+    /// Size of CBFS region
+    cbfs_size: u64,
+    /// Flash offset of CBFS region
+    cbfs_flash_offset: u64,
+}
+
+impl Cbfs {
+    /// Create a new CBFS accessor using boot media info from coreboot tables
+    ///
+    /// Returns None if boot media info is not available.
+    pub fn new() -> Option<Self> {
+        let boot_media = super::get_boot_media()?;
+
+        // Calculate host base address for CBFS
+        // Flash is memory-mapped at end of 4GB: host_addr = 0x100000000 - boot_media_size + flash_offset
+        let cbfs_host_base = flash_to_host_addr(boot_media.cbfs_offset, boot_media.boot_media_size);
+
+        log::info!(
+            "CBFS: flash offset {:#x}, size {} KB, host base {:#x}",
+            boot_media.cbfs_offset,
+            boot_media.cbfs_size / 1024,
+            cbfs_host_base
+        );
+
+        Some(Self {
+            cbfs_host_base,
+            cbfs_size: boot_media.cbfs_size,
+            cbfs_flash_offset: boot_media.cbfs_offset,
+        })
+    }
+
+    /// Find a file in CBFS by name
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The file name to search for
+    ///
+    /// # Returns
+    ///
+    /// File info if found, None otherwise.
+    pub fn find(&self, name: &str) -> Option<CbfsFileInfo> {
+        let mut offset = 0usize;
+
+        while offset + size_of::<CbfsFileHeader>() < self.cbfs_size as usize {
+            // Read file header
+            let header_ptr = (self.cbfs_host_base + offset as u64) as *const u8;
+            let header_bytes =
+                unsafe { core::slice::from_raw_parts(header_ptr, size_of::<CbfsFileHeader>()) };
+
+            let Ok((header, _)) = CbfsFileHeader::read_from_prefix(header_bytes) else {
+                offset += CBFS_ALIGNMENT;
+                continue;
+            };
+
+            // Check for LARCHIVE magic
+            if &header.magic != CBFS_FILE_MAGIC {
+                offset += CBFS_ALIGNMENT;
+                continue;
+            }
+
+            // Parse header fields (convert from big-endian)
+            let data_offset = u32::from_be(header.offset) as usize;
+            let data_len = u32::from_be(header.len);
+            let file_type = CbfsType::from_be(header.type_);
+            let attr_offset = u32::from_be(header.attributes_offset) as usize;
+
+            // Validate offsets
+            if data_offset > CBFS_METADATA_MAX_SIZE || data_offset < size_of::<CbfsFileHeader>() {
+                log::warn!("CBFS: invalid data offset {} at {:#x}", data_offset, offset);
+                offset += CBFS_ALIGNMENT;
+                continue;
+            }
+
+            // Skip deleted/null entries
+            if matches!(file_type, CbfsType::Deleted | CbfsType::Null) {
+                offset = align_up(offset + data_offset + data_len as usize, CBFS_ALIGNMENT);
+                continue;
+            }
+
+            // Read filename (starts after header, null-terminated)
+            let filename_start = header_ptr as usize + size_of::<CbfsFileHeader>();
+            let filename_max_len = if attr_offset > size_of::<CbfsFileHeader>() {
+                attr_offset - size_of::<CbfsFileHeader>()
+            } else {
+                data_offset - size_of::<CbfsFileHeader>()
+            };
+
+            let filename = unsafe {
+                let filename_bytes =
+                    core::slice::from_raw_parts(filename_start as *const u8, filename_max_len);
+                let len = filename_bytes
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap_or(filename_max_len);
+                core::str::from_utf8(&filename_bytes[..len]).unwrap_or("")
+            };
+
+            log::trace!(
+                "CBFS file: '{}' type={:?} at offset {:#x}",
+                filename,
+                file_type,
+                offset
+            );
+
+            // Check if this is the file we're looking for
+            if filename == name {
+                // Parse attributes if present
+                let (compression, decompressed_size, load_info) = if attr_offset > 0 {
+                    self.parse_attributes(header_ptr, attr_offset, data_offset)
+                } else {
+                    (CbfsCompression::None, data_len, None)
+                };
+
+                let data_host_addr = self.cbfs_host_base + offset as u64 + data_offset as u64;
+                let data_flash_offset = self.cbfs_flash_offset + offset as u64 + data_offset as u64;
+
+                // Use data_len as fallback if decompressed_size is 0
+                let final_decompressed_size = if decompressed_size > 0 {
+                    decompressed_size
+                } else {
+                    data_len
+                };
+
+                log::info!(
+                    "CBFS: found '{}' at {:#x}, {} bytes (compressed: {} bytes, {:?})",
+                    name,
+                    data_flash_offset,
+                    final_decompressed_size,
+                    data_len,
+                    compression
+                );
+
+                if let Some(ref info) = load_info {
+                    log::info!(
+                        "CBFS: load_addr={:#x}, entry={:#x}, mem_size={}",
+                        info.load_addr,
+                        info.entry_point,
+                        info.mem_size
+                    );
+                }
+
+                return Some(CbfsFileInfo {
+                    name: String::from(filename),
+                    file_type,
+                    compression,
+                    compressed_size: data_len,
+                    decompressed_size: final_decompressed_size,
+                    data_addr: data_host_addr,
+                    flash_offset: data_flash_offset,
+                    load_info,
+                });
+            }
+
+            // Move to next file (aligned)
+            offset = align_up(offset + data_offset + data_len as usize, CBFS_ALIGNMENT);
+        }
+
+        log::debug!("CBFS: file '{}' not found", name);
+        None
+    }
+
+    /// Parse all attributes from file metadata
+    ///
+    /// Returns (compression, decompressed_size, load_info)
+    fn parse_attributes(
+        &self,
+        header_ptr: *const u8,
+        attr_offset: usize,
+        data_offset: usize,
+    ) -> (CbfsCompression, u32, Option<CbfsLoadInfo>) {
+        let mut offset = attr_offset;
+        let mut compression = CbfsCompression::None;
+        let mut decompressed_size = 0u32;
+        let mut load_info: Option<CbfsLoadInfo> = None;
+
+        while offset + size_of::<CbfsFileAttribute>() <= data_offset {
+            let attr_ptr = unsafe { header_ptr.add(offset) };
+            let attr_bytes =
+                unsafe { core::slice::from_raw_parts(attr_ptr, size_of::<CbfsFileAttribute>()) };
+
+            let Ok((attr, _)) = CbfsFileAttribute::read_from_prefix(attr_bytes) else {
+                break;
+            };
+
+            let tag = u32::from_be(attr.tag);
+            let len = u32::from_be(attr.len) as usize;
+
+            if len < size_of::<CbfsFileAttribute>() || offset + len > data_offset {
+                break;
+            }
+
+            match tag {
+                attr_tags::COMPRESSION => {
+                    // Read compression attribute
+                    let comp_bytes = unsafe {
+                        core::slice::from_raw_parts(attr_ptr, size_of::<CbfsAttrCompression>())
+                    };
+
+                    if let Ok((comp_attr, _)) = CbfsAttrCompression::read_from_prefix(comp_bytes) {
+                        compression = CbfsCompression::from_be(comp_attr.compression);
+                        decompressed_size = u32::from_be(comp_attr.decompressed_size);
+                    }
+                }
+                attr_tags::STAGEHEADER => {
+                    // Read stage header attribute
+                    let stage_bytes = unsafe {
+                        core::slice::from_raw_parts(attr_ptr, size_of::<CbfsAttrStageHeader>())
+                    };
+
+                    if let Ok((stage_attr, _)) = CbfsAttrStageHeader::read_from_prefix(stage_bytes)
+                    {
+                        let loadaddr = u64::from_be(stage_attr.loadaddr);
+                        let entry_offset = u32::from_be(stage_attr.entry_offset);
+                        let memlen = u32::from_be(stage_attr.memlen);
+
+                        load_info = Some(CbfsLoadInfo {
+                            load_addr: loadaddr,
+                            entry_point: loadaddr + entry_offset as u64,
+                            mem_size: memlen,
+                        });
+                    }
+                }
+                attr_tags::UNUSED | attr_tags::UNUSED2 => {
+                    // End of attributes
+                    break;
+                }
+                _ => {
+                    // Unknown attribute, skip it
+                }
+            }
+
+            offset += len;
+        }
+
+        (compression, decompressed_size, load_info)
+    }
+
+    /// Read file data into a buffer
+    ///
+    /// # Arguments
+    ///
+    /// * `file` - File info from `find()`
+    /// * `buffer` - Buffer to read into (must be at least `decompressed_size` bytes)
+    ///
+    /// # Returns
+    ///
+    /// Number of bytes read, or error.
+    pub fn read(&self, file: &CbfsFileInfo, buffer: &mut [u8]) -> Result<usize, CbfsError> {
+        if buffer.len() < file.decompressed_size as usize {
+            return Err(CbfsError::BufferTooSmall);
+        }
+
+        match file.compression {
+            CbfsCompression::None => {
+                // Direct copy from memory-mapped flash
+                let src = unsafe {
+                    core::slice::from_raw_parts(
+                        file.data_addr as *const u8,
+                        file.compressed_size as usize,
+                    )
+                };
+                buffer[..file.compressed_size as usize].copy_from_slice(src);
+                Ok(file.compressed_size as usize)
+            }
+            CbfsCompression::Lzma => {
+                // LZMA decompression using lzma-rs
+                let src = unsafe {
+                    core::slice::from_raw_parts(
+                        file.data_addr as *const u8,
+                        file.compressed_size as usize,
+                    )
+                };
+                decompress_lzma(src, buffer)
+            }
+            CbfsCompression::Lz4 => {
+                // LZ4 decompression using lz4_flex
+                let src = unsafe {
+                    core::slice::from_raw_parts(
+                        file.data_addr as *const u8,
+                        file.compressed_size as usize,
+                    )
+                };
+                decompress_lz4(src, buffer, file.decompressed_size as usize)
+            }
+            CbfsCompression::Zstd => {
+                // ZSTD decompression using ruzstd
+                let src = unsafe {
+                    core::slice::from_raw_parts(
+                        file.data_addr as *const u8,
+                        file.compressed_size as usize,
+                    )
+                };
+                decompress_zstd(src, buffer)
+            }
+        }
+    }
+
+    /// Read file data into a newly allocated buffer
+    ///
+    /// # Arguments
+    ///
+    /// * `file` - File info from `find()`
+    ///
+    /// # Returns
+    ///
+    /// Vector containing file data, or error.
+    pub fn read_alloc(&self, file: &CbfsFileInfo) -> Result<Vec<u8>, CbfsError> {
+        let mut buffer = alloc::vec![0u8; file.decompressed_size as usize];
+        let size = self.read(file, &mut buffer)?;
+        buffer.truncate(size);
+        Ok(buffer)
+    }
+
+    /// Load a stage/payload directly to its target memory address
+    ///
+    /// This function decompresses the file directly into the memory address
+    /// specified in the stage header, avoiding intermediate buffer allocation.
+    /// It also zeroes the BSS section if mem_size > decompressed_size.
+    ///
+    /// If the target address conflicts with CrabEFI's own memory, this function
+    /// uses a bounce buffer and trampoline to safely relocate the payload.
+    ///
+    /// # Arguments
+    ///
+    /// * `file` - File info from `find()` (must have load_info)
+    ///
+    /// # Returns
+    ///
+    /// The entry point address on success, or error.
+    /// Note: If a trampoline is used, this function never returns.
+    ///
+    /// # Safety
+    ///
+    /// This function writes directly to the target memory address specified
+    /// in the file's load_info. The caller must ensure:
+    /// - The target memory region is valid and writable
+    /// - The memory region is large enough (at least mem_size bytes)
+    /// - No other code is using that memory region
+    pub unsafe fn load_to_target(&self, file: &CbfsFileInfo) -> Result<u64, CbfsError> {
+        let load_info = file.load_info.ok_or_else(|| {
+            log::error!("CBFS: file '{}' has no load info", file.name);
+            CbfsError::InvalidFormat
+        })?;
+
+        // Check if target conflicts with CrabEFI's own memory
+        let conflicts_with_crabefi = crate::efi::allocator::conflicts_with_runtime(
+            load_info.load_addr,
+            load_info.mem_size as u64,
+        );
+
+        if conflicts_with_crabefi {
+            // Use bounce buffer + trampoline approach
+            return self.load_with_trampoline(file, &load_info);
+        }
+
+        // Direct loading path - target doesn't conflict with CrabEFI
+
+        // Check that target is in usable RAM (not MMIO, reserved, or ACPI regions)
+        if !crate::efi::allocator::is_usable_memory(load_info.load_addr, load_info.mem_size as u64)
+        {
+            log::error!(
+                "CBFS: target region {:#x}-{:#x} is not in usable RAM",
+                load_info.load_addr,
+                load_info.load_addr + load_info.mem_size as u64
+            );
+            return Err(CbfsError::InvalidTarget);
+        }
+
+        log::info!(
+            "CBFS: loading '{}' to {:#x} ({} bytes, entry={:#x})",
+            file.name,
+            load_info.load_addr,
+            load_info.mem_size,
+            load_info.entry_point
+        );
+
+        // Create a slice for the target memory region
+        let target = unsafe {
+            core::slice::from_raw_parts_mut(
+                load_info.load_addr as *mut u8,
+                load_info.mem_size as usize,
+            )
+        };
+
+        // Decompress directly into target
+        let decompressed_size = self.read(file, target)?;
+
+        // Zero BSS (memory beyond decompressed data up to mem_size)
+        if decompressed_size < load_info.mem_size as usize {
+            let bss_start = decompressed_size;
+            let bss_size = load_info.mem_size as usize - decompressed_size;
+            log::debug!(
+                "CBFS: zeroing BSS at {:#x}, {} bytes",
+                load_info.load_addr + bss_start as u64,
+                bss_size
+            );
+            target[bss_start..].fill(0);
+        }
+
+        log::info!(
+            "CBFS: loaded '{}', entry point at {:#x}",
+            file.name,
+            load_info.entry_point
+        );
+
+        Ok(load_info.entry_point)
+    }
+
+    /// Load a payload using bounce buffer and trampoline
+    ///
+    /// This is used when the target address conflicts with CrabEFI's memory.
+    /// The payload is decompressed to a bounce buffer, then a trampoline
+    /// copies it to the final location and jumps to the entry point.
+    ///
+    /// # Safety
+    ///
+    /// This function never returns - it jumps to the trampoline which
+    /// eventually jumps to the payload entry point.
+    unsafe fn load_with_trampoline(
+        &self,
+        file: &CbfsFileInfo,
+        load_info: &CbfsLoadInfo,
+    ) -> Result<u64, CbfsError> {
+        use super::trampoline::{self, TrampolineParams};
+
+        let (runtime_start, runtime_end) = crate::efi::allocator::get_runtime_bounds();
+        log::warn!(
+            "CBFS: target {:#x}-{:#x} conflicts with CrabEFI ({:#x}-{:#x}), using trampoline",
+            load_info.load_addr,
+            load_info.load_addr + load_info.mem_size as u64,
+            runtime_start,
+            runtime_end
+        );
+
+        // Allocate bounce buffer for decompression
+        let mut bounce_buffer = trampoline::allocate_bounce_buffer(file.decompressed_size as usize)
+            .ok_or_else(|| {
+                log::error!("CBFS: failed to allocate bounce buffer");
+                CbfsError::AllocationFailed
+            })?;
+
+        log::info!(
+            "CBFS: decompressing '{}' to bounce buffer at {:#x}",
+            file.name,
+            bounce_buffer.as_ptr() as u64
+        );
+
+        // Decompress to bounce buffer
+        let decompressed_size = self.read(file, &mut bounce_buffer)?;
+
+        // Calculate BSS size
+        let bss_size = (load_info.mem_size as usize).saturating_sub(decompressed_size);
+
+        // Get coreboot table pointer for passing to payload
+        let cbtable_ptr = crate::state::get_coreboot_table_ptr().unwrap_or(0);
+
+        // Set up trampoline parameters
+        let params = TrampolineParams {
+            src_addr: bounce_buffer.as_ptr() as u64,
+            dst_addr: load_info.load_addr,
+            copy_size: decompressed_size as u64,
+            bss_size: bss_size as u64,
+            entry_point: load_info.entry_point,
+            coreboot_table_ptr: cbtable_ptr,
+        };
+
+        // Execute the trampoline - this never returns
+        // The bounce buffer was allocated via EFI pages, so it stays allocated
+        match trampoline::execute_trampoline(&params) {
+            // execute_trampoline returns ! on success, so this is unreachable
+            Err(e) => {
+                log::error!("CBFS: trampoline setup failed: {:?}", e);
+                Err(CbfsError::TrampolineFailed)
+            }
+        }
+    }
+
+    /// Iterate over all files in CBFS
+    ///
+    /// # Arguments
+    ///
+    /// * `callback` - Function to call for each file. Return `false` to stop iteration.
+    pub fn for_each<F>(&self, mut callback: F)
+    where
+        F: FnMut(&CbfsFileInfo) -> bool,
+    {
+        let mut offset = 0usize;
+
+        while offset + size_of::<CbfsFileHeader>() < self.cbfs_size as usize {
+            let header_ptr = (self.cbfs_host_base + offset as u64) as *const u8;
+            let header_bytes =
+                unsafe { core::slice::from_raw_parts(header_ptr, size_of::<CbfsFileHeader>()) };
+
+            let Ok((header, _)) = CbfsFileHeader::read_from_prefix(header_bytes) else {
+                offset += CBFS_ALIGNMENT;
+                continue;
+            };
+
+            if &header.magic != CBFS_FILE_MAGIC {
+                offset += CBFS_ALIGNMENT;
+                continue;
+            }
+
+            let data_offset = u32::from_be(header.offset) as usize;
+            let data_len = u32::from_be(header.len);
+            let file_type = CbfsType::from_be(header.type_);
+            let attr_offset = u32::from_be(header.attributes_offset) as usize;
+
+            if data_offset > CBFS_METADATA_MAX_SIZE || data_offset < size_of::<CbfsFileHeader>() {
+                offset += CBFS_ALIGNMENT;
+                continue;
+            }
+
+            // Skip deleted/null entries
+            if matches!(file_type, CbfsType::Deleted | CbfsType::Null) {
+                offset = align_up(offset + data_offset + data_len as usize, CBFS_ALIGNMENT);
+                continue;
+            }
+
+            // Read filename
+            let filename_start = header_ptr as usize + size_of::<CbfsFileHeader>();
+            let filename_max_len = if attr_offset > size_of::<CbfsFileHeader>() {
+                attr_offset - size_of::<CbfsFileHeader>()
+            } else {
+                data_offset - size_of::<CbfsFileHeader>()
+            };
+
+            let filename = unsafe {
+                let filename_bytes =
+                    core::slice::from_raw_parts(filename_start as *const u8, filename_max_len);
+                let len = filename_bytes
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap_or(filename_max_len);
+                core::str::from_utf8(&filename_bytes[..len]).unwrap_or("")
+            };
+
+            // Parse attributes
+            let (compression, decompressed_size, load_info) = if attr_offset > 0 {
+                self.parse_attributes(header_ptr, attr_offset, data_offset)
+            } else {
+                (CbfsCompression::None, data_len, None)
+            };
+
+            let file_info = CbfsFileInfo {
+                name: String::from(filename),
+                file_type,
+                compression,
+                compressed_size: data_len,
+                decompressed_size: if decompressed_size > 0 {
+                    decompressed_size
+                } else {
+                    data_len
+                },
+                data_addr: self.cbfs_host_base + offset as u64 + data_offset as u64,
+                flash_offset: self.cbfs_flash_offset + offset as u64 + data_offset as u64,
+                load_info,
+            };
+
+            if !callback(&file_info) {
+                return;
+            }
+
+            offset = align_up(offset + data_offset + data_len as usize, CBFS_ALIGNMENT);
+        }
+    }
+
+    /// List all files in CBFS (for debugging)
+    pub fn list(&self) {
+        log::info!("CBFS file listing:");
+        self.for_each(|file| {
+            log::info!(
+                "  {:40} {:10?} {:8} bytes @ {:#x}",
+                file.name,
+                file.file_type,
+                file.decompressed_size,
+                file.flash_offset
+            );
+            true
+        });
+    }
+}
+
+/// Decompress LZ4 data
+///
+/// # Arguments
+///
+/// * `src` - Compressed data
+/// * `dst` - Output buffer (must be large enough for decompressed data)
+/// * `decompressed_size` - Expected decompressed size
+///
+/// # Returns
+///
+/// Number of bytes written to dst, or error.
+fn decompress_lz4(
+    src: &[u8],
+    dst: &mut [u8],
+    decompressed_size: usize,
+) -> Result<usize, CbfsError> {
+    log::debug!(
+        "CBFS: LZ4 decompress {} bytes -> {} bytes",
+        src.len(),
+        decompressed_size
+    );
+
+    match lz4_flex::block::decompress_into(src, &mut dst[..decompressed_size]) {
+        Ok(size) => {
+            log::debug!("CBFS: LZ4 decompressed {} bytes", size);
+            Ok(size)
+        }
+        Err(e) => {
+            log::error!("CBFS: LZ4 decompression failed: {:?}", e);
+            Err(CbfsError::DecompressionError)
+        }
+    }
+}
+
+/// Decompress ZSTD data
+///
+/// # Arguments
+///
+/// * `src` - Compressed data
+/// * `dst` - Output buffer (must be large enough for decompressed data)
+///
+/// # Returns
+///
+/// Number of bytes written to dst, or error.
+fn decompress_zstd(src: &[u8], dst: &mut [u8]) -> Result<usize, CbfsError> {
+    log::debug!(
+        "CBFS: ZSTD decompress {} bytes -> {} bytes max",
+        src.len(),
+        dst.len()
+    );
+
+    let mut decoder = ruzstd::decoding::FrameDecoder::new();
+    match decoder.decode_all(src, dst) {
+        Ok(size) => {
+            log::debug!("CBFS: ZSTD decompressed {} bytes", size);
+            Ok(size)
+        }
+        Err(e) => {
+            log::error!("CBFS: ZSTD decompression failed: {:?}", e);
+            Err(CbfsError::DecompressionError)
+        }
+    }
+}
+
+/// Decompress LZMA data
+///
+/// # Arguments
+///
+/// * `src` - Compressed data
+/// * `dst` - Output buffer (must be large enough for decompressed data)
+///
+/// # Returns
+///
+/// Number of bytes written to dst, or error.
+fn decompress_lzma(src: &[u8], dst: &mut [u8]) -> Result<usize, CbfsError> {
+    use lzma_rust2::{LzmaReader, Read};
+
+    log::debug!(
+        "CBFS: LZMA decompress {} bytes -> {} bytes max",
+        src.len(),
+        dst.len()
+    );
+
+    // Create LZMA reader from source slice
+    // u32::MAX for mem_limit allows any dictionary size
+    let mut reader = match LzmaReader::new_mem_limit(src, u32::MAX, None) {
+        Ok(r) => r,
+        Err(e) => {
+            log::error!("CBFS: LZMA reader creation failed: {:?}", e);
+            return Err(CbfsError::DecompressionError);
+        }
+    };
+
+    // Read decompressed data into destination buffer
+    let mut total_read = 0;
+    loop {
+        match reader.read(&mut dst[total_read..]) {
+            Ok(0) => break, // EOF
+            Ok(n) => total_read += n,
+            Err(e) => {
+                log::error!("CBFS: LZMA decompression failed: {:?}", e);
+                return Err(CbfsError::DecompressionError);
+            }
+        }
+    }
+
+    log::debug!("CBFS: LZMA decompressed {} bytes", total_read);
+    Ok(total_read)
+}
+
+/// CBFS errors
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CbfsError {
+    /// File not found
+    NotFound,
+    /// Buffer too small
+    BufferTooSmall,
+    /// Decompression failed
+    DecompressionError,
+    /// IO error
+    IoError,
+    /// Invalid CBFS structure
+    InvalidFormat,
+    /// Target address conflicts with CrabEFI's memory (handled via trampoline)
+    TargetConflict,
+    /// Target address is not in usable RAM
+    InvalidTarget,
+    /// Failed to allocate bounce buffer
+    AllocationFailed,
+    /// Trampoline setup or execution failed
+    TrampolineFailed,
+}
+
+/// Convert flash offset to host memory address
+///
+/// On x86, flash is memory-mapped at the end of the 4GB address space:
+/// `host_addr = 0x100000000 - boot_media_size + flash_offset`
+///
+/// For example, an 8MB flash would be mapped at:
+/// `0x100000000 - 0x800000 = 0xFF800000`
+#[inline]
+fn flash_to_host_addr(flash_offset: u64, boot_media_size: u64) -> u64 {
+    // Flash is mapped just below 4GB (0x100000000)
+    // This gives addresses like 0xFF800000 for 8MB flash
+    0x100000000u64 - boot_media_size + flash_offset
+}
+
+/// Align value up to alignment boundary
+#[inline]
+const fn align_up(value: usize, alignment: usize) -> usize {
+    (value + alignment - 1) & !(alignment - 1)
+}
+
+/// Load a stage/payload directly to its target memory address
+///
+/// This function finds a file by name and decompresses it directly
+/// into the memory address specified in its stage header.
+///
+/// # Arguments
+///
+/// * `name` - File name to find and load
+///
+/// # Returns
+///
+/// The entry point address on success, or None if not found or error.
+///
+/// # Safety
+///
+/// See [`Cbfs::load_to_target`] for safety requirements.
+pub unsafe fn load_file(name: &str) -> Option<u64> {
+    let cbfs = Cbfs::new()?;
+    let file = cbfs.find(name)?;
+    match cbfs.load_to_target(&file) {
+        Ok(entry) => Some(entry),
+        Err(e) => {
+            log::error!("CBFS: failed to load '{}': {:?}", name, e);
+            None
+        }
+    }
+}
+
+/// Parsed self-extracting payload (CBFS_TYPE_SELF)
+///
+/// Contains all segments that need to be loaded and the entry point.
+#[derive(Debug)]
+pub struct SelfPayload {
+    /// Segments to load (CODE, DATA, BSS)
+    pub segments: heapless::Vec<PayloadSegmentInfo, 16>,
+    /// Entry point address
+    pub entry_point: u64,
+}
+
+/// Parsed payload segment information
+#[derive(Debug, Clone)]
+pub struct PayloadSegmentInfo {
+    /// Segment type (CODE, DATA, BSS)
+    pub seg_type: PayloadSegmentType,
+    /// Compression algorithm
+    pub compression: CbfsCompression,
+    /// Offset of segment data within the payload file
+    pub file_offset: u32,
+    /// Memory address to load this segment
+    pub load_addr: u64,
+    /// Length of compressed data in file
+    pub compressed_len: u32,
+    /// Length in memory after decompression (includes BSS)
+    pub mem_len: u32,
+}
+
+/// Payload segment type
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PayloadSegmentType {
+    Code,
+    Data,
+    Bss,
+    Params,
+    Entry,
+    Unknown(u32),
+}
+
+impl PayloadSegmentType {
+    fn from_be(value: u32) -> Self {
+        let type_val = u32::from_be(value);
+        match type_val {
+            payload_segment_types::CODE => Self::Code,
+            payload_segment_types::DATA => Self::Data,
+            payload_segment_types::BSS => Self::Bss,
+            payload_segment_types::PARAMS => Self::Params,
+            payload_segment_types::ENTRY => Self::Entry,
+            _ => Self::Unknown(type_val),
+        }
+    }
+}
+
+impl Cbfs {
+    /// Parse a self-extracting payload (CBFS_TYPE_SELF)
+    ///
+    /// Self-extracting payloads contain an array of segment headers followed by
+    /// the segment data. Each segment can have its own compression.
+    ///
+    /// # Arguments
+    ///
+    /// * `file` - File info from `find()` (must be CBFS_TYPE_SELF)
+    ///
+    /// # Returns
+    ///
+    /// Parsed payload information including all segments and entry point.
+    pub fn parse_self_payload(&self, file: &CbfsFileInfo) -> Result<SelfPayload, CbfsError> {
+        if !matches!(file.file_type, CbfsType::Self_) {
+            log::error!("CBFS: {} is not a self-extracting payload", file.name);
+            return Err(CbfsError::InvalidFormat);
+        }
+
+        let mut payload = SelfPayload {
+            segments: heapless::Vec::new(),
+            entry_point: 0,
+        };
+
+        // Read segment headers from the file data
+        let data_ptr = file.data_addr as *const u8;
+        let mut offset = 0usize;
+        let segment_size = size_of::<CbfsPayloadSegment>();
+
+        log::debug!("CBFS: parsing self-extracting payload '{}'", file.name);
+
+        loop {
+            if offset + segment_size > file.compressed_size as usize {
+                log::error!("CBFS: payload segment header extends beyond file");
+                return Err(CbfsError::InvalidFormat);
+            }
+
+            let seg_bytes =
+                unsafe { core::slice::from_raw_parts(data_ptr.add(offset), segment_size) };
+
+            let Ok((segment, _)) = CbfsPayloadSegment::read_from_prefix(seg_bytes) else {
+                log::error!("CBFS: failed to parse payload segment header");
+                return Err(CbfsError::InvalidFormat);
+            };
+
+            let seg_type = PayloadSegmentType::from_be(segment.seg_type);
+            let compression = CbfsCompression::from_be(segment.compression);
+            let file_offset = u32::from_be(segment.offset);
+            let load_addr = u64::from_be(segment.load_addr);
+            let compressed_len = u32::from_be(segment.len);
+            let mem_len = u32::from_be(segment.mem_len);
+
+            log::debug!(
+                "  Segment {:?}: load={:#x}, file_off={:#x}, len={}, mem={}",
+                seg_type,
+                load_addr,
+                file_offset,
+                compressed_len,
+                mem_len
+            );
+
+            match seg_type {
+                PayloadSegmentType::Entry => {
+                    // Entry segment - load_addr is the entry point
+                    payload.entry_point = load_addr;
+                    log::debug!("  Entry point: {:#x}", load_addr);
+                    break; // ENTRY is always the last segment
+                }
+                PayloadSegmentType::Code | PayloadSegmentType::Data => {
+                    let seg_info = PayloadSegmentInfo {
+                        seg_type,
+                        compression,
+                        file_offset,
+                        load_addr,
+                        compressed_len,
+                        mem_len,
+                    };
+                    if payload.segments.push(seg_info).is_err() {
+                        log::error!("CBFS: too many payload segments");
+                        return Err(CbfsError::InvalidFormat);
+                    }
+                }
+                PayloadSegmentType::Bss => {
+                    // BSS segment - just zero memory, no data to copy
+                    let seg_info = PayloadSegmentInfo {
+                        seg_type,
+                        compression: CbfsCompression::None,
+                        file_offset: 0,
+                        load_addr,
+                        compressed_len: 0,
+                        mem_len,
+                    };
+                    if payload.segments.push(seg_info).is_err() {
+                        log::error!("CBFS: too many payload segments");
+                        return Err(CbfsError::InvalidFormat);
+                    }
+                }
+                PayloadSegmentType::Params => {
+                    // PARAMS segment - optional, skip for now
+                    log::debug!("  Skipping PARAMS segment");
+                }
+                PayloadSegmentType::Unknown(t) => {
+                    log::warn!("  Unknown segment type: {:#x}", t);
+                }
+            }
+
+            offset += segment_size;
+        }
+
+        if payload.entry_point == 0 {
+            log::error!("CBFS: payload has no entry point");
+            return Err(CbfsError::InvalidFormat);
+        }
+
+        log::info!(
+            "CBFS: parsed payload '{}': {} segments, entry={:#x}",
+            file.name,
+            payload.segments.len(),
+            payload.entry_point
+        );
+
+        Ok(payload)
+    }
+
+    /// Load a self-extracting payload to memory and return entry point
+    ///
+    /// This loads all CODE/DATA segments (decompressing if needed) and zeroes
+    /// BSS segments. If any segment conflicts with CrabEFI's memory, it uses
+    /// the trampoline approach.
+    ///
+    /// # Arguments
+    ///
+    /// * `file` - File info from `find()` (must be CBFS_TYPE_SELF)
+    ///
+    /// # Returns
+    ///
+    /// The entry point address on success, or error.
+    /// Note: If a trampoline is used, this function never returns.
+    ///
+    /// # Safety
+    ///
+    /// This function writes directly to the target memory addresses.
+    pub unsafe fn load_self_payload(&self, file: &CbfsFileInfo) -> Result<u64, CbfsError> {
+        let payload = self.parse_self_payload(file)?;
+
+        // Check if any segment conflicts with CrabEFI
+        let has_conflict = payload.segments.iter().any(|seg| {
+            crate::efi::allocator::conflicts_with_runtime(seg.load_addr, seg.mem_len as u64)
+        });
+
+        if has_conflict {
+            return self.load_self_payload_with_trampoline(file, &payload);
+        }
+
+        // Direct loading - load each segment
+        let data_ptr = file.data_addr as *const u8;
+
+        for seg in &payload.segments {
+            // Check target is usable
+            if !crate::efi::allocator::is_usable_memory(seg.load_addr, seg.mem_len as u64) {
+                log::error!(
+                    "CBFS: segment target {:#x}-{:#x} is not usable",
+                    seg.load_addr,
+                    seg.load_addr + seg.mem_len as u64
+                );
+                return Err(CbfsError::InvalidTarget);
+            }
+
+            let target =
+                core::slice::from_raw_parts_mut(seg.load_addr as *mut u8, seg.mem_len as usize);
+
+            match seg.seg_type {
+                PayloadSegmentType::Bss => {
+                    // Just zero the memory
+                    log::debug!(
+                        "  Zeroing BSS at {:#x}, {} bytes",
+                        seg.load_addr,
+                        seg.mem_len
+                    );
+                    target.fill(0);
+                }
+                PayloadSegmentType::Code | PayloadSegmentType::Data => {
+                    let src = core::slice::from_raw_parts(
+                        data_ptr.add(seg.file_offset as usize),
+                        seg.compressed_len as usize,
+                    );
+
+                    let decompressed_size = match seg.compression {
+                        CbfsCompression::None => {
+                            target[..seg.compressed_len as usize].copy_from_slice(src);
+                            seg.compressed_len as usize
+                        }
+                        CbfsCompression::Lz4 => decompress_lz4(src, target, seg.mem_len as usize)?,
+                        CbfsCompression::Lzma => decompress_lzma(src, target)?,
+                        CbfsCompression::Zstd => decompress_zstd(src, target)?,
+                    };
+
+                    // Zero any BSS (mem_len > decompressed_size)
+                    if decompressed_size < seg.mem_len as usize {
+                        target[decompressed_size..].fill(0);
+                    }
+
+                    log::debug!(
+                        "  Loaded {:?} to {:#x}, {} bytes",
+                        seg.seg_type,
+                        seg.load_addr,
+                        decompressed_size
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        log::info!(
+            "CBFS: loaded payload, entry point {:#x}",
+            payload.entry_point
+        );
+        Ok(payload.entry_point)
+    }
+
+    /// Load a self-extracting payload using trampoline (when segments conflict)
+    ///
+    /// This is called when one or more segments would overwrite CrabEFI's memory.
+    /// The entire payload is decompressed to a bounce buffer, then the trampoline
+    /// copies it to the final location.
+    unsafe fn load_self_payload_with_trampoline(
+        &self,
+        file: &CbfsFileInfo,
+        payload: &SelfPayload,
+    ) -> Result<u64, CbfsError> {
+        use super::trampoline::{self, TrampolineParams};
+
+        let (runtime_start, runtime_end) = crate::efi::allocator::get_runtime_bounds();
+        log::warn!(
+            "CBFS: payload segments conflict with CrabEFI ({:#x}-{:#x}), using trampoline",
+            runtime_start,
+            runtime_end
+        );
+
+        // For multi-segment payloads with conflicts, we need to:
+        // 1. Find the lowest and highest load addresses
+        // 2. Allocate a contiguous bounce buffer
+        // 3. Load all segments into the bounce buffer at their relative offsets
+        // 4. Use trampoline to copy the entire region
+
+        let lowest_addr = payload
+            .segments
+            .iter()
+            .map(|s| s.load_addr)
+            .min()
+            .unwrap_or(0);
+        let highest_end = payload
+            .segments
+            .iter()
+            .map(|s| s.load_addr + s.mem_len as u64)
+            .max()
+            .unwrap_or(0);
+        let total_size = (highest_end - lowest_addr) as usize;
+
+        log::info!(
+            "CBFS: payload range {:#x}-{:#x} ({} bytes)",
+            lowest_addr,
+            highest_end,
+            total_size
+        );
+
+        // Allocate bounce buffer
+        let bounce_buffer = trampoline::allocate_bounce_buffer(total_size).ok_or_else(|| {
+            log::error!("CBFS: failed to allocate bounce buffer");
+            CbfsError::AllocationFailed
+        })?;
+
+        // Zero the entire buffer first (for BSS and gaps)
+        bounce_buffer.fill(0);
+
+        // Load each segment into the bounce buffer
+        let data_ptr = file.data_addr as *const u8;
+
+        for seg in &payload.segments {
+            let offset_in_buffer = (seg.load_addr - lowest_addr) as usize;
+            let target =
+                &mut bounce_buffer[offset_in_buffer..offset_in_buffer + seg.mem_len as usize];
+
+            match seg.seg_type {
+                PayloadSegmentType::Bss => {
+                    // Already zeroed
+                }
+                PayloadSegmentType::Code | PayloadSegmentType::Data => {
+                    let src = core::slice::from_raw_parts(
+                        data_ptr.add(seg.file_offset as usize),
+                        seg.compressed_len as usize,
+                    );
+
+                    let decompressed_size = match seg.compression {
+                        CbfsCompression::None => {
+                            target[..seg.compressed_len as usize].copy_from_slice(src);
+                            seg.compressed_len as usize
+                        }
+                        CbfsCompression::Lz4 => decompress_lz4(src, target, seg.mem_len as usize)?,
+                        CbfsCompression::Lzma => decompress_lzma(src, target)?,
+                        CbfsCompression::Zstd => decompress_zstd(src, target)?,
+                    };
+
+                    log::debug!(
+                        "  Loaded {:?} to bounce buffer offset {:#x}, {} bytes",
+                        seg.seg_type,
+                        offset_in_buffer,
+                        decompressed_size
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        // Get coreboot table pointer for passing to payload
+        let cbtable_ptr = crate::state::get_coreboot_table_ptr().unwrap_or(0);
+
+        // Set up trampoline parameters
+        let params = TrampolineParams {
+            src_addr: bounce_buffer.as_ptr() as u64,
+            dst_addr: lowest_addr,
+            copy_size: total_size as u64,
+            bss_size: 0, // Already zeroed in bounce buffer
+            entry_point: payload.entry_point,
+            coreboot_table_ptr: cbtable_ptr,
+        };
+
+        // Execute the trampoline - this never returns
+        // The bounce buffer was allocated via EFI pages, so it stays allocated
+        match trampoline::execute_trampoline(&params) {
+            Err(e) => {
+                log::error!("CBFS: trampoline setup failed: {:?}", e);
+                Err(CbfsError::TrampolineFailed)
+            }
+        }
+    }
+}
+
+/// Load and execute a self-extracting payload from CBFS
+///
+/// This is a convenience function that finds a payload by name and executes it.
+///
+/// # Arguments
+///
+/// * `name` - Name of the payload file in CBFS
+/// * `cbtable_ptr` - Pointer to coreboot tables (passed to payload in RDI)
+///
+/// # Returns
+///
+/// This function does not return on success (jumps to payload).
+/// Returns an error if the payload cannot be loaded.
+///
+/// # Safety
+///
+/// Jumps to the payload entry point and does not return.
+pub unsafe fn load_and_execute_payload(name: &str, cbtable_ptr: *const u8) -> Result<!, CbfsError> {
+    let cbfs = Cbfs::new().ok_or(CbfsError::NotFound)?;
+    let file = cbfs.find(name).ok_or(CbfsError::NotFound)?;
+
+    // Dispatch based on file type
+    let entry_point = match file.file_type {
+        CbfsType::Self_ => {
+            // Self-extracting payload with segments
+            cbfs.load_self_payload(&file)?
+        }
+        CbfsType::Stage => {
+            // Stage format - use load_to_target
+            cbfs.load_to_target(&file)?
+        }
+        _ => {
+            log::error!("CBFS: {} is not a loadable payload type", name);
+            return Err(CbfsError::InvalidFormat);
+        }
+    };
+
+    log::info!("CBFS: jumping to payload at {:#x}", entry_point);
+
+    // Jump to the payload (switches to 32-bit mode since coreboot payloads expect it)
+    jump_to_payload_32bit(entry_point, cbtable_ptr as u64);
+}
+
+/// Jump to a 32-bit payload, switching from 64-bit long mode to 32-bit protected mode
+///
+/// Coreboot payloads (SeaBIOS, etc.) expect to be entered in 32-bit protected mode
+/// with the coreboot table pointer in EBX.
+///
+/// # Safety
+///
+/// This function never returns. It switches CPU mode and jumps to the entry point.
+unsafe fn jump_to_payload_32bit(entry_point: u64, cbtable_ptr: u64) -> ! {
+    // We reuse the trampoline's mode-switching code
+    // Create params that don't need to copy anything (src=dst, size=0)
+    use super::trampoline::{self, TrampolineParams};
+
+    let params = TrampolineParams {
+        src_addr: 0,
+        dst_addr: 0,
+        copy_size: 0,
+        bss_size: 0,
+        entry_point,
+        coreboot_table_ptr: cbtable_ptr,
+    };
+
+    // This never returns
+    match trampoline::execute_trampoline(&params) {
+        Err(e) => {
+            log::error!("Failed to jump to payload: {:?}", e);
+            panic!("Failed to execute payload");
+        }
+    }
+}
+
+/// Discovered CBFS payload entry for the boot menu
+#[derive(Debug, Clone)]
+pub struct CbfsPayloadEntry {
+    /// Display name for the menu
+    pub name: String,
+    /// File name in CBFS
+    pub cbfs_name: String,
+    /// File type
+    pub file_type: CbfsType,
+    /// File size (compressed)
+    pub size: u32,
+}
+
+/// Discover bootable payloads in CBFS
+///
+/// Scans CBFS for files that can be chainloaded:
+/// - CBFS_TYPE_SELF (self-extracting payloads like SeaBIOS)
+/// - CBFS_TYPE_STAGE (stage files with stage headers)
+/// - CBFS_TYPE_FIT_PAYLOAD (Flat Image Tree payloads)
+///
+/// # Returns
+///
+/// A vector of discovered payload entries.
+pub fn discover_payloads() -> heapless::Vec<CbfsPayloadEntry, 16> {
+    let mut entries = heapless::Vec::new();
+
+    let Some(cbfs) = Cbfs::new() else {
+        log::debug!("CBFS not available for payload discovery");
+        return entries;
+    };
+
+    cbfs.for_each(|file| {
+        // Log all files found (INFO for now to debug discovery)
+        log::info!(
+            "CBFS file: '{}' type={:?} size={}",
+            file.name,
+            file.file_type,
+            file.decompressed_size
+        );
+
+        // Check if this is a bootable payload type
+        // - Self_ = self-extracting payloads (SeaBIOS, etc.)
+        // - FitPayload = Flat Image Tree payloads
+        // Note: Stage type is for internal coreboot stages (romstage, ramstage, etc.), not user payloads
+        let is_bootable = matches!(file.file_type, CbfsType::Self_ | CbfsType::FitPayload);
+
+        if !is_bootable {
+            log::debug!("  -> skipped (type {:?} is not bootable)", file.file_type);
+            return true; // Continue
+        }
+
+        if is_bootable {
+            // Create a display name from the file name
+            let display_name = create_display_name(&file.name, file.file_type);
+
+            let entry = CbfsPayloadEntry {
+                name: display_name,
+                cbfs_name: file.name.clone(),
+                file_type: file.file_type,
+                size: file.decompressed_size,
+            };
+
+            log::info!(
+                "CBFS: discovered payload '{}' ({:?}, {} KB)",
+                entry.name,
+                file.file_type,
+                file.decompressed_size / 1024
+            );
+
+            let _ = entries.push(entry);
+        }
+
+        true // Continue iterating
+    });
+
+    // Count total files for logging
+    let mut total_files = 0;
+    cbfs.for_each(|_| {
+        total_files += 1;
+        true
+    });
+
+    log::info!(
+        "CBFS: {} total files, {} bootable payloads",
+        total_files,
+        entries.len()
+    );
+    entries
+}
+
+/// Create a user-friendly display name from a CBFS file name
+fn create_display_name(cbfs_name: &str, file_type: CbfsType) -> String {
+    let mut name = String::new();
+
+    // Known payload names with friendly descriptions
+    let known_payloads = [
+        ("seabios", "SeaBIOS (Legacy BIOS)"),
+        ("coreinfo", "Coreinfo (Diagnostics)"),
+        ("nvramcui", "NVRAM Configuration"),
+        ("tint", "TINT Game"),
+        ("memtest", "Memtest86+"),
+        ("linuxboot", "LinuxBoot"),
+        ("uroot", "u-root"),
+        ("edk2", "EDK2 UEFI"),
+        ("tianocore", "TianoCore UEFI"),
+        ("grub", "GRUB2 Bootloader"),
+        ("depthcharge", "Depthcharge"),
+    ];
+
+    let lower_name = cbfs_name.to_ascii_lowercase();
+    for (pattern, friendly_name) in known_payloads {
+        if lower_name.contains(pattern) {
+            name.push_str(friendly_name);
+            return name;
+        }
+    }
+
+    // Generate a name from the file name
+    name.push_str("Payload: ");
+    name.push_str(cbfs_name);
+
+    // Add type suffix if not obvious
+    match file_type {
+        CbfsType::Self_ => {
+            // Usually obvious
+        }
+        CbfsType::Stage => {
+            name.push_str(" (Stage)");
+        }
+        CbfsType::FitPayload => {
+            name.push_str(" (FIT)");
+        }
+        _ => {}
+    }
+
+    name
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_flash_to_host_addr() {
+        // 16MB flash, CBFS at offset 0x200000
+        let boot_media_size = 16 * 1024 * 1024;
+        let flash_offset = 0x200000;
+
+        let host_addr = flash_to_host_addr(flash_offset, boot_media_size);
+
+        // Expected: 0x100000000 - 0x1000000 + 0x200000 = 0xFF200000
+        assert_eq!(host_addr, 0xFF200000);
+    }
+
+    #[test]
+    fn test_align_up() {
+        assert_eq!(align_up(0, 64), 0);
+        assert_eq!(align_up(1, 64), 64);
+        assert_eq!(align_up(63, 64), 64);
+        assert_eq!(align_up(64, 64), 64);
+        assert_eq!(align_up(65, 64), 128);
+    }
+}

--- a/src/coreboot/mod.rs
+++ b/src/coreboot/mod.rs
@@ -4,16 +4,22 @@
 //! the system hardware, including memory map, serial port, framebuffer,
 //! CBMEM console, and ACPI tables.
 //!
-//! It also provides FMAP (Flash Map) parsing for locating flash regions
-//! like SMMSTORE. The FMAP location is obtained from coreboot's
+//! It also provides:
+//! - FMAP (Flash Map) parsing for locating flash regions like SMMSTORE
+//! - CBFS (Coreboot File System) parsing for reading files from flash
+//!
+//! The FMAP and CBFS locations are obtained from coreboot's
 //! LB_TAG_BOOT_MEDIA_PARAMS table entry.
 
+pub mod cbfs;
 pub mod cbmem_console;
 pub mod fmap;
 pub mod framebuffer;
 pub mod memory;
 pub mod tables;
+pub mod trampoline;
 
+pub use cbfs::{Cbfs, CbfsCompression, CbfsError, CbfsFileInfo, CbfsType};
 pub use framebuffer::FramebufferInfo;
 pub use memory::{MemoryRegion, MemoryType};
 pub use tables::{

--- a/src/coreboot/trampoline.rs
+++ b/src/coreboot/trampoline.rs
@@ -247,10 +247,10 @@ fn get_trampoline_code() -> &'static [u8] {
 /// Allocated buffer as a raw slice, or None if allocation fails.
 /// The caller is responsible for not freeing this memory (use `core::mem::forget`).
 pub fn allocate_bounce_buffer(size: usize) -> Option<&'static mut [u8]> {
-    use crate::efi::allocator::{allocate_pages, AllocateType, MemoryType, PAGE_SIZE};
+    use crate::efi::allocator::{AllocateType, MemoryType, PAGE_SIZE, allocate_pages};
 
     // Round up to pages
-    let num_pages = (size as u64 + PAGE_SIZE - 1) / PAGE_SIZE;
+    let num_pages = (size as u64).div_ceil(PAGE_SIZE);
 
     let mut addr = 0u64;
     let status = allocate_pages(

--- a/src/coreboot/trampoline.rs
+++ b/src/coreboot/trampoline.rs
@@ -1,0 +1,361 @@
+//! Payload relocation trampoline
+//!
+//! This module provides a mechanism to load payloads that need to be placed
+//! at memory addresses that conflict with CrabEFI's own code/data.
+//!
+//! The approach is:
+//! 1. Decompress the payload to a "bounce buffer" in safe high memory
+//! 2. Set up a small trampoline routine at a fixed safe address (0x8000)
+//! 3. Jump to the trampoline, which:
+//!    - Copies the payload from bounce buffer to final target
+//!    - Zeros the BSS section
+//!    - Jumps to the entry point
+//!
+//! This is similar to how GRUB's relocator works.
+
+use core::arch::global_asm;
+
+/// Trampoline location - 0x8000 is in the BIOS data area, typically safe
+/// after early boot. This is below where CrabEFI loads (0x100000).
+const TRAMPOLINE_ADDR: u64 = 0x8000;
+
+/// Maximum trampoline size (4KB should be plenty)
+const TRAMPOLINE_MAX_SIZE: usize = 0x1000;
+
+/// Parameters for the relocation trampoline (passed in registers)
+///
+/// Layout matches the register assignment in the trampoline:
+/// - rdi: src_addr (bounce buffer)
+/// - rsi: dst_addr (target)  
+/// - rdx: copy_size
+/// - rcx: bss_size
+/// - r8:  entry_point
+/// - r9:  coreboot_table_ptr
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct TrampolineParams {
+    /// Source address (bounce buffer)
+    pub src_addr: u64,
+    /// Destination address (final target)
+    pub dst_addr: u64,
+    /// Number of bytes to copy
+    pub copy_size: u64,
+    /// Number of bytes to zero after copy (BSS)
+    pub bss_size: u64,
+    /// Entry point to jump to after relocation
+    pub entry_point: u64,
+    /// Coreboot table pointer (passed to payload in EBX)
+    pub coreboot_table_ptr: u64,
+}
+
+// The trampoline code in assembly
+// This is position-independent and will be copied to TRAMPOLINE_ADDR (0x8000)
+//
+// The trampoline:
+// 1. Saves all parameters to fixed memory locations (0x7F00 area)
+// 2. Switches from 64-bit long mode to 32-bit protected mode with paging DISABLED
+//    (must disable paging BEFORE copying since destination may overwrite page tables)
+// 3. Copies payload from bounce buffer to target address
+// 4. Zeros BSS section
+// 5. Jumps to the payload entry point with coreboot table pointer in EBX
+//
+// The 64->32 bit transition follows coreboot's exit32.inc approach:
+// 1. Load GDT with 32-bit and 64-bit segments (coreboot layout)
+// 2. Use iretq to switch to 32-bit compatibility mode
+// 3. Set up data segments
+// 4. Disable paging (CR0.PG=0)
+// 5. Disable long mode (EFER.LME=0)
+// 6. Disable PAE (CR4.PAE=0)
+// 7. Clear page table register (CR3=0)
+// 8. Copy payload and jump
+
+global_asm!(
+    r#"
+    .section .text.trampoline, "ax"
+    .code64
+    .global trampoline_start
+    .global trampoline_end
+
+trampoline_start:
+    // Parameters passed in registers:
+    // rdi = src_addr (bounce buffer)
+    // rsi = dst_addr (target)
+    // rdx = copy_size
+    // rcx = bss_size  
+    // r8  = entry_point
+    // r9  = coreboot_table_ptr (for passing to payload)
+
+    // Save ALL parameters to memory at 0x7F00 IMMEDIATELY
+    // (we'll switch to 32-bit mode where r8-r15 don't exist!)
+    // Memory layout at 0x7F00:
+    //   0x7F00: coreboot_table_ptr (4 bytes)
+    //   0x7F04: entry_point (4 bytes)
+    //   0x7F08: src_addr (4 bytes) 
+    //   0x7F0C: dst_addr (4 bytes)
+    //   0x7F10: copy_size (4 bytes)
+    //   0x7F14: bss_size (4 bytes)
+    //   0x7F18: GDT pointer (6 bytes)
+    //   0x7F20: GDT (32 bytes)
+    
+    mov dword ptr [0x7F00], r9d     // coreboot_table_ptr
+    mov dword ptr [0x7F04], r8d     // entry_point
+    mov dword ptr [0x7F08], edi     // src_addr (low 32 bits, should be enough)
+    mov dword ptr [0x7F0C], esi     // dst_addr
+    mov dword ptr [0x7F10], edx     // copy_size
+    mov dword ptr [0x7F14], ecx     // bss_size
+
+    // We must disable paging BEFORE copying to 0x100000 because that
+    // will overwrite CrabEFI's page tables. Switch to 32-bit mode first.
+    
+    // Set up GDT at 0x7F40, GDT pointer at 0x7F38
+    mov word ptr [0x7F38], 31       // GDT limit (4 entries * 8 - 1)
+    mov dword ptr [0x7F3A], 0x7F40  // GDT base address
+    
+    // Entry 0x00: Null descriptor
+    mov qword ptr [0x7F40], 0
+    // Entry 0x08: 32-bit code segment
+    mov dword ptr [0x7F48], 0x0000FFFF
+    mov dword ptr [0x7F4C], 0x00CF9B00
+    // Entry 0x10: 32-bit data segment
+    mov dword ptr [0x7F50], 0x0000FFFF
+    mov dword ptr [0x7F54], 0x00CF9300
+    // Entry 0x18: 64-bit code segment (needed for iretq target)
+    mov dword ptr [0x7F58], 0x0000FFFF
+    mov dword ptr [0x7F5C], 0x00AF9B00
+    
+    lgdt [0x7F38]
+
+    // Switch to 32-bit compatibility mode using iretq
+    mov rcx, 0x08               // 32-bit code segment selector
+    mov rdx, rsp
+    mov ax, ss
+    push rax                    // SS
+    push rdx                    // RSP
+    pushfq                      // RFLAGS
+    push rcx                    // CS
+    lea rax, [rip + compat_mode]
+    push rax                    // RIP
+    iretq
+
+    .code32
+compat_mode:
+    // Now in 32-bit compatibility mode (paging still enabled)
+    // Set up data segments
+    mov eax, 0x10
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+    mov fs, ax
+    mov gs, ax
+
+    // Disable paging (CR0.PG = 0)
+    mov eax, cr0
+    and eax, 0x7FFFFFFF
+    mov cr0, eax
+
+    // Disable long mode (EFER.LME = 0)
+    mov ecx, 0xC0000080
+    rdmsr
+    and eax, 0xFFFFFEFF
+    wrmsr
+
+    // Disable PAE
+    mov eax, cr4
+    and eax, 0xFFFFFFDF
+    mov cr4, eax
+
+    // Clear CR3
+    xor eax, eax
+    mov cr3, eax
+
+    // Far jump to reload CS in true 32-bit protected mode
+    .byte 0xEA
+    .long 0x8000 + (protected_mode - trampoline_start)
+    .word 0x08
+
+protected_mode:
+    // Now in 32-bit protected mode with paging DISABLED
+    // Safe to copy to 0x100000 without breaking page tables
+    
+    // Reload data segments
+    mov eax, 0x10
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+
+    // Set up stack
+    mov esp, 0x7000
+    
+    // Load copy parameters from memory
+    mov esi, [0x7F08]       // src_addr
+    mov edi, [0x7F0C]       // dst_addr
+    mov ecx, [0x7F10]       // copy_size
+
+    // Do the copy
+    test ecx, ecx
+    jz copy_done
+    cld
+    rep movsb
+
+copy_done:
+    // Zero BSS
+    mov ecx, [0x7F14]       // bss_size
+    test ecx, ecx
+    jz bss_done
+    xor eax, eax
+    rep stosb
+    
+bss_done:
+    // Load entry point and coreboot table pointer
+    mov eax, [0x7F04]       // entry_point
+    mov ebx, [0x7F00]       // coreboot_table_ptr
+
+    // Jump to payload!
+    jmp eax
+
+trampoline_end:
+    .previous
+"#
+);
+
+unsafe extern "C" {
+    static trampoline_start: u8;
+    static trampoline_end: u8;
+}
+
+/// Get the trampoline code as a byte slice
+fn get_trampoline_code() -> &'static [u8] {
+    unsafe {
+        let start = &trampoline_start as *const u8;
+        let end = &trampoline_end as *const u8;
+        let len = end.offset_from(start) as usize;
+        core::slice::from_raw_parts(start, len)
+    }
+}
+
+/// Allocate a bounce buffer using EFI page allocator
+///
+/// Uses the EFI page allocator to allocate large buffers that wouldn't fit
+/// in the Rust heap. The buffer is allocated as BootServicesData.
+///
+/// # Arguments
+///
+/// * `size` - Size of the bounce buffer needed
+///
+/// # Returns
+///
+/// Allocated buffer as a raw slice, or None if allocation fails.
+/// The caller is responsible for not freeing this memory (use `core::mem::forget`).
+pub fn allocate_bounce_buffer(size: usize) -> Option<&'static mut [u8]> {
+    use crate::efi::allocator::{allocate_pages, AllocateType, MemoryType, PAGE_SIZE};
+
+    // Round up to pages
+    let num_pages = (size as u64 + PAGE_SIZE - 1) / PAGE_SIZE;
+
+    let mut addr = 0u64;
+    let status = allocate_pages(
+        AllocateType::AllocateAnyPages,
+        MemoryType::BootServicesData,
+        num_pages,
+        &mut addr,
+    );
+
+    if status != r_efi::efi::Status::SUCCESS {
+        log::error!(
+            "Failed to allocate bounce buffer: {} pages, status={:?}",
+            num_pages,
+            status
+        );
+        return None;
+    }
+
+    log::debug!(
+        "Allocated bounce buffer: {:#x}-{:#x} ({} bytes, {} pages)",
+        addr,
+        addr + size as u64,
+        size,
+        num_pages
+    );
+
+    // Create a mutable slice from the allocated memory
+    let buffer = unsafe { core::slice::from_raw_parts_mut(addr as *mut u8, size) };
+
+    Some(buffer)
+}
+
+/// Set up and execute the relocation trampoline
+///
+/// This function:
+/// 1. Copies the trampoline code to TRAMPOLINE_ADDR
+/// 2. Disables interrupts
+/// 3. Jumps to the trampoline with parameters in registers (never returns)
+///
+/// # Arguments
+///
+/// * `params` - Trampoline parameters (addresses, sizes, entry point)
+///
+/// # Safety
+///
+/// This function never returns. It will overwrite memory at `dst_addr`
+/// and jump to `entry_point`. The caller must ensure:
+/// - The bounce buffer contains valid payload data
+/// - The target address is valid and writable
+/// - The entry point is valid executable code
+/// - The trampoline address (0x8000) is not in use
+///
+/// # Returns
+///
+/// This function never returns on success. Returns an error if the
+/// trampoline code is too large.
+pub unsafe fn execute_trampoline(params: &TrampolineParams) -> Result<!, TrampolineError> {
+    log::info!("Setting up relocation trampoline:");
+    log::info!("  src:    {:#x} (bounce buffer)", params.src_addr);
+    log::info!("  dst:    {:#x} (target)", params.dst_addr);
+    log::info!("  copy:   {} bytes", params.copy_size);
+    log::info!("  bss:    {} bytes", params.bss_size);
+    log::info!("  entry:  {:#x}", params.entry_point);
+
+    // Get the trampoline code
+    let code = get_trampoline_code();
+
+    if code.len() > TRAMPOLINE_MAX_SIZE {
+        log::error!(
+            "Trampoline code too large: {} bytes (max {})",
+            code.len(),
+            TRAMPOLINE_MAX_SIZE
+        );
+        return Err(TrampolineError::CodeTooLarge);
+    }
+
+    log::debug!("Trampoline code: {} bytes", code.len());
+
+    // Copy trampoline code to fixed address
+    let trampoline_ptr = TRAMPOLINE_ADDR as *mut u8;
+    core::ptr::copy_nonoverlapping(code.as_ptr(), trampoline_ptr, code.len());
+
+    log::info!("Jumping to trampoline at {:#x}...", TRAMPOLINE_ADDR);
+
+    // Disable interrupts and jump to trampoline with parameters in registers
+    // Parameters: rdi=src, rsi=dst, rdx=copy_size, rcx=bss_size, r8=entry, r9=cbtable
+    core::arch::asm!(
+        "cli",
+        "jmp {trampoline}",
+        trampoline = in(reg) TRAMPOLINE_ADDR,
+        in("rdi") params.src_addr,
+        in("rsi") params.dst_addr,
+        in("rdx") params.copy_size,
+        in("rcx") params.bss_size,
+        in("r8") params.entry_point,
+        in("r9") params.coreboot_table_ptr,
+        options(noreturn)
+    );
+}
+
+/// Trampoline errors
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrampolineError {
+    /// Generated trampoline code exceeds maximum size
+    CodeTooLarge,
+    /// Failed to allocate bounce buffer
+    AllocationFailed,
+}

--- a/src/efi/allocator.rs
+++ b/src/efi/allocator.rs
@@ -1189,6 +1189,64 @@ unsafe extern "C" {
     static __runtime_data_end: u8;
 }
 
+/// Get CrabEFI's memory region boundaries (code + data)
+///
+/// Returns (start_addr, end_addr) of the region occupied by CrabEFI.
+/// This includes code, data, BSS, and stack.
+pub fn get_runtime_bounds() -> (u64, u64) {
+    let code_start = unsafe { &__runtime_code_start as *const u8 as u64 };
+    let data_end = unsafe { &__runtime_data_end as *const u8 as u64 };
+
+    // Align to page boundaries
+    let start = code_start & !(PAGE_SIZE - 1);
+    let end = (data_end + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
+
+    (start, end)
+}
+
+/// Check if a memory region conflicts with CrabEFI's code/data
+///
+/// Returns true if the region [addr, addr+size) overlaps with CrabEFI.
+pub fn conflicts_with_runtime(addr: u64, size: u64) -> bool {
+    let (runtime_start, runtime_end) = get_runtime_bounds();
+    let region_end = addr.saturating_add(size);
+
+    // Check for overlap: regions overlap if one starts before the other ends
+    addr < runtime_end && region_end > runtime_start
+}
+
+/// Check if a memory region is in usable RAM
+///
+/// Returns true if the entire region [addr, addr+size) is within conventional
+/// or boot services memory that can be safely written to.
+pub fn is_usable_memory(addr: u64, size: u64) -> bool {
+    let alloc = state::allocator();
+    let region_end = addr.saturating_add(size);
+
+    // Find a single contiguous region that contains the entire target
+    for entry in alloc.entries.iter() {
+        let entry_end = entry.end();
+
+        // Check if this entry contains the entire region
+        if entry.physical_start <= addr && entry_end >= region_end {
+            // Check if the memory type is usable (conventional memory or boot services)
+            let mem_type = MemoryType::from_u32(entry.memory_type);
+            return matches!(
+                mem_type,
+                Some(
+                    MemoryType::ConventionalMemory
+                        | MemoryType::BootServicesCode
+                        | MemoryType::BootServicesData
+                        | MemoryType::LoaderCode
+                        | MemoryType::LoaderData
+                )
+            );
+        }
+    }
+
+    false
+}
+
 /// Reserve the CrabEFI runtime regions using linker-provided section boundaries
 ///
 /// This marks the memory containing our code and data sections so that the OS

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -156,7 +156,7 @@ static ALLOCATOR: BumpAllocator = BumpAllocator::new();
 ///
 /// `true` if initialization succeeded, `false` otherwise.
 pub fn init() -> bool {
-    use crate::efi::allocator::{allocate_pages, AllocateType, MemoryType};
+    use crate::efi::allocator::{AllocateType, MemoryType, allocate_pages};
     use r_efi::efi::Status;
 
     // Allocate heap pages from the EFI allocator

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -21,8 +21,9 @@ use core::cell::UnsafeCell;
 use core::ptr::null_mut;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-/// Heap size (2 MB should be sufficient for crypto operations)
-const HEAP_SIZE: usize = 2 * 1024 * 1024;
+/// Heap size - LZMA decompression needs dictionary buffers up to 64MB
+/// The heap is allocated from EFI pages at runtime, not compiled into the binary
+const HEAP_SIZE: usize = 4 * 1024 * 1024;
 
 /// Page size (4KB)
 const PAGE_SIZE: usize = 4096;
@@ -155,7 +156,7 @@ static ALLOCATOR: BumpAllocator = BumpAllocator::new();
 ///
 /// `true` if initialization succeeded, `false` otherwise.
 pub fn init() -> bool {
-    use crate::efi::allocator::{AllocateType, MemoryType, allocate_pages};
+    use crate::efi::allocator::{allocate_pages, AllocateType, MemoryType};
     use r_efi::efi::Status;
 
     // Allocate heap pages from the EFI allocator
@@ -179,16 +180,4 @@ pub fn init() -> bool {
     }
 
     true
-}
-
-/// Check if the allocator is initialized
-pub fn is_initialized() -> bool {
-    ALLOCATOR.is_initialized()
-}
-
-/// Get heap usage statistics
-pub fn stats() -> (usize, usize) {
-    let used = ALLOCATOR.offset.load(Ordering::Acquire);
-    let total = ALLOCATOR.heap_size;
-    (used, total)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,9 @@ pub fn init(coreboot_table_ptr: u64) {
     // Initialize PS/2 keyboard (if available)
     drivers::keyboard::init();
 
+    // Store coreboot table pointer for payload chainloading
+    state::set_coreboot_table_ptr(coreboot_table_ptr);
+
     log::info!("CrabEFI v{} starting...", env!("CARGO_PKG_VERSION"));
     log::info!("Coreboot table pointer: {:#x}", coreboot_table_ptr);
 
@@ -235,6 +238,13 @@ pub fn init(coreboot_table_ptr: u64) {
             smmstore.num_blocks,
             smmstore.block_size / 1024,
             smmstore.mmap_addr
+        );
+    }
+    if let Some(ref boot_media) = cb_info.boot_media {
+        log::info!(
+            "  CBFS: offset {:#x}, size {} KB",
+            boot_media.cbfs_offset,
+            boot_media.cbfs_size / 1024
         );
     }
     log::info!("  Memory regions: {}", cb_info.memory_map.len());
@@ -422,7 +432,8 @@ fn init_storage() {
 /// Dispatches to the appropriate boot method based on the entry kind:
 /// - UEFI/UKI entries: Load and execute EFI application
 /// - BLS/GRUB Linux entries: Direct Linux boot via linux_boot module
-/// - Payload entries: Chainload coreboot payload
+/// - Payload entries: Chainload coreboot payload from disk
+/// - CBFS Payload entries: Chainload coreboot payload from flash
 fn boot_selected_entry(entry: &menu::BootEntry) {
     log::info!("boot_selected_entry called");
 
@@ -449,10 +460,16 @@ fn boot_selected_entry(entry: &menu::BootEntry) {
             boot_linux_entry(entry, linux_path, initrd_path, cmdline);
         }
 
-        // Coreboot payload chainloading
+        // Coreboot payload chainloading from disk
         menu::BootEntryKind::Payload { path, format } => {
-            log::info!("Dispatching to payload chainload");
+            log::info!("Dispatching to payload chainload (disk)");
             boot_payload_entry(entry, path, *format);
+        }
+
+        // CBFS payload chainloading from flash
+        menu::BootEntryKind::CbfsPayload { cbfs_name } => {
+            log::info!("Dispatching to CBFS payload chainload");
+            boot_cbfs_payload_entry(cbfs_name);
         }
     }
 }
@@ -736,6 +753,10 @@ fn boot_uefi_entry(entry: &menu::BootEntry) {
             }
             log::error!("Failed to boot SDHCI entry");
         }
+        menu::DeviceType::Cbfs => {
+            // CBFS entries should use boot_cbfs_payload_entry, not UEFI boot path
+            log::error!("CBFS entries cannot use UEFI boot path");
+        }
     }
 }
 
@@ -986,6 +1007,10 @@ fn boot_linux_entry(
                 log::error!("Failed to get SDHCI controller {}", controller_id);
             }
         }
+        menu::DeviceType::Cbfs => {
+            // CBFS entries don't have disk storage for Linux boot
+            log::error!("CBFS entries cannot boot Linux directly");
+        }
     }
 
     // Note: We intentionally don't fall back to UEFI boot here.
@@ -1006,14 +1031,177 @@ fn boot_payload_entry(
     log::info!("  Path: {}", path);
     log::info!("  Format: {:?}", format);
 
-    // TODO: Implement full payload chainloading
-    // This requires:
-    // 1. Mount FAT filesystem on the partition
-    // 2. Create PayloadEntry from the menu entry
-    // 3. Call payload::chainload_payload()
-    //
-    // For now, log the attempt and return
-    log::warn!("Payload chainloading not yet fully implemented");
+    // Get the coreboot table pointer
+    let cbtable_ptr = match state::get_coreboot_table_ptr() {
+        Some(ptr) => ptr as *const u8,
+        None => {
+            log::error!("Coreboot table pointer not available");
+            return;
+        }
+    };
+
+    // Create PayloadEntry from menu entry
+    let mut payload_entry = payload::PayloadEntry {
+        name: heapless::String::new(),
+        path: path.clone(),
+        format,
+        size: 0, // Will be determined when reading
+    };
+    let _ = payload_entry.name.push_str(&entry.name);
+
+    // Dispatch based on device type to mount the filesystem
+    match entry.device_type {
+        menu::DeviceType::Nvme {
+            controller_id,
+            nsid,
+        } => {
+            if !drivers::nvme::store_global_device(controller_id, nsid) {
+                log::error!("Failed to store NVMe device globally");
+                return;
+            }
+            if let Some(controller) = drivers::nvme::get_controller(controller_id) {
+                let mut disk = NvmeDisk::new(controller, nsid);
+                if let Ok(mut fat) =
+                    fs::fat::FatFilesystem::new(&mut disk, entry.partition.first_lba)
+                {
+                    boot_payload_from_fat(&mut fat, &payload_entry, cbtable_ptr);
+                } else {
+                    log::error!("Failed to mount FAT filesystem on NVMe partition");
+                }
+            }
+        }
+        menu::DeviceType::Ahci {
+            controller_id,
+            port,
+        } => {
+            if !drivers::ahci::store_global_device(controller_id, port) {
+                log::error!("Failed to store AHCI device globally");
+                return;
+            }
+            if let Some(controller) = drivers::ahci::get_controller(controller_id) {
+                let mut disk = AhciDisk::new(controller, port);
+                if let Ok(mut fat) =
+                    fs::fat::FatFilesystem::new(&mut disk, entry.partition.first_lba)
+                {
+                    boot_payload_from_fat(&mut fat, &payload_entry, cbtable_ptr);
+                } else {
+                    log::error!("Failed to mount FAT filesystem on AHCI partition");
+                }
+            }
+        }
+        menu::DeviceType::Usb {
+            controller_id,
+            device_addr: _,
+        } => {
+            let controller_ptr = match drivers::usb::get_controller_ptr(controller_id) {
+                Some(ptr) => ptr,
+                None => {
+                    log::error!("Failed to get USB controller {}", controller_id);
+                    return;
+                }
+            };
+            if let Some(usb_device) = drivers::usb::mass_storage::get_global_device() {
+                let controller = unsafe { &mut *controller_ptr };
+                let mut disk = UsbDisk::new(usb_device, controller);
+                if let Ok(mut fat) =
+                    fs::fat::FatFilesystem::new(&mut disk, entry.partition.first_lba)
+                {
+                    boot_payload_from_fat(&mut fat, &payload_entry, cbtable_ptr);
+                } else {
+                    log::error!("Failed to mount FAT filesystem on USB partition");
+                }
+            }
+        }
+        menu::DeviceType::Sdhci { controller_id } => {
+            if !drivers::sdhci::store_global_device(controller_id) {
+                log::error!("Failed to store SDHCI device globally");
+                return;
+            }
+            if let Some(controller) = drivers::sdhci::get_controller(controller_id) {
+                let mut disk = SdhciDisk::new(controller);
+                if let Ok(mut fat) =
+                    fs::fat::FatFilesystem::new(&mut disk, entry.partition.first_lba)
+                {
+                    boot_payload_from_fat(&mut fat, &payload_entry, cbtable_ptr);
+                } else {
+                    log::error!("Failed to mount FAT filesystem on SDHCI partition");
+                }
+            }
+        }
+        menu::DeviceType::Cbfs => {
+            // CBFS payloads should use boot_cbfs_payload_entry, not disk-based boot
+            log::error!("Use boot_cbfs_payload_entry for CBFS payloads");
+        }
+    }
+
+    log::error!("Payload chainloading failed - returning to menu");
+}
+
+/// Boot a payload from a mounted FAT filesystem
+fn boot_payload_from_fat(
+    fat: &mut fs::fat::FatFilesystem<'_>,
+    entry: &payload::PayloadEntry,
+    cbtable_ptr: *const u8,
+) {
+    // Get file size to create a proper entry
+    let size = match fat.file_size(&entry.path) {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("Failed to get payload size: {:?}", e);
+            return;
+        }
+    };
+
+    if size == 0 {
+        log::error!("Payload file is empty");
+        return;
+    }
+
+    let full_entry = payload::PayloadEntry {
+        name: entry.name.clone(),
+        path: entry.path.clone(),
+        format: entry.format,
+        size,
+    };
+
+    log::info!("Loading payload: {} ({} bytes)", full_entry.name, size);
+
+    // Chainload the payload (this should not return on success)
+    unsafe {
+        match payload::chainload_payload(fat, &full_entry, cbtable_ptr) {
+            Err(e) => {
+                log::error!("Payload chainload failed: {:?}", e);
+            }
+        }
+    }
+}
+
+/// Boot a CBFS payload entry
+///
+/// This loads and executes a payload stored in the CBFS region of flash.
+/// Payloads are discovered by discover_cbfs_payloads() in the menu module.
+fn boot_cbfs_payload_entry(cbfs_name: &heapless::String<128>) {
+    log::info!("Chainloading CBFS payload: {}", cbfs_name);
+
+    // Get the coreboot table pointer
+    let cbtable_ptr = match state::get_coreboot_table_ptr() {
+        Some(ptr) => ptr as *const u8,
+        None => {
+            log::error!("Coreboot table pointer not available");
+            return;
+        }
+    };
+
+    // Load and execute the payload (this should not return on success)
+    unsafe {
+        match coreboot::cbfs::load_and_execute_payload(cbfs_name, cbtable_ptr) {
+            Err(e) => {
+                log::error!("CBFS payload chainload failed: {:?}", e);
+            }
+        }
+    }
+
+    log::error!("CBFS payload chainloading failed - returning to menu");
 }
 
 /// Install BlockIO protocols for a disk and all its partitions

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -54,6 +54,8 @@ pub enum DeviceType {
     },
     /// SDHCI (SD card)
     Sdhci { controller_id: usize },
+    /// CBFS (Coreboot File System) - payloads in flash
+    Cbfs,
 }
 
 /// Boot entry kind - how this entry should be booted
@@ -86,12 +88,18 @@ pub enum BootEntryKind {
         cmdline: String<512>,
     },
 
-    /// Coreboot payload (ELF or flat binary)
+    /// Coreboot payload from disk (ELF or flat binary)
     Payload {
         /// Path to payload file
         path: String<128>,
         /// Payload format
         format: crate::payload::PayloadFormat,
+    },
+
+    /// CBFS payload (payload stored in flash)
+    CbfsPayload {
+        /// CBFS file name
+        cbfs_name: String<128>,
     },
 }
 
@@ -128,6 +136,7 @@ impl DeviceType {
             DeviceType::Ahci { .. } => "SATA",
             DeviceType::Usb { .. } => "USB",
             DeviceType::Sdhci { .. } => "SD",
+            DeviceType::Cbfs => "CBFS",
         }
     }
 }
@@ -237,7 +246,15 @@ impl BootEntry {
 
     /// Check if this is a payload entry
     pub fn is_payload(&self) -> bool {
-        matches!(self.kind, BootEntryKind::Payload { .. })
+        matches!(
+            self.kind,
+            BootEntryKind::Payload { .. } | BootEntryKind::CbfsPayload { .. }
+        )
+    }
+
+    /// Check if this is a CBFS payload entry
+    pub fn is_cbfs_payload(&self) -> bool {
+        matches!(self.kind, BootEntryKind::CbfsPayload { .. })
     }
 
     /// Check if this entry has an editable command line
@@ -337,7 +354,7 @@ impl BootMenu {
 
 /// Discover boot entries from all storage devices
 ///
-/// Scans NVMe, AHCI, and USB devices for ESPs containing `EFI\BOOT\BOOTX64.EFI`.
+/// Scans NVMe, AHCI, USB devices, and CBFS for bootable entries.
 ///
 /// # Returns
 ///
@@ -347,6 +364,7 @@ pub fn discover_boot_entries() -> BootMenu {
 
     log::info!("Discovering boot entries...");
 
+    // Scan storage devices first (they take priority)
     // Scan NVMe devices
     discover_nvme_entries(&mut menu);
 
@@ -359,9 +377,53 @@ pub fn discover_boot_entries() -> BootMenu {
     // Scan SDHCI devices (SD cards)
     discover_sdhci_entries(&mut menu);
 
+    // Scan CBFS for chainloadable payloads (lower priority)
+    discover_cbfs_payloads(&mut menu);
+
     log::info!("Found {} boot entries", menu.entry_count());
 
     menu
+}
+
+/// Discover chainloadable payloads in CBFS
+fn discover_cbfs_payloads(menu: &mut BootMenu) {
+    use crate::coreboot::cbfs;
+
+    let payloads = cbfs::discover_payloads();
+
+    for payload in payloads {
+        // Create a synthetic partition for CBFS entries
+        // (partition_num = 0, empty partition info)
+        let empty_partition = gpt::Partition {
+            type_guid: [0u8; 16],
+            partition_guid: [0u8; 16],
+            first_lba: 0,
+            last_lba: 0,
+            attributes: 0,
+            is_esp: false,
+            block_size: 0,
+        };
+
+        let mut cbfs_name: String<128> = String::new();
+        let _ = cbfs_name.push_str(&payload.cbfs_name);
+
+        let entry = BootEntry::new_with_kind(
+            &payload.name,
+            &payload.cbfs_name, // Use CBFS name as path
+            DeviceType::Cbfs,
+            0, // No partition
+            empty_partition,
+            0, // No PCI device
+            0, // No PCI function
+            BootEntryKind::CbfsPayload { cbfs_name },
+            BootCategory::Payload,
+        );
+
+        if !menu.add_entry(entry) {
+            log::warn!("Boot menu full, skipping CBFS payload: {}", payload.name);
+            return;
+        }
+    }
 }
 
 /// Discover boot entries from NVMe devices

--- a/src/payload/mod.rs
+++ b/src/payload/mod.rs
@@ -227,36 +227,41 @@ pub unsafe fn chainload_payload(
     jump_to_payload(entry_point, cbtable_ptr)
 }
 
-/// Jump to a loaded payload
+/// Jump to a loaded payload, switching from 64-bit long mode to 32-bit protected mode
+///
+/// Coreboot payloads (SeaBIOS, etc.) expect to be entered in 32-bit protected mode
+/// with the coreboot table pointer in EBX.
 ///
 /// # Arguments
 ///
 /// * `entry` - Entry point address
-/// * `cbtable` - Pointer to coreboot tables (passed in RDI)
+/// * `cbtable` - Pointer to coreboot tables (passed in EBX in 32-bit mode)
 ///
 /// # Safety
 ///
 /// The payload must be loaded at the entry address and be valid.
+/// This function never returns - it switches CPU mode and jumps to the entry point.
 unsafe fn jump_to_payload(entry: u64, cbtable: *const u8) -> ! {
-    // Disable interrupts
-    core::arch::asm!("cli");
+    use crate::coreboot::trampoline::{self, TrampolineParams};
 
-    // Clear registers and jump to payload
-    // Pass coreboot table pointer in RDI (x86-64 calling convention)
-    core::arch::asm!(
-        "mov rdi, {cbtable}",   // Coreboot table pointer
-        "xor rsi, rsi",         // Clear RSI
-        "xor rdx, rdx",         // Clear RDX
-        "xor rcx, rcx",         // Clear RCX
-        "xor r8, r8",           // Clear R8
-        "xor r9, r9",           // Clear R9
-        "xor r10, r10",         // Clear R10
-        "xor r11, r11",         // Clear R11
-        "jmp {entry}",
-        cbtable = in(reg) cbtable as u64,
-        entry = in(reg) entry,
-        options(noreturn)
-    );
+    // We reuse the trampoline's mode-switching code
+    // Create params that don't need to copy anything (src=dst, size=0)
+    let params = TrampolineParams {
+        src_addr: 0,
+        dst_addr: 0,
+        copy_size: 0,
+        bss_size: 0,
+        entry_point: entry,
+        coreboot_table_ptr: cbtable as u64,
+    };
+
+    // This never returns
+    match trampoline::execute_trampoline(&params) {
+        Err(e) => {
+            log::error!("Failed to jump to payload: {:?}", e);
+            panic!("Failed to execute payload");
+        }
+    }
 }
 
 /// Determine payload format from file extension

--- a/src/state.rs
+++ b/src/state.rs
@@ -535,6 +535,9 @@ pub struct DriverState {
 
     /// ACPI RSDP address (from coreboot)
     pub acpi_rsdp: Option<u64>,
+
+    /// Coreboot table pointer (needed for payload chainloading)
+    pub coreboot_table_ptr: Option<u64>,
 }
 
 impl DriverState {
@@ -552,6 +555,7 @@ impl DriverState {
             storage: None,
             memory_regions: HeaplessVec::new(),
             acpi_rsdp: None,
+            coreboot_table_ptr: None,
         }
     }
 }
@@ -899,4 +903,24 @@ pub fn set_exit_boot_services_called() {
     with_efi_mut(|efi| {
         efi.exit_boot_services_called = true;
     });
+}
+
+// ============================================================================
+// Coreboot Table Pointer
+// ============================================================================
+
+/// Store the coreboot table pointer for payload chainloading.
+#[inline]
+pub fn set_coreboot_table_ptr(ptr: u64) {
+    with_drivers_mut(|drivers| {
+        drivers.coreboot_table_ptr = Some(ptr);
+    });
+}
+
+/// Get the coreboot table pointer.
+///
+/// Returns `None` if not yet stored.
+#[inline]
+pub fn get_coreboot_table_ptr() -> Option<u64> {
+    try_get().and_then(|state| state.drivers.coreboot_table_ptr)
 }

--- a/x86_64-coreboot.ld
+++ b/x86_64-coreboot.ld
@@ -7,6 +7,15 @@ ENTRY(_start)
 /* Coreboot loads payloads at a configurable address, typically 0x100000 (1MB) */
 PAYLOAD_BASE = 0x100000;
 
+/* Define program headers explicitly to separate LOAD and NOLOAD sections */
+PHDRS
+{
+    text PT_LOAD FLAGS(5);   /* R-X */
+    rodata PT_LOAD FLAGS(4); /* R-- */
+    data PT_LOAD FLAGS(6);   /* RW- */
+    bss PT_NULL FLAGS(6);    /* RW- but not loaded from file */
+}
+
 SECTIONS
 {
     . = PAYLOAD_BASE;
@@ -17,14 +26,14 @@ SECTIONS
     /* 32-bit entry code - must be first */
     .entry32 : ALIGN(4096) {
         *(.entry32)
-    }
+    } :text
 
     /* Text section */
     .text : ALIGN(4096) {
         _text_start = .;
         *(.text .text.*)
         _text_end = .;
-    }
+    } :text
     
     /* Runtime code ends here */
     __runtime_code_end = .;
@@ -37,36 +46,41 @@ SECTIONS
         _rodata_start = .;
         *(.rodata .rodata.*)
         _rodata_end = .;
-    }
+    } :rodata
+
+    /* GOT - must be writable for dynamic linking (even though we don't use it) */
+    .got : ALIGN(8) {
+        *(.got .got.*)
+    } :data
 
     /* Initialized data */
     .data : ALIGN(4096) {
         _data_start = .;
         *(.data .data.*)
         _data_end = .;
-    }
+    } :data
 
     /* Page tables - must be 4KB aligned */
     .page_tables : ALIGN(4096) {
         _page_tables_start = .;
         *(.page_tables)
         _page_tables_end = .;
-    }
+    } :data
 
-    /* Uninitialized data (BSS) */
-    .bss : ALIGN(4096) {
+    /* Uninitialized data (BSS) - PT_NULL means no LOAD segment */
+    .bss (NOLOAD) : ALIGN(4096) {
         _bss_start = .;
         *(.bss .bss.*)
         *(COMMON)
         _bss_end = .;
-    }
+    } :bss
 
-    /* Stack - 256KB (increased from 64KB for large structs) */
-    .stack : ALIGN(4096) {
+    /* Stack - 2MB */
+    .stack (NOLOAD) : ALIGN(4096) {
         _stack_bottom = .;
         . += 0x200000;
         _stack_top = .;
-    }
+    } :bss
 
     /* Runtime data ends here (after BSS and stack) */
     __runtime_data_end = .;
@@ -80,7 +94,7 @@ SECTIONS
         _deferred_buffer_start = .;
         . += 64K;
         _deferred_buffer_end = .;
-    }
+    } :bss
 
     _end = .;
 


### PR DESCRIPTION
This PR adds comprehensive support for chainloading payloads stored in the Coreboot File System (CBFS) in flash memory.

**Key Features:**

- **CBFS Parser**: Full read-only CBFS implementation that locates files in flash using memory-mapped SPI access
- **Decompression Support**: Handles LZ4, LZMA, and ZSTD compressed payloads using `lz4_flex`, `lzma-rust2`, and `ruzstd` (all no_std compatible)
- **Payload Formats**: Supports both CBFS_TYPE_SELF (multi-segment self-extracting) and CBFS_TYPE_STAGE formats
- **Smart Relocation**: Automatically detects when payload target addresses conflict with CrabEFI's memory and uses a trampoline to safely relocate
- **Trampoline Implementation**: Assembly routine at 0x8000 that switches from 64-bit to 32-bit mode, copies payload to target, and jumps to entry point (coreboot payloads expect 32-bit protected mode)
- **Boot Menu Integration**: Discovers bootable payloads in CBFS and adds them to the boot menu automatically

**Implementation Details:**

- CBFS metadata parsed from coreboot tables (LB_TAG_BOOT_MEDIA_PARAMS provides flash offset/size)
- Flash memory-mapped at end of 4GB address space (e.g., 0xFF800000 for 8MB flash)
- Bounce buffer allocated via EFI pages for decompression when target conflicts with runtime
- Mode switching follows coreboot's exit32.inc approach (GDT setup, iretq to 32-bit, disable paging/long mode/PAE)
- Heap size increased to 4MB to accommodate LZMA dictionary buffers (up to 64MB)
- BSS/stack/deferred_buffer now zeroed together before stack initialization
- Linker script updated with explicit program headers (PT_LOAD vs PT_NULL for NOLOAD sections)

**Memory Safety:**

- Validates target addresses are in usable RAM (not MMIO/reserved/ACPI)
- Detects conflicts with CrabEFI's runtime code/data bounds
- Trampoline disables paging before copy to prevent page table corruption

**Testing:**

- Tested with SeaBIOS and other common coreboot payloads
- Handles both compressed and uncompressed files
- Works with payloads at various load addresses