### PR TITLE
feat: append CrabEFI boot timestamps to coreboot's timestamp table

### DIFF
--- a/crabefi-core/src/boot_manager.rs
+++ b/crabefi-core/src/boot_manager.rs
@@ -14,12 +14,14 @@ use crate::boot_vars;
 use crate::drivers;
 use crate::efi;
 use crate::menu;
+use crate::timestamp;
 
 /// Initialize storage subsystem (PCI drivers, USB keyboards, etc.)
 ///
 /// This is called once before the boot manager starts trying boot options.
 fn init_storage_subsystem() {
     log::info!("Initializing storage subsystem...");
+    timestamp::record(timestamp::TS_CRABEFI_STORAGE_INIT_START);
 
     // Print PCI devices (already initialized earlier for SPI detection)
     drivers::pci::print_devices();
@@ -44,6 +46,7 @@ fn init_storage_subsystem() {
     efi::protocols::pass_thru_init::init();
 
     log::info!("Storage subsystem initialized");
+    timestamp::record(timestamp::TS_CRABEFI_STORAGE_INIT_DONE);
 }
 
 /// Run the UEFI boot manager.

--- a/crabefi-core/src/efi/boot_services.rs
+++ b/crabefi-core/src/efi/boot_services.rs
@@ -1516,6 +1516,7 @@ extern "efiapi" fn exit_boot_services(image_handle: Handle, map_key: usize) -> S
 
     if status == Status::SUCCESS {
         log::info!("ExitBootServices SUCCESS - transitioning to OS");
+        crate::timestamp::record(crate::timestamp::TS_CRABEFI_EXIT_BOOT_SERVICES);
 
         // Mark that ExitBootServices has been called
         // After this, SPI flash is locked and variable writes go to ESP file

--- a/crabefi-core/src/lib.rs
+++ b/crabefi-core/src/lib.rs
@@ -41,6 +41,7 @@ pub mod platform;
 pub mod secure_boot_menu;
 pub mod state;
 pub mod time;
+pub mod timestamp;
 #[cfg(feature = "ui")]
 pub mod ui;
 
@@ -52,8 +53,9 @@ pub use platform::{
     ConsoleInput, DebugOutput, DeferredBufferConfig, FirmwareInfo, FirmwareMmapWindow,
     FirmwareStorage, FirmwareStorageLocation, FirmwareStorageRegion, FmapRegion, FramebufferConfig,
     Key, KeyState, MemoryRegion, MemoryType, PlatformConfig, PlatformHooks, ResetHandler,
-    ResetType, Rng, RngError, RuntimeRegion, StorageBackend, StorageError, Timer, VarBackendError,
-    VariableBackend, VariableStoreLocator, VariableStoreRegion, VariableVisitor,
+    ResetType, Rng, RngError, RuntimeRegion, StorageBackend, StorageError, Timer,
+    TimestampRecorder, VarBackendError, VariableBackend, VariableStoreLocator, VariableStoreRegion,
+    VariableVisitor,
 };
 
 /// Display a Secure Boot violation error on screen
@@ -148,6 +150,7 @@ fn init_persistence_and_boot(
     }
 
     efi::varstore::init_deferred_buffer();
+    timestamp::record(timestamp::TS_CRABEFI_VARSTORE_INIT);
 
     // ---- Boot manager ----
     let boot_var_state = boot_vars::read_boot_var_state();
@@ -191,6 +194,7 @@ fn init_persistence_and_boot(
 /// let config = crabefi::PlatformConfig {
 ///     memory_map: &memory_regions,
 ///     timer: &my_timer,
+///     timestamp_recorder: None,
 ///     reset: &my_reset,
 ///     block_devices: &mut [],
 ///     debug_output: Some(&mut my_uart),
@@ -327,9 +331,21 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
             >(hooks)
         }
     });
+    let timestamp_recorder: Option<&'static dyn crate::platform::TimestampRecorder> =
+        config.timestamp_recorder.map(|recorder| {
+            // SAFETY: init_platform() is -> !, so platform recorder references
+            // live for the entire firmware lifetime.
+            unsafe {
+                core::mem::transmute::<
+                    &dyn crate::platform::TimestampRecorder,
+                    &'static dyn crate::platform::TimestampRecorder,
+                >(recorder)
+            }
+        });
     state::with_drivers_mut(|d| {
         d.platform.efi_fw_info = config.firmware_info;
         d.platform.hooks = hooks;
+        d.platform.timestamp_recorder = timestamp_recorder;
         d.platform.capsule_regions.clear();
         for region in config.capsule_regions {
             if d.platform.capsule_regions.push(*region).is_err() {
@@ -345,6 +361,7 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
     // This works on any architecture (x86, aarch64, riscv64) without
     // architecture-specific hardware detection inside the library.
     time::init_from_platform(config.timer);
+    timestamp::record(timestamp::TS_CRABEFI_COUNTER_CALIBRATED);
 
     // Print memory summary
     let total_ram: u64 = config
@@ -365,6 +382,7 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
     // allocator is idempotent: if the caller already bootstrapped it
     // (to get a heap before entry), re-initialization is skipped.
     efi::init_from_platform(&config);
+    timestamp::record(timestamp::TS_CRABEFI_EFI_INIT);
 
     // Initialize mouse cursor system (ui feature only).
     // Must come after efi::init_from_platform(), which stores the framebuffer
@@ -423,6 +441,7 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
     }
 
     drivers::pci::init();
+    timestamp::record(timestamp::TS_CRABEFI_PCI_INIT);
 
     // ---- 13. Register deferred variable buffer if provided ----
     if let Some(buf) = config.deferred_buffer {

--- a/crabefi-core/src/logger.rs
+++ b/crabefi-core/src/logger.rs
@@ -3,25 +3,29 @@
 //! This module provides logging via the `log` crate, outputting to the
 //! serial port and optionally the framebuffer.
 //!
+//! Log lines are prefixed with microseconds since boot. Before timer
+//! calibration, the platform's initial frequency estimate is used.
+//!
 //! Framebuffer logging is disabled by default as it is very slow.
 //! Enable with the `fb-log` feature flag.
 
 use crate::time::read_counter;
 use log::{Level, LevelFilter, Metadata, Record};
 
-/// Get relative counter ticks since boot (in thousands for readability)
+/// Get microseconds elapsed since boot.
 ///
 /// Uses raw-pointer read (see *Log-Path Contract* in [`crate::state`]) to
 /// avoid creating a `&DriverState` reference that would alias with a live
 /// `&mut` from `with_*_mut()` closures.
-pub fn get_timestamp_k() -> u64 {
+pub fn get_us_since_boot() -> u64 {
     let current = read_counter();
     // SAFETY: single-threaded firmware; field is written once at init,
-    // only read afterwards.  Raw pointer avoids aliasing with &mut held
+    // only read afterwards. Raw pointer avoids aliasing with &mut held
     // by with_*_mut() closures that may log.
     let boot = unsafe { (*crate::state::drivers_mut_ptr()).timing.boot_counter };
-    // Return delta in thousands (k-ticks) to keep numbers manageable
-    current.saturating_sub(boot) / 1000
+    let delta = current.saturating_sub(boot);
+    let freq = crate::time::counter_frequency().max(1);
+    ((delta as u128 * 1_000_000) / freq as u128) as u64
 }
 
 /// Combined serial + framebuffer logger
@@ -43,8 +47,8 @@ impl log::Log for CombinedLogger {
                 Level::Trace => "\x1b[35mTRACE\x1b[0m",
             };
 
-            // Get timestamp (k-ticks since boot)
-            let ts = get_timestamp_k();
+            // Get timestamp (microseconds since boot)
+            let ts = get_us_since_boot();
 
             // Output to serial with timestamp
             crate::serial_println!("[{:>10}] [{}] {}", ts, level_str_serial, record.args());

--- a/crabefi-core/src/platform.rs
+++ b/crabefi-core/src/platform.rs
@@ -36,6 +36,7 @@
 //! let config = crabefi::PlatformConfig {
 //!     memory_map: &my_memory_map,
 //!     timer: &my_timer,
+//!     timestamp_recorder: None,
 //!     reset: &my_reset_handler,
 //!     block_devices: &mut [&mut my_emmc],
 //!     variable_backend: None, // direct VariableBackend routing is not wired yet
@@ -874,6 +875,22 @@ pub trait Timer {
 }
 
 // ============================================================================
+// Boot Timestamp Recording
+// ============================================================================
+
+/// Platform boot timestamp sink.
+///
+/// CrabEFI records well-known boot milestones through this trait. Platforms
+/// that have a firmware-visible timestamp log (for example coreboot's CBMEM
+/// timestamp table) can implement this trait and pass it in
+/// [`PlatformConfig::timestamp_recorder`]. Platforms without such a facility
+/// can leave the field as `None`; timestamp recording then becomes a no-op.
+pub trait TimestampRecorder {
+    /// Record the current platform timestamp for `id`.
+    fn record(&self, id: u32);
+}
+
+// ============================================================================
 // Reset
 // ============================================================================
 
@@ -1329,6 +1346,9 @@ pub struct PlatformConfig<'a> {
 
     /// Monotonic timer for `Stall()` and EFI timer events.
     pub timer: &'a dyn Timer,
+
+    /// Optional firmware-visible boot timestamp recorder.
+    pub timestamp_recorder: Option<&'a dyn TimestampRecorder>,
 
     /// System reset handler for `ResetSystem` runtime service.
     pub reset: &'a dyn ResetHandler,

--- a/crabefi-core/src/state.rs
+++ b/crabefi-core/src/state.rs
@@ -46,7 +46,7 @@
 //! Functions called from the `log` crate macros — serial output
 //! ([`crate::drivers::serial`]), platform log sinks, framebuffer logging
 //! ([`crate::fb_log`]), and the timestamp helper
-//! ([`crate::logger::get_timestamp_k`]) — must **never** create Rust
+//! ([`crate::logger::get_us_since_boot`]) — must **never** create Rust
 //! references (`&` or `&mut`) into `FirmwareState`.
 //!
 //! This is necessary because `log::info!()` and friends may fire *inside*
@@ -733,7 +733,7 @@ impl Default for PciState {
 
 /// Serial port state: hardware driver and EFI protocol mode.
 pub struct SerialState {
-    /// Active serial port driver (16550 UART or PL011)
+    /// Active serial port driver (16550 UART, PL011, or platform-provided primary output).
     pub(crate) driver: Option<AnySerial>,
     /// EFI Serial IO protocol mode (current port settings).
     ///
@@ -840,6 +840,9 @@ pub struct PlatformInfo {
 
     /// Optional platform lifecycle callbacks.
     pub hooks: Option<&'static dyn crate::platform::PlatformHooks>,
+
+    /// Optional firmware-visible boot timestamp recorder.
+    pub timestamp_recorder: Option<&'static dyn crate::platform::TimestampRecorder>,
 }
 
 impl PlatformInfo {
@@ -852,6 +855,7 @@ impl PlatformInfo {
             efi_fw_info: None,
             capsule_regions: HeaplessVec::new(),
             hooks: None,
+            timestamp_recorder: None,
         }
     }
 }

--- a/crabefi-core/src/timestamp.rs
+++ b/crabefi-core/src/timestamp.rs
@@ -1,0 +1,37 @@
+//! Boot timestamp recording abstraction.
+//!
+//! The core library records boot-stage milestones via [`record`]. Platforms
+//! provide the backend by passing a [`crate::TimestampRecorder`] in
+//! [`crate::PlatformConfig`]. Without a recorder, all calls are no-ops.
+//!
+//! CrabEFI uses timestamp IDs 1500–1599. Coreboot reserves IDs 1000+ for
+//! payloads, and the same IDs are useful for any platform that wants stable
+//! CrabEFI milestone identifiers.
+
+/// CrabEFI payload entry point reached.
+pub const TS_CRABEFI_START: u32 = 1500;
+/// Platform tables parsed.
+pub const TS_CRABEFI_TABLES_PARSED: u32 = 1501;
+/// Timing subsystem calibrated.
+pub const TS_CRABEFI_COUNTER_CALIBRATED: u32 = 1502;
+/// EFI environment initialized.
+pub const TS_CRABEFI_EFI_INIT: u32 = 1503;
+/// PCI bus enumeration complete.
+pub const TS_CRABEFI_PCI_INIT: u32 = 1504;
+/// Variable store and Secure Boot initialization complete.
+pub const TS_CRABEFI_VARSTORE_INIT: u32 = 1505;
+/// Storage controller initialization started.
+pub const TS_CRABEFI_STORAGE_INIT_START: u32 = 1506;
+/// Storage controllers ready.
+pub const TS_CRABEFI_STORAGE_INIT_DONE: u32 = 1507;
+/// `ExitBootServices` succeeded; handing off to the OS.
+pub const TS_CRABEFI_EXIT_BOOT_SERVICES: u32 = 1508;
+
+/// Record a boot milestone with the current platform timestamp.
+///
+/// This is a no-op when the platform did not provide a timestamp recorder.
+pub fn record(id: u32) {
+    if let Some(recorder) = crate::state::drivers().platform.timestamp_recorder {
+        recorder.record(id);
+    }
+}

--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -21,6 +21,8 @@ mod fmap;
 mod framebuffer;
 mod memory;
 mod tables;
+#[cfg(target_arch = "x86_64")]
+mod timestamps;
 
 use core::panic::PanicInfo;
 #[cfg(target_arch = "riscv64")]
@@ -513,6 +515,7 @@ fn riscv_fdt_only_boot(fdt_ptr: u64, fdt_size: u32) -> ! {
     let config = crabefi::PlatformConfig {
         memory_map: &memory_regions[..region_count],
         timer: &timer,
+        timestamp_recorder: None,
         reset: &reset,
         block_devices: &mut [],
         variable_backend: None,
@@ -603,6 +606,9 @@ fn build_memory_map_from_fdt(
 ///   (passed in RDI on x86_64, X0 on aarch64).
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
+    #[cfg(target_arch = "x86_64")]
+    let entry_counter = crabefi::time::read_counter();
+
     // ================================================================
     // Phase 1: Initialize firmware state (needed for all state access)
     // ================================================================
@@ -641,6 +647,14 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
     if let Some(cbmem_addr) = cb_info.cbmem_console {
         cbmem_console::init(cbmem_addr);
     }
+
+    #[cfg(target_arch = "x86_64")]
+    let timestamp_recorder = cb_info.timestamps.and_then(|table_addr| {
+        let recorder = timestamps::CorebootTimestampRecorder::new(table_addr)?;
+        recorder.record_counter(crabefi::timestamp::TS_CRABEFI_START, entry_counter);
+        recorder.record_now(crabefi::timestamp::TS_CRABEFI_TABLES_PARSED);
+        Some(recorder)
+    });
 
     if let Some(fb) = cb_info.framebuffer {
         crabefi::state::store_framebuffer(crabefi::FramebufferConfig::from(fb));
@@ -722,6 +736,12 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
     let reset = CorebootReset;
     let hooks = CorebootHooks;
     let variable_store_locator = CorebootVariableStoreLocator::new(&cb_info);
+    #[cfg(target_arch = "x86_64")]
+    let timestamp_recorder_ref = timestamp_recorder
+        .as_ref()
+        .map(|recorder| recorder as &dyn crabefi::TimestampRecorder);
+    #[cfg(not(target_arch = "x86_64"))]
+    let timestamp_recorder_ref: Option<&dyn crabefi::TimestampRecorder> = None;
 
     // Extract FDT bytes slice.
     //
@@ -771,6 +791,7 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
     let mut config = crabefi::PlatformConfig {
         memory_map: &memory_regions[..region_count],
         timer: &timer,
+        timestamp_recorder: timestamp_recorder_ref,
         reset: &reset,
         block_devices: &mut [],
         variable_backend: None,
@@ -916,6 +937,9 @@ fn log_coreboot_info(cb_info: &tables::CorebootInfo) {
     }
     if let Some(cbmem_console) = cb_info.cbmem_console {
         log::info!("  CBMEM console: {:#x}", cbmem_console);
+    }
+    if let Some(timestamps) = cb_info.timestamps {
+        log::info!("  Timestamp table: {:#x}", timestamps);
     }
     if let Some(ref smmstore) = cb_info.smmstorev2 {
         log::info!(

--- a/crabefi-coreboot/src/tables.rs
+++ b/crabefi-coreboot/src/tables.rs
@@ -414,6 +414,8 @@ pub struct CorebootInfo {
     pub version: Option<&'static str>,
     /// CBMEM console address
     pub cbmem_console: Option<u64>,
+    /// Timestamp table address (from CB_TAG_TIMESTAMPS)
+    pub timestamps: Option<u64>,
     /// SMBIOS tables address (from CBMEM entry)
     pub smbios: Option<u64>,
     /// SMMSTORE v2 information for UEFI variable storage
@@ -444,6 +446,7 @@ impl CorebootInfo {
             acpi_rsdp: None,
             version: None,
             cbmem_console: None,
+            timestamps: None,
             smbios: None,
             smmstorev2: None,
             spi_flash: None,
@@ -660,6 +663,9 @@ fn parse_record(record_bytes: &[u8], info: &mut CorebootInfo) {
         }
         tags::CB_TAG_ACPI_RSDP => {
             parse_acpi_rsdp(record_bytes, info);
+        }
+        tags::CB_TAG_TIMESTAMPS => {
+            parse_timestamps(record_bytes, info);
         }
         tags::CB_TAG_CBMEM_CONSOLE => {
             parse_cbmem_console(record_bytes, info);
@@ -1030,6 +1036,21 @@ fn parse_cbmem_console(record_bytes: &[u8], info: &mut CorebootInfo) {
     info.cbmem_console = Some(cbmem_addr);
 
     log::debug!("CBMEM console: {:#x}", cbmem_addr);
+}
+
+/// Parse timestamp table reference.
+///
+/// The CB_TAG_TIMESTAMPS record is an `lb_cbmem_ref` that points to the
+/// coreboot timestamp table in CBMEM.
+fn parse_timestamps(record_bytes: &[u8], info: &mut CorebootInfo) {
+    let Ok((cbmem_ref, _)) = CbCbmemRef::read_from_prefix(record_bytes) else {
+        log::warn!("Failed to parse timestamps record");
+        return;
+    };
+    let cbmem_addr = cbmem_ref.cbmem_addr;
+    info.timestamps = Some(cbmem_addr);
+
+    log::debug!("Timestamp table: {:#x}", cbmem_addr);
 }
 
 /// Parse CBMEM entry record

--- a/crabefi-coreboot/src/timestamps.rs
+++ b/crabefi-coreboot/src/timestamps.rs
@@ -1,0 +1,115 @@
+//! Coreboot timestamp table support.
+//!
+//! Coreboot stores boot timestamps in a CBMEM table and exposes its address via
+//! `CB_TAG_TIMESTAMPS`. Payloads may append their own entries so `cbmem -t`
+//! shows a combined firmware-to-payload timeline.
+//!
+//! The table layout matches coreboot's serialized timestamp table:
+//!
+//! ```text
+//! +0x00: base_time     u64
+//! +0x08: max_entries   u16
+//! +0x0a: tick_freq_mhz u16
+//! +0x0c: num_entries   u32
+//! +0x10: entries[]     { u32 entry_id, i64 entry_stamp }
+//! ```
+//!
+//! Entry stamps are relative to `base_time`.
+
+/// Coreboot timestamp table header.
+#[repr(C, packed)]
+struct TimestampTable {
+    base_time: u64,
+    max_entries: u16,
+    tick_freq_mhz: u16,
+    num_entries: u32,
+}
+
+/// Coreboot timestamp table entry.
+#[repr(C, packed)]
+struct TimestampEntry {
+    entry_id: u32,
+    entry_stamp: i64,
+}
+
+/// Recorder that appends CrabEFI milestones to coreboot's timestamp table.
+#[derive(Clone, Copy)]
+pub(crate) struct CorebootTimestampRecorder {
+    table_addr: u64,
+}
+
+impl CorebootTimestampRecorder {
+    /// Create a recorder from a coreboot timestamp table address.
+    pub(crate) fn new(table_addr: u64) -> Option<Self> {
+        if table_addr == 0 {
+            return None;
+        }
+
+        // SAFETY: The address comes from coreboot's CB_TAG_TIMESTAMPS record.
+        // We only perform unaligned reads from the fixed-size table header and
+        // validate the entry capacity before accepting the table.
+        let (max_entries, num_entries) = unsafe {
+            let table = table_addr as *const TimestampTable;
+            let max_entries = core::ptr::addr_of!((*table).max_entries).read_unaligned();
+            let num_entries = core::ptr::addr_of!((*table).num_entries).read_unaligned();
+            (max_entries, num_entries)
+        };
+
+        if !(16..=1024).contains(&max_entries) || num_entries > max_entries as u32 {
+            log::warn!(
+                "Ignoring suspicious coreboot timestamp table at {:#x}: entries={}/{}",
+                table_addr,
+                num_entries,
+                max_entries
+            );
+            return None;
+        }
+
+        Some(Self { table_addr })
+    }
+
+    /// Append a milestone using the current architecture counter.
+    pub(crate) fn record_now(&self, id: u32) {
+        self.record_counter(id, crabefi::time::read_counter());
+    }
+
+    /// Append a milestone using an explicit architecture counter value.
+    pub(crate) fn record_counter(&self, id: u32, counter: u64) {
+        // SAFETY: `table_addr` was accepted by `new()`. CrabEFI is
+        // single-threaded during boot, so the non-atomic num_entries update
+        // cannot race with another CrabEFI writer.
+        unsafe {
+            let table = self.table_addr as *mut TimestampTable;
+
+            let max_entries = core::ptr::addr_of!((*table).max_entries).read_unaligned();
+            let num_ptr = core::ptr::addr_of_mut!((*table).num_entries);
+            let num_entries = num_ptr.read_unaligned();
+
+            if num_entries >= max_entries as u32 {
+                log::warn!(
+                    "Coreboot timestamp table full ({}/{}), dropping id={}",
+                    num_entries,
+                    max_entries,
+                    id
+                );
+                return;
+            }
+
+            let base_time = core::ptr::addr_of!((*table).base_time).read_unaligned();
+            let entry_stamp = counter.wrapping_sub(base_time) as i64;
+            let entries_base = (table as *mut u8).add(core::mem::size_of::<TimestampTable>())
+                as *mut TimestampEntry;
+            let entry = entries_base.add(num_entries as usize);
+
+            core::ptr::addr_of_mut!((*entry).entry_id).write_unaligned(id);
+            core::ptr::addr_of_mut!((*entry).entry_stamp).write_unaligned(entry_stamp);
+            num_ptr.write_unaligned(num_entries + 1);
+        }
+    }
+}
+
+impl crabefi::TimestampRecorder for CorebootTimestampRecorder {
+    fn record(&self, id: u32) {
+        self.record_now(id);
+    }
+}

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -17,6 +17,7 @@ fn firmware_main() -> ! {
     let config = crabefi::PlatformConfig {
         memory_map: &MY_MEMORY_MAP,
         timer: &timer,
+        timestamp_recorder: None,
         reset: &MyReset,
         block_devices: &mut [&mut emmc as &mut dyn crabefi::BlockDevice],
         variable_backend: None,       // direct VariableBackend routing is not wired yet


### PR DESCRIPTION
Parse CB_TAG_TIMESTAMPS in the coreboot payload crate to discover the CBMEM timestamp table, then append CrabEFI boot milestones (IDs 1500-1508) so they appear in `cbmem -t` alongside coreboot entries.

The core crate now exposes a small `TimestampRecorder` platform trait and records generic milestones through that abstraction; the coreboot crate provides the CBMEM timestamp-table implementation.

Also update logger prefixes to show microseconds since boot using the calibrated platform counter frequency instead of raw k-ticks.