### PR TITLE
Add SimpleTextInputEx protocol and improve EFI console rendering

### DIFF
--- a/src/drivers/usb/mod.rs
+++ b/src/drivers/usb/mod.rs
@@ -446,6 +446,15 @@ pub fn keyboard_get_key() -> Option<(u16, u16)> {
     hid_keyboard::get_key()
 }
 
+/// Get EFI key shift/toggle state from USB keyboard
+///
+/// Returns (shift_state_bits, toggle_state_bits) without the VALID flags —
+/// the caller is responsible for OR-ing these into a combined state that
+/// already has the VALID bits set.
+pub fn keyboard_get_efi_state() -> (u32, u8) {
+    hid_keyboard::get_efi_state()
+}
+
 // ============================================================================
 // Controller Access
 // ============================================================================

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -143,6 +143,28 @@ fn init_console() -> Option<efi::Handle> {
         log::error!("Failed to install text input protocol: {:?}", status);
     }
 
+    // Install text input ex protocol on the same console handle
+    {
+        use protocols::simple_text_input_ex::{
+            SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID, create_protocol as create_text_input_ex,
+        };
+        let input_ex = create_text_input_ex();
+        if input_ex.is_null() {
+            log::error!("Failed to create SimpleTextInputEx protocol");
+        } else {
+            let status = boot_services::install_protocol(
+                console_handle,
+                &SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID,
+                input_ex,
+            );
+            if status != Status::SUCCESS {
+                log::error!("Failed to install SimpleTextInputEx protocol: {:?}", status);
+            } else {
+                log::debug!("SimpleTextInputEx protocol installed on console handle");
+            }
+        }
+    }
+
     // Install text output protocol
     let output_protocol = get_text_output_protocol();
     let status = boot_services::install_protocol(

--- a/src/efi/protocols/console_control.rs
+++ b/src/efi/protocols/console_control.rs
@@ -110,11 +110,10 @@ extern "efiapi" fn console_set_mode(
                 let (cols, rows, delta_x, delta_y) =
                     crate::efi::protocols::console::compute_centered_text_layout(fb);
 
-                // Clear entire framebuffer
-                let fb_size = fb.y_resolution as usize * fb.bytes_per_line as usize;
+                // Clear entire framebuffer with the current background color
+                let (bg_r, bg_g, bg_b) = console.bg_color;
                 unsafe {
-                    let dst = fb.physical_address as *mut u8;
-                    core::slice::from_raw_parts_mut(dst, fb_size).fill(0);
+                    fb.fill_solid(bg_r, bg_g, bg_b);
                 }
 
                 console.start_row = 0;
@@ -139,10 +138,9 @@ extern "efiapi" fn console_set_mode(
                     return;
                 };
 
-                let fb_size = fb.y_resolution as usize * fb.bytes_per_line as usize;
+                // Graphics mode always clears to black (GOP starts fresh)
                 unsafe {
-                    let dst = fb.physical_address as *mut u8;
-                    core::slice::from_raw_parts_mut(dst, fb_size).fill(0);
+                    fb.fill_solid(0, 0, 0);
                 }
 
                 // Reset centering offsets (GOP uses raw pixel addressing)

--- a/src/efi/protocols/mod.rs
+++ b/src/efi/protocols/mod.rs
@@ -16,5 +16,6 @@ pub mod pass_thru_init;
 pub mod scsi_pass_thru;
 pub mod serial_io;
 pub mod simple_file_system;
+pub mod simple_text_input_ex;
 pub mod storage_security;
 pub mod unicode_collation;

--- a/src/efi/protocols/simple_text_input_ex.rs
+++ b/src/efi/protocols/simple_text_input_ex.rs
@@ -138,6 +138,12 @@ extern "efiapi" fn text_input_ex_reset(
     _extended_verification: Boolean,
 ) -> Status {
     log::debug!("SimpleTextInputEx.Reset()");
+    state::with_console_mut(|console| {
+        console.input.pending_key = None;
+        console.input.queued_key = None;
+        console.input.in_escape = false;
+        console.input.escape_len = 0;
+    });
     Status::SUCCESS
 }
 

--- a/src/efi/protocols/simple_text_input_ex.rs
+++ b/src/efi/protocols/simple_text_input_ex.rs
@@ -1,0 +1,367 @@
+//! EFI Simple Text Input Ex Protocol
+//!
+//! This module implements EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL, which extends
+//! the basic Simple Text Input protocol with:
+//! - Key state reporting (shift/ctrl/alt/logo modifiers, toggle keys)
+//! - Key notification callbacks (register for specific key combinations)
+//! - SetState for controlling toggle key LEDs
+//!
+//! The protocol shares the keyboard event (KEYBOARD_EVENT_ID) with the
+//! basic Simple Text Input protocol, and is installed on the same console handle.
+
+use crate::drivers::keyboard;
+use crate::efi::boot_services::KEYBOARD_EVENT_ID;
+use crate::efi::protocols::console;
+use crate::efi::utils::allocate_protocol_with_log;
+use crate::state;
+use core::ffi::c_void;
+use r_efi::efi::{Boolean, Event, Guid, Handle, Status};
+use r_efi::protocols::simple_text_input::InputKey;
+
+// ============================================================================
+// Protocol GUID
+// ============================================================================
+
+/// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID
+/// {DD9E7534-7762-4698-8C14-F58517A625AA}
+pub const SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID: Guid = Guid::from_fields(
+    0xdd9e7534,
+    0x7762,
+    0x4698,
+    0x8c,
+    0x14,
+    &[0xf5, 0x85, 0x17, 0xa6, 0x25, 0xaa],
+);
+
+// ============================================================================
+// Protocol Structures (matching UEFI spec)
+// ============================================================================
+
+/// EFI_KEY_STATE - describes the shift/toggle state of the keyboard
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct KeyState {
+    /// Shift key state (EFI_SHIFT_STATE_VALID | modifier bits)
+    pub key_shift_state: u32,
+    /// Toggle key state (EFI_TOGGLE_STATE_VALID | toggle bits)
+    pub key_toggle_state: u8,
+}
+
+/// EFI_KEY_DATA - a key press with associated state
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct KeyData {
+    /// The EFI scan code and Unicode value
+    pub key: InputKey,
+    /// Shift and toggle state at time of key press
+    pub key_state: KeyState,
+}
+
+// Compile-time layout assertions matching UEFI spec sizes:
+// EFI_KEY_STATE: UINT32 + UINT8 = 5 bytes + 3 padding = 8 bytes (repr(C))
+// EFI_KEY_DATA: EFI_INPUT_KEY (4 bytes) + EFI_KEY_STATE (8 bytes) = 12 bytes
+const _: () = assert!(core::mem::size_of::<KeyState>() == 8);
+const _: () = assert!(core::mem::size_of::<KeyData>() == 12);
+
+/// Key notification callback function type
+pub type KeyNotifyFunction = extern "efiapi" fn(key_data: *mut KeyData) -> Status;
+
+/// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL
+#[repr(C)]
+pub struct SimpleTextInputExProtocol {
+    pub reset: extern "efiapi" fn(
+        this: *mut SimpleTextInputExProtocol,
+        extended_verification: Boolean,
+    ) -> Status,
+    pub read_key_stroke_ex:
+        extern "efiapi" fn(this: *mut SimpleTextInputExProtocol, key_data: *mut KeyData) -> Status,
+    pub wait_for_key_ex: Event,
+    pub set_state: extern "efiapi" fn(
+        this: *mut SimpleTextInputExProtocol,
+        key_toggle_state: *mut u8,
+    ) -> Status,
+    pub register_key_notify: extern "efiapi" fn(
+        this: *mut SimpleTextInputExProtocol,
+        key_data: *mut KeyData,
+        key_notification_function: KeyNotifyFunction,
+        notify_handle: *mut Handle,
+    ) -> Status,
+    pub unregister_key_notify: extern "efiapi" fn(
+        this: *mut SimpleTextInputExProtocol,
+        notification_handle: Handle,
+    ) -> Status,
+}
+
+// ============================================================================
+// Key Notification Registry
+// ============================================================================
+
+/// Maximum number of registered key notifications
+const MAX_KEY_NOTIFY: usize = 16;
+
+/// A registered key notification entry
+struct KeyNotifyEntry {
+    /// Whether this slot is in use
+    active: bool,
+    /// The key pattern to match (scan_code + unicode_char)
+    key: InputKey,
+    /// Shift state to match (0 = match any)
+    shift_state: u32,
+    /// The callback function
+    callback: Option<KeyNotifyFunction>,
+}
+
+impl KeyNotifyEntry {
+    const fn empty() -> Self {
+        Self {
+            active: false,
+            key: InputKey {
+                scan_code: 0,
+                unicode_char: 0,
+            },
+            shift_state: 0,
+            callback: None,
+        }
+    }
+}
+
+/// Global key notification registry
+static KEY_NOTIFY_REGISTRY: spin::Mutex<[KeyNotifyEntry; MAX_KEY_NOTIFY]> =
+    spin::Mutex::new([const { KeyNotifyEntry::empty() }; MAX_KEY_NOTIFY]);
+
+// ============================================================================
+// Protocol Implementation
+// ============================================================================
+
+extern "efiapi" fn text_input_ex_reset(
+    _this: *mut SimpleTextInputExProtocol,
+    _extended_verification: Boolean,
+) -> Status {
+    log::debug!("SimpleTextInputEx.Reset()");
+    Status::SUCCESS
+}
+
+extern "efiapi" fn text_input_ex_read_key_stroke(
+    _this: *mut SimpleTextInputExProtocol,
+    key_data: *mut KeyData,
+) -> Status {
+    if key_data.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+
+    // Get current shift/toggle state (always valid, even if no key pressed)
+    let (shift_state, toggle_state) = keyboard::get_efi_key_state();
+
+    state::with_console_mut(|console_state| {
+        let input_state = &mut console_state.input;
+
+        // Use the shared key-reading function from console module
+        match console::try_read_key(input_state) {
+            Some((scan_code, unicode_char)) => {
+                unsafe {
+                    (*key_data).key.scan_code = scan_code;
+                    (*key_data).key.unicode_char = unicode_char;
+                    (*key_data).key_state.key_shift_state = shift_state;
+                    (*key_data).key_state.key_toggle_state = toggle_state;
+                }
+
+                log::trace!(
+                    "SimpleTextInputEx.ReadKeyStrokeEx: scan={:#x}, unicode={:#x}, shift={:#x}, toggle={:#x}",
+                    scan_code,
+                    unicode_char,
+                    shift_state,
+                    toggle_state
+                );
+
+                // Dispatch key notifications
+                dispatch_key_notifications(scan_code, unicode_char, shift_state, toggle_state);
+
+                Status::SUCCESS
+            }
+            None => {
+                // No key available — still report the current state per spec
+                unsafe {
+                    (*key_data).key.scan_code = 0;
+                    (*key_data).key.unicode_char = 0;
+                    (*key_data).key_state.key_shift_state = shift_state;
+                    (*key_data).key_state.key_toggle_state = toggle_state;
+                }
+                Status::NOT_READY
+            }
+        }
+    })
+}
+
+extern "efiapi" fn text_input_ex_set_state(
+    _this: *mut SimpleTextInputExProtocol,
+    key_toggle_state: *mut u8,
+) -> Status {
+    if key_toggle_state.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+
+    let toggle = unsafe { *key_toggle_state };
+    log::debug!("SimpleTextInputEx.SetState(toggle={:#x})", toggle);
+
+    // We can't actually control keyboard LEDs from firmware easily,
+    // so just accept the request. This matches the EDK2 terminal driver behavior.
+    Status::SUCCESS
+}
+
+extern "efiapi" fn text_input_ex_register_key_notify(
+    _this: *mut SimpleTextInputExProtocol,
+    key_data: *mut KeyData,
+    key_notification_function: KeyNotifyFunction,
+    notify_handle: *mut Handle,
+) -> Status {
+    if key_data.is_null() || notify_handle.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+
+    let kd = unsafe { &*key_data };
+    log::debug!(
+        "SimpleTextInputEx.RegisterKeyNotify(scan={:#x}, unicode={:#x}, shift={:#x})",
+        kd.key.scan_code,
+        kd.key.unicode_char,
+        kd.key_state.key_shift_state
+    );
+
+    let mut registry = KEY_NOTIFY_REGISTRY.lock();
+
+    // Find a free slot
+    for (i, entry) in registry.iter_mut().enumerate() {
+        if !entry.active {
+            entry.active = true;
+            entry.key = kd.key;
+            entry.shift_state = kd.key_state.key_shift_state;
+            entry.callback = Some(key_notification_function);
+
+            // Return slot index + 1 as the handle (avoid null)
+            let handle = (i + 1) as *mut c_void;
+            unsafe {
+                *notify_handle = handle;
+            }
+            log::debug!("  -> registered as handle {:p}", handle);
+            return Status::SUCCESS;
+        }
+    }
+
+    log::warn!("SimpleTextInputEx: too many key notifications registered");
+    Status::OUT_OF_RESOURCES
+}
+
+extern "efiapi" fn text_input_ex_unregister_key_notify(
+    _this: *mut SimpleTextInputExProtocol,
+    notification_handle: Handle,
+) -> Status {
+    let idx = notification_handle as usize;
+    log::debug!("SimpleTextInputEx.UnregisterKeyNotify(handle={})", idx);
+
+    if idx == 0 || idx > MAX_KEY_NOTIFY {
+        return Status::INVALID_PARAMETER;
+    }
+
+    let mut registry = KEY_NOTIFY_REGISTRY.lock();
+    let entry = &mut registry[idx - 1];
+
+    if !entry.active {
+        return Status::INVALID_PARAMETER;
+    }
+
+    *entry = KeyNotifyEntry::empty();
+    Status::SUCCESS
+}
+
+/// A pending key notification to dispatch outside the lock
+struct PendingNotify {
+    callback: KeyNotifyFunction,
+    key_data: KeyData,
+}
+
+/// Dispatch key notifications for a key press
+fn dispatch_key_notifications(
+    scan_code: u16,
+    unicode_char: u16,
+    shift_state: u32,
+    toggle_state: u8,
+) {
+    // Collect callbacks to invoke outside the lock
+    // Use MaybeUninit to avoid zeroed() warning on function pointers
+    let mut callbacks: [core::mem::MaybeUninit<PendingNotify>; MAX_KEY_NOTIFY] =
+        [const { core::mem::MaybeUninit::uninit() }; MAX_KEY_NOTIFY];
+    let mut count = 0;
+
+    {
+        let registry = KEY_NOTIFY_REGISTRY.lock();
+        for entry in registry.iter() {
+            if !entry.active {
+                continue;
+            }
+            let callback = match entry.callback {
+                Some(f) => f,
+                None => continue,
+            };
+
+            // Match key pattern: if registered key has non-zero scan/unicode, it must match
+            let key_matches = (entry.key.scan_code == 0 && entry.key.unicode_char == 0)
+                || (entry.key.scan_code == scan_code && entry.key.unicode_char == unicode_char);
+
+            // Match shift state: if registered shift state has VALID bit, compare
+            let shift_matches = (entry.shift_state & keyboard::efi_shift_state::SHIFT_STATE_VALID)
+                == 0
+                || (entry.shift_state & !keyboard::efi_shift_state::SHIFT_STATE_VALID)
+                    == (shift_state & !keyboard::efi_shift_state::SHIFT_STATE_VALID);
+
+            if key_matches && shift_matches && count < MAX_KEY_NOTIFY {
+                let kd = KeyData {
+                    key: InputKey {
+                        scan_code,
+                        unicode_char,
+                    },
+                    key_state: KeyState {
+                        key_shift_state: shift_state,
+                        key_toggle_state: toggle_state,
+                    },
+                };
+                callbacks[count].write(PendingNotify {
+                    callback,
+                    key_data: kd,
+                });
+                count += 1;
+            }
+        }
+    }
+
+    // Invoke callbacks outside the lock
+    for entry in callbacks.iter().take(count) {
+        // Safety: we only read entries that were written above
+        let pending = unsafe { entry.assume_init_ref() };
+        let mut kd = pending.key_data;
+        (pending.callback)(&mut kd);
+    }
+}
+
+// ============================================================================
+// Protocol Creation
+// ============================================================================
+
+/// Create a Simple Text Input Ex Protocol instance
+///
+/// Returns a pointer to the allocated protocol, or null on failure.
+pub fn create_protocol() -> *mut c_void {
+    let ptr =
+        allocate_protocol_with_log::<SimpleTextInputExProtocol>("SimpleTextInputExProtocol", |p| {
+            p.reset = text_input_ex_reset;
+            p.read_key_stroke_ex = text_input_ex_read_key_stroke;
+            p.wait_for_key_ex = KEYBOARD_EVENT_ID as *mut c_void as Event;
+            p.set_state = text_input_ex_set_state;
+            p.register_key_notify = text_input_ex_register_key_notify;
+            p.unregister_key_notify = text_input_ex_unregister_key_notify;
+        });
+    if ptr.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    log::debug!("Created SimpleTextInputExProtocol at {:p}", ptr);
+    ptr as *mut c_void
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -152,11 +152,7 @@ pub fn try_get() -> Option<&'static FirmwareState> {
 #[inline]
 pub fn try_get_mut_ptr() -> Option<*mut FirmwareState> {
     let ptr = STATE_PTR.load(Ordering::Acquire);
-    if ptr.is_null() {
-        None
-    } else {
-        Some(ptr)
-    }
+    if ptr.is_null() { None } else { Some(ptr) }
 }
 
 // ============================================================================
@@ -706,7 +702,7 @@ impl ConsoleState {
             start_row: 0,
             delta_x: 0,
             delta_y: 0,
-            fg_color: (255, 255, 255), // EFI_LIGHTGRAY default
+            fg_color: (170, 170, 170), // EFI_LIGHTGRAY (attribute 0x07, index 7)
             bg_color: (0, 0, 0),       // EFI_BLACK default
             input: InputState::new(),
             logger_framebuffer: None,
@@ -735,6 +731,10 @@ pub struct InputState {
     pub in_escape: bool,
     /// Queued key to return (scan_code, unicode_char)
     pub queued_key: Option<(u16, u16)>,
+    /// Key read-ahead by CheckEvent/WaitForEvent to confirm real input
+    /// This prevents false "keyboard ready" signals from modifier-only
+    /// or mouse data in the PS/2 output buffer.
+    pub pending_key: Option<(u16, u16)>,
 }
 
 impl Default for InputState {
@@ -750,6 +750,7 @@ impl InputState {
             escape_len: 0,
             in_escape: false,
             queued_key: None,
+            pending_key: None,
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -152,7 +152,11 @@ pub fn try_get() -> Option<&'static FirmwareState> {
 #[inline]
 pub fn try_get_mut_ptr() -> Option<*mut FirmwareState> {
     let ptr = STATE_PTR.load(Ordering::Acquire);
-    if ptr.is_null() { None } else { Some(ptr) }
+    if ptr.is_null() {
+        None
+    } else {
+        Some(ptr)
+    }
 }
 
 // ============================================================================
@@ -671,6 +675,16 @@ pub struct ConsoleState {
     /// Console start row (EFI console uses bottom half of screen)
     pub start_row: u32,
 
+    /// Pixel offset for centering the text region horizontally (EDK2 DeltaX)
+    pub delta_x: u32,
+    /// Pixel offset for centering the text region vertically (EDK2 DeltaY)
+    pub delta_y: u32,
+
+    /// Current foreground color (RGB) set by SetAttribute
+    pub fg_color: (u8, u8, u8),
+    /// Current background color (RGB) set by SetAttribute
+    pub bg_color: (u8, u8, u8),
+
     /// Input state for escape sequence parsing
     pub input: InputState,
 
@@ -690,6 +704,10 @@ impl ConsoleState {
             cursor_pos: (0, 0),
             dimensions: (80, 25),
             start_row: 0,
+            delta_x: 0,
+            delta_y: 0,
+            fg_color: (255, 255, 255), // EFI_LIGHTGRAY default
+            bg_color: (0, 0, 0),       // EFI_BLACK default
             input: InputState::new(),
             logger_framebuffer: None,
             logger_cursor: (0, 0),


### PR DESCRIPTION
## Summary

This PR adds support for the EFI SimpleTextInputEx protocol and makes several improvements to the EFI console implementation, including centered text rendering, proper color support, and better keyboard input handling.

## Key Changes

### SimpleTextInputEx Protocol Implementation
- Implements `EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL` with full keyboard state reporting (shift/ctrl/alt/logo modifiers, toggle keys)
- Adds key notification callback registry supporting up to 16 registered callbacks
- Shares the keyboard event with basic SimpleTextInput protocol to prevent key stealing
- Reports left/right distinction for modifier keys when using USB keyboards

### Console Text Rendering Improvements
- Implements centered text layout matching EDK2 GraphicsConsole behavior (DeltaX/DeltaY offsets)
- Adds proper EFI color attribute support (16 foreground + 8 background colors) with RGB mapping
- Scrolling now only affects the centered text region, not the entire framebuffer
- Text mode screen clears fill with the current background color instead of always black

### Framebuffer Optimizations
- Adds `fill_pixels()` and `fill_solid()` methods for fast bulk fill operations
- Avoids per-pixel bounds checks when clearing regions
- Handles both 16bpp and 32bpp framebuffers efficiently

### Keyboard Input Fixes
- Introduces `keyboard_check_ready()` that performs real read-ahead to avoid false positives from modifier-only scancodes or PS/2 mouse data
- Consolidates key reading into a single `try_read_key()` function shared by both text input protocols
- Adds `pending_key` field to stash read-ahead keys for the next ReadKeyStroke call
- Fixes `ConIn.Reset()` to properly clear input state

### ConsoleControl Protocol
- `SetMode()` now properly switches between text and graphics modes
- Text mode sets up centered rendering; graphics mode clears to black for GOP
- Mode switches handle framebuffer clearing with appropriate colors

### Other
- `QueryMode()` now returns actual text dimensions from the framebuffer instead of hardcoded 80x25
- Adds EFI shift state and toggle state flag constants matching UEFI spec