### PR TITLE
# Add Windows Boot Manager support with full UEFI protocol compliance

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,7 +6,8 @@ target = "x86_64-unknown-none"
 [target.x86_64-unknown-none]
 rustflags = [
     "-C", "link-arg=-Tx86_64-coreboot.ld",
-    "-C", "relocation-model=static",
+    "-C", "link-arg=-no-pie",
+    "-C", "relocation-model=pic",
     "-C", "code-model=kernel",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ readme = "README.md"
 default = []
 # Enable logging output to framebuffer (very slow, for debugging only)
 fb-log = []
+# Enable runtime services serial debug logging (post-SetVirtualAddressMap)
+rt-debug = []
 
 [dependencies]
 r-efi = "5.3"

--- a/src/drivers/ahci/mod.rs
+++ b/src/drivers/ahci/mod.rs
@@ -898,8 +898,10 @@ impl AhciController {
                 Err(e) => return Err(e),
             }
         }
-        // All code paths return inside the loop (Ok on success, Err on final attempt)
-        unreachable!()
+        // All code paths return inside the loop: Ok on success, Err on final attempt
+        // (the `Err(e) if attempt + 1 < MAX_RETRIES` guard ensures the last iteration
+        // falls through to the unconditional `Err(e)` arm).
+        unreachable!("MAX_RETRIES must be >= 1")
     }
 
     /// Read sectors from a SATA device using READ DMA EXT

--- a/src/drivers/block.rs
+++ b/src/drivers/block.rs
@@ -253,8 +253,8 @@ impl BlockDevice for AhciBlockDevice {
             &mut *ahci::get_controller(self.controller_id).ok_or(BlockError::DeviceError)?
         };
 
-        controller
-            .read_sectors(self.port, lba, count, buffer.as_mut_ptr())
+        // Safety: buffer.as_mut_ptr() is valid for buffer.len() bytes
+        unsafe { controller.read_sectors(self.port, lba, count, buffer.as_mut_ptr()) }
             .map_err(BlockError::from)
     }
 }
@@ -467,9 +467,12 @@ impl<'a> BlockDevice for AhciDisk<'a> {
     }
 
     fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError> {
-        self.controller
-            .read_sectors(self.port, lba, count, buffer.as_mut_ptr())
-            .map_err(BlockError::from)
+        // Safety: buffer.as_mut_ptr() is valid for buffer.len() bytes
+        unsafe {
+            self.controller
+                .read_sectors(self.port, lba, count, buffer.as_mut_ptr())
+        }
+        .map_err(BlockError::from)
     }
 }
 

--- a/src/efi/boot_services.rs
+++ b/src/efi/boot_services.rs
@@ -597,8 +597,10 @@ const EFI_EVENT_GROUP_EXIT_BOOT_SERVICES: Guid = Guid::from_fields(
 /// Signal all events belonging to a specific event group
 fn signal_event_group(group_guid: &Guid) {
     // Collect events to signal (need to avoid holding state lock during callbacks)
-    let mut events_to_signal: heapless::Vec<(usize, Option<efi::EventNotify>, *mut c_void), MAX_EVENTS> =
-        heapless::Vec::new();
+    let mut events_to_signal: heapless::Vec<
+        (usize, Option<efi::EventNotify>, *mut c_void),
+        MAX_EVENTS,
+    > = heapless::Vec::new();
 
     state::with_efi_mut(|efi_state| {
         for i in 0..MAX_EVENTS {
@@ -875,7 +877,10 @@ extern "efiapi" fn locate_handle(
                 .collect()
         }
         _ => {
-            log::debug!("  -> INVALID_PARAMETER (unknown search type {})", search_type);
+            log::debug!(
+                "  -> INVALID_PARAMETER (unknown search type {})",
+                search_type
+            );
             return Status::INVALID_PARAMETER;
         }
     };
@@ -1298,8 +1303,7 @@ unsafe fn count_device_path_prefix_nodes(dp: *const DevicePathProtocol) -> usize
     loop {
         let node_type = (*current).r#type;
         let node_subtype = (*current).sub_type;
-        let node_length =
-            u16::from_le_bytes([(*current).length[0], (*current).length[1]]) as usize;
+        let node_length = u16::from_le_bytes([(*current).length[0], (*current).length[1]]) as usize;
 
         // Stop at End node
         if node_type == DEVICE_PATH_TYPE_END {
@@ -2368,11 +2372,7 @@ extern "efiapi" fn uninstall_multiple_protocol_interfaces(
     Status::SUCCESS
 }
 
-extern "efiapi" fn calculate_crc32(
-    data: *mut c_void,
-    data_size: usize,
-    crc32: *mut u32,
-) -> Status {
+extern "efiapi" fn calculate_crc32(data: *mut c_void, data_size: usize, crc32: *mut u32) -> Status {
     if data.is_null() || crc32.is_null() || data_size == 0 {
         return Status::INVALID_PARAMETER;
     }

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -58,6 +58,10 @@ pub fn init(cb_info: &CorebootInfo) {
     // Required for efi_pstore, efivars, and other kernel modules.
     system_table::install_rt_properties_table();
 
+    // Install minimal TPM2 event log tables
+    // Prevents kernel errors about failing to map ACPI memory for TPM log
+    system_table::install_tpm_event_log();
+
     // Create console handle - this will also have GOP installed on it
     let console_handle = init_console();
 
@@ -82,6 +86,10 @@ pub fn init(cb_info: &CorebootInfo) {
 
     // Install Console Control protocol (legacy, but some bootloaders need it)
     init_console_control();
+
+    // Install EFI Memory Attributes Table
+    // Linux and Windows use this to set proper page permissions for runtime regions
+    system_table::install_memory_attributes_table();
 
     // Dump configuration tables for debugging
     system_table::dump_configuration_tables();

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -86,6 +86,10 @@ pub fn init(cb_info: &CorebootInfo) {
     // Dump configuration tables for debugging
     system_table::dump_configuration_tables();
 
+    // Compute CRC32 checksums for all EFI table headers.
+    // Must be done after all configuration tables and protocols are installed.
+    system_table::update_crc32();
+
     log::info!("EFI environment initialized");
 }
 

--- a/src/efi/protocols/device_path.rs
+++ b/src/efi/protocols/device_path.rs
@@ -11,7 +11,7 @@ use r_efi::protocols::device_path::{
     self, End, HardDriveMedia, Media, Protocol, TYPE_END, TYPE_MEDIA,
 };
 
-use crate::efi::allocator::{allocate_pool, MemoryType};
+use crate::efi::allocator::{MemoryType, allocate_pool};
 
 /// Re-export the GUID for external use
 pub const DEVICE_PATH_PROTOCOL_GUID: Guid = device_path::PROTOCOL_GUID;

--- a/src/efi/protocols/disk_io.rs
+++ b/src/efi/protocols/disk_io.rs
@@ -1,0 +1,282 @@
+//! EFI Disk I/O Protocol
+//!
+//! Provides byte-granular read/write access on top of the Block I/O protocol.
+//! The UEFI specification requires firmware to install this protocol on every
+//! handle that carries Block I/O. Windows Boot Manager uses Disk I/O to read
+//! the BCD registry hive at arbitrary byte offsets.
+
+use core::ffi::c_void;
+use r_efi::efi::{Handle, Status};
+
+use super::block_io::{BLOCK_IO_PROTOCOL_GUID, BlockIoProtocol};
+use crate::efi::boot_services;
+use crate::efi::utils::allocate_protocol_with_log;
+
+/// Disk I/O Protocol GUID
+pub const DISK_IO_PROTOCOL_GUID: r_efi::efi::Guid = r_efi::efi::Guid::from_fields(
+    0xCE345171,
+    0xBA0B,
+    0x11d2,
+    0x8E,
+    0x4F,
+    &[0x00, 0xA0, 0xC9, 0x69, 0x72, 0x3B],
+);
+
+/// Disk I/O Protocol revision
+const DISK_IO_REVISION: u64 = 0x0001_0000;
+
+/// Disk I/O Protocol structure (matches r_efi::protocols::disk_io::Protocol)
+#[repr(C)]
+pub struct DiskIoProtocol {
+    pub revision: u64,
+    pub read_disk: extern "efiapi" fn(
+        this: *mut DiskIoProtocol,
+        media_id: u32,
+        offset: u64,
+        buffer_size: usize,
+        buffer: *mut c_void,
+    ) -> Status,
+    pub write_disk: extern "efiapi" fn(
+        this: *mut DiskIoProtocol,
+        media_id: u32,
+        offset: u64,
+        buffer_size: usize,
+        buffer: *mut c_void,
+    ) -> Status,
+}
+
+/// Maximum number of DiskIO instances (must match MAX_BLOCK_IO_INSTANCES)
+const MAX_DISK_IO_INSTANCES: usize = 16;
+
+/// DiskIO context: stores the handle so we can find BlockIO at read time
+struct DiskIoContext {
+    /// Handle on which both DiskIO and BlockIO are installed
+    handle: Handle,
+}
+
+/// Global storage for DiskIO contexts
+static mut DISK_IO_CONTEXTS: [Option<DiskIoContext>; MAX_DISK_IO_INSTANCES] =
+    [const { None }; MAX_DISK_IO_INSTANCES];
+
+/// Protocol instance to context mapping
+static mut PROTOCOL_TO_CONTEXT: [Option<*mut DiskIoProtocol>; MAX_DISK_IO_INSTANCES] =
+    [const { None }; MAX_DISK_IO_INSTANCES];
+
+/// Find context index for a protocol instance
+fn find_context_index(protocol: *mut DiskIoProtocol) -> Option<usize> {
+    unsafe {
+        let map = core::ptr::addr_of!(PROTOCOL_TO_CONTEXT);
+        for (i, p) in (*map).iter().enumerate() {
+            if let Some(ptr) = p
+                && *ptr == protocol
+            {
+                return Some(i);
+            }
+        }
+    }
+    None
+}
+
+/// Read from the disk at a byte offset
+///
+/// This reads `buffer_size` bytes starting at byte `offset` from the beginning
+/// of the partition/disk. Internally it converts to block-aligned reads via BlockIO.
+extern "efiapi" fn disk_io_read_disk(
+    this: *mut DiskIoProtocol,
+    media_id: u32,
+    offset: u64,
+    buffer_size: usize,
+    buffer: *mut c_void,
+) -> Status {
+    if this.is_null() || buffer.is_null() || buffer_size == 0 {
+        return Status::INVALID_PARAMETER;
+    }
+
+    log::trace!(
+        "DiskIO.ReadDisk(media={}, offset={:#x}, size={})",
+        media_id,
+        offset,
+        buffer_size
+    );
+
+    let ctx_idx = match find_context_index(this) {
+        Some(idx) => idx,
+        None => {
+            log::error!("DiskIO.ReadDisk: unknown protocol instance");
+            return Status::INVALID_PARAMETER;
+        }
+    };
+
+    let handle = unsafe {
+        let contexts = core::ptr::addr_of!(DISK_IO_CONTEXTS);
+        match &(*contexts)[ctx_idx] {
+            Some(c) => c.handle,
+            None => return Status::INVALID_PARAMETER,
+        }
+    };
+
+    // Get the BlockIO protocol from the same handle
+    let block_io_ptr = boot_services::get_protocol_on_handle(handle, &BLOCK_IO_PROTOCOL_GUID);
+    if block_io_ptr.is_null() {
+        log::error!("DiskIO.ReadDisk: no BlockIO on handle {:?}", handle);
+        return Status::DEVICE_ERROR;
+    }
+
+    let block_io = block_io_ptr as *mut BlockIoProtocol;
+    let media = unsafe { &*(*block_io).media };
+    let block_size = media.block_size as u64;
+
+    if block_size == 0 {
+        return Status::DEVICE_ERROR;
+    }
+
+    // Verify media ID
+    if media_id != media.media_id {
+        return Status::MEDIA_CHANGED;
+    }
+
+    // Calculate block-aligned read parameters
+    let start_lba = offset / block_size;
+    let start_offset = (offset % block_size) as usize;
+    let end_byte = offset + buffer_size as u64;
+    let end_lba = end_byte.div_ceil(block_size);
+    let total_blocks = end_lba - start_lba;
+    let aligned_size = (total_blocks * block_size) as usize;
+
+    // If already block-aligned, read directly into buffer
+    if start_offset == 0 && buffer_size == aligned_size {
+        let status = unsafe {
+            ((*block_io).read_blocks)(block_io, media_id, start_lba, buffer_size, buffer)
+        };
+        return status;
+    }
+
+    // Unaligned: allocate a temporary buffer for block-aligned read
+    let temp_buf = match crate::efi::allocator::allocate_pool(
+        crate::efi::allocator::MemoryType::BootServicesData,
+        aligned_size,
+    ) {
+        Ok(ptr) => ptr,
+        Err(_) => {
+            log::error!(
+                "DiskIO.ReadDisk: failed to allocate {} bytes for temp buffer",
+                aligned_size
+            );
+            return Status::OUT_OF_RESOURCES;
+        }
+    };
+
+    let status = unsafe {
+        ((*block_io).read_blocks)(
+            block_io,
+            media_id,
+            start_lba,
+            aligned_size,
+            temp_buf as *mut c_void,
+        )
+    };
+
+    if status == Status::SUCCESS {
+        // Copy the requested portion from the aligned buffer
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                temp_buf.add(start_offset),
+                buffer as *mut u8,
+                buffer_size,
+            );
+        }
+    }
+
+    let _ = crate::efi::allocator::free_pool(temp_buf);
+    status
+}
+
+/// Write to the disk (not supported - read only for boot)
+extern "efiapi" fn disk_io_write_disk(
+    _this: *mut DiskIoProtocol,
+    _media_id: u32,
+    _offset: u64,
+    _buffer_size: usize,
+    _buffer: *mut c_void,
+) -> Status {
+    log::debug!("DiskIO.WriteDisk: not supported (read-only)");
+    Status::WRITE_PROTECTED
+}
+
+/// Install DiskIO protocol on a handle that already has BlockIO
+///
+/// # Arguments
+/// * `handle` - Handle with BlockIO protocol already installed
+pub fn install_disk_io_on_handle(handle: Handle) {
+    if handle.is_null() {
+        return;
+    }
+
+    // Verify BlockIO is present
+    let block_io_ptr = boot_services::get_protocol_on_handle(handle, &BLOCK_IO_PROTOCOL_GUID);
+    if block_io_ptr.is_null() {
+        log::warn!(
+            "DiskIO: skipping handle {:?} — no BlockIO installed",
+            handle
+        );
+        return;
+    }
+
+    // Find a free context slot
+    let ctx_idx = unsafe {
+        let mut found = None;
+        let contexts = core::ptr::addr_of!(DISK_IO_CONTEXTS);
+        for (i, slot) in (*contexts).iter().enumerate() {
+            if slot.is_none() {
+                found = Some(i);
+                break;
+            }
+        }
+        match found {
+            Some(i) => i,
+            None => {
+                log::error!("DiskIO: no free context slots");
+                return;
+            }
+        }
+    };
+
+    // Allocate the protocol structure
+    let protocol_ptr = allocate_protocol_with_log::<DiskIoProtocol>("DiskIoProtocol", |p| {
+        p.revision = DISK_IO_REVISION;
+        p.read_disk = disk_io_read_disk;
+        p.write_disk = disk_io_write_disk;
+    });
+
+    if protocol_ptr.is_null() {
+        return;
+    }
+
+    // Store context
+    unsafe {
+        let contexts = core::ptr::addr_of_mut!(DISK_IO_CONTEXTS);
+        (*contexts)[ctx_idx] = Some(DiskIoContext { handle });
+        let proto_map = core::ptr::addr_of_mut!(PROTOCOL_TO_CONTEXT);
+        (*proto_map)[ctx_idx] = Some(protocol_ptr);
+    }
+
+    // Install on the handle
+    let status = boot_services::install_protocol(
+        handle,
+        &DISK_IO_PROTOCOL_GUID,
+        protocol_ptr as *mut c_void,
+    );
+
+    if status == Status::SUCCESS {
+        log::info!(
+            "DiskIO protocol installed on handle {:?}",
+            handle
+        );
+    } else {
+        log::error!(
+            "DiskIO: failed to install on handle {:?}: {:?}",
+            handle,
+            status
+        );
+    }
+}

--- a/src/efi/protocols/disk_io.rs
+++ b/src/efi/protocols/disk_io.rs
@@ -268,10 +268,7 @@ pub fn install_disk_io_on_handle(handle: Handle) {
     );
 
     if status == Status::SUCCESS {
-        log::info!(
-            "DiskIO protocol installed on handle {:?}",
-            handle
-        );
+        log::info!("DiskIO protocol installed on handle {:?}", handle);
     } else {
         log::error!(
             "DiskIO: failed to install on handle {:?}: {:?}",

--- a/src/efi/protocols/mod.rs
+++ b/src/efi/protocols/mod.rs
@@ -5,9 +5,9 @@
 pub mod ata_pass_thru;
 pub mod block_io;
 pub mod console;
-pub mod disk_io;
 pub mod console_control;
 pub mod device_path;
+pub mod disk_io;
 pub mod graphics_output;
 pub mod loaded_image;
 pub mod memory_attribute;

--- a/src/efi/protocols/mod.rs
+++ b/src/efi/protocols/mod.rs
@@ -5,6 +5,7 @@
 pub mod ata_pass_thru;
 pub mod block_io;
 pub mod console;
+pub mod disk_io;
 pub mod console_control;
 pub mod device_path;
 pub mod graphics_output;

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -279,6 +279,19 @@ extern "efiapi" fn set_virtual_address_map(
     }
 
     let num_entries = memory_map_size / descriptor_size;
+
+    // Sanity check: a realistic memory map has at most a few hundred entries.
+    // Reject obviously corrupted sizes to prevent walking off into unmapped memory.
+    const MAX_REASONABLE_ENTRIES: usize = 4096;
+    if num_entries > MAX_REASONABLE_ENTRIES {
+        log::error!(
+            "SetVirtualAddressMap: unreasonable entry count {} (max {})",
+            num_entries,
+            MAX_REASONABLE_ENTRIES
+        );
+        return Status::INVALID_PARAMETER;
+    }
+
     log::info!("SetVirtualAddressMap: {} entries", num_entries);
 
     // Step 0: Disable CBMEM console -- its buffer is not in a runtime region

--- a/src/state.rs
+++ b/src/state.rs
@@ -62,6 +62,19 @@ pub fn is_initialized() -> bool {
     !STATE_PTR.load(Ordering::Acquire).is_null()
 }
 
+/// Relocate the global state pointer to a new virtual address.
+///
+/// Called by `SetVirtualAddressMap` when the OS remaps runtime services
+/// memory from physical to virtual addresses.
+///
+/// # Safety
+///
+/// The new pointer must point to valid `FirmwareState` memory that has been
+/// remapped by the OS.
+pub unsafe fn relocate_state_ptr(new_ptr: *mut FirmwareState) {
+    STATE_PTR.store(new_ptr, Ordering::Release);
+}
+
 /// Get a reference to the global firmware state.
 ///
 /// # Panics

--- a/src/state.rs
+++ b/src/state.rs
@@ -152,11 +152,7 @@ pub fn try_get() -> Option<&'static FirmwareState> {
 #[inline]
 pub fn try_get_mut_ptr() -> Option<*mut FirmwareState> {
     let ptr = STATE_PTR.load(Ordering::Acquire);
-    if ptr.is_null() {
-        None
-    } else {
-        Some(ptr)
-    }
+    if ptr.is_null() { None } else { Some(ptr) }
 }
 
 // ============================================================================

--- a/src/state.rs
+++ b/src/state.rs
@@ -284,6 +284,12 @@ pub struct EventEntry {
     pub notify_tpl: efi::Tpl,
     pub signaled: bool,
     pub is_keyboard_event: bool,
+    /// Timer type: 0 = cancelled, 1 = periodic, 2 = relative (one-shot)
+    pub timer_type: u32,
+    /// Timer period in 100-ns units (for periodic timers)
+    pub timer_period_100ns: u64,
+    /// TSC deadline for the next timer firing (0 = no timer)
+    pub timer_deadline: u64,
 }
 
 impl EventEntry {
@@ -293,6 +299,9 @@ impl EventEntry {
             notify_tpl: 0,
             signaled: false,
             is_keyboard_event: false,
+            timer_type: 0,
+            timer_period_100ns: 0,
+            timer_deadline: 0,
         }
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -299,6 +299,22 @@ pub fn delay_ms(ms: u64) {
     delay_us(ms * 1000);
 }
 
+/// Return a TSC deadline value that is `us` microseconds from now.
+///
+/// Useful for storing raw deadlines in structures that cannot hold a `Timeout`.
+#[inline]
+pub fn deadline_after_us(us: u64) -> u64 {
+    let cycles = us * TSC_CYCLES_PER_US.load(Ordering::Relaxed);
+    rdtsc().wrapping_add(cycles)
+}
+
+/// Check whether a TSC deadline (from [`deadline_after_us`]) has been reached.
+#[inline]
+pub fn deadline_expired(deadline: u64) -> bool {
+    let diff = deadline.wrapping_sub(rdtsc()) as i64;
+    diff <= 0
+}
+
 /// A deadline-based timeout for polling loops
 ///
 /// # Example

--- a/src/time.rs
+++ b/src/time.rs
@@ -299,22 +299,6 @@ pub fn delay_ms(ms: u64) {
     delay_us(ms * 1000);
 }
 
-/// Return a TSC deadline value that is `us` microseconds from now.
-///
-/// Useful for storing raw deadlines in structures that cannot hold a `Timeout`.
-#[inline]
-pub fn deadline_after_us(us: u64) -> u64 {
-    let cycles = us * TSC_CYCLES_PER_US.load(Ordering::Relaxed);
-    rdtsc().wrapping_add(cycles)
-}
-
-/// Check whether a TSC deadline (from [`deadline_after_us`]) has been reached.
-#[inline]
-pub fn deadline_expired(deadline: u64) -> bool {
-    let diff = deadline.wrapping_sub(rdtsc()) as i64;
-    diff <= 0
-}
-
 /// A deadline-based timeout for polling loops
 ///
 /// # Example

--- a/x86_64-coreboot.ld
+++ b/x86_64-coreboot.ld
@@ -70,7 +70,7 @@ SECTIONS
         _bss_end = .;
     }
 
-    /* Stack - 256KB (increased from 64KB for large structs) */
+    /* Stack - 2MB (increased from 64KB for large structs like FirmwareState) */
     .stack : ALIGN(4096) {
         _stack_bottom = .;
         . += 0x200000;

--- a/x86_64-coreboot.ld
+++ b/x86_64-coreboot.ld
@@ -39,6 +39,15 @@ SECTIONS
         _rodata_end = .;
     }
 
+    /* Global Offset Table (PIC indirect calls to memcpy/memset/etc.)
+     * These entries contain absolute addresses that must be relocated
+     * during SetVirtualAddressMap. */
+    .got : ALIGN(8) {
+        _got_start = .;
+        *(.got .got.*)
+        _got_end = .;
+    }
+
     /* Initialized data */
     .data : ALIGN(4096) {
         _data_start = .;


### PR DESCRIPTION
This PR implements comprehensive Windows Boot Manager support by adding missing UEFI protocols, fixing device path handling, and improving runtime services for OS handoff.

## Key Changes

### Device Path & Boot Protocol Enhancements
- Install DiskIO protocol on all BlockIO handles for byte-granular disk access
- Add CDROM device path support for El Torito (ISO) boot entries
- Install LoadedImageDevicePath protocol required by Windows Boot Manager
- Implement device path matching in LoadImage to select correct disk on multi-disk systems
- Probe FAT BPB to determine real El Torito image sizes (catalog often reports 0 or 1)

### Event & Timer System
- Implement full timer event support (Periodic/Relative with TSC-based deadline tracking)
- Add event group support (ReadyToBoot, ExitBootServices, VirtualAddressChange)
- Store and invoke notify callbacks for signaled events
- Fix CheckEvent/WaitForEvent to check timer expiration

### Runtime Services (SetVirtualAddressMap)
- Implement full virtual address map conversion with pointer relocation
- Relocate RuntimeServices function pointers and GOT entries for PIC code
- Signal VirtualAddressChange events before pointer conversion
- Rebuild Memory Attributes Table in-place before ExitBootServices
- Add runtime serial logging (direct port I/O) for post-SVAM debugging
- Update all table CRC32 checksums after modifications

### Memory Management
- Strip protection attributes (RO/XP/RP) from GetMemoryMap output per EDK2 behavior
- Merge adjacent same-type entries in memory map for compactness
- Install Memory Attributes Table with correct RO/XP flags per region type
- Mark ACPI tables as AcpiReclaimMemory (merge overlapping regions)

### Boot Services Improvements
- Implement GetNextMonotonicCount
- Stub SetWatchdogTimer (accept but don't enforce)
- Stub Connect/DisconnectController (no-op for built-in driver model)
- Fix OpenProtocolInformation (return empty list instead of UNSUPPORTED)
- Support ALL_HANDLES search type in LocateHandle
- Fix ProtocolsPerHandle to return single contiguous buffer per spec

### Build System & Relocation
- Switch to `-C relocation-model=pic` + `-no-pie` for GOT-based PIC
- Add `.got` section to linker script with runtime relocation markers
- Implement GOT entry relocation during SetVirtualAddressMap

### AHCI & Storage
- Add automatic chunking for large reads (128 sectors SATA, 16 sectors ATAPI)
- Implement per-chunk retry logic (up to 3 attempts with 1ms delay)
- Fix ATAPI PACKET command: set DMA bit in feature register, cap byte count hint
- Clear stale interrupt/error status before issuing commands
- Wait for device ready (BSY=0, DRQ=0) after error recovery

### Configuration Tables
- Install empty TPM2 event log to prevent kernel ACPI memory errors
- Update System Table CRC32 after all modifications

## Implementation Details

**Device Path Matching**: LoadImage now scores each SimpleFileSystem handle by comparing device path node prefixes, selecting the handle with the longest match. This fixes multi-disk boot where the first SFS handle isn't necessarily the boot disk.

**Timer Events**: Store TSC deadline in EventEntry, check on every CheckEvent/WaitForEvent. Periodic timers automatically reset deadline; Relative timers fire once.

**SVAM Pointer Relocation**: Walk virtual map to find offset for each runtime region, apply to RT function pointers, GOT entries, and System Table pointers. Recompute CRC32s afterward.

**Memory Attributes Table**: Built at init with 2 regions, rebuilt in-place before ExitBootServices to include deferred variable buffer (3rd region). Uses same physical page to avoid changing map_key.

**PIC Relocation Model**: Compiler emits `call *GOT(%rip)` for intrinsics. Linker populates GOT with physical addresses. SVAM adjusts GOT entries by virtual offset so intrinsics remain callable post-SVAM.

## Testing

Tested with Windows Boot Manager and Windows installer (both ISO and USB). Successfully boots to Windows desktop, passes SetVirtualAddressMap, and handles runtime variable access.