### PR TITLE
Refactor PCI driver model, unify boot paths, and optimize boot entry discovery

### DIFF
--- a/src/bls/mod.rs
+++ b/src/bls/mod.rs
@@ -230,6 +230,5 @@ fn try_load_entry(fs: &mut FatFilesystem<'_>, path: &str) -> Option<BlsEntry> {
 /// * `fs` - FAT filesystem to check
 pub fn has_bls_entries(fs: &mut FatFilesystem<'_>) -> bool {
     // Check if loader.conf or the entries directory exists
-    fs.file_size(LOADER_CONF_PATH).is_ok()
-        || fs.find_file(ENTRIES_DIR).is_ok()
+    fs.file_size(LOADER_CONF_PATH).is_ok() || fs.find_file(ENTRIES_DIR).is_ok()
 }

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -1,0 +1,603 @@
+//! Unified Boot Path Module
+//!
+//! This module consolidates the boot logic that was previously duplicated
+//! per-storage-type in lib.rs. It provides:
+//!
+//! - `install_block_io_protocols()` — Generic function to install BlockIO and DevicePath
+//!   protocols for a disk and all its GPT partitions
+//! - `try_boot_from_esp()` — Generic function to mount FAT on the ESP, install
+//!   SimpleFileSystem, and load/execute the EFI bootloader
+//!
+//! These replace the four `install_block_io_for_{usb,nvme,ahci,sdhci}_disk` functions
+//! and the four `try_boot_from_esp_{usb,nvme,ahci,sdhci}` functions.
+
+use crate::drivers::block::{
+    AhciBlockDevice, AnyBlockDevice, BlockDevice, NvmeBlockDevice, SdhciBlockDevice, UsbBlockDevice,
+};
+use crate::drivers::storage::{self, StorageType};
+use crate::efi;
+use crate::efi::boot_services;
+use crate::efi::protocols::block_io::{self, BLOCK_IO_PROTOCOL_GUID};
+use crate::efi::protocols::device_path::{self, DEVICE_PATH_PROTOCOL_GUID, DevicePathInfo};
+use crate::efi::protocols::simple_file_system::{self, SIMPLE_FILE_SYSTEM_GUID};
+use crate::fs;
+use crate::menu;
+use crate::pe;
+use r_efi::efi::Status;
+
+/// Install BlockIO and DevicePath protocols for a disk and all its GPT partitions
+///
+/// This replaces the four `install_block_io_for_{usb,nvme,ahci,sdhci}_disk` functions.
+///
+/// # Arguments
+/// * `disk` - Block device to read GPT from
+/// * `storage_id` - Storage device ID for BlockIO media_id
+/// * `block_size` - Block size in bytes
+/// * `num_blocks` - Total number of blocks on the device
+/// * `path_info` - Device-specific info for constructing device paths
+///
+/// # Returns
+/// The ESP partition and its 1-based partition number, if found
+pub fn install_block_io_protocols<D: BlockDevice>(
+    disk: &mut D,
+    storage_id: u32,
+    block_size: u32,
+    num_blocks: u64,
+    path_info: &DevicePathInfo,
+) -> Option<(u32, fs::gpt::Partition)> {
+    // Create BlockIO for the raw disk (whole device)
+    let disk_block_io = block_io::create_disk_block_io(storage_id, num_blocks, block_size);
+
+    if !disk_block_io.is_null()
+        && let Some(disk_handle) = boot_services::create_handle()
+    {
+        // Install BlockIO protocol
+        let status = boot_services::install_protocol(
+            disk_handle,
+            &BLOCK_IO_PROTOCOL_GUID,
+            disk_block_io as *mut core::ffi::c_void,
+        );
+        if status == Status::SUCCESS {
+            log::info!(
+                "BlockIO protocol installed for raw disk on handle {:?}",
+                disk_handle
+            );
+        }
+
+        // Install DevicePath protocol for the raw disk
+        let disk_device_path = device_path::create_disk_device_path(path_info);
+        if !disk_device_path.is_null() {
+            let status = boot_services::install_protocol(
+                disk_handle,
+                &DEVICE_PATH_PROTOCOL_GUID,
+                disk_device_path as *mut core::ffi::c_void,
+            );
+            if status == Status::SUCCESS {
+                log::info!(
+                    "DevicePath protocol installed for raw disk on handle {:?}",
+                    disk_handle
+                );
+            }
+        }
+    }
+
+    // Read GPT header and all partitions
+    let header = match fs::gpt::read_gpt_header(disk) {
+        Ok(h) => h,
+        Err(e) => {
+            log::debug!("Failed to read GPT header: {:?}", e);
+            return None;
+        }
+    };
+
+    let partitions = match fs::gpt::read_partitions(disk, &header) {
+        Ok(p) => p,
+        Err(e) => {
+            log::debug!("Failed to read partitions: {:?}", e);
+            return None;
+        }
+    };
+
+    let mut esp_partition: Option<(u32, fs::gpt::Partition)> = None;
+    let mut candidate_partitions: heapless::Vec<(u32, fs::gpt::Partition), 8> =
+        heapless::Vec::new();
+
+    // Create BlockIO for each partition
+    for (i, partition) in partitions.iter().enumerate() {
+        let partition_num = (i + 1) as u32;
+        let partition_blocks = partition.size_sectors();
+
+        let partition_block_io = block_io::create_partition_block_io(
+            storage_id,
+            partition_num,
+            partition.first_lba,
+            partition_blocks,
+            block_size,
+        );
+
+        if !partition_block_io.is_null()
+            && let Some(part_handle) = boot_services::create_handle()
+        {
+            // Install BlockIO
+            let status = boot_services::install_protocol(
+                part_handle,
+                &BLOCK_IO_PROTOCOL_GUID,
+                partition_block_io as *mut core::ffi::c_void,
+            );
+            if status == Status::SUCCESS {
+                log::info!(
+                    "BlockIO protocol installed for partition {} on handle {:?}",
+                    partition_num,
+                    part_handle
+                );
+            }
+
+            // Install DevicePath for partition
+            let part_device_path = device_path::create_partition_device_path(
+                path_info,
+                partition_num,
+                partition.first_lba,
+                partition_blocks,
+                &partition.partition_guid,
+            );
+
+            if !part_device_path.is_null() {
+                let status = boot_services::install_protocol(
+                    part_handle,
+                    &DEVICE_PATH_PROTOCOL_GUID,
+                    part_device_path as *mut core::ffi::c_void,
+                );
+                if status == Status::SUCCESS {
+                    log::info!(
+                        "DevicePath protocol installed for partition {} on handle {:?}",
+                        partition_num,
+                        part_handle
+                    );
+                }
+            }
+        }
+
+        // Remember ESP for later (with partition number)
+        if partition.is_esp {
+            log::info!(
+                "Found ESP: partition {}, LBA {}-{} ({} MB)",
+                partition_num,
+                partition.first_lba,
+                partition.last_lba,
+                partition.size_bytes() / (1024 * 1024)
+            );
+            esp_partition = Some((partition_num, partition.clone()));
+        } else {
+            // Track as candidate for fallback (small partitions are more likely to be EFI boot)
+            let size_mb = partition.size_bytes() / (1024 * 1024);
+            if size_mb > 0 && size_mb < 512 && partition.first_lba > 0 {
+                let _ = candidate_partitions.push((partition_num, partition.clone()));
+            }
+        }
+    }
+
+    // If we found a proper ESP, return it
+    if esp_partition.is_some() {
+        return esp_partition;
+    }
+
+    // No proper ESP found - try candidate partitions (smaller ones first)
+    candidate_partitions
+        .as_mut_slice()
+        .sort_unstable_by_key(|(_, partition)| partition.size_bytes());
+
+    if let Some((partition_num, partition)) = candidate_partitions.first() {
+        log::debug!(
+            "Trying partition {} as potential ESP (no proper ESP found)",
+            partition_num
+        );
+        return Some((*partition_num, partition.clone()));
+    }
+
+    None
+}
+
+/// Create an `AnyBlockDevice` for the SimpleFileSystem protocol
+///
+/// This creates the correct block device variant based on device type,
+/// used by the SFS protocol for filesystem reads.
+fn create_block_device_for_sfs(
+    device_type: &menu::DeviceType,
+    num_blocks: u64,
+    block_size: u32,
+) -> Option<AnyBlockDevice> {
+    match *device_type {
+        menu::DeviceType::Nvme {
+            controller_id: _,
+            nsid,
+        } => {
+            let block_dev = NvmeBlockDevice::new(0, nsid, num_blocks, block_size, 0);
+            Some(AnyBlockDevice::Nvme(block_dev))
+        }
+        menu::DeviceType::Ahci {
+            controller_id: _,
+            port,
+        } => {
+            let block_dev = AhciBlockDevice::new(0, port, num_blocks, block_size, 0);
+            Some(AnyBlockDevice::Ahci(block_dev))
+        }
+        menu::DeviceType::Usb {
+            controller_id: _,
+            device_addr,
+        } => {
+            let block_dev = UsbBlockDevice::new(0, device_addr, num_blocks, block_size, 0);
+            Some(AnyBlockDevice::Usb(block_dev))
+        }
+        menu::DeviceType::Sdhci { controller_id: _ } => {
+            let block_dev = SdhciBlockDevice::new(0, num_blocks, block_size, 0);
+            Some(AnyBlockDevice::Sdhci(block_dev))
+        }
+    }
+}
+
+/// Create a StorageType for registering with the storage registry
+fn create_storage_type(device_type: &menu::DeviceType) -> StorageType {
+    match *device_type {
+        menu::DeviceType::Nvme {
+            controller_id,
+            nsid,
+        } => StorageType::Nvme {
+            controller_id,
+            nsid,
+        },
+        menu::DeviceType::Ahci {
+            controller_id,
+            port,
+        } => StorageType::Ahci {
+            controller_id,
+            port,
+        },
+        menu::DeviceType::Usb {
+            controller_id: _,
+            device_addr: _,
+        } => StorageType::Usb { slot_id: 0 },
+        menu::DeviceType::Sdhci { controller_id } => StorageType::Sdhci { controller_id },
+    }
+}
+
+/// Try to boot from an ESP partition
+///
+/// This replaces the four `try_boot_from_esp_{usb,nvme,ahci,sdhci}` functions.
+/// It mounts FAT on the ESP, installs SimpleFileSystem + DevicePath + BlockIO
+/// protocols on a new handle, then loads and executes the EFI bootloader.
+///
+/// # Arguments
+/// * `disk` - Block device to read from
+/// * `esp` - ESP partition info
+/// * `partition_num` - 1-based partition number of the ESP
+/// * `path_info` - Device path info for protocol installation
+/// * `device_type` - Device type for creating block device and storage registration
+/// * `num_blocks` - Total number of blocks on the device
+/// * `block_size` - Block size in bytes
+pub fn try_boot_from_esp<D: BlockDevice>(
+    disk: &mut D,
+    esp: &fs::gpt::Partition,
+    partition_num: u32,
+    path_info: &DevicePathInfo,
+    device_type: &menu::DeviceType,
+    num_blocks: u64,
+    block_size: u32,
+) -> bool {
+    // Create block device for SimpleFileSystem
+    let block_device = match create_block_device_for_sfs(device_type, num_blocks, block_size) {
+        Some(bd) => bd,
+        None => {
+            log::error!("Failed to create block device for SFS");
+            return false;
+        }
+    };
+
+    // Initialize SimpleFileSystem protocol with the block device
+    let sfs_protocol = simple_file_system::init(block_device, esp.first_lba);
+    if sfs_protocol.is_null() {
+        log::error!("Failed to initialize SimpleFileSystem protocol");
+        return false;
+    }
+
+    // Mount FAT filesystem
+    match fs::fat::FatFilesystem::new(disk, esp.first_lba) {
+        Ok(mut fat) => {
+            log::info!("FAT filesystem mounted on ESP");
+
+            // Create a device handle with SimpleFileSystem and DevicePath protocols
+            let device_handle = match boot_services::create_handle() {
+                Some(h) => h,
+                None => {
+                    log::error!("Failed to create device handle");
+                    return false;
+                }
+            };
+
+            // Install DevicePath protocol on the device handle
+            let partition_size = esp.size_sectors();
+            let dp = device_path::create_partition_device_path(
+                path_info,
+                partition_num,
+                esp.first_lba,
+                partition_size,
+                &esp.partition_guid,
+            );
+
+            if !dp.is_null() {
+                let status = boot_services::install_protocol(
+                    device_handle,
+                    &DEVICE_PATH_PROTOCOL_GUID,
+                    dp as *mut core::ffi::c_void,
+                );
+                if status == Status::SUCCESS {
+                    log::info!(
+                        "DevicePath protocol installed on device handle {:?}",
+                        device_handle
+                    );
+                } else {
+                    log::warn!("Failed to install DevicePath protocol: {:?}", status);
+                }
+            }
+
+            // Install BlockIO protocol on the device handle
+            let storage_type = create_storage_type(device_type);
+            let storage_id = storage::register_device(storage_type, num_blocks, block_size);
+
+            if let Some(storage_id) = storage_id {
+                let block_io = block_io::create_partition_block_io(
+                    storage_id,
+                    partition_num,
+                    esp.first_lba,
+                    partition_size,
+                    block_size,
+                );
+
+                if !block_io.is_null() {
+                    let status = boot_services::install_protocol(
+                        device_handle,
+                        &BLOCK_IO_PROTOCOL_GUID,
+                        block_io as *mut core::ffi::c_void,
+                    );
+                    if status == Status::SUCCESS {
+                        log::info!(
+                            "BlockIO protocol installed on device handle {:?}",
+                            device_handle
+                        );
+                    } else {
+                        log::warn!("Failed to install BlockIO protocol: {:?}", status);
+                    }
+                }
+            }
+
+            // Install SimpleFileSystem protocol on the device handle
+            let status = boot_services::install_protocol(
+                device_handle,
+                &SIMPLE_FILE_SYSTEM_GUID,
+                sfs_protocol as *mut core::ffi::c_void,
+            );
+
+            if status != Status::SUCCESS {
+                log::error!("Failed to install SimpleFileSystem protocol: {:?}", status);
+                return false;
+            }
+
+            log::info!(
+                "SimpleFileSystem protocol installed on device handle {:?}",
+                device_handle
+            );
+
+            // Look for EFI bootloader
+            let boot_path = "EFI\\BOOT\\BOOTX64.EFI";
+            match fat.file_size(boot_path) {
+                Ok(size) => {
+                    log::info!("Found bootloader: {} ({} bytes)", boot_path, size);
+
+                    // Load and execute the bootloader with device handle
+                    match load_and_execute_bootloader(&mut fat, boot_path, size, device_handle) {
+                        Ok(()) => return true,
+                        Err(e) => {
+                            log::error!("Failed to execute bootloader: {:?}", e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    log::warn!("Bootloader not found: {:?}", e);
+                }
+            }
+        }
+        Err(e) => {
+            log::error!("Failed to mount FAT filesystem: {:?}", e);
+        }
+    }
+    false
+}
+
+/// Load and execute an EFI bootloader from the filesystem
+fn load_and_execute_bootloader(
+    fat: &mut fs::fat::FatFilesystem<'_>,
+    path: &str,
+    file_size: u32,
+    device_handle: r_efi::efi::Handle,
+) -> Result<(), Status> {
+    use crate::display_secure_boot_error;
+    use efi::allocator::{MemoryType, allocate_pool, free_pool};
+    use efi::protocols::loaded_image::{LOADED_IMAGE_PROTOCOL_GUID, create_loaded_image_protocol};
+
+    log::info!("Loading bootloader: {} ({} bytes)", path, file_size);
+
+    // Allocate buffer for raw file data
+    let buffer_ptr = allocate_pool(MemoryType::LoaderData, file_size as usize)
+        .map_err(|_| Status::OUT_OF_RESOURCES)?;
+
+    // Read the file into the buffer
+    let buffer = unsafe { core::slice::from_raw_parts_mut(buffer_ptr, file_size as usize) };
+
+    let bytes_read = fat.read_file_all(path, buffer).map_err(|e| {
+        log::error!("Failed to read bootloader file: {:?}", e);
+        let _ = free_pool(buffer_ptr);
+        Status::DEVICE_ERROR
+    })?;
+
+    log::info!("Read {} bytes from {}", bytes_read, path);
+
+    // Secure Boot verification (if enabled)
+    if efi::auth::is_secure_boot_enabled() {
+        log::debug!("Secure Boot: Verifying image...");
+        match efi::auth::verify_pe_image_secure_boot(&buffer[..bytes_read]) {
+            Ok(true) => {
+                log::info!("Secure Boot: Image verification passed");
+            }
+            Ok(false) => {
+                log::error!("Secure Boot: Image verification FAILED - not authorized");
+                display_secure_boot_error();
+                let _ = free_pool(buffer_ptr);
+                return Err(Status::SECURITY_VIOLATION);
+            }
+            Err(e) => {
+                log::error!("Secure Boot: Verification error: {:?}", e);
+                display_secure_boot_error();
+                let _ = free_pool(buffer_ptr);
+                return Err(Status::SECURITY_VIOLATION);
+            }
+        }
+    }
+
+    // Load the PE image
+    let loaded_image = pe::load_image(&buffer[..bytes_read]).inspect_err(|&status| {
+        log::error!("Failed to load PE image: {:?}", status);
+        let _ = free_pool(buffer_ptr);
+    })?;
+
+    // Free the raw file buffer
+    let _ = free_pool(buffer_ptr);
+
+    log::info!(
+        "PE image loaded at {:#x}, entry point {:#x}, size {:#x}",
+        loaded_image.image_base,
+        loaded_image.entry_point,
+        loaded_image.image_size
+    );
+
+    // Create an image handle for the loaded bootloader
+    let image_handle = boot_services::create_handle().ok_or_else(|| {
+        log::error!("Failed to create image handle");
+        Status::OUT_OF_RESOURCES
+    })?;
+
+    // Create and install LoadedImageProtocol
+    let system_table = efi::get_system_table();
+    let firmware_handle = efi::get_firmware_handle();
+
+    let loaded_image_protocol = create_loaded_image_protocol(
+        firmware_handle,
+        system_table,
+        device_handle,
+        loaded_image.image_base,
+        loaded_image.image_size,
+    );
+
+    if loaded_image_protocol.is_null() {
+        log::error!("Failed to create LoadedImageProtocol");
+        pe::unload_image(&loaded_image);
+        return Err(Status::OUT_OF_RESOURCES);
+    }
+
+    // Set the file path in LoadedImageProtocol
+    let file_path = device_path::create_file_path_device_path(path);
+    if !file_path.is_null() {
+        unsafe {
+            efi::protocols::loaded_image::set_file_path(loaded_image_protocol, file_path);
+        }
+        log::debug!("Set LoadedImage.FilePath to: {}", path);
+    }
+
+    let status = boot_services::install_protocol(
+        image_handle,
+        &LOADED_IMAGE_PROTOCOL_GUID,
+        loaded_image_protocol as *mut core::ffi::c_void,
+    );
+
+    if status != Status::SUCCESS {
+        log::error!("Failed to install LoadedImageProtocol: {:?}", status);
+        pe::unload_image(&loaded_image);
+        return Err(status);
+    }
+
+    log::info!("LoadedImageProtocol installed on handle {:?}", image_handle);
+    if !device_handle.is_null() {
+        log::info!(
+            "DeviceHandle set to {:?} (with SimpleFileSystem)",
+            device_handle
+        );
+    }
+    log::info!("Executing bootloader...");
+
+    // Debug: verify system table integrity before execution
+    unsafe {
+        let st = &*system_table;
+        log::debug!(
+            "SystemTable check: boot_services={:?}, runtime_services={:?}",
+            st.boot_services,
+            st.runtime_services
+        );
+        if !st.boot_services.is_null() {
+            let bs = &*st.boot_services;
+            log::debug!(
+                "BootServices check: signature={:#x}, check_event={:?}",
+                bs.hdr.signature,
+                bs.check_event
+            );
+        } else {
+            log::error!("CRITICAL: boot_services is NULL!");
+        }
+    }
+
+    // Execute the bootloader
+    let exec_status = pe::execute_image(&loaded_image, image_handle, system_table);
+
+    // If the bootloader returns, log it
+    log::info!("Bootloader returned with status: {:?}", exec_status);
+
+    // Clean up
+    pe::unload_image(&loaded_image);
+
+    if exec_status == Status::SUCCESS {
+        Ok(())
+    } else {
+        Err(exec_status)
+    }
+}
+
+/// Create DevicePathInfo from a BootEntry's device type and PCI info
+pub fn device_path_info_from_entry(entry: &menu::BootEntry) -> DevicePathInfo {
+    match entry.device_type {
+        menu::DeviceType::Nvme {
+            controller_id: _,
+            nsid,
+        } => DevicePathInfo::Nvme {
+            pci_device: entry.pci_device,
+            pci_function: entry.pci_function,
+            namespace_id: nsid,
+        },
+        menu::DeviceType::Ahci {
+            controller_id: _,
+            port,
+        } => DevicePathInfo::Ahci {
+            pci_device: entry.pci_device,
+            pci_function: entry.pci_function,
+            port: port as u16,
+        },
+        menu::DeviceType::Usb {
+            controller_id: _,
+            device_addr: _,
+        } => DevicePathInfo::Usb {
+            pci_device: entry.pci_device,
+            pci_function: entry.pci_function,
+            usb_port: 0,
+        },
+        menu::DeviceType::Sdhci { controller_id: _ } => DevicePathInfo::Sdhci {
+            pci_device: entry.pci_device,
+            pci_function: entry.pci_function,
+        },
+    }
+}

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -1,6 +1,25 @@
-//! Hardware drivers for CrabEFI
+//! Hardware Drivers for CrabEFI
 //!
 //! This module contains drivers for hardware devices needed to boot.
+//!
+//! # Driver Model
+//!
+//! PCI-based drivers implement the `pci::driver::PciDriver` trait with lifecycle
+//! methods (`probe`, `init`, `shutdown`). During PCI enumeration, the driver
+//! registry automatically binds matching drivers to discovered devices.
+//!
+//! Platform drivers (serial, keyboard, SPI) are initialized directly from
+//! hardware info provided by coreboot tables.
+//!
+//! # Storage Abstraction
+//!
+//! All storage drivers provide:
+//! - `init_device(&PciDevice)` — Initialize from a discovered PCI device
+//! - `shutdown()` — Clean shutdown for OS handoff
+//! - `BlockDevice` trait implementation for unified I/O
+//!
+//! The `block` module provides the `BlockDevice` trait and `AnyBlockDevice`
+//! enum for type-safe dispatch across storage types.
 
 pub mod ahci;
 pub mod block;

--- a/src/drivers/pci/access.rs
+++ b/src/drivers/pci/access.rs
@@ -1,0 +1,286 @@
+//! PCI Configuration Space Access Methods
+//!
+//! This module provides an abstraction over different PCI configuration space
+//! access methods:
+//! - **Legacy I/O CAM** (Configuration Access Mechanism): Uses I/O ports 0xCF8/0xCFC,
+//!   limited to 256 bytes of config space per function.
+//! - **ECAM** (Enhanced Configuration Access Mechanism): Memory-mapped PCIe extended
+//!   config space, supporting 4096 bytes per function.
+//!
+//! The access method is selected at runtime based on whether an ECAM base address
+//! is available (typically from ACPI MCFG table or coreboot tables).
+
+use super::PciAddress;
+
+/// Trait for PCI configuration space access
+///
+/// Implementations provide read/write access to PCI configuration space
+/// registers using different hardware mechanisms.
+pub trait PciAccess {
+    /// Read a 32-bit value from PCI configuration space
+    fn read32(&self, addr: PciAddress, offset: u16) -> u32;
+
+    /// Write a 32-bit value to PCI configuration space
+    fn write32(&self, addr: PciAddress, offset: u16, value: u32);
+
+    /// Read a 16-bit value from PCI configuration space
+    fn read16(&self, addr: PciAddress, offset: u16) -> u16 {
+        let aligned_offset = offset & !0x3;
+        let shift = (offset & 0x02) * 8;
+        let value = self.read32(addr, aligned_offset);
+        ((value >> shift) & 0xFFFF) as u16
+    }
+
+    /// Write a 16-bit value to PCI configuration space
+    fn write16(&self, addr: PciAddress, offset: u16, value: u16) {
+        let aligned_offset = offset & !0x3;
+        let shift = (offset & 0x02) * 8;
+        let current = self.read32(addr, aligned_offset);
+        let mask = !(0xFFFF_u32 << shift);
+        let new_value = (current & mask) | ((value as u32) << shift);
+        self.write32(addr, aligned_offset, new_value);
+    }
+
+    /// Read an 8-bit value from PCI configuration space
+    fn read8(&self, addr: PciAddress, offset: u16) -> u8 {
+        let aligned_offset = offset & !0x3;
+        let shift = (offset & 0x03) * 8;
+        let value = self.read32(addr, aligned_offset);
+        ((value >> shift) & 0xFF) as u8
+    }
+
+    /// Write an 8-bit value to PCI configuration space
+    fn write8(&self, addr: PciAddress, offset: u16, value: u8) {
+        let aligned_offset = offset & !0x3;
+        let shift = (offset & 0x03) * 8;
+        let current = self.read32(addr, aligned_offset);
+        let mask = !(0xFF_u32 << shift);
+        let new_value = (current & mask) | ((value as u32) << shift);
+        self.write32(addr, aligned_offset, new_value);
+    }
+
+    /// Name of this access method (for logging)
+    fn name(&self) -> &'static str;
+
+    /// Maximum config space offset supported
+    fn max_offset(&self) -> u16;
+}
+
+// ============================================================================
+// Legacy I/O CAM Access (ports 0xCF8/0xCFC)
+// ============================================================================
+
+/// PCI configuration space ports (legacy CAM)
+const PCI_CONFIG_ADDRESS: u16 = 0xCF8;
+const PCI_CONFIG_DATA: u16 = 0xCFC;
+
+/// Legacy I/O port-based PCI Configuration Access Mechanism
+///
+/// Uses x86 I/O ports 0xCF8 (address) and 0xCFC (data) to access
+/// the first 256 bytes of PCI configuration space.
+pub struct IoCamAccess;
+
+impl PciAccess for IoCamAccess {
+    #[cfg(target_arch = "x86_64")]
+    fn read32(&self, addr: PciAddress, offset: u16) -> u32 {
+        use x86_64::instructions::port::{Port, PortWriteOnly};
+
+        // Legacy CAM only supports 8-bit offsets (0-255)
+        debug_assert!(
+            offset <= 255,
+            "Legacy CAM only supports offsets 0-255, got {}",
+            offset
+        );
+        let offset = offset as u8;
+        let mut address_port: PortWriteOnly<u32> = PortWriteOnly::new(PCI_CONFIG_ADDRESS);
+        let mut data_port: Port<u32> = Port::new(PCI_CONFIG_DATA);
+
+        unsafe {
+            address_port.write(addr.cam_address(offset));
+            data_port.read()
+        }
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    fn read32(&self, _addr: PciAddress, _offset: u16) -> u32 {
+        0xFFFFFFFF
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn write32(&self, addr: PciAddress, offset: u16, value: u32) {
+        use x86_64::instructions::port::{Port, PortWriteOnly};
+
+        debug_assert!(
+            offset <= 255,
+            "Legacy CAM only supports offsets 0-255, got {}",
+            offset
+        );
+        let offset = offset as u8;
+        let mut address_port: PortWriteOnly<u32> = PortWriteOnly::new(PCI_CONFIG_ADDRESS);
+        let mut data_port: Port<u32> = Port::new(PCI_CONFIG_DATA);
+
+        unsafe {
+            address_port.write(addr.cam_address(offset));
+            data_port.write(value);
+        }
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    fn write32(&self, _addr: PciAddress, _offset: u16, _value: u32) {}
+
+    fn name(&self) -> &'static str {
+        "Legacy I/O CAM"
+    }
+
+    fn max_offset(&self) -> u16 {
+        255
+    }
+}
+
+// ============================================================================
+// PCIe ECAM Access (Memory-Mapped)
+// ============================================================================
+
+/// PCIe Enhanced Configuration Access Mechanism
+///
+/// Uses memory-mapped I/O to access the full 4096-byte PCIe extended
+/// configuration space. The base address comes from the ACPI MCFG table
+/// or coreboot tables.
+pub struct EcamAccess {
+    /// ECAM base address in physical memory
+    base: u64,
+}
+
+impl EcamAccess {
+    /// Create a new ECAM access instance
+    ///
+    /// # Arguments
+    /// * `base` - Physical base address of the ECAM region
+    pub const fn new(base: u64) -> Self {
+        Self { base }
+    }
+
+    /// Calculate the ECAM address for a given BDF and register offset
+    ///
+    /// ECAM address = base + (bus << 20) | (device << 15) | (function << 12) | offset
+    fn ecam_address(&self, addr: PciAddress, offset: u16) -> u64 {
+        self.base
+            | ((addr.bus as u64) << 20)
+            | ((addr.device as u64) << 15)
+            | ((addr.function as u64) << 12)
+            | ((offset as u64) & 0xFFC) // 4-byte aligned
+    }
+}
+
+impl PciAccess for EcamAccess {
+    fn read32(&self, addr: PciAddress, offset: u16) -> u32 {
+        let mmio_addr = self.ecam_address(addr, offset) as *const u32;
+        // Safety: ECAM region is mapped and valid, we only access aligned addresses
+        unsafe { core::ptr::read_volatile(mmio_addr) }
+    }
+
+    fn write32(&self, addr: PciAddress, offset: u16, value: u32) {
+        let mmio_addr = self.ecam_address(addr, offset) as *mut u32;
+        // Safety: ECAM region is mapped and valid, we only access aligned addresses
+        unsafe { core::ptr::write_volatile(mmio_addr, value) }
+    }
+
+    fn name(&self) -> &'static str {
+        "PCIe ECAM"
+    }
+
+    fn max_offset(&self) -> u16 {
+        4095
+    }
+}
+
+// ============================================================================
+// Runtime-Selected Access Method
+// ============================================================================
+
+/// Runtime-selected PCI access method
+///
+/// Wraps either `IoCamAccess` or `EcamAccess` and delegates all operations.
+/// This follows the same enum dispatch pattern used by `AnySpiController`
+/// and `AnyBlockDevice` elsewhere in the codebase.
+pub enum AnyPciAccess {
+    /// Legacy I/O port-based access (0xCF8/0xCFC)
+    IoCam(IoCamAccess),
+    /// Memory-mapped PCIe ECAM access
+    Ecam(EcamAccess),
+}
+
+impl PciAccess for AnyPciAccess {
+    fn read32(&self, addr: PciAddress, offset: u16) -> u32 {
+        match self {
+            Self::IoCam(a) => a.read32(addr, offset),
+            Self::Ecam(a) => a.read32(addr, offset),
+        }
+    }
+
+    fn write32(&self, addr: PciAddress, offset: u16, value: u32) {
+        match self {
+            Self::IoCam(a) => a.write32(addr, offset, value),
+            Self::Ecam(a) => a.write32(addr, offset, value),
+        }
+    }
+
+    fn read16(&self, addr: PciAddress, offset: u16) -> u16 {
+        match self {
+            Self::IoCam(a) => a.read16(addr, offset),
+            Self::Ecam(a) => a.read16(addr, offset),
+        }
+    }
+
+    fn write16(&self, addr: PciAddress, offset: u16, value: u16) {
+        match self {
+            Self::IoCam(a) => a.write16(addr, offset, value),
+            Self::Ecam(a) => a.write16(addr, offset, value),
+        }
+    }
+
+    fn read8(&self, addr: PciAddress, offset: u16) -> u8 {
+        match self {
+            Self::IoCam(a) => a.read8(addr, offset),
+            Self::Ecam(a) => a.read8(addr, offset),
+        }
+    }
+
+    fn write8(&self, addr: PciAddress, offset: u16, value: u8) {
+        match self {
+            Self::IoCam(a) => a.write8(addr, offset, value),
+            Self::Ecam(a) => a.write8(addr, offset, value),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::IoCam(a) => a.name(),
+            Self::Ecam(a) => a.name(),
+        }
+    }
+
+    fn max_offset(&self) -> u16 {
+        match self {
+            Self::IoCam(a) => a.max_offset(),
+            Self::Ecam(a) => a.max_offset(),
+        }
+    }
+}
+
+/// Create the appropriate PCI access method
+///
+/// If an ECAM base address is provided, uses memory-mapped ECAM access.
+/// Otherwise falls back to legacy I/O port CAM access.
+pub fn create_access(ecam_base: Option<u64>) -> AnyPciAccess {
+    match ecam_base {
+        Some(base) => {
+            log::info!("PCI: Using PCIe ECAM access at {:#x}", base);
+            AnyPciAccess::Ecam(EcamAccess::new(base))
+        }
+        None => {
+            log::info!("PCI: Using legacy I/O CAM access");
+            AnyPciAccess::IoCam(IoCamAccess)
+        }
+    }
+}

--- a/src/drivers/pci/driver.rs
+++ b/src/drivers/pci/driver.rs
@@ -1,0 +1,308 @@
+//! PCI Driver Model
+//!
+//! This module defines the PCI driver trait and a table-driven binding mechanism.
+//! Each PCI driver registers match criteria (class/subclass/vendor/device) and
+//! lifecycle methods (probe, init, shutdown).
+//!
+//! During PCI enumeration, the driver registry matches discovered devices against
+//! registered drivers and calls their lifecycle methods.
+
+use super::PciDevice;
+
+/// Error type for driver operations
+#[derive(Debug)]
+pub enum DriverError {
+    /// Device initialization failed
+    InitFailed,
+}
+
+impl core::fmt::Display for DriverError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InitFailed => write!(f, "initialization failed"),
+        }
+    }
+}
+
+/// Match criteria for PCI driver binding
+///
+/// Specifies which PCI devices a driver can handle, based on class codes
+/// and optionally vendor/device IDs.
+#[derive(Debug, Clone, Copy)]
+pub struct PciDriverMatch {
+    /// PCI class code (e.g., 0x01 for storage, 0x0C for serial bus)
+    pub class: u8,
+    /// PCI subclass code (e.g., 0x08 for NVMe, 0x06 for AHCI)
+    pub subclass: u8,
+    /// Optional programming interface filter (None = match any prog_if)
+    pub prog_if: Option<u8>,
+}
+
+/// PCI driver lifecycle trait
+///
+/// All PCI-based device drivers implement this trait to participate in
+/// automatic device binding during PCI enumeration.
+///
+/// # Lifecycle
+///
+/// 1. **Match**: PCI subsystem checks `match_criteria()` against discovered devices
+/// 2. **Probe**: `probe()` is called for matching devices to confirm the driver can handle them
+/// 3. **Init**: `init()` is called to initialize the hardware
+/// 4. **Shutdown**: `shutdown()` is called during ExitBootServices or system reset
+pub trait PciDriver: Sync {
+    /// Human-readable driver name
+    fn name(&self) -> &'static str;
+
+    /// PCI class/subclass criteria this driver handles
+    ///
+    /// The driver will be considered for any device matching one of these entries.
+    fn match_criteria(&self) -> &'static [PciDriverMatch];
+
+    /// Probe a PCI device to check if this driver can handle it
+    ///
+    /// Called after match_criteria filtering. This allows drivers to perform
+    /// additional checks (e.g., vendor ID filtering, capability checks).
+    ///
+    /// # Arguments
+    /// * `device` - The PCI device to probe
+    ///
+    /// # Returns
+    /// `true` if this driver claims the device
+    fn probe(&self, device: &PciDevice) -> bool;
+
+    /// Initialize the device
+    ///
+    /// Called after `probe()` returns `true`. The driver should:
+    /// 1. Enable the device (bus master, memory/IO space)
+    /// 2. Configure hardware (queues, ports, DMA, etc.)
+    /// 3. Register any discovered sub-devices (namespaces, ports, etc.)
+    ///
+    /// # Arguments
+    /// * `device` - The PCI device to initialize
+    fn init(&self, device: &PciDevice) -> Result<(), DriverError>;
+
+    /// Shutdown all devices managed by this driver
+    ///
+    /// Called during ExitBootServices or system reset. The driver should:
+    /// 1. Stop all pending I/O operations
+    /// 2. Disable interrupts
+    /// 3. Put hardware into a safe state
+    fn shutdown(&self) -> Result<(), DriverError>;
+}
+
+// ============================================================================
+// Driver Registry
+// ============================================================================
+
+use crate::drivers::{ahci, nvme, sdhci, usb};
+
+/// NVMe PCI driver
+struct NvmePciDriver;
+
+static NVME_MATCH: [PciDriverMatch; 1] = [PciDriverMatch {
+    class: super::CLASS_STORAGE,
+    subclass: super::SUBCLASS_NVME,
+    prog_if: None,
+}];
+
+impl PciDriver for NvmePciDriver {
+    fn name(&self) -> &'static str {
+        "NVMe"
+    }
+
+    fn match_criteria(&self) -> &'static [PciDriverMatch] {
+        &NVME_MATCH
+    }
+
+    fn probe(&self, _device: &PciDevice) -> bool {
+        true // Accept all NVMe controllers
+    }
+
+    fn init(&self, device: &PciDevice) -> Result<(), DriverError> {
+        nvme::init_device(device).map_err(|()| DriverError::InitFailed)
+    }
+
+    fn shutdown(&self) -> Result<(), DriverError> {
+        nvme::shutdown();
+        Ok(())
+    }
+}
+
+/// AHCI PCI driver
+struct AhciPciDriver;
+
+static AHCI_MATCH: [PciDriverMatch; 1] = [PciDriverMatch {
+    class: super::CLASS_STORAGE,
+    subclass: super::SUBCLASS_SATA,
+    prog_if: None,
+}];
+
+impl PciDriver for AhciPciDriver {
+    fn name(&self) -> &'static str {
+        "AHCI"
+    }
+
+    fn match_criteria(&self) -> &'static [PciDriverMatch] {
+        &AHCI_MATCH
+    }
+
+    fn probe(&self, _device: &PciDevice) -> bool {
+        true // Accept all AHCI controllers
+    }
+
+    fn init(&self, device: &PciDevice) -> Result<(), DriverError> {
+        ahci::init_device(device).map_err(|()| DriverError::InitFailed)
+    }
+
+    fn shutdown(&self) -> Result<(), DriverError> {
+        ahci::shutdown();
+        Ok(())
+    }
+}
+
+/// USB PCI driver (handles xHCI, EHCI, OHCI, UHCI via prog_if)
+struct UsbPciDriver;
+
+static USB_MATCH: [PciDriverMatch; 1] = [PciDriverMatch {
+    class: super::CLASS_SERIAL,
+    subclass: 0x03, // USB controller
+    prog_if: None,  // Match all: xHCI(0x30), EHCI(0x20), OHCI(0x10), UHCI(0x00)
+}];
+
+impl PciDriver for UsbPciDriver {
+    fn name(&self) -> &'static str {
+        "USB"
+    }
+
+    fn match_criteria(&self) -> &'static [PciDriverMatch] {
+        &USB_MATCH
+    }
+
+    fn probe(&self, device: &PciDevice) -> bool {
+        // Accept known USB controller types
+        matches!(device.prog_if, 0x00 | 0x10 | 0x20 | 0x30)
+    }
+
+    fn init(&self, device: &PciDevice) -> Result<(), DriverError> {
+        usb::init_device(device).map_err(|()| DriverError::InitFailed)
+    }
+
+    fn shutdown(&self) -> Result<(), DriverError> {
+        usb::shutdown();
+        Ok(())
+    }
+}
+
+/// SDHCI PCI driver
+struct SdhciPciDriver;
+
+static SDHCI_MATCH: [PciDriverMatch; 1] = [PciDriverMatch {
+    class: super::CLASS_SYSTEM,
+    subclass: super::SUBCLASS_SDHCI,
+    prog_if: None,
+}];
+
+impl PciDriver for SdhciPciDriver {
+    fn name(&self) -> &'static str {
+        "SDHCI"
+    }
+
+    fn match_criteria(&self) -> &'static [PciDriverMatch] {
+        &SDHCI_MATCH
+    }
+
+    fn probe(&self, _device: &PciDevice) -> bool {
+        true
+    }
+
+    fn init(&self, device: &PciDevice) -> Result<(), DriverError> {
+        sdhci::init_device(device).map_err(|()| DriverError::InitFailed)
+    }
+
+    fn shutdown(&self) -> Result<(), DriverError> {
+        sdhci::shutdown();
+        Ok(())
+    }
+}
+
+/// Static table of all PCI drivers
+///
+/// Drivers are probed in order. The first driver that matches and successfully
+/// probes a device gets to initialize it.
+static PCI_DRIVERS: &[&dyn PciDriver] = &[
+    &NvmePciDriver,
+    &AhciPciDriver,
+    &UsbPciDriver,
+    &SdhciPciDriver,
+];
+
+/// Bind drivers to a discovered PCI device
+///
+/// Iterates the driver table and calls probe/init for the first matching driver.
+///
+/// # Arguments
+/// * `device` - The PCI device to bind
+///
+/// # Returns
+/// The name of the driver that claimed the device, or None
+pub fn bind_driver(device: &PciDevice) -> Option<&'static str> {
+    for driver in PCI_DRIVERS {
+        // Check match criteria
+        let matches = driver.match_criteria().iter().any(|m| {
+            m.class == device.class_code
+                && m.subclass == device.subclass
+                && m.prog_if.is_none_or(|pif| pif == device.prog_if)
+        });
+
+        if !matches {
+            continue;
+        }
+
+        // Probe the device
+        if !driver.probe(device) {
+            continue;
+        }
+
+        // Initialize
+        log::info!(
+            "PCI {}: binding {} driver to {:04x}:{:04x}",
+            device.address,
+            driver.name(),
+            device.vendor_id,
+            device.device_id
+        );
+
+        match driver.init(device) {
+            Ok(()) => {
+                log::info!(
+                    "PCI {}: {} driver initialized successfully",
+                    device.address,
+                    driver.name()
+                );
+                return Some(driver.name());
+            }
+            Err(e) => {
+                log::error!(
+                    "PCI {}: {} driver init failed: {}",
+                    device.address,
+                    driver.name(),
+                    e
+                );
+                // Continue to try other drivers
+            }
+        }
+    }
+
+    None
+}
+
+/// Shutdown all PCI drivers
+///
+/// Called during ExitBootServices to cleanly stop all hardware.
+pub fn shutdown_all() {
+    for driver in PCI_DRIVERS {
+        if let Err(e) = driver.shutdown() {
+            log::warn!("{} driver shutdown failed: {}", driver.name(), e);
+        }
+    }
+}

--- a/src/efi/boot_services.rs
+++ b/src/efi/boot_services.rs
@@ -1411,8 +1411,8 @@ extern "efiapi" fn exit_boot_services(image_handle: Handle, map_key: usize) -> S
         // Re-enable keyboard interrupts so Linux's i8042 driver works
         crate::drivers::keyboard::cleanup();
 
-        // Stop and reset USB controllers so Linux can reinitialize them
-        crate::drivers::usb::cleanup();
+        // Shutdown all PCI drivers (USB, NVMe, AHCI, SDHCI) for OS handoff
+        crate::drivers::pci::shutdown_drivers();
 
         // Invalidate the coreboot framebuffer record to prevent a race condition
         // between Linux's simplefb (coreboot) and efifb (EFI GOP) drivers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ extern crate alloc;
 
 pub mod arch;
 pub mod bls;
+pub mod boot;
 pub mod coreboot;
 pub mod drivers;
 pub mod efi;
@@ -35,7 +36,7 @@ pub mod secure_boot_menu;
 pub mod state;
 pub mod time;
 
-use crate::drivers::block::{AhciDisk, BlockDevice, NvmeDisk, SdhciDisk, UsbDisk};
+use crate::drivers::block::{AhciDisk, NvmeDisk, SdhciDisk, UsbDisk};
 use core::panic::PanicInfo;
 
 /// Global panic handler
@@ -111,15 +112,6 @@ pub fn display_secure_boot_error() {
 
     // Wait 3 seconds so the user can see the message
     time::delay_ms(3000);
-}
-
-/// Sort partition candidates by size (smallest first)
-///
-/// Smaller partitions are tried first as they're more likely to be EFI boot partitions.
-fn sort_partitions_by_size(partitions: &mut heapless::Vec<(u32, fs::gpt::Partition), 8>) {
-    partitions
-        .as_mut_slice()
-        .sort_unstable_by_key(|(_, partition): &(u32, fs::gpt::Partition)| partition.size_bytes());
 }
 
 /// Initialize the CrabEFI firmware
@@ -375,11 +367,12 @@ fn init_storage() {
     // Print PCI devices (already initialized earlier for SPI detection)
     drivers::pci::print_devices();
 
-    // Initialize all storage controllers
-    drivers::nvme::init();
-    drivers::ahci::init();
-    drivers::usb::init_all();
-    drivers::sdhci::init();
+    // Bind PCI drivers to discovered devices (NVMe, AHCI, USB, SDHCI)
+    // This uses the table-driven driver model instead of hardcoded init calls
+    drivers::pci::bind_drivers();
+
+    // Initialize USB keyboards (needs to happen after USB controllers are bound)
+    drivers::usb::init_keyboards_public();
 
     // Initialize pass-through protocols for TCG Opal support
     efi::protocols::pass_thru_init::init();
@@ -458,22 +451,29 @@ fn boot_selected_entry(entry: &menu::BootEntry) {
 }
 
 /// Boot a UEFI entry (EFI application or UKI)
+///
+/// Uses the unified boot module to handle all storage types generically.
+/// The per-device-type code is limited to:
+/// 1. Storing the device globally (for SimpleFileSystem reads)
+/// 2. Getting disk info (num_blocks, block_size)
+/// 3. Creating a disk to pass to the generic functions
 fn boot_uefi_entry(entry: &menu::BootEntry) {
+    use drivers::storage::{self, StorageType};
+
+    let path_info = boot::device_path_info_from_entry(entry);
+
+    // Per-device-type: store globally, get info, register, install BlockIO, then boot
     match entry.device_type {
         menu::DeviceType::Nvme {
             controller_id,
             nsid,
         } => {
-            use drivers::storage::{self, StorageType};
-
-            // Ensure device is stored globally
             if !drivers::nvme::store_global_device(controller_id, nsid) {
                 log::error!("Failed to store NVMe device globally");
                 return;
             }
 
             if let Some(controller) = drivers::nvme::get_controller(controller_id) {
-                // Get disk info for storage registration
                 let (num_blocks, block_size) = match controller.default_namespace() {
                     Some(ns) => (ns.num_blocks, ns.block_size),
                     None => {
@@ -482,7 +482,6 @@ fn boot_uefi_entry(entry: &menu::BootEntry) {
                     }
                 };
 
-                // Register with storage abstraction (needed for BlockIO)
                 let storage_id = match storage::register_device(
                     StorageType::Nvme {
                         controller_id,
@@ -493,41 +492,34 @@ fn boot_uefi_entry(entry: &menu::BootEntry) {
                 ) {
                     Some(id) => id,
                     None => {
-                        log::error!("Failed to register NVMe device with storage");
+                        log::error!("Failed to register device");
                         return;
                     }
                 };
 
-                // Get PCI address
-                let pci_addr = controller.pci_address();
-
-                // Create disk for partition installation
                 let mut disk = NvmeDisk::new(controller, nsid);
-
-                // Install BlockIO for ALL partitions (GRUB needs this to enumerate)
-                let _ = install_block_io_for_nvme_disk(
-                    &mut disk,
-                    storage_id,
-                    block_size,
-                    num_blocks,
-                    pci_addr.device,
-                    pci_addr.function,
-                    nsid,
+                let _ = boot::install_block_io_protocols(
+                    &mut disk, storage_id, block_size, num_blocks, &path_info,
                 );
+            }
 
-                // Re-create disk and boot from ESP
-                if let Some(controller) = drivers::nvme::get_controller(controller_id) {
-                    let mut disk = NvmeDisk::new(controller, nsid);
-                    if try_boot_from_esp_nvme(
-                        &mut disk,
-                        &entry.partition,
-                        entry.partition_num,
-                        entry.pci_device,
-                        entry.pci_function,
-                        nsid,
-                    ) {
-                        return;
-                    }
+            // Re-create disk for ESP boot (previous borrows ended)
+            if let Some(controller) = drivers::nvme::get_controller(controller_id) {
+                let info = {
+                    let ns = controller.default_namespace().unwrap();
+                    (ns.num_blocks, ns.block_size)
+                };
+                let mut disk = NvmeDisk::new(controller, nsid);
+                if boot::try_boot_from_esp(
+                    &mut disk,
+                    &entry.partition,
+                    entry.partition_num,
+                    &path_info,
+                    &entry.device_type,
+                    info.0,
+                    info.1,
+                ) {
+                    return;
                 }
             }
             log::error!("Failed to boot NVMe entry");
@@ -536,16 +528,12 @@ fn boot_uefi_entry(entry: &menu::BootEntry) {
             controller_id,
             port,
         } => {
-            use drivers::storage::{self, StorageType};
-
-            // Ensure device is stored globally
             if !drivers::ahci::store_global_device(controller_id, port) {
                 log::error!("Failed to store AHCI device globally");
                 return;
             }
 
             if let Some(controller) = drivers::ahci::get_controller(controller_id) {
-                // Get disk info for storage registration
                 let (num_blocks, block_size) = match controller.get_port(port) {
                     Some(port_info) => (port_info.sector_count, port_info.sector_size),
                     None => {
@@ -554,7 +542,6 @@ fn boot_uefi_entry(entry: &menu::BootEntry) {
                     }
                 };
 
-                // Register with storage abstraction (needed for BlockIO)
                 let storage_id = match storage::register_device(
                     StorageType::Ahci {
                         controller_id,
@@ -565,41 +552,33 @@ fn boot_uefi_entry(entry: &menu::BootEntry) {
                 ) {
                     Some(id) => id,
                     None => {
-                        log::error!("Failed to register AHCI device with storage");
+                        log::error!("Failed to register device");
                         return;
                     }
                 };
 
-                // Get PCI address
-                let pci_addr = controller.pci_address();
-
-                // Create disk for partition installation
                 let mut disk = AhciDisk::new(controller, port);
-
-                // Install BlockIO for ALL partitions (GRUB needs this to enumerate)
-                let _ = install_block_io_for_ahci_disk(
-                    &mut disk,
-                    storage_id,
-                    block_size,
-                    num_blocks,
-                    pci_addr.device,
-                    pci_addr.function,
-                    port as u16,
+                let _ = boot::install_block_io_protocols(
+                    &mut disk, storage_id, block_size, num_blocks, &path_info,
                 );
+            }
 
-                // Re-create disk and boot from ESP
-                if let Some(controller) = drivers::ahci::get_controller(controller_id) {
-                    let mut disk = AhciDisk::new(controller, port);
-                    if try_boot_from_esp_ahci(
-                        &mut disk,
-                        &entry.partition,
-                        entry.partition_num,
-                        entry.pci_device,
-                        entry.pci_function,
-                        port as u16,
-                    ) {
-                        return;
-                    }
+            if let Some(controller) = drivers::ahci::get_controller(controller_id) {
+                let info = match controller.get_port(port) {
+                    Some(p) => (p.sector_count, p.sector_size),
+                    None => return,
+                };
+                let mut disk = AhciDisk::new(controller, port);
+                if boot::try_boot_from_esp(
+                    &mut disk,
+                    &entry.partition,
+                    entry.partition_num,
+                    &path_info,
+                    &entry.device_type,
+                    info.0,
+                    info.1,
+                ) {
+                    return;
                 }
             }
             log::error!("Failed to boot AHCI entry");
@@ -608,10 +587,6 @@ fn boot_uefi_entry(entry: &menu::BootEntry) {
             controller_id,
             device_addr: _,
         } => {
-            use drivers::storage::{self, StorageType};
-
-            // Get the controller pointer directly (no lock needed for the boot phase
-            // since global_read_sectors stores the pointer)
             let controller_ptr = match drivers::usb::get_controller_ptr(controller_id) {
                 Some(ptr) => ptr,
                 None => {
@@ -620,13 +595,10 @@ fn boot_uefi_entry(entry: &menu::BootEntry) {
                 }
             };
 
-            // USB device should already be stored globally from discovery
             if let Some(usb_device) = drivers::usb::mass_storage::get_global_device() {
-                // Get disk info for storage registration
                 let num_blocks = usb_device.num_blocks;
                 let block_size = usb_device.block_size;
 
-                // Register with storage abstraction (needed for BlockIO)
                 let storage_id = match storage::register_device(
                     StorageType::Usb { slot_id: 0 },
                     num_blocks,
@@ -634,42 +606,32 @@ fn boot_uefi_entry(entry: &menu::BootEntry) {
                 ) {
                     Some(id) => id,
                     None => {
-                        log::error!("Failed to register USB device with storage");
+                        log::error!("Failed to register device");
                         return;
                     }
                 };
 
                 // Safety: controller_ptr is valid for the entire boot process
                 let controller = unsafe { &mut *controller_ptr };
-
-                // Create disk for partition installation
                 if let Some(usb_device) = drivers::usb::mass_storage::get_global_device() {
                     let mut disk = UsbDisk::new(usb_device, controller);
-
-                    // Install BlockIO for ALL partitions (GRUB needs this to enumerate)
-                    let _ = install_block_io_for_disk(
-                        &mut disk,
-                        storage_id,
-                        block_size,
-                        num_blocks,
-                        entry.pci_device,
-                        entry.pci_function,
-                        0, // USB port
+                    let _ = boot::install_block_io_protocols(
+                        &mut disk, storage_id, block_size, num_blocks, &path_info,
                     );
                 }
 
-                // Re-get usb_device and controller for boot attempt
-                // (previous borrows have ended)
+                // Re-borrow for ESP boot
                 let controller = unsafe { &mut *controller_ptr };
                 if let Some(usb_device) = drivers::usb::mass_storage::get_global_device() {
                     let mut disk = UsbDisk::new(usb_device, controller);
-                    if try_boot_from_esp_usb(
+                    if boot::try_boot_from_esp(
                         &mut disk,
                         &entry.partition,
                         entry.partition_num,
-                        entry.pci_device,
-                        entry.pci_function,
-                        0, // USB port (default)
+                        &path_info,
+                        &entry.device_type,
+                        num_blocks,
+                        block_size,
                     ) {
                         return;
                     }
@@ -678,20 +640,15 @@ fn boot_uefi_entry(entry: &menu::BootEntry) {
             log::error!("Failed to boot USB entry");
         }
         menu::DeviceType::Sdhci { controller_id } => {
-            use drivers::storage::{self, StorageType};
-
-            // Ensure device is stored globally
             if !drivers::sdhci::store_global_device(controller_id) {
                 log::error!("Failed to store SDHCI device globally");
                 return;
             }
 
             if let Some(controller) = drivers::sdhci::get_controller(controller_id) {
-                // Get disk info for storage registration
                 let num_blocks = controller.num_blocks();
                 let block_size = controller.block_size();
 
-                // Register with storage abstraction (needed for BlockIO)
                 let storage_id = match storage::register_device(
                     StorageType::Sdhci { controller_id },
                     num_blocks,
@@ -699,39 +656,31 @@ fn boot_uefi_entry(entry: &menu::BootEntry) {
                 ) {
                     Some(id) => id,
                     None => {
-                        log::error!("Failed to register SDHCI device with storage");
+                        log::error!("Failed to register device");
                         return;
                     }
                 };
 
-                // Get PCI address
-                let pci_addr = controller.pci_address();
-
-                // Create disk for partition installation
                 let mut disk = SdhciDisk::new(controller);
-
-                // Install BlockIO for ALL partitions (GRUB needs this to enumerate)
-                let _ = install_block_io_for_sdhci_disk(
-                    &mut disk,
-                    storage_id,
-                    block_size,
-                    num_blocks,
-                    pci_addr.device,
-                    pci_addr.function,
+                let _ = boot::install_block_io_protocols(
+                    &mut disk, storage_id, block_size, num_blocks, &path_info,
                 );
+            }
 
-                // Re-create disk and boot from ESP
-                if let Some(controller) = drivers::sdhci::get_controller(controller_id) {
-                    let mut disk = SdhciDisk::new(controller);
-                    if try_boot_from_esp_sdhci(
-                        &mut disk,
-                        &entry.partition,
-                        entry.partition_num,
-                        entry.pci_device,
-                        entry.pci_function,
-                    ) {
-                        return;
-                    }
+            if let Some(controller) = drivers::sdhci::get_controller(controller_id) {
+                let num_blocks = controller.num_blocks();
+                let block_size = controller.block_size();
+                let mut disk = SdhciDisk::new(controller);
+                if boot::try_boot_from_esp(
+                    &mut disk,
+                    &entry.partition,
+                    entry.partition_num,
+                    &path_info,
+                    &entry.device_type,
+                    num_blocks,
+                    block_size,
+                ) {
+                    return;
                 }
             }
             log::error!("Failed to boot SDHCI entry");
@@ -1014,1605 +963,4 @@ fn boot_payload_entry(
     //
     // For now, log the attempt and return
     log::warn!("Payload chainloading not yet fully implemented");
-}
-
-/// Install BlockIO protocols for a disk and all its partitions
-///
-/// Returns the ESP partition and its partition number (1-based) if found.
-///
-/// # Arguments
-/// * `disk` - Disk to read GPT from
-/// * `storage_id` - Storage device ID for BlockIO
-/// * `block_size` - Block size in bytes
-/// * `num_blocks` - Total number of blocks
-/// * `pci_device` - PCI device number of the controller (for USB device path)
-/// * `pci_function` - PCI function number
-/// * `usb_port` - USB port number (0 for non-USB devices)
-fn install_block_io_for_disk<R: BlockDevice>(
-    disk: &mut R,
-    storage_id: u32,
-    block_size: u32,
-    num_blocks: u64,
-    pci_device: u8,
-    pci_function: u8,
-    usb_port: u8,
-) -> Option<(u32, fs::gpt::Partition)> {
-    use efi::boot_services;
-    use efi::protocols::block_io::{self, BLOCK_IO_PROTOCOL_GUID};
-    use efi::protocols::device_path::{self, DEVICE_PATH_PROTOCOL_GUID};
-    use r_efi::efi::Status;
-
-    // First, create BlockIO for the raw disk (whole device)
-    let disk_block_io = block_io::create_disk_block_io(storage_id, num_blocks, block_size);
-
-    if !disk_block_io.is_null()
-        && let Some(disk_handle) = boot_services::create_handle()
-    {
-        // Install BlockIO protocol
-        let status = boot_services::install_protocol(
-            disk_handle,
-            &BLOCK_IO_PROTOCOL_GUID,
-            disk_block_io as *mut core::ffi::c_void,
-        );
-        if status == Status::SUCCESS {
-            log::info!(
-                "BlockIO protocol installed for raw disk on handle {:?}",
-                disk_handle
-            );
-        }
-
-        // Install DevicePath protocol for the raw disk (USB device path)
-        let disk_device_path =
-            device_path::create_usb_device_path(pci_device, pci_function, usb_port);
-        if !disk_device_path.is_null() {
-            let status = boot_services::install_protocol(
-                disk_handle,
-                &DEVICE_PATH_PROTOCOL_GUID,
-                disk_device_path as *mut core::ffi::c_void,
-            );
-            if status == Status::SUCCESS {
-                log::info!(
-                    "DevicePath protocol installed for raw disk on handle {:?}",
-                    disk_handle
-                );
-            }
-        }
-    }
-
-    // Read GPT header and all partitions
-    let header = match fs::gpt::read_gpt_header(disk) {
-        Ok(h) => h,
-        Err(e) => {
-            log::debug!("Failed to read GPT header: {:?}", e);
-            return None;
-        }
-    };
-
-    let partitions = match fs::gpt::read_partitions(disk, &header) {
-        Ok(p) => p,
-        Err(e) => {
-            log::debug!("Failed to read partitions: {:?}", e);
-            return None;
-        }
-    };
-
-    let mut esp_partition: Option<(u32, fs::gpt::Partition)> = None;
-    let mut candidate_partitions: heapless::Vec<(u32, fs::gpt::Partition), 8> =
-        heapless::Vec::new();
-
-    // Create BlockIO for each partition
-    for (i, partition) in partitions.iter().enumerate() {
-        let partition_num = (i + 1) as u32;
-        let partition_blocks = partition.size_sectors();
-
-        let partition_block_io = block_io::create_partition_block_io(
-            storage_id,
-            partition_num,
-            partition.first_lba,
-            partition_blocks,
-            block_size,
-        );
-
-        if !partition_block_io.is_null()
-            && let Some(part_handle) = boot_services::create_handle()
-        {
-            // Install BlockIO
-            let status = boot_services::install_protocol(
-                part_handle,
-                &BLOCK_IO_PROTOCOL_GUID,
-                partition_block_io as *mut core::ffi::c_void,
-            );
-            if status == Status::SUCCESS {
-                log::info!(
-                    "BlockIO protocol installed for partition {} on handle {:?}",
-                    partition_num,
-                    part_handle
-                );
-            }
-
-            // Install DevicePath for partition (with full USB prefix for proper hierarchy)
-            let device_path = device_path::create_usb_partition_device_path(
-                pci_device,
-                pci_function,
-                usb_port,
-                partition_num,
-                partition.first_lba,
-                partition_blocks,
-                &partition.partition_guid,
-            );
-
-            if !device_path.is_null() {
-                let status = boot_services::install_protocol(
-                    part_handle,
-                    &DEVICE_PATH_PROTOCOL_GUID,
-                    device_path as *mut core::ffi::c_void,
-                );
-                if status == Status::SUCCESS {
-                    log::info!(
-                        "DevicePath protocol installed for partition {} on handle {:?}",
-                        partition_num,
-                        part_handle
-                    );
-                }
-            }
-        }
-
-        // Remember ESP for later (with partition number)
-        if partition.is_esp {
-            log::info!(
-                "Found ESP: partition {}, LBA {}-{} ({} MB)",
-                partition_num,
-                partition.first_lba,
-                partition.last_lba,
-                partition.size_bytes() / (1024 * 1024)
-            );
-            esp_partition = Some((partition_num, partition.clone()));
-        } else {
-            // Track as candidate for fallback (small partitions are more likely to be EFI boot)
-            // Prioritize smaller partitions (< 512 MB) as they're more likely to be EFI boot partitions
-            let size_mb = partition.size_bytes() / (1024 * 1024);
-            if size_mb > 0 && size_mb < 512 && partition.first_lba > 0 {
-                let _ = candidate_partitions.push((partition_num, partition.clone()));
-            }
-        }
-    }
-
-    // If we found a proper ESP, return it
-    if esp_partition.is_some() {
-        return esp_partition;
-    }
-
-    // No proper ESP found - try candidate partitions (smaller ones first, as they're more likely EFI)
-    sort_partitions_by_size(&mut candidate_partitions);
-
-    if let Some((partition_num, partition)) = candidate_partitions.first() {
-        log::debug!(
-            "Trying partition {} as potential ESP (no proper ESP found)",
-            partition_num
-        );
-        return Some((*partition_num, partition.clone()));
-    }
-
-    None
-}
-
-/// Install BlockIO protocols for an NVMe disk and all its partitions
-///
-/// Returns the ESP partition and its partition number (1-based) if found.
-///
-/// # Arguments
-/// * `disk` - Disk to read GPT from
-/// * `storage_id` - Storage device ID for BlockIO
-/// * `block_size` - Block size in bytes
-/// * `num_blocks` - Total number of blocks
-/// * `pci_device` - PCI device number of the NVMe controller
-/// * `pci_function` - PCI function number
-/// * `namespace_id` - NVMe namespace ID
-fn install_block_io_for_nvme_disk<R: BlockDevice>(
-    disk: &mut R,
-    storage_id: u32,
-    block_size: u32,
-    num_blocks: u64,
-    pci_device: u8,
-    pci_function: u8,
-    namespace_id: u32,
-) -> Option<(u32, fs::gpt::Partition)> {
-    use efi::boot_services;
-    use efi::protocols::block_io::{self, BLOCK_IO_PROTOCOL_GUID};
-    use efi::protocols::device_path::{self, DEVICE_PATH_PROTOCOL_GUID};
-    use r_efi::efi::Status;
-
-    // First, create BlockIO for the raw disk (whole device)
-    let disk_block_io = block_io::create_disk_block_io(storage_id, num_blocks, block_size);
-
-    if !disk_block_io.is_null()
-        && let Some(disk_handle) = boot_services::create_handle()
-    {
-        // Install BlockIO protocol
-        let status = boot_services::install_protocol(
-            disk_handle,
-            &BLOCK_IO_PROTOCOL_GUID,
-            disk_block_io as *mut core::ffi::c_void,
-        );
-        if status == Status::SUCCESS {
-            log::info!(
-                "BlockIO protocol installed for raw NVMe disk on handle {:?}",
-                disk_handle
-            );
-        }
-
-        // Install DevicePath protocol for the raw disk (NVMe device path)
-        let disk_device_path =
-            device_path::create_nvme_device_path(pci_device, pci_function, namespace_id);
-        if !disk_device_path.is_null() {
-            let status = boot_services::install_protocol(
-                disk_handle,
-                &DEVICE_PATH_PROTOCOL_GUID,
-                disk_device_path as *mut core::ffi::c_void,
-            );
-            if status == Status::SUCCESS {
-                log::info!(
-                    "DevicePath protocol installed for raw NVMe disk on handle {:?}",
-                    disk_handle
-                );
-            }
-        }
-    }
-
-    // Read GPT header and all partitions
-    let header = match fs::gpt::read_gpt_header(disk) {
-        Ok(h) => h,
-        Err(e) => {
-            log::debug!("Failed to read GPT header: {:?}", e);
-            return None;
-        }
-    };
-
-    let partitions = match fs::gpt::read_partitions(disk, &header) {
-        Ok(p) => p,
-        Err(e) => {
-            log::debug!("Failed to read partitions: {:?}", e);
-            return None;
-        }
-    };
-
-    let mut esp_partition: Option<(u32, fs::gpt::Partition)> = None;
-    let mut candidate_partitions: heapless::Vec<(u32, fs::gpt::Partition), 8> =
-        heapless::Vec::new();
-
-    // Create BlockIO for each partition
-    for (i, partition) in partitions.iter().enumerate() {
-        let partition_num = (i + 1) as u32;
-        let partition_blocks = partition.size_sectors();
-
-        let partition_block_io = block_io::create_partition_block_io(
-            storage_id,
-            partition_num,
-            partition.first_lba,
-            partition_blocks,
-            block_size,
-        );
-
-        if !partition_block_io.is_null()
-            && let Some(part_handle) = boot_services::create_handle()
-        {
-            // Install BlockIO
-            let status = boot_services::install_protocol(
-                part_handle,
-                &BLOCK_IO_PROTOCOL_GUID,
-                partition_block_io as *mut core::ffi::c_void,
-            );
-            if status == Status::SUCCESS {
-                log::info!(
-                    "BlockIO protocol installed for NVMe partition {} on handle {:?}",
-                    partition_num,
-                    part_handle
-                );
-            }
-
-            // Install DevicePath for partition (with full NVMe prefix for proper hierarchy)
-            let device_path = device_path::create_nvme_partition_device_path(
-                pci_device,
-                pci_function,
-                namespace_id,
-                partition_num,
-                partition.first_lba,
-                partition_blocks,
-                &partition.partition_guid,
-            );
-
-            if !device_path.is_null() {
-                let status = boot_services::install_protocol(
-                    part_handle,
-                    &DEVICE_PATH_PROTOCOL_GUID,
-                    device_path as *mut core::ffi::c_void,
-                );
-                if status == Status::SUCCESS {
-                    log::info!(
-                        "DevicePath protocol installed for NVMe partition {} on handle {:?}",
-                        partition_num,
-                        part_handle
-                    );
-                }
-            }
-        }
-
-        // Remember ESP for later (with partition number)
-        if partition.is_esp {
-            log::info!(
-                "Found ESP on NVMe: partition {}, LBA {}-{} ({} MB)",
-                partition_num,
-                partition.first_lba,
-                partition.last_lba,
-                partition.size_bytes() / (1024 * 1024)
-            );
-            esp_partition = Some((partition_num, partition.clone()));
-        } else {
-            // Track as candidate for fallback (small partitions are more likely to be EFI boot)
-            let size_mb = partition.size_bytes() / (1024 * 1024);
-            if size_mb > 0 && size_mb < 512 && partition.first_lba > 0 {
-                let _ = candidate_partitions.push((partition_num, partition.clone()));
-            }
-        }
-    }
-
-    // If we found a proper ESP, return it
-    if esp_partition.is_some() {
-        return esp_partition;
-    }
-
-    // No proper ESP found - try candidate partitions (smaller ones first)
-    sort_partitions_by_size(&mut candidate_partitions);
-
-    if let Some((partition_num, partition)) = candidate_partitions.first() {
-        log::debug!(
-            "Trying NVMe partition {} as potential ESP (no proper ESP found)",
-            partition_num
-        );
-        return Some((*partition_num, partition.clone()));
-    }
-
-    None
-}
-
-/// Install BlockIO protocols for an AHCI disk and all its partitions
-///
-/// Returns the ESP partition and its partition number (1-based) if found.
-///
-/// # Arguments
-/// * `disk` - Disk to read GPT from
-/// * `storage_id` - Storage device ID for BlockIO
-/// * `block_size` - Block size in bytes
-/// * `num_blocks` - Total number of blocks
-/// * `pci_device` - PCI device number of the AHCI controller
-/// * `pci_function` - PCI function number
-/// * `port` - AHCI port number
-fn install_block_io_for_ahci_disk<R: BlockDevice>(
-    disk: &mut R,
-    storage_id: u32,
-    block_size: u32,
-    num_blocks: u64,
-    pci_device: u8,
-    pci_function: u8,
-    port: u16,
-) -> Option<(u32, fs::gpt::Partition)> {
-    use efi::boot_services;
-    use efi::protocols::block_io::{self, BLOCK_IO_PROTOCOL_GUID};
-    use efi::protocols::device_path::{self, DEVICE_PATH_PROTOCOL_GUID};
-    use r_efi::efi::Status;
-
-    // First, create BlockIO for the raw disk (whole device)
-    let disk_block_io = block_io::create_disk_block_io(storage_id, num_blocks, block_size);
-
-    if !disk_block_io.is_null()
-        && let Some(disk_handle) = boot_services::create_handle()
-    {
-        // Install BlockIO protocol
-        let status = boot_services::install_protocol(
-            disk_handle,
-            &BLOCK_IO_PROTOCOL_GUID,
-            disk_block_io as *mut core::ffi::c_void,
-        );
-        if status == Status::SUCCESS {
-            log::info!(
-                "BlockIO protocol installed for raw AHCI disk on handle {:?}",
-                disk_handle
-            );
-        }
-
-        // Install DevicePath protocol for the raw disk (SATA device path)
-        let disk_device_path = device_path::create_sata_device_path(pci_device, pci_function, port);
-        if !disk_device_path.is_null() {
-            let status = boot_services::install_protocol(
-                disk_handle,
-                &DEVICE_PATH_PROTOCOL_GUID,
-                disk_device_path as *mut core::ffi::c_void,
-            );
-            if status == Status::SUCCESS {
-                log::info!(
-                    "DevicePath protocol installed for raw AHCI disk on handle {:?}",
-                    disk_handle
-                );
-            }
-        }
-    }
-
-    // Read GPT header and all partitions
-    let header = match fs::gpt::read_gpt_header(disk) {
-        Ok(h) => h,
-        Err(e) => {
-            log::debug!("Failed to read GPT header: {:?}", e);
-            return None;
-        }
-    };
-
-    let partitions = match fs::gpt::read_partitions(disk, &header) {
-        Ok(p) => p,
-        Err(e) => {
-            log::debug!("Failed to read partitions: {:?}", e);
-            return None;
-        }
-    };
-
-    let mut esp_partition: Option<(u32, fs::gpt::Partition)> = None;
-    let mut candidate_partitions: heapless::Vec<(u32, fs::gpt::Partition), 8> =
-        heapless::Vec::new();
-
-    // Create BlockIO for each partition
-    for (i, partition) in partitions.iter().enumerate() {
-        let partition_num = (i + 1) as u32;
-        let partition_blocks = partition.size_sectors();
-
-        let partition_block_io = block_io::create_partition_block_io(
-            storage_id,
-            partition_num,
-            partition.first_lba,
-            partition_blocks,
-            block_size,
-        );
-
-        if !partition_block_io.is_null()
-            && let Some(part_handle) = boot_services::create_handle()
-        {
-            // Install BlockIO
-            let status = boot_services::install_protocol(
-                part_handle,
-                &BLOCK_IO_PROTOCOL_GUID,
-                partition_block_io as *mut core::ffi::c_void,
-            );
-            if status == Status::SUCCESS {
-                log::info!(
-                    "BlockIO protocol installed for AHCI partition {} on handle {:?}",
-                    partition_num,
-                    part_handle
-                );
-            }
-
-            // Install DevicePath for partition (with full SATA prefix for proper hierarchy)
-            let device_path = device_path::create_sata_partition_device_path(
-                pci_device,
-                pci_function,
-                port,
-                partition_num,
-                partition.first_lba,
-                partition_blocks,
-                &partition.partition_guid,
-            );
-
-            if !device_path.is_null() {
-                let status = boot_services::install_protocol(
-                    part_handle,
-                    &DEVICE_PATH_PROTOCOL_GUID,
-                    device_path as *mut core::ffi::c_void,
-                );
-                if status == Status::SUCCESS {
-                    log::info!(
-                        "DevicePath protocol installed for AHCI partition {} on handle {:?}",
-                        partition_num,
-                        part_handle
-                    );
-                }
-            }
-        }
-
-        // Remember ESP for later (with partition number)
-        if partition.is_esp {
-            log::info!(
-                "Found ESP on AHCI: partition {}, LBA {}-{} ({} MB)",
-                partition_num,
-                partition.first_lba,
-                partition.last_lba,
-                partition.size_bytes() / (1024 * 1024)
-            );
-            esp_partition = Some((partition_num, partition.clone()));
-        } else {
-            // Track as candidate for fallback (small partitions are more likely to be EFI boot)
-            let size_mb = partition.size_bytes() / (1024 * 1024);
-            if size_mb > 0 && size_mb < 512 && partition.first_lba > 0 {
-                let _ = candidate_partitions.push((partition_num, partition.clone()));
-            }
-        }
-    }
-
-    // If we found a proper ESP, return it
-    if esp_partition.is_some() {
-        return esp_partition;
-    }
-
-    // No proper ESP found - try candidate partitions (smaller ones first)
-    sort_partitions_by_size(&mut candidate_partitions);
-
-    if let Some((partition_num, partition)) = candidate_partitions.first() {
-        log::debug!(
-            "Trying AHCI partition {} as potential ESP (no proper ESP found)",
-            partition_num
-        );
-        return Some((*partition_num, partition.clone()));
-    }
-
-    None
-}
-
-/// Try to boot from an ESP on USB (with SimpleFileSystem support)
-///
-/// # Arguments
-/// * `disk` - USB disk to read from (any SectorRead implementer)
-/// * `esp` - ESP partition info
-/// * `partition_num` - 1-based partition number of the ESP
-/// * `pci_device` - PCI device number of USB controller
-/// * `pci_function` - PCI function number
-/// * `usb_port` - USB port number
-fn try_boot_from_esp_usb<D: BlockDevice>(
-    disk: &mut D,
-    esp: &fs::gpt::Partition,
-    partition_num: u32,
-    pci_device: u8,
-    pci_function: u8,
-    usb_port: u8,
-) -> bool {
-    use drivers::block::{AnyBlockDevice, UsbBlockDevice};
-    use drivers::storage::{self, StorageType};
-    use efi::boot_services;
-    use efi::protocols::block_io::{self, BLOCK_IO_PROTOCOL_GUID};
-    use efi::protocols::device_path::{self, DEVICE_PATH_PROTOCOL_GUID};
-    use efi::protocols::simple_file_system::{self, SIMPLE_FILE_SYSTEM_GUID};
-    use r_efi::efi::Status;
-
-    // Get USB device info for creating block device
-    let (controller_id, device_addr, num_blocks, block_size) =
-        match drivers::usb::mass_storage::get_global_device() {
-            Some(usb_device) => (
-                0usize, // Controller ID (we only support one controller)
-                usb_device.slot_id(),
-                usb_device.num_blocks,
-                usb_device.block_size,
-            ),
-            None => {
-                log::error!("USB device not available");
-                return false;
-            }
-        };
-
-    // Create a UsbBlockDevice for the SimpleFileSystem protocol
-    let usb_block_device =
-        UsbBlockDevice::new(controller_id, device_addr, num_blocks, block_size, 0);
-    let block_device = AnyBlockDevice::Usb(usb_block_device);
-
-    // Initialize SimpleFileSystem protocol with the block device
-    let sfs_protocol = simple_file_system::init(block_device, esp.first_lba);
-    if sfs_protocol.is_null() {
-        log::error!("Failed to initialize SimpleFileSystem protocol");
-        return false;
-    }
-
-    // Verify filesystem is accessible by creating a temporary FatFilesystem
-    match fs::fat::FatFilesystem::new(disk, esp.first_lba) {
-        Ok(mut fat) => {
-            log::info!("FAT filesystem mounted on ESP");
-
-            // Create a device handle with SimpleFileSystem and DevicePath protocols
-            let device_handle = match boot_services::create_handle() {
-                Some(h) => h,
-                None => {
-                    log::error!("Failed to create device handle");
-                    return false;
-                }
-            };
-
-            // Install DevicePath protocol on the device handle
-            // Use full USB partition path for proper hierarchy matching
-            let partition_size = esp.size_sectors();
-            let device_path = device_path::create_usb_partition_device_path(
-                pci_device,
-                pci_function,
-                usb_port,
-                partition_num,
-                esp.first_lba,
-                partition_size,
-                &esp.partition_guid,
-            );
-
-            if !device_path.is_null() {
-                let status = boot_services::install_protocol(
-                    device_handle,
-                    &DEVICE_PATH_PROTOCOL_GUID,
-                    device_path as *mut core::ffi::c_void,
-                );
-                if status == Status::SUCCESS {
-                    log::info!(
-                        "DevicePath protocol installed on device handle {:?}",
-                        device_handle
-                    );
-                } else {
-                    log::warn!("Failed to install DevicePath protocol: {:?}", status);
-                }
-            }
-
-            // Install BlockIO protocol on the device handle
-            // The bootloader needs this to access the disk
-            if let Some(usb_device) = drivers::usb::mass_storage::get_global_device() {
-                let block_size = usb_device.block_size;
-                let num_blocks = usb_device.num_blocks;
-                // Get slot_id from the device
-                let slot_id = usb_device.slot_id();
-
-                let storage_id =
-                    storage::register_device(StorageType::Usb { slot_id }, num_blocks, block_size);
-
-                if let Some(storage_id) = storage_id {
-                    let block_io = block_io::create_partition_block_io(
-                        storage_id,
-                        partition_num,
-                        esp.first_lba,
-                        partition_size,
-                        block_size,
-                    );
-
-                    if !block_io.is_null() {
-                        let status = boot_services::install_protocol(
-                            device_handle,
-                            &BLOCK_IO_PROTOCOL_GUID,
-                            block_io as *mut core::ffi::c_void,
-                        );
-                        if status == Status::SUCCESS {
-                            log::info!(
-                                "BlockIO protocol installed on device handle {:?}",
-                                device_handle
-                            );
-                        } else {
-                            log::warn!("Failed to install BlockIO protocol: {:?}", status);
-                        }
-                    }
-                }
-            }
-
-            // Install SimpleFileSystem protocol on the device handle
-            let status = boot_services::install_protocol(
-                device_handle,
-                &SIMPLE_FILE_SYSTEM_GUID,
-                sfs_protocol as *mut core::ffi::c_void,
-            );
-
-            if status != Status::SUCCESS {
-                log::error!("Failed to install SimpleFileSystem protocol: {:?}", status);
-                return false;
-            }
-
-            log::info!(
-                "SimpleFileSystem protocol installed on device handle {:?}",
-                device_handle
-            );
-
-            // Look for EFI bootloader
-            let boot_path = "EFI\\BOOT\\BOOTX64.EFI";
-            match fat.file_size(boot_path) {
-                Ok(size) => {
-                    log::info!("Found bootloader: {} ({} bytes)", boot_path, size);
-
-                    // Load and execute the bootloader with device handle
-                    match load_and_execute_bootloader(&mut fat, boot_path, size, device_handle) {
-                        Ok(()) => return true,
-                        Err(e) => {
-                            log::error!("Failed to execute bootloader: {:?}", e);
-                        }
-                    }
-                }
-                Err(e) => {
-                    log::warn!("Bootloader not found: {:?}", e);
-                }
-            }
-        }
-        Err(e) => {
-            log::error!("Failed to mount FAT filesystem: {:?}", e);
-        }
-    }
-    false
-}
-
-/// Debug helper: check if system table is intact
-fn check_system_table_integrity(label: &str) {
-    let st = efi::get_system_table();
-    unsafe {
-        let bs = (*st).boot_services;
-        if bs.is_null() {
-            log::error!("[{}] CORRUPTION: boot_services is NULL!", label);
-        } else {
-            let sig = (*bs).hdr.signature;
-            if sig != 0x56524553544f4f42 {
-                // "BOOTSERV"
-                log::error!(
-                    "[{}] CORRUPTION: boot_services signature wrong: {:#x}",
-                    label,
-                    sig
-                );
-            } else {
-                log::debug!("[{}] SystemTable OK, BS={:?}", label, bs);
-            }
-        }
-    }
-}
-
-/// Try to boot from an ESP on NVMe (with SimpleFileSystem support)
-///
-/// # Arguments
-/// * `disk` - NVMe disk to read from
-/// * `esp` - ESP partition info
-/// * `partition_num` - 1-based partition number of the ESP
-/// * `pci_device` - PCI device number of NVMe controller
-/// * `pci_function` - PCI function number
-/// * `namespace_id` - NVMe namespace ID
-fn try_boot_from_esp_nvme(
-    disk: &mut NvmeDisk,
-    esp: &fs::gpt::Partition,
-    partition_num: u32,
-    pci_device: u8,
-    pci_function: u8,
-    namespace_id: u32,
-) -> bool {
-    use drivers::block::{AnyBlockDevice, NvmeBlockDevice};
-    use drivers::storage::{self, StorageType};
-    use efi::boot_services;
-    use efi::protocols::block_io::{self, BLOCK_IO_PROTOCOL_GUID};
-    use efi::protocols::device_path::{self, DEVICE_PATH_PROTOCOL_GUID};
-    use efi::protocols::simple_file_system::{self, SIMPLE_FILE_SYSTEM_GUID};
-    use r_efi::efi::Status;
-
-    check_system_table_integrity("NVMe: start");
-
-    // Get NVMe device info for creating block device
-    let (num_blocks, block_size) = {
-        let info = disk.info();
-        (info.num_blocks, info.block_size)
-    };
-
-    // Create an NvmeBlockDevice for the SimpleFileSystem protocol
-    let nvme_block_device = NvmeBlockDevice::new(0, namespace_id, num_blocks, block_size, 0);
-    let block_device = AnyBlockDevice::Nvme(nvme_block_device);
-
-    // Initialize SimpleFileSystem protocol with the block device
-    let sfs_protocol = simple_file_system::init(block_device, esp.first_lba);
-    if sfs_protocol.is_null() {
-        log::error!("Failed to initialize SimpleFileSystem protocol");
-        return false;
-    }
-    check_system_table_integrity("NVMe: after SFS init");
-
-    match fs::fat::FatFilesystem::new(disk, esp.first_lba) {
-        Ok(mut fat) => {
-            log::info!("FAT filesystem mounted on ESP");
-            check_system_table_integrity("NVMe: after FAT mount");
-
-            // Create a device handle with SimpleFileSystem and DevicePath protocols
-            let device_handle = match boot_services::create_handle() {
-                Some(h) => h,
-                None => {
-                    log::error!("Failed to create device handle");
-                    return false;
-                }
-            };
-
-            // Install DevicePath protocol on the device handle
-            // Use full NVMe partition path for proper hierarchy matching
-            let partition_size = esp.size_sectors();
-            let device_path = device_path::create_nvme_partition_device_path(
-                pci_device,
-                pci_function,
-                namespace_id,
-                partition_num,
-                esp.first_lba,
-                partition_size,
-                &esp.partition_guid,
-            );
-
-            if !device_path.is_null() {
-                let status = boot_services::install_protocol(
-                    device_handle,
-                    &DEVICE_PATH_PROTOCOL_GUID,
-                    device_path as *mut core::ffi::c_void,
-                );
-                if status == Status::SUCCESS {
-                    log::info!(
-                        "DevicePath protocol installed on device handle {:?}",
-                        device_handle
-                    );
-                } else {
-                    log::warn!("Failed to install DevicePath protocol: {:?}", status);
-                }
-            }
-
-            // Install BlockIO protocol on the device handle
-            // The bootloader needs this to access the disk
-            if let Some(controller) = drivers::nvme::get_controller(0)
-                && let Some(ns) = controller.default_namespace()
-            {
-                let block_size = ns.block_size;
-                let storage_id = storage::register_device(
-                    StorageType::Nvme {
-                        controller_id: 0,
-                        nsid: namespace_id,
-                    },
-                    ns.num_blocks,
-                    block_size,
-                );
-
-                if let Some(storage_id) = storage_id {
-                    let block_io = block_io::create_partition_block_io(
-                        storage_id,
-                        partition_num,
-                        esp.first_lba,
-                        partition_size,
-                        block_size,
-                    );
-
-                    if !block_io.is_null() {
-                        let status = boot_services::install_protocol(
-                            device_handle,
-                            &BLOCK_IO_PROTOCOL_GUID,
-                            block_io as *mut core::ffi::c_void,
-                        );
-                        if status == Status::SUCCESS {
-                            log::info!(
-                                "BlockIO protocol installed on device handle {:?}",
-                                device_handle
-                            );
-                        } else {
-                            log::warn!("Failed to install BlockIO protocol: {:?}", status);
-                        }
-                    }
-                }
-            }
-
-            // Install SimpleFileSystem protocol on the device handle
-            let status = boot_services::install_protocol(
-                device_handle,
-                &SIMPLE_FILE_SYSTEM_GUID,
-                sfs_protocol as *mut core::ffi::c_void,
-            );
-
-            if status != Status::SUCCESS {
-                log::error!("Failed to install SimpleFileSystem protocol: {:?}", status);
-                return false;
-            }
-
-            log::info!(
-                "SimpleFileSystem protocol installed on device handle {:?}",
-                device_handle
-            );
-
-            // Look for EFI bootloader
-            let boot_path = "EFI\\BOOT\\BOOTX64.EFI";
-            match fat.file_size(boot_path) {
-                Ok(size) => {
-                    log::info!("Found bootloader: {} ({} bytes)", boot_path, size);
-
-                    // Load and execute the bootloader with device handle
-                    match load_and_execute_bootloader(&mut fat, boot_path, size, device_handle) {
-                        Ok(()) => return true,
-                        Err(e) => {
-                            log::error!("Failed to execute bootloader: {:?}", e);
-                        }
-                    }
-                }
-                Err(e) => {
-                    log::warn!("Bootloader not found: {:?}", e);
-                }
-            }
-        }
-        Err(e) => {
-            log::error!("Failed to mount FAT filesystem: {:?}", e);
-        }
-    }
-    false
-}
-
-/// Try to boot from an ESP on AHCI (with SimpleFileSystem support)
-///
-/// # Arguments
-/// * `disk` - AHCI disk to read from
-/// * `esp` - ESP partition info
-/// * `partition_num` - 1-based partition number of the ESP
-/// * `pci_device` - PCI device number of AHCI controller
-/// * `pci_function` - PCI function number
-/// * `port` - AHCI port number
-fn try_boot_from_esp_ahci(
-    disk: &mut AhciDisk,
-    esp: &fs::gpt::Partition,
-    partition_num: u32,
-    pci_device: u8,
-    pci_function: u8,
-    port: u16,
-) -> bool {
-    use drivers::block::{AhciBlockDevice, AnyBlockDevice};
-    use drivers::storage::{self, StorageType};
-    use efi::boot_services;
-    use efi::protocols::block_io::{self, BLOCK_IO_PROTOCOL_GUID};
-    use efi::protocols::device_path::{self, DEVICE_PATH_PROTOCOL_GUID};
-    use efi::protocols::simple_file_system::{self, SIMPLE_FILE_SYSTEM_GUID};
-    use r_efi::efi::Status;
-
-    // Get AHCI device info for creating block device
-    let (num_blocks, block_size) = {
-        let info = disk.info();
-        (info.num_blocks, info.block_size)
-    };
-
-    // Create an AhciBlockDevice for the SimpleFileSystem protocol
-    let ahci_block_device = AhciBlockDevice::new(0, port as usize, num_blocks, block_size, 0);
-    let block_device = AnyBlockDevice::Ahci(ahci_block_device);
-
-    // Initialize SimpleFileSystem protocol with the block device
-    let sfs_protocol = simple_file_system::init(block_device, esp.first_lba);
-    if sfs_protocol.is_null() {
-        log::error!("Failed to initialize SimpleFileSystem protocol");
-        return false;
-    }
-
-    match fs::fat::FatFilesystem::new(disk, esp.first_lba) {
-        Ok(mut fat) => {
-            log::info!("FAT filesystem mounted on ESP");
-
-            // Create a device handle with SimpleFileSystem and DevicePath protocols
-            let device_handle = match boot_services::create_handle() {
-                Some(h) => h,
-                None => {
-                    log::error!("Failed to create device handle");
-                    return false;
-                }
-            };
-
-            // Install DevicePath protocol on the device handle
-            // Use CDROM device path for El Torito (partition_num = 0) or
-            // HardDrive device path for GPT partitions
-            let partition_size = esp.size_sectors();
-            let device_path = if partition_num == 0 {
-                // El Torito boot - use CD-ROM device path
-                device_path::create_sata_cdrom_device_path(
-                    pci_device,
-                    pci_function,
-                    port,
-                    0, // boot_entry (El Torito catalog entry)
-                    esp.first_lba,
-                    partition_size,
-                )
-            } else {
-                // GPT partition - use HardDrive device path
-                device_path::create_sata_partition_device_path(
-                    pci_device,
-                    pci_function,
-                    port,
-                    partition_num,
-                    esp.first_lba,
-                    partition_size,
-                    &esp.partition_guid,
-                )
-            };
-
-            if !device_path.is_null() {
-                let status = boot_services::install_protocol(
-                    device_handle,
-                    &DEVICE_PATH_PROTOCOL_GUID,
-                    device_path as *mut core::ffi::c_void,
-                );
-                if status == Status::SUCCESS {
-                    log::info!(
-                        "DevicePath protocol installed on device handle {:?}",
-                        device_handle
-                    );
-                } else {
-                    log::warn!("Failed to install DevicePath protocol: {:?}", status);
-                }
-            }
-
-            // Install BlockIO protocol on the device handle
-            // The bootloader needs this to access the disk
-            // First register the storage device
-            if let Some(controller) = drivers::ahci::get_controller(0)
-                && let Some(port_info) = controller.get_port(port as usize)
-            {
-                let block_size = port_info.sector_size;
-                let storage_id = storage::register_device(
-                    StorageType::Ahci {
-                        controller_id: 0,
-                        port: port as usize,
-                    },
-                    port_info.sector_count,
-                    block_size,
-                );
-
-                if let Some(storage_id) = storage_id {
-                    let block_io = block_io::create_partition_block_io(
-                        storage_id,
-                        partition_num,
-                        esp.first_lba,
-                        partition_size,
-                        block_size,
-                    );
-
-                    if !block_io.is_null() {
-                        let status = boot_services::install_protocol(
-                            device_handle,
-                            &BLOCK_IO_PROTOCOL_GUID,
-                            block_io as *mut core::ffi::c_void,
-                        );
-                        if status == Status::SUCCESS {
-                            log::info!(
-                                "BlockIO protocol installed on device handle {:?}",
-                                device_handle
-                            );
-                        } else {
-                            log::warn!("Failed to install BlockIO protocol: {:?}", status);
-                        }
-                    }
-                }
-            }
-
-            // Install SimpleFileSystem protocol on the device handle
-            let status = boot_services::install_protocol(
-                device_handle,
-                &SIMPLE_FILE_SYSTEM_GUID,
-                sfs_protocol as *mut core::ffi::c_void,
-            );
-
-            if status != Status::SUCCESS {
-                log::error!("Failed to install SimpleFileSystem protocol: {:?}", status);
-                return false;
-            }
-
-            log::info!(
-                "SimpleFileSystem protocol installed on device handle {:?}",
-                device_handle
-            );
-
-            // Look for EFI bootloader
-            let boot_path = "EFI\\BOOT\\BOOTX64.EFI";
-            match fat.file_size(boot_path) {
-                Ok(size) => {
-                    log::info!("Found bootloader: {} ({} bytes)", boot_path, size);
-
-                    // Load and execute the bootloader with device handle
-                    match load_and_execute_bootloader(&mut fat, boot_path, size, device_handle) {
-                        Ok(()) => return true,
-                        Err(e) => {
-                            log::error!("Failed to execute bootloader: {:?}", e);
-                        }
-                    }
-                }
-                Err(e) => {
-                    log::warn!("Bootloader not found: {:?}", e);
-                }
-            }
-        }
-        Err(e) => {
-            log::error!("Failed to mount FAT filesystem: {:?}", e);
-        }
-    }
-    false
-}
-
-/// Load and execute an EFI bootloader from the filesystem
-fn load_and_execute_bootloader(
-    fat: &mut fs::fat::FatFilesystem<'_>,
-    path: &str,
-    file_size: u32,
-    device_handle: r_efi::efi::Handle,
-) -> Result<(), r_efi::efi::Status> {
-    use efi::allocator::{MemoryType, allocate_pool, free_pool};
-    use efi::boot_services;
-    use efi::protocols::loaded_image::{LOADED_IMAGE_PROTOCOL_GUID, create_loaded_image_protocol};
-    use r_efi::efi::Status;
-
-    log::info!("Loading bootloader: {} ({} bytes)", path, file_size);
-
-    // Allocate buffer for raw file data
-    let buffer_ptr = allocate_pool(MemoryType::LoaderData, file_size as usize)
-        .map_err(|_| Status::OUT_OF_RESOURCES)?;
-
-    // Read the file into the buffer
-    let buffer = unsafe { core::slice::from_raw_parts_mut(buffer_ptr, file_size as usize) };
-
-    let bytes_read = fat.read_file_all(path, buffer).map_err(|e| {
-        log::error!("Failed to read bootloader file: {:?}", e);
-        let _ = free_pool(buffer_ptr);
-        Status::DEVICE_ERROR
-    })?;
-
-    log::info!("Read {} bytes from {}", bytes_read, path);
-
-    // Secure Boot verification (if enabled)
-    if efi::auth::is_secure_boot_enabled() {
-        log::debug!("Secure Boot: Verifying image...");
-        match efi::auth::verify_pe_image_secure_boot(&buffer[..bytes_read]) {
-            Ok(true) => {
-                log::info!("Secure Boot: Image verification passed");
-            }
-            Ok(false) => {
-                log::error!("Secure Boot: Image verification FAILED - not authorized");
-                display_secure_boot_error();
-                let _ = free_pool(buffer_ptr);
-                return Err(Status::SECURITY_VIOLATION);
-            }
-            Err(e) => {
-                log::error!("Secure Boot: Verification error: {:?}", e);
-                display_secure_boot_error();
-                let _ = free_pool(buffer_ptr);
-                return Err(Status::SECURITY_VIOLATION);
-            }
-        }
-    }
-
-    // Load the PE image
-    let loaded_image = pe::load_image(&buffer[..bytes_read]).inspect_err(|&status| {
-        log::error!("Failed to load PE image: {:?}", status);
-        let _ = free_pool(buffer_ptr);
-    })?;
-
-    // Free the raw file buffer (we no longer need it - PE loader copied sections)
-    let _ = free_pool(buffer_ptr);
-
-    log::info!(
-        "PE image loaded at {:#x}, entry point {:#x}, size {:#x}",
-        loaded_image.image_base,
-        loaded_image.entry_point,
-        loaded_image.image_size
-    );
-
-    // Create an image handle for the loaded bootloader
-    let image_handle = boot_services::create_handle().ok_or_else(|| {
-        log::error!("Failed to create image handle");
-        Status::OUT_OF_RESOURCES
-    })?;
-
-    // Create and install LoadedImageProtocol
-    let system_table = efi::get_system_table();
-    let firmware_handle = efi::get_firmware_handle();
-
-    let loaded_image_protocol = create_loaded_image_protocol(
-        firmware_handle, // parent_handle
-        system_table,    // system_table
-        device_handle,   // device_handle - now with SimpleFileSystem!
-        loaded_image.image_base,
-        loaded_image.image_size,
-    );
-
-    if loaded_image_protocol.is_null() {
-        log::error!("Failed to create LoadedImageProtocol");
-        pe::unload_image(&loaded_image);
-        return Err(Status::OUT_OF_RESOURCES);
-    }
-
-    // Set the file path in LoadedImageProtocol (tells bootloader what file was loaded)
-    let file_path = efi::protocols::device_path::create_file_path_device_path(path);
-    if !file_path.is_null() {
-        unsafe {
-            efi::protocols::loaded_image::set_file_path(loaded_image_protocol, file_path);
-        }
-        log::debug!("Set LoadedImage.FilePath to: {}", path);
-    }
-
-    let status = boot_services::install_protocol(
-        image_handle,
-        &LOADED_IMAGE_PROTOCOL_GUID,
-        loaded_image_protocol as *mut core::ffi::c_void,
-    );
-
-    if status != Status::SUCCESS {
-        log::error!("Failed to install LoadedImageProtocol: {:?}", status);
-        pe::unload_image(&loaded_image);
-        return Err(status);
-    }
-
-    log::info!("LoadedImageProtocol installed on handle {:?}", image_handle);
-    if !device_handle.is_null() {
-        log::info!(
-            "DeviceHandle set to {:?} (with SimpleFileSystem)",
-            device_handle
-        );
-    }
-    log::info!("Executing bootloader...");
-
-    // Debug: verify system table integrity before execution
-    unsafe {
-        let st = &*system_table;
-        log::debug!(
-            "SystemTable check: boot_services={:?}, runtime_services={:?}",
-            st.boot_services,
-            st.runtime_services
-        );
-        if !st.boot_services.is_null() {
-            let bs = &*st.boot_services;
-            log::debug!(
-                "BootServices check: signature={:#x}, check_event={:?}",
-                bs.hdr.signature,
-                bs.check_event
-            );
-        } else {
-            log::error!("CRITICAL: boot_services is NULL!");
-        }
-    }
-
-    // Execute the bootloader
-    let exec_status = pe::execute_image(&loaded_image, image_handle, system_table);
-
-    // If the bootloader returns, log it
-    log::info!("Bootloader returned with status: {:?}", exec_status);
-
-    // Clean up (normally the bootloader would call ExitBootServices and never return)
-    pe::unload_image(&loaded_image);
-
-    if exec_status == Status::SUCCESS {
-        Ok(())
-    } else {
-        Err(exec_status)
-    }
-}
-
-/// Install BlockIO protocols for an SDHCI disk and all its partitions
-///
-/// Returns the ESP partition and its partition number (1-based) if found.
-///
-/// # Arguments
-/// * `disk` - Disk to read GPT from
-/// * `storage_id` - Storage device ID for BlockIO
-/// * `block_size` - Block size in bytes
-/// * `num_blocks` - Total number of blocks
-/// * `pci_device` - PCI device number of the SDHCI controller
-/// * `pci_function` - PCI function number
-fn install_block_io_for_sdhci_disk<R: BlockDevice>(
-    disk: &mut R,
-    storage_id: u32,
-    block_size: u32,
-    num_blocks: u64,
-    pci_device: u8,
-    pci_function: u8,
-) -> Option<(u32, fs::gpt::Partition)> {
-    use efi::boot_services;
-    use efi::protocols::block_io::{self, BLOCK_IO_PROTOCOL_GUID};
-    use efi::protocols::device_path::{self, DEVICE_PATH_PROTOCOL_GUID};
-    use r_efi::efi::Status;
-
-    // First, create BlockIO for the raw disk (whole device)
-    let disk_block_io = block_io::create_disk_block_io(storage_id, num_blocks, block_size);
-
-    if !disk_block_io.is_null()
-        && let Some(disk_handle) = boot_services::create_handle()
-    {
-        // Install BlockIO protocol
-        let status = boot_services::install_protocol(
-            disk_handle,
-            &BLOCK_IO_PROTOCOL_GUID,
-            disk_block_io as *mut core::ffi::c_void,
-        );
-        if status == Status::SUCCESS {
-            log::info!(
-                "BlockIO protocol installed for raw SDHCI disk on handle {:?}",
-                disk_handle
-            );
-        }
-
-        // Install DevicePath protocol for the raw disk (SD device path)
-        // Use USB device path format for now (SD cards are often USB-connected logically)
-        let disk_device_path = device_path::create_usb_device_path(pci_device, pci_function, 0);
-        if !disk_device_path.is_null() {
-            let status = boot_services::install_protocol(
-                disk_handle,
-                &DEVICE_PATH_PROTOCOL_GUID,
-                disk_device_path as *mut core::ffi::c_void,
-            );
-            if status == Status::SUCCESS {
-                log::info!(
-                    "DevicePath protocol installed for raw SDHCI disk on handle {:?}",
-                    disk_handle
-                );
-            }
-        }
-    }
-
-    // Read GPT header and all partitions
-    let header = match fs::gpt::read_gpt_header(disk) {
-        Ok(h) => h,
-        Err(e) => {
-            log::debug!("Failed to read GPT header: {:?}", e);
-            return None;
-        }
-    };
-
-    let partitions = match fs::gpt::read_partitions(disk, &header) {
-        Ok(p) => p,
-        Err(e) => {
-            log::debug!("Failed to read partitions: {:?}", e);
-            return None;
-        }
-    };
-
-    let mut esp_partition: Option<(u32, fs::gpt::Partition)> = None;
-    let mut candidate_partitions: heapless::Vec<(u32, fs::gpt::Partition), 8> =
-        heapless::Vec::new();
-
-    // Create BlockIO for each partition
-    for (i, partition) in partitions.iter().enumerate() {
-        let partition_num = (i + 1) as u32;
-        let partition_blocks = partition.size_sectors();
-
-        let partition_block_io = block_io::create_partition_block_io(
-            storage_id,
-            partition_num,
-            partition.first_lba,
-            partition_blocks,
-            block_size,
-        );
-
-        if !partition_block_io.is_null()
-            && let Some(part_handle) = boot_services::create_handle()
-        {
-            // Install BlockIO
-            let status = boot_services::install_protocol(
-                part_handle,
-                &BLOCK_IO_PROTOCOL_GUID,
-                partition_block_io as *mut core::ffi::c_void,
-            );
-            if status == Status::SUCCESS {
-                log::info!(
-                    "BlockIO protocol installed for SDHCI partition {} on handle {:?}",
-                    partition_num,
-                    part_handle
-                );
-            }
-
-            // Install DevicePath for partition
-            let device_path = device_path::create_usb_partition_device_path(
-                pci_device,
-                pci_function,
-                0,
-                partition_num,
-                partition.first_lba,
-                partition_blocks,
-                &partition.partition_guid,
-            );
-
-            if !device_path.is_null() {
-                let status = boot_services::install_protocol(
-                    part_handle,
-                    &DEVICE_PATH_PROTOCOL_GUID,
-                    device_path as *mut core::ffi::c_void,
-                );
-                if status == Status::SUCCESS {
-                    log::info!(
-                        "DevicePath protocol installed for SDHCI partition {} on handle {:?}",
-                        partition_num,
-                        part_handle
-                    );
-                }
-            }
-        }
-
-        // Remember ESP for later (with partition number)
-        if partition.is_esp {
-            log::info!(
-                "Found ESP on SDHCI: partition {}, LBA {}-{} ({} MB)",
-                partition_num,
-                partition.first_lba,
-                partition.last_lba,
-                partition.size_bytes() / (1024 * 1024)
-            );
-            esp_partition = Some((partition_num, partition.clone()));
-        } else {
-            // Track as candidate for fallback (small partitions are more likely to be EFI boot)
-            let size_mb = partition.size_bytes() / (1024 * 1024);
-            if size_mb > 0 && size_mb < 512 && partition.first_lba > 0 {
-                let _ = candidate_partitions.push((partition_num, partition.clone()));
-            }
-        }
-    }
-
-    // If we found a proper ESP, return it
-    if esp_partition.is_some() {
-        return esp_partition;
-    }
-
-    // No proper ESP found - try candidate partitions (smaller ones first)
-    for i in 0..candidate_partitions.len() {
-        for j in (i + 1)..candidate_partitions.len() {
-            if candidate_partitions[j].1.size_bytes() < candidate_partitions[i].1.size_bytes() {
-                let tmp = candidate_partitions[i].clone();
-                candidate_partitions[i] = candidate_partitions[j].clone();
-                candidate_partitions[j] = tmp;
-            }
-        }
-    }
-
-    if let Some((partition_num, partition)) = candidate_partitions.first() {
-        log::debug!(
-            "Trying SDHCI partition {} as potential ESP (no proper ESP found)",
-            partition_num
-        );
-        return Some((*partition_num, partition.clone()));
-    }
-
-    None
-}
-
-/// Try to boot from an ESP on SDHCI (with SimpleFileSystem support)
-///
-/// # Arguments
-/// * `disk` - SDHCI disk to read from
-/// * `esp` - ESP partition info
-/// * `partition_num` - 1-based partition number of the ESP
-/// * `pci_device` - PCI device number of SDHCI controller
-/// * `pci_function` - PCI function number
-fn try_boot_from_esp_sdhci(
-    disk: &mut SdhciDisk,
-    esp: &fs::gpt::Partition,
-    partition_num: u32,
-    pci_device: u8,
-    pci_function: u8,
-) -> bool {
-    use drivers::block::{AnyBlockDevice, SdhciBlockDevice};
-    use drivers::storage::{self, StorageType};
-    use efi::boot_services;
-    use efi::protocols::block_io::{self, BLOCK_IO_PROTOCOL_GUID};
-    use efi::protocols::device_path::{self, DEVICE_PATH_PROTOCOL_GUID};
-    use efi::protocols::simple_file_system::{self, SIMPLE_FILE_SYSTEM_GUID};
-    use r_efi::efi::Status;
-
-    // Get SDHCI device info for creating block device
-    let (num_blocks, block_size) = {
-        let info = disk.info();
-        (info.num_blocks, info.block_size)
-    };
-
-    log::debug!(
-        "SDHCI device: num_blocks={}, block_size={}",
-        num_blocks,
-        block_size
-    );
-
-    // Create an SdhciBlockDevice for the SimpleFileSystem protocol
-    let sdhci_block_device = SdhciBlockDevice::new(0, num_blocks, block_size, 0);
-    let block_device = AnyBlockDevice::Sdhci(sdhci_block_device);
-
-    // Initialize SimpleFileSystem protocol with the block device
-    let sfs_protocol = simple_file_system::init(block_device, esp.first_lba);
-    if sfs_protocol.is_null() {
-        log::error!("Failed to initialize SimpleFileSystem protocol");
-        return false;
-    }
-
-    match fs::fat::FatFilesystem::new(disk, esp.first_lba) {
-        Ok(mut fat) => {
-            log::info!("FAT filesystem mounted on ESP");
-
-            // Create a device handle with SimpleFileSystem and DevicePath protocols
-            let device_handle = match boot_services::create_handle() {
-                Some(h) => h,
-                None => {
-                    log::error!("Failed to create device handle");
-                    return false;
-                }
-            };
-
-            // Install DevicePath protocol on the device handle
-            let partition_size = esp.size_sectors();
-            let device_path = device_path::create_usb_partition_device_path(
-                pci_device,
-                pci_function,
-                0,
-                partition_num,
-                esp.first_lba,
-                partition_size,
-                &esp.partition_guid,
-            );
-
-            if !device_path.is_null() {
-                let status = boot_services::install_protocol(
-                    device_handle,
-                    &DEVICE_PATH_PROTOCOL_GUID,
-                    device_path as *mut core::ffi::c_void,
-                );
-                if status == Status::SUCCESS {
-                    log::info!(
-                        "DevicePath protocol installed on device handle {:?}",
-                        device_handle
-                    );
-                } else {
-                    log::warn!("Failed to install DevicePath protocol: {:?}", status);
-                }
-            }
-
-            // Install BlockIO protocol on the device handle
-            if let Some(controller) = drivers::sdhci::get_controller(0) {
-                let block_size = controller.block_size();
-                let storage_id = storage::register_device(
-                    StorageType::Sdhci { controller_id: 0 },
-                    controller.num_blocks(),
-                    block_size,
-                );
-
-                if let Some(storage_id) = storage_id {
-                    let block_io = block_io::create_partition_block_io(
-                        storage_id,
-                        partition_num,
-                        esp.first_lba,
-                        partition_size,
-                        block_size,
-                    );
-
-                    if !block_io.is_null() {
-                        let status = boot_services::install_protocol(
-                            device_handle,
-                            &BLOCK_IO_PROTOCOL_GUID,
-                            block_io as *mut core::ffi::c_void,
-                        );
-                        if status == Status::SUCCESS {
-                            log::info!(
-                                "BlockIO protocol installed on device handle {:?}",
-                                device_handle
-                            );
-                        } else {
-                            log::warn!("Failed to install BlockIO protocol: {:?}", status);
-                        }
-                    }
-                }
-            }
-
-            // Install SimpleFileSystem protocol on the device handle
-            let status = boot_services::install_protocol(
-                device_handle,
-                &SIMPLE_FILE_SYSTEM_GUID,
-                sfs_protocol as *mut core::ffi::c_void,
-            );
-
-            if status != Status::SUCCESS {
-                log::error!("Failed to install SimpleFileSystem protocol: {:?}", status);
-                return false;
-            }
-
-            log::info!(
-                "SimpleFileSystem protocol installed on device handle {:?}",
-                device_handle
-            );
-
-            // Look for EFI bootloader
-            let boot_path = "EFI\\BOOT\\BOOTX64.EFI";
-            match fat.file_size(boot_path) {
-                Ok(size) => {
-                    log::info!("Found bootloader: {} ({} bytes)", boot_path, size);
-
-                    // Load and execute the bootloader with device handle
-                    match load_and_execute_bootloader(&mut fat, boot_path, size, device_handle) {
-                        Ok(()) => return true,
-                        Err(e) => {
-                            log::error!("Failed to execute bootloader: {:?}", e);
-                        }
-                    }
-                }
-                Err(e) => {
-                    log::warn!("Bootloader not found: {:?}", e);
-                }
-            }
-        }
-        Err(e) => {
-            log::error!("Failed to mount FAT filesystem: {:?}", e);
-        }
-    }
-    false
 }


### PR DESCRIPTION
## Summary

This PR introduces a table-driven PCI driver model, consolidates duplicated boot logic into a unified module, and replaces hardcoded file/directory probing with dynamic filesystem enumeration.

## Key Changes

### PCI Driver Model
- **New driver trait**: `drivers/pci/driver.rs` defines `PciDriver` with lifecycle methods (`probe`, `init`, `shutdown`)
- **Automatic binding**: Drivers register match criteria (class/subclass); `pci::bind_drivers()` matches devices to drivers at runtime
- **Unified access**: `drivers/pci/access.rs` abstracts I/O CAM vs. PCIe ECAM config space access via `PciAccess` trait
- **Per-driver init**: NVMe, AHCI, USB, SDHCI now expose `init_device()` called by the driver model instead of scanning PCI bus themselves
- **Centralized shutdown**: `pci::shutdown_drivers()` cleanly quiesces all hardware during ExitBootServices

### Unified Boot Path
- **Single boot module**: `boot.rs` replaces four `try_boot_from_esp_{nvme,ahci,usb,sdhci}` functions with one generic `try_boot_from_esp()` parameterized by `DeviceType`
- **Generic BlockIO installation**: `install_block_io_protocols()` replaces four device-specific variants
- **Device path abstraction**: `DevicePathInfo` enum captures per-device differences for protocol construction

### Boot Entry Discovery Optimization
- **BLS entries**: Use `fs.list_directory_files("loader\\entries", ".conf")` instead of probing 15+ hardcoded filenames
- **GRUB configs**: Dynamically enumerate `EFI\*` subdirectories instead of checking 9 hardcoded distro names
- **FAT directory listing**: New `FatFilesystem::list_directory_files()` and `list_subdirectories()` methods for efficient enumeration
- **Faster detection**: `has_bls_entries()` now checks if `loader\entries` directory exists instead of probing specific files

## Implementation Details

### Driver Lifecycle
1. **Enumeration**: `pci::init()` scans bus, calls `access::create_access()` to select I/O CAM or ECAM
2. **Binding**: `pci::bind_drivers()` iterates `PCI_DRIVERS` table, calls `probe()` then `init()` for matches
3. **Shutdown**: `exit_boot_services()` calls `pci::shutdown_drivers()` to stop all controllers

### Boot Flow
```rust
// Old: separate per-device functions
install_block_io_for_nvme_disk(...) -> try_boot_from_esp_nvme(...)
install_block_io_for_ahci_disk(...) -> try_boot_from_esp_ahci(...)

// New: unified generic path
let path_info = boot::device_path_info_from_entry(entry);
boot::install_block_io_protocols(&mut disk, ..., &path_info);
boot::try_boot_from_esp(&mut disk, ..., &path_info, &entry.device_type, ...);
```

## Benefits
- **Less code duplication**: ~1600 lines removed from `lib.rs`, replaced with ~600 lines of generic code
- **Faster boot discovery**: Directory enumeration replaces O(n) file probing
- **Easier to extend**: Adding a new storage driver = implement `PciDriver` trait + register in `PCI_DRIVERS` table
- **Cleaner separation**: PCI access, driver binding, and boot logic are now in separate modules with clear interfaces