### PR TITLE
# Add CFR Firmware Settings Menu

### DIFF
--- a/src/cfr_menu.rs
+++ b/src/cfr_menu.rs
@@ -1,0 +1,1087 @@
+//! CFR Firmware Settings Menu
+//!
+//! This module provides a user interface for viewing and modifying
+//! coreboot firmware options exposed via CFR (Coreboot Form Representation).
+//!
+//! The menu displays all CFR forms and their options, allowing the user
+//! to navigate and modify settings. Changes are persisted to UEFI variables.
+//!
+//! Dependency evaluation is supported: options whose dependencies are not
+//! met are hidden or shown as inactive according to their flags.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use crate::coreboot::{
+    self,
+    cfr::{self, CfrInfo, CfrOption, CfrOptionType, CfrValue},
+};
+use crate::drivers::serial as serial_driver;
+use crate::framebuffer_console::{
+    Color, FramebufferConsole, DEFAULT_BG, DEFAULT_FG, HIGHLIGHT_BG, HIGHLIGHT_FG,
+};
+use crate::menu_common::{self, KeyPress, SerialWriter};
+use crate::time::delay_ms;
+use core::fmt::Write;
+
+/// Menu title
+const MENU_TITLE: &str = "Firmware Settings";
+
+/// Help text
+const HELP_TEXT: &str =
+    "Up/Down: Navigate | Enter/Space: Edit | +/-: Inc/Dec | ?: Help | Esc: Exit";
+
+/// Menu item types
+#[derive(Debug, Clone)]
+enum MenuItem {
+    /// Form header (category separator)
+    FormHeader { name: String },
+    /// Editable option
+    Option {
+        form_idx: usize,
+        option_idx: usize,
+        current_value: CfrValue,
+        /// Snapshot of the value when the menu was opened, used to detect changes
+        original_value: CfrValue,
+    },
+    /// Informational comment
+    Comment { text: String },
+    /// Nested subform section header (indented)
+    SubformHeader { name: String },
+}
+
+/// Returns true if any option's current value differs from its original value
+fn has_changes(items: &[MenuItem]) -> bool {
+    items.iter().any(|item| {
+        matches!(
+            item,
+            MenuItem::Option {
+                current_value,
+                original_value,
+                ..
+            } if current_value != original_value
+        )
+    })
+}
+
+/// Show the CFR firmware settings menu
+///
+/// Displays the menu and handles user interaction.
+/// Returns when the user exits the menu.
+pub fn show_cfr_menu() {
+    let cfr_info = match coreboot::get_cfr() {
+        Some(cfr) => cfr,
+        None => {
+            show_no_cfr_message();
+            return;
+        }
+    };
+
+    let fb_info = coreboot::get_framebuffer();
+    let mut fb_console = fb_info.as_ref().map(FramebufferConsole::new);
+
+    let mut items = build_menu_items(cfr_info);
+
+    if items.is_empty() {
+        show_no_options_message(&mut fb_console);
+        return;
+    }
+
+    let mut selected = find_first_selectable(cfr_info, &items, 0);
+    let mut status_message: Option<(&str, bool)> = None;
+    let mut scroll_offset = 0usize;
+
+    loop {
+        menu_common::clear_screen(&mut fb_console);
+        let modified = has_changes(&items);
+        // Ensure scroll keeps selected item visible
+        let vis = visible_indices(cfr_info, &items);
+        let sel_vis_pos = vis.iter().position(|&i| i == selected).unwrap_or(0);
+        let screen_rows = get_visible_rows(&fb_console);
+        if sel_vis_pos < scroll_offset {
+            scroll_offset = sel_vis_pos;
+        } else if sel_vis_pos >= scroll_offset + screen_rows {
+            scroll_offset = sel_vis_pos - screen_rows + 1;
+        }
+        draw_menu(
+            cfr_info,
+            &items,
+            selected,
+            scroll_offset,
+            modified,
+            status_message,
+            &mut fb_console,
+        );
+
+        status_message = None;
+
+        loop {
+            if let Some(key) = menu_common::read_key() {
+                match key {
+                    KeyPress::Up | KeyPress::Char('k') => {
+                        selected = find_prev_selectable(cfr_info, &items, selected);
+                        break;
+                    }
+                    KeyPress::Down | KeyPress::Char('j') => {
+                        selected = find_next_selectable(cfr_info, &items, selected);
+                        break;
+                    }
+                    KeyPress::Enter | KeyPress::Char(' ') => {
+                        // Check visibility/editability before taking a mutable borrow
+                        let can_edit = if let Some(item @ MenuItem::Option { form_idx, option_idx, .. }) =
+                            items.get(selected)
+                        {
+                            is_item_visible(cfr_info, &items, item)
+                                && get_option(cfr_info, *form_idx, *option_idx)
+                                    .is_some_and(|o| o.is_editable())
+                        } else {
+                            false
+                        };
+                        if can_edit {
+                            if let Some(MenuItem::Option {
+                                form_idx,
+                                option_idx,
+                                current_value,
+                                ..
+                            }) = items.get_mut(selected)
+                            {
+                                let (fi, oi) = (*form_idx, *option_idx);
+                                if let Some(option) = get_option(cfr_info, fi, oi) {
+                                    toggle_value(option, current_value);
+                                }
+                            }
+                        } else if matches!(items.get(selected), Some(MenuItem::Option { .. })) {
+                            status_message = Some(("Option is read-only", false));
+                        }
+                        break;
+                    }
+                    KeyPress::Char('+') | KeyPress::Char('=') => {
+                        increment_option(cfr_info, &mut items, selected);
+                        break;
+                    }
+                    KeyPress::Char('-') => {
+                        decrement_option(cfr_info, &mut items, selected);
+                        break;
+                    }
+                    KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
+                        if has_changes(&items) && confirm_save(&mut fb_console) {
+                            let (saved, failed) = save_all_changes(cfr_info, &items);
+                            show_save_result(saved, failed, &mut fb_console);
+                        }
+                        return;
+                    }
+                    KeyPress::Char('?') => {
+                        if let Some(MenuItem::Option {
+                            form_idx,
+                            option_idx,
+                            ..
+                        }) = items.get(selected)
+                            && let Some(option) = get_option(cfr_info, *form_idx, *option_idx) {
+                                show_help(option, &mut fb_console);
+                            }
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            delay_ms(10);
+        }
+    }
+}
+
+/// Build menu items from CFR info.
+///
+/// All non-suppressed items are included regardless of dependency state.
+/// Dependencies are evaluated dynamically at draw/interaction time so that
+/// toggling a "parent" option immediately shows or hides dependent items.
+fn build_menu_items(cfr: &CfrInfo) -> Vec<MenuItem> {
+    let mut items = Vec::new();
+
+    for (form_idx, form) in cfr.forms.iter().enumerate() {
+        if !form.is_visible() {
+            continue;
+        }
+
+        items.push(MenuItem::FormHeader {
+            name: form.ui_name.clone(),
+        });
+
+        for (option_idx, option) in form.options.iter().enumerate() {
+            if !option.is_visible() {
+                continue;
+            }
+
+            match &option.option_type {
+                CfrOptionType::Comment => {
+                    // Check if this is a flattened subform header (has object_id, no opt_name)
+                    let is_subform = option.opt_name.is_empty() && option.object_id != 0;
+                    if is_subform {
+                        items.push(MenuItem::SubformHeader {
+                            name: option.ui_name.clone(),
+                        });
+                    } else {
+                        items.push(MenuItem::Comment {
+                            text: option.ui_name.clone(),
+                        });
+                    }
+                }
+                _ => {
+                    let current_value = cfr::read_option_value(option);
+                    items.push(MenuItem::Option {
+                        form_idx,
+                        option_idx,
+                        original_value: current_value.clone(),
+                        current_value,
+                    });
+                }
+            }
+        }
+    }
+
+    items
+}
+
+/// Look up the current in-flight numeric value for an option identified by
+/// `object_id`, checking the menu items first (which reflect the user's
+/// uncommitted edits) and falling back to persistent storage via
+/// `CfrInfo::find_numeric_value`.
+fn find_live_numeric_value(cfr: &CfrInfo, items: &[MenuItem], object_id: u64) -> Option<u32> {
+    if object_id == 0 {
+        return None;
+    }
+    // Search menu items for an option whose CfrOption::object_id matches
+    for item in items {
+        if let MenuItem::Option {
+            form_idx,
+            option_idx,
+            current_value,
+            ..
+        } = item
+            && let Some(option) = get_option(cfr, *form_idx, *option_idx)
+            && option.object_id == object_id
+        {
+            return match current_value {
+                CfrValue::Bool(b) => Some(if *b { 1 } else { 0 }),
+                CfrValue::Number(n) => Some(*n),
+                _ => None,
+            };
+        }
+    }
+    // Fallback to stored value
+    cfr.find_numeric_value(object_id)
+}
+
+/// Evaluate whether a dependency is met using live (in-flight) menu values.
+fn is_dep_met_live(
+    cfr: &CfrInfo,
+    items: &[MenuItem],
+    dependency_id: u64,
+    dep_values: &[u32],
+) -> bool {
+    if dependency_id == 0 {
+        return true;
+    }
+    match find_live_numeric_value(cfr, items, dependency_id) {
+        Some(current) => {
+            if dep_values.is_empty() {
+                current != 0
+            } else {
+                dep_values.contains(&current)
+            }
+        }
+        None => true,
+    }
+}
+
+/// Check if a menu item is currently visible based on live dependency state.
+///
+/// Form headers are visible if the form's dependency is met. Options, comments,
+/// and subform headers are visible if the owning form's dependency AND the
+/// item's own dependency are both met.
+fn is_item_visible(cfr: &CfrInfo, items: &[MenuItem], item: &MenuItem) -> bool {
+    match item {
+        MenuItem::FormHeader { name } => {
+            // Find the form by name and check its dependency
+            cfr.forms
+                .iter()
+                .find(|f| f.ui_name == *name)
+                .is_none_or(|form| {
+                    is_dep_met_live(cfr, items, form.dependency_id, &form.dep_values)
+                })
+        }
+        MenuItem::Option {
+            form_idx,
+            option_idx,
+            ..
+        } => {
+            let form_ok = cfr
+                .forms
+                .get(*form_idx)
+                .is_none_or(|form| {
+                    is_dep_met_live(cfr, items, form.dependency_id, &form.dep_values)
+                });
+            let opt_ok = get_option(cfr, *form_idx, *option_idx)
+                .is_none_or(|opt| {
+                    is_dep_met_live(cfr, items, opt.dependency_id, &opt.dep_values)
+                });
+            form_ok && opt_ok
+        }
+        // Comments and subform headers don't carry their own indices, so
+        // they stay visible (their parent form header hides the section).
+        MenuItem::Comment { .. } | MenuItem::SubformHeader { .. } => true,
+    }
+}
+
+/// Get an option by form and option index
+fn get_option(cfr: &CfrInfo, form_idx: usize, option_idx: usize) -> Option<&CfrOption> {
+    cfr.forms
+        .get(form_idx)
+        .and_then(|f| f.options.get(option_idx))
+}
+
+/// Find the first selectable and visible item starting from index
+fn find_first_selectable(cfr: &CfrInfo, items: &[MenuItem], start: usize) -> usize {
+    for (i, item) in items.iter().enumerate().skip(start) {
+        if is_selectable(item) && is_item_visible(cfr, items, item) {
+            return i;
+        }
+    }
+    for (i, item) in items.iter().enumerate().take(start) {
+        if is_selectable(item) && is_item_visible(cfr, items, item) {
+            return i;
+        }
+    }
+    0
+}
+
+fn find_prev_selectable(cfr: &CfrInfo, items: &[MenuItem], current: usize) -> usize {
+    for i in (0..current).rev() {
+        if is_selectable(&items[i]) && is_item_visible(cfr, items, &items[i]) {
+            return i;
+        }
+    }
+    current
+}
+
+fn find_next_selectable(cfr: &CfrInfo, items: &[MenuItem], current: usize) -> usize {
+    for (i, item) in items.iter().enumerate().skip(current + 1) {
+        if is_selectable(item) && is_item_visible(cfr, items, item) {
+            return i;
+        }
+    }
+    current
+}
+
+fn is_selectable(item: &MenuItem) -> bool {
+    matches!(item, MenuItem::Option { .. })
+}
+
+/// Check if the item at `index` is an editable, visible option (immutable borrow).
+fn can_edit_item(cfr: &CfrInfo, items: &[MenuItem], index: usize) -> bool {
+    if let Some(item @ MenuItem::Option { form_idx, option_idx, .. }) = items.get(index) {
+        is_item_visible(cfr, items, item)
+            && get_option(cfr, *form_idx, *option_idx).is_some_and(|o| o.is_editable())
+    } else {
+        false
+    }
+}
+
+fn get_visible_rows(fb_console: &Option<FramebufferConsole>) -> usize {
+    fb_console
+        .as_ref()
+        .map(|c| c.rows() as usize)
+        .unwrap_or(20)
+        .saturating_sub(10)
+}
+
+/// Toggle/cycle a value (Enter/Space)
+fn toggle_value(option: &CfrOption, value: &mut CfrValue) -> bool {
+    match (&option.option_type, value) {
+        (CfrOptionType::Bool { .. }, CfrValue::Bool(b)) => {
+            *b = !*b;
+            true
+        }
+        (CfrOptionType::Enum { choices, .. }, CfrValue::Number(n)) => {
+            if choices.is_empty() {
+                return false;
+            }
+            let current_idx = choices.iter().position(|c| c.value == *n).unwrap_or(0);
+            let next_idx = (current_idx + 1) % choices.len();
+            if let Some(choice) = choices.get(next_idx) {
+                *n = choice.value;
+                return true;
+            }
+            false
+        }
+        (CfrOptionType::Number { min, max, step, .. }, CfrValue::Number(n)) => {
+            let new_val = (*n).saturating_add(*step);
+            if new_val <= *max {
+                *n = new_val;
+            } else {
+                *n = *min; // Wrap around
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Increment a numeric/enum option in-place
+fn increment_option(cfr: &CfrInfo, items: &mut [MenuItem], index: usize) -> bool {
+    // Check editability with live dependencies before taking a mutable borrow
+    if !can_edit_item(cfr, items, index) {
+        return false;
+    }
+    let Some(MenuItem::Option {
+        form_idx,
+        option_idx,
+        current_value,
+        ..
+    }) = items.get_mut(index)
+    else {
+        return false;
+    };
+    let (fi, oi) = (*form_idx, *option_idx);
+    let Some(option) = get_option(cfr, fi, oi) else {
+        return false;
+    };
+    match (&option.option_type, current_value) {
+        (CfrOptionType::Bool { .. }, CfrValue::Bool(b)) => {
+            *b = !*b;
+            true
+        }
+        (CfrOptionType::Enum { choices, .. }, CfrValue::Number(n)) => {
+            if choices.is_empty() {
+                return false;
+            }
+            let current_idx = choices.iter().position(|c| c.value == *n).unwrap_or(0);
+            let next_idx = (current_idx + 1) % choices.len();
+            if let Some(choice) = choices.get(next_idx) {
+                *n = choice.value;
+                true
+            } else {
+                false
+            }
+        }
+        (CfrOptionType::Number { max, step, .. }, CfrValue::Number(n)) => {
+            let new_val = (*n).saturating_add(*step);
+            if new_val <= *max {
+                *n = new_val;
+                true
+            } else if *n < *max {
+                // Unaligned: clamp to max
+                *n = *max;
+                true
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Decrement a numeric/enum option in-place
+fn decrement_option(cfr: &CfrInfo, items: &mut [MenuItem], index: usize) -> bool {
+    // Check editability with live dependencies before taking a mutable borrow
+    if !can_edit_item(cfr, items, index) {
+        return false;
+    }
+    let Some(MenuItem::Option {
+        form_idx,
+        option_idx,
+        current_value,
+        ..
+    }) = items.get_mut(index)
+    else {
+        return false;
+    };
+    let (fi, oi) = (*form_idx, *option_idx);
+    let Some(option) = get_option(cfr, fi, oi) else {
+        return false;
+    };
+    match (&option.option_type, current_value) {
+        (CfrOptionType::Bool { .. }, CfrValue::Bool(b)) => {
+            *b = !*b;
+            true
+        }
+        (CfrOptionType::Enum { choices, .. }, CfrValue::Number(n)) => {
+            if choices.is_empty() {
+                return false;
+            }
+            let current_idx = choices.iter().position(|c| c.value == *n).unwrap_or(0);
+            let prev_idx = if current_idx == 0 {
+                choices.len().saturating_sub(1)
+            } else {
+                current_idx - 1
+            };
+            if let Some(choice) = choices.get(prev_idx) {
+                *n = choice.value;
+                true
+            } else {
+                false
+            }
+        }
+        (CfrOptionType::Number { min, step, .. }, CfrValue::Number(n)) => {
+            if *n >= *min + *step {
+                *n -= *step;
+                true
+            } else if *n > *min {
+                // Unaligned: clamp to min
+                *n = *min;
+                true
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Save modified option values to persistent storage.
+///
+/// Only writes options that were actually changed by the user, reducing
+/// unnecessary SPI flash wear. Returns `(saved, failed)` counts.
+fn save_all_changes(cfr: &CfrInfo, items: &[MenuItem]) -> (usize, usize) {
+    let mut saved = 0usize;
+    let mut failed = 0usize;
+    for item in items {
+        if let MenuItem::Option {
+            form_idx,
+            option_idx,
+            current_value,
+            original_value,
+        } = item
+            && current_value != original_value
+            && let Some(option) = get_option(cfr, *form_idx, *option_idx)
+        {
+            match cfr::write_option_value(option, current_value) {
+                Ok(()) => saved += 1,
+                Err(e) => {
+                    log::warn!("Failed to save '{}': {}", option.opt_name, e);
+                    failed += 1;
+                }
+            }
+        }
+    }
+    (saved, failed)
+}
+
+/// Show confirmation dialog for saving on exit
+fn confirm_save(fb_console: &mut Option<FramebufferConsole>) -> bool {
+    serial_driver::write_str("\x1b[2J\x1b[H");
+    serial_driver::write_str("\r\n\r\n");
+    serial_driver::write_str("\x1b[1;33m");
+    serial_driver::write_str("  Save changes? (takes effect after reset)\r\n");
+    serial_driver::write_str("\x1b[0m\r\n");
+    serial_driver::write_str("  Press Y to save, N to discard\r\n");
+
+    if let Some(console) = fb_console {
+        console.clear();
+        let rows = console.rows();
+        let confirm_row = rows / 2;
+        console.set_fg_color(Color::new(255, 255, 0));
+        console.write_centered(confirm_row, "Save changes? (takes effect after reset)");
+        console.reset_colors();
+        console.write_centered(confirm_row + 2, "Press Y to save, N to discard");
+    }
+
+    loop {
+        if let Some(key) = menu_common::read_key() {
+            match key {
+                KeyPress::Char('y') | KeyPress::Char('Y') => return true,
+                KeyPress::Char('n') | KeyPress::Char('N') | KeyPress::Escape => return false,
+                _ => {}
+            }
+        }
+        delay_ms(10);
+    }
+}
+
+/// Show a brief save result message (displayed on the confirm screen)
+fn show_save_result(saved: usize, failed: usize, fb_console: &mut Option<FramebufferConsole>) {
+    if failed == 0 {
+        let _ = write!(SerialWriter, "\r\n\x1b[1;32m  Saved {} option(s).\x1b[0m\r\n", saved);
+        if let Some(console) = fb_console {
+            let rows = console.rows();
+            console.set_fg_color(Color::new(0, 255, 0));
+            let mut buf = [0u8; 64];
+            let msg = fmt_save_msg(&mut buf, saved, 0);
+            console.write_centered(rows / 2 + 4, msg);
+            console.reset_colors();
+        }
+    } else {
+        let _ = write!(
+            SerialWriter,
+            "\r\n\x1b[1;31m  Saved {} option(s), {} failed to write.\x1b[0m\r\n",
+            saved, failed
+        );
+        if let Some(console) = fb_console {
+            let rows = console.rows();
+            console.set_fg_color(Color::new(255, 64, 64));
+            let mut buf = [0u8; 64];
+            let msg = fmt_save_msg(&mut buf, saved, failed);
+            console.write_centered(rows / 2 + 4, msg);
+            console.reset_colors();
+        }
+    }
+    // Brief pause so the user can read the message
+    delay_ms(1500);
+}
+
+/// Format save result into a stack buffer (no alloc needed for a short message)
+fn fmt_save_msg(buf: &mut [u8; 64], saved: usize, failed: usize) -> &str {
+    use core::fmt::Write;
+    struct BufWriter<'a> {
+        buf: &'a mut [u8],
+        pos: usize,
+    }
+    impl<'a> core::fmt::Write for BufWriter<'a> {
+        fn write_str(&mut self, s: &str) -> core::fmt::Result {
+            let bytes = s.as_bytes();
+            let end = (self.pos + bytes.len()).min(self.buf.len());
+            let count = end - self.pos;
+            self.buf[self.pos..end].copy_from_slice(&bytes[..count]);
+            self.pos = end;
+            Ok(())
+        }
+    }
+    let mut w = BufWriter { buf: buf.as_mut_slice(), pos: 0 };
+    if failed == 0 {
+        let _ = write!(w, "Saved {} option(s).", saved);
+    } else {
+        let _ = write!(w, "Saved {}, {} failed to write.", saved, failed);
+    }
+    let len = w.pos;
+    core::str::from_utf8(&buf[..len]).unwrap_or("Save complete.")
+}
+
+/// Show help for an option
+fn show_help(option: &CfrOption, fb_console: &mut Option<FramebufferConsole>) {
+    serial_driver::write_str("\x1b[2J\x1b[H");
+    serial_driver::write_str("\r\n");
+    serial_driver::write_str("\x1b[1;36m");
+    serial_driver::write_str("  ");
+    serial_driver::write_str(&option.ui_name);
+    serial_driver::write_str("\x1b[0m\r\n\r\n");
+
+    if !option.ui_helptext.is_empty() {
+        serial_driver::write_str("  ");
+        serial_driver::write_str(&option.ui_helptext);
+        serial_driver::write_str("\r\n");
+    } else {
+        serial_driver::write_str("  No help available for this option.\r\n");
+    }
+
+    serial_driver::write_str("\r\n  Press any key to continue...\r\n");
+
+    if let Some(console) = fb_console {
+        console.clear();
+        let rows = console.rows();
+        console.set_fg_color(Color::new(0, 192, 192));
+        console.write_centered(4, &option.ui_name);
+        console.reset_colors();
+
+        if !option.ui_helptext.is_empty() {
+            console.set_position(4, 7);
+            let _ = console.write_str(&option.ui_helptext);
+        } else {
+            console.write_centered(7, "No help available for this option.");
+        }
+
+        console.write_centered(rows - 3, "Press any key to continue...");
+    }
+
+    loop {
+        if menu_common::read_key().is_some() {
+            break;
+        }
+        delay_ms(10);
+    }
+}
+
+/// Show message that CFR is not available
+fn show_no_cfr_message() {
+    let fb_info = coreboot::get_framebuffer();
+    let mut fb_console = fb_info.as_ref().map(FramebufferConsole::new);
+
+    serial_driver::write_str("\r\n");
+    serial_driver::write_str("\x1b[1;33m");
+    serial_driver::write_str("  Firmware settings not available\r\n");
+    serial_driver::write_str("\x1b[0m");
+    serial_driver::write_str("  This firmware does not expose CFR configuration options.\r\n");
+    serial_driver::write_str("\r\n  Press any key to continue...\r\n");
+
+    if let Some(console) = &mut fb_console {
+        console.clear();
+        let rows = console.rows();
+        console.set_fg_color(Color::new(255, 255, 0));
+        console.write_centered(rows / 2 - 1, "Firmware settings not available");
+        console.reset_colors();
+        console.write_centered(
+            rows / 2 + 1,
+            "This firmware does not expose CFR configuration options.",
+        );
+        console.write_centered(rows / 2 + 3, "Press any key to continue...");
+    }
+
+    loop {
+        if menu_common::read_key().is_some() {
+            break;
+        }
+        delay_ms(10);
+    }
+}
+
+/// Show message that no options are available
+fn show_no_options_message(fb_console: &mut Option<FramebufferConsole>) {
+    serial_driver::write_str("\r\n");
+    serial_driver::write_str("\x1b[1;33m");
+    serial_driver::write_str("  No configurable options found\r\n");
+    serial_driver::write_str("\x1b[0m");
+    serial_driver::write_str("\r\n  Press any key to continue...\r\n");
+
+    if let Some(console) = fb_console {
+        console.clear();
+        let rows = console.rows();
+        console.set_fg_color(Color::new(255, 255, 0));
+        console.write_centered(rows / 2, "No configurable options found");
+        console.reset_colors();
+        console.write_centered(rows / 2 + 2, "Press any key to continue...");
+    }
+
+    loop {
+        if menu_common::read_key().is_some() {
+            break;
+        }
+        delay_ms(10);
+    }
+}
+
+// ============================================================================
+// Drawing
+// ============================================================================
+
+/// Collect the indices of items that are currently visible (dependency-aware).
+fn visible_indices(cfr: &CfrInfo, items: &[MenuItem]) -> Vec<usize> {
+    items
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| is_item_visible(cfr, items, item))
+        .map(|(i, _)| i)
+        .collect()
+}
+
+/// Draw the complete menu
+fn draw_menu(
+    cfr: &CfrInfo,
+    items: &[MenuItem],
+    selected: usize,
+    scroll_offset: usize,
+    modified: bool,
+    status_message: Option<(&str, bool)>,
+    fb_console: &mut Option<FramebufferConsole>,
+) {
+    let cols = fb_console.as_ref().map(|c| c.cols()).unwrap_or(80) as usize;
+    let rows = fb_console.as_ref().map(|c| c.rows()).unwrap_or(25) as usize;
+
+    // Draw header
+    let title = if modified {
+        "Firmware Settings (modified)"
+    } else {
+        MENU_TITLE
+    };
+    menu_common::draw_header(title, fb_console, cols);
+
+    // Build list of visible item indices (dependency-aware)
+    let vis = visible_indices(cfr, items);
+
+    // Calculate visible area
+    let start_row = 4;
+    let visible_rows = rows.saturating_sub(8);
+
+    // Draw items — only the visible ones, respecting scroll_offset
+    for (screen_idx, &item_idx) in vis.iter().enumerate().skip(scroll_offset).take(visible_rows) {
+        let row = start_row + (screen_idx - scroll_offset);
+        let is_selected = item_idx == selected;
+        draw_item(cfr, &items[item_idx], is_selected, row, fb_console, cols);
+    }
+
+    // Draw scroll indicators
+    if scroll_offset > 0 {
+        draw_scroll_indicator(start_row - 1, "^", fb_console);
+    }
+    if scroll_offset + visible_rows < vis.len() {
+        draw_scroll_indicator(start_row + visible_rows, "v", fb_console);
+    }
+
+    // Draw help text
+    let help_row = rows.saturating_sub(3);
+    draw_help(help_row, fb_console, cols);
+
+    // Draw status message if any
+    if let Some((msg, is_success)) = status_message {
+        draw_status_message(rows.saturating_sub(2), msg, is_success, fb_console);
+    }
+}
+
+/// Draw a single menu item
+fn draw_item(
+    cfr: &CfrInfo,
+    item: &MenuItem,
+    is_selected: bool,
+    row: usize,
+    fb_console: &mut Option<FramebufferConsole>,
+    cols: usize,
+) {
+    match item {
+        MenuItem::FormHeader { name } => {
+            draw_form_header(name, row, fb_console);
+        }
+        MenuItem::SubformHeader { name } => {
+            draw_subform_header(name, row, fb_console);
+        }
+        MenuItem::Option {
+            form_idx,
+            option_idx,
+            current_value,
+            ..
+        } => {
+            if let Some(option) = get_option(cfr, *form_idx, *option_idx) {
+                draw_option_item(option, current_value, is_selected, row, fb_console, cols);
+            }
+        }
+        MenuItem::Comment { text } => {
+            draw_comment(text, row, fb_console);
+        }
+    }
+}
+
+/// Draw a form header (category separator)
+fn draw_form_header(name: &str, row: usize, fb_console: &mut Option<FramebufferConsole>) {
+    let ansi_row = row + 1;
+    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
+    serial_driver::write_str("\x1b[1;36m");
+    serial_driver::write_str("--- ");
+    serial_driver::write_str(name);
+    serial_driver::write_str(" ---");
+    serial_driver::write_str("\x1b[0m\x1b[K\r\n");
+
+    if let Some(console) = fb_console {
+        console.set_position(0, row as u32);
+        console.set_fg_color(Color::new(0, 192, 192));
+        let _ = console.write_str("--- ");
+        let _ = console.write_str(name);
+        let _ = console.write_str(" ---");
+        clear_line_remainder(console);
+        console.reset_colors();
+    }
+}
+
+/// Draw a subform header (indented section within a form)
+fn draw_subform_header(name: &str, row: usize, fb_console: &mut Option<FramebufferConsole>) {
+    let ansi_row = row + 1;
+    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
+    serial_driver::write_str("\x1b[1;35m"); // Magenta bold
+    serial_driver::write_str("     ");
+    serial_driver::write_str(name);
+    serial_driver::write_str("\x1b[0m\x1b[K\r\n");
+
+    if let Some(console) = fb_console {
+        console.set_position(0, row as u32);
+        console.set_fg_color(Color::new(192, 0, 192)); // Magenta
+        let _ = console.write_str("     ");
+        let _ = console.write_str(name);
+        clear_line_remainder(console);
+        console.reset_colors();
+    }
+}
+
+/// Draw an option item
+fn draw_option_item(
+    option: &CfrOption,
+    value: &CfrValue,
+    is_selected: bool,
+    row: usize,
+    fb_console: &mut Option<FramebufferConsole>,
+    cols: usize,
+) {
+    let is_editable = option.is_editable();
+
+    // Format the value for display
+    let mut value_str = String::new();
+    match (&option.option_type, value) {
+        (CfrOptionType::Bool { .. }, CfrValue::Bool(b)) => {
+            value_str.push_str(if *b { "[Enabled]" } else { "[Disabled]" });
+        }
+        (CfrOptionType::Enum { choices, .. }, CfrValue::Number(n)) => {
+            if let Some(choice) = choices.iter().find(|c| c.value == *n) {
+                value_str.push('[');
+                value_str.push_str(&choice.ui_name);
+                value_str.push(']');
+            } else {
+                let _ = write!(value_str, "[{}]", n);
+            }
+        }
+        (CfrOptionType::Number { hex_display, .. }, CfrValue::Number(n)) => {
+            if *hex_display {
+                let _ = write!(value_str, "[0x{:X}]", n);
+            } else {
+                let _ = write!(value_str, "[{}]", n);
+            }
+        }
+        (CfrOptionType::Varchar { .. }, CfrValue::Varchar(s)) => {
+            value_str.push('[');
+            let max_len = 20;
+            if s.len() > max_len {
+                value_str.push_str(&s[..max_len]);
+                value_str.push_str("...");
+            } else {
+                value_str.push_str(s);
+            }
+            value_str.push(']');
+        }
+        _ => {
+            value_str.push_str("[-]");
+        }
+    }
+
+    // Serial output
+    let ansi_row = row + 1;
+    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
+
+    if is_selected {
+        serial_driver::write_str("\x1b[7m");
+    }
+    if !is_editable {
+        serial_driver::write_str("\x1b[90m");
+    }
+
+    serial_driver::write_str("   ");
+    serial_driver::write_str(&option.ui_name);
+
+    let name_len = option.ui_name.len();
+    let pad_to = 40.min(cols.saturating_sub(value_str.len() + 5));
+    for _ in name_len + 3..pad_to {
+        serial_driver::write_str(" ");
+    }
+    serial_driver::write_str(&value_str);
+
+    serial_driver::write_str("\x1b[0m\x1b[K\r\n");
+
+    // Framebuffer output
+    if let Some(console) = fb_console {
+        console.set_position(0, row as u32);
+
+        if is_selected {
+            console.set_colors(HIGHLIGHT_FG, HIGHLIGHT_BG);
+        } else if !is_editable {
+            console.set_fg_color(Color::new(128, 128, 128));
+        } else {
+            console.set_colors(DEFAULT_FG, DEFAULT_BG);
+        }
+
+        let _ = console.write_str("   ");
+        let _ = console.write_str(&option.ui_name);
+
+        let name_len = option.ui_name.len();
+        let term_cols = console.cols() as usize;
+        let pad_to = 40.min(term_cols.saturating_sub(value_str.len() + 5));
+        for _ in name_len + 3..pad_to {
+            let _ = console.write_str(" ");
+        }
+        let _ = console.write_str(&value_str);
+
+        clear_line_remainder(console);
+        console.reset_colors();
+    }
+}
+
+/// Draw a comment item
+fn draw_comment(text: &str, row: usize, fb_console: &mut Option<FramebufferConsole>) {
+    let ansi_row = row + 1;
+    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
+    serial_driver::write_str("\x1b[90m");
+    serial_driver::write_str("   ");
+    serial_driver::write_str(text);
+    serial_driver::write_str("\x1b[0m\x1b[K\r\n");
+
+    if let Some(console) = fb_console {
+        console.set_position(0, row as u32);
+        console.set_fg_color(Color::new(128, 128, 128));
+        let _ = console.write_str("   ");
+        let _ = console.write_str(text);
+        clear_line_remainder(console);
+        console.reset_colors();
+    }
+}
+
+/// Draw scroll indicator
+fn draw_scroll_indicator(row: usize, indicator: &str, fb_console: &mut Option<FramebufferConsole>) {
+    let ansi_row = row + 1;
+    let _ = write!(SerialWriter, "\x1b[{};40H{}", ansi_row, indicator);
+
+    if let Some(console) = fb_console {
+        let cols = console.cols();
+        console.set_position(cols / 2, row as u32);
+        console.set_fg_color(Color::new(128, 128, 128));
+        let _ = console.write_str(indicator);
+        console.reset_colors();
+    }
+}
+
+/// Draw help text
+fn draw_help(row: usize, fb_console: &mut Option<FramebufferConsole>, cols: usize) {
+    let ansi_row = row + 1;
+    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
+    serial_driver::write_str("\x1b[36m");
+    let help_pad = (cols.saturating_sub(HELP_TEXT.len())) / 2;
+    for _ in 0..help_pad {
+        serial_driver::write_str(" ");
+    }
+    serial_driver::write_str(HELP_TEXT);
+    serial_driver::write_str("\x1b[0m");
+
+    if let Some(console) = fb_console {
+        console.set_fg_color(Color::new(0, 192, 192));
+        console.write_centered(row as u32, HELP_TEXT);
+        console.reset_colors();
+    }
+}
+
+/// Draw a status message
+fn draw_status_message(
+    row: usize,
+    message: &str,
+    is_success: bool,
+    fb_console: &mut Option<FramebufferConsole>,
+) {
+    let color = if is_success {
+        Color::new(0, 255, 0)
+    } else {
+        Color::new(255, 0, 0)
+    };
+
+    let ansi_row = row + 1;
+    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
+    if is_success {
+        serial_driver::write_str("\x1b[32m");
+    } else {
+        serial_driver::write_str("\x1b[31m");
+    }
+    serial_driver::write_str("  ");
+    serial_driver::write_str(message);
+    serial_driver::write_str("\x1b[0m");
+
+    if let Some(console) = fb_console {
+        console.set_fg_color(color);
+        console.write_centered(row as u32, message);
+        console.reset_colors();
+    }
+}
+
+/// Clear remaining characters on the current line of a framebuffer console
+fn clear_line_remainder(console: &mut FramebufferConsole) {
+    let (col, _) = console.position();
+    for _ in col..console.cols() {
+        let _ = console.write_str(" ");
+    }
+}

--- a/src/coreboot/cfr.rs
+++ b/src/coreboot/cfr.rs
@@ -706,17 +706,19 @@ fn parse_option_children(data: &[u8], option: &mut CfrOption) {
             }
             CFR_TAG_VARCHAR_DEF_VALUE => {
                 if let CfrOptionType::Varchar { ref mut default } = option.option_type
-                    && let Some(def) = parse_varbinary_string(record_bytes) {
-                        *default = def;
-                    }
+                    && let Some(def) = parse_varbinary_string(record_bytes)
+                {
+                    *default = def;
+                }
             }
             CFR_TAG_ENUM_VALUE => {
                 if let CfrOptionType::Enum {
                     ref mut choices, ..
                 } = option.option_type
-                    && let Some(choice) = parse_enum_value(record_bytes) {
-                        choices.push(choice);
-                    }
+                    && let Some(choice) = parse_enum_value(record_bytes)
+                {
+                    choices.push(choice);
+                }
             }
             CFR_TAG_DEP_VALUES => {
                 parse_dep_values_into(record_bytes, &mut option.dep_values);
@@ -749,7 +751,10 @@ fn parse_varbinary_string(data: &[u8]) -> Option<String> {
 
     let string_data = &data[header_size..header_size + data_length];
 
-    let nul_pos = string_data.iter().position(|&b| b == 0).unwrap_or(string_data.len());
+    let nul_pos = string_data
+        .iter()
+        .position(|&b| b == 0)
+        .unwrap_or(string_data.len());
     let result = String::from_utf8_lossy(&string_data[..nul_pos]).into_owned();
 
     Some(result)
@@ -829,9 +834,9 @@ fn parse_enum_value(data: &[u8]) -> Option<CfrEnumChoice> {
             if child_tag == CFR_TAG_VARCHAR_UI_NAME
                 && let Some(name) =
                     parse_varbinary_string(&children_data[offset..offset + child_size])
-                {
-                    choice.ui_name = name;
-                }
+            {
+                choice.ui_name = name;
+            }
 
             offset += child_size;
         }

--- a/src/coreboot/cfr.rs
+++ b/src/coreboot/cfr.rs
@@ -1,0 +1,1007 @@
+//! CFR (Coreboot Form Representation) Parser
+//!
+//! This module parses coreboot's CFR data structure which exposes firmware
+//! configuration options to payloads. CFR allows displaying and modifying
+//! boot-time configurable options like "Hyper-Threading Enable", "SATA Mode", etc.
+//!
+//! # CFR Structure
+//!
+//! CFR records form a tree structure where:
+//! - Root record (LB_TAG_CFR_ROOT) contains forms
+//! - Forms (CFR_TAG_OPTION_FORM) contain options and can nest
+//! - Options (BOOL, NUMBER, ENUM, VARCHAR) have names, help text, and defaults
+//! - Each option has an `opt_name` for storage and `ui_name` for display
+//! - Dependencies between options control visibility/grayout
+//!
+//! # Reference
+//!
+//! - coreboot/src/commonlib/include/commonlib/cfr.h
+//! - coreboot/Documentation/drivers/cfr.md
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
+
+/// CFR version (must match coreboot)
+pub const CFR_VERSION: u32 = 0x0000_0000;
+
+/// Coreboot table tag for CFR root
+pub const CB_TAG_CFR_ROOT: u32 = 0x0047;
+
+// CFR record tags
+pub const CFR_TAG_OPTION_FORM: u32 = 1;
+pub const CFR_TAG_ENUM_VALUE: u32 = 2;
+pub const CFR_TAG_OPTION_ENUM: u32 = 3;
+pub const CFR_TAG_OPTION_NUMBER: u32 = 4;
+pub const CFR_TAG_OPTION_BOOL: u32 = 5;
+pub const CFR_TAG_OPTION_VARCHAR: u32 = 6;
+pub const CFR_TAG_VARCHAR_OPT_NAME: u32 = 7;
+pub const CFR_TAG_VARCHAR_UI_NAME: u32 = 8;
+pub const CFR_TAG_VARCHAR_UI_HELPTEXT: u32 = 9;
+pub const CFR_TAG_VARCHAR_DEF_VALUE: u32 = 10;
+pub const CFR_TAG_OPTION_COMMENT: u32 = 11;
+pub const CFR_TAG_DEP_VALUES: u32 = 12;
+
+// CFR option flags
+pub const CFR_OPTFLAG_READONLY: u32 = 1 << 0;
+pub const CFR_OPTFLAG_INACTIVE: u32 = 1 << 1;
+pub const CFR_OPTFLAG_SUPPRESS: u32 = 1 << 2;
+pub const CFR_OPTFLAG_VOLATILE: u32 = 1 << 3;
+pub const CFR_OPTFLAG_RUNTIME: u32 = 1 << 4;
+
+// Numeric display flags
+pub const CFR_NUM_OPT_DISPFLAG_HEX: u32 = 1 << 0;
+
+/// CFR root record header (matches lb_cfr in coreboot_tables.h)
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Debug, Clone, Copy)]
+pub struct CbCfrRoot {
+    pub tag: u32,
+    pub size: u32,
+    pub version: u32,
+    pub checksum: u32,
+}
+
+/// Generic CFR record header
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Debug, Clone, Copy)]
+pub struct CfrHeader {
+    pub tag: u32,
+    pub size: u32,
+}
+
+/// CFR option form header
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Debug, Clone, Copy)]
+pub struct CfrOptionFormHeader {
+    pub tag: u32,
+    pub size: u32,
+    pub object_id: u64,
+    pub dependency_id: u64,
+    pub flags: u32,
+}
+
+/// CFR numeric option header (BOOL, NUMBER, ENUM)
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Debug, Clone, Copy)]
+pub struct CfrNumericOptionHeader {
+    pub tag: u32,
+    pub size: u32,
+    pub object_id: u64,
+    pub dependency_id: u64,
+    pub flags: u32,
+    pub default_value: u32,
+    pub min: u32,
+    pub max: u32,
+    pub step: u32,
+    pub display_flags: u32,
+}
+
+/// CFR varchar option header
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Debug, Clone, Copy)]
+pub struct CfrVarcharOptionHeader {
+    pub tag: u32,
+    pub size: u32,
+    pub object_id: u64,
+    pub dependency_id: u64,
+    pub flags: u32,
+}
+
+/// CFR option comment header
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Debug, Clone, Copy)]
+pub struct CfrCommentHeader {
+    pub tag: u32,
+    pub size: u32,
+    pub object_id: u64,
+    pub dependency_id: u64,
+    pub flags: u32,
+}
+
+/// CFR enum value header
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Debug, Clone, Copy)]
+pub struct CfrEnumValueHeader {
+    pub tag: u32,
+    pub size: u32,
+    pub value: u32,
+}
+
+/// CFR variable-length binary header (for strings and dep values)
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Debug, Clone, Copy)]
+pub struct CfrVarbinaryHeader {
+    pub tag: u32,
+    pub size: u32,
+    pub data_length: u32,
+}
+
+/// Enum choice (value and display name)
+#[derive(Debug, Clone)]
+pub struct CfrEnumChoice {
+    pub value: u32,
+    pub ui_name: String,
+}
+
+/// CFR option type with type-specific data
+#[derive(Debug, Clone)]
+pub enum CfrOptionType {
+    /// Boolean option (true/false)
+    Bool { default: bool },
+
+    /// Numeric option with range
+    Number {
+        default: u32,
+        min: u32,
+        max: u32,
+        step: u32,
+        hex_display: bool,
+    },
+
+    /// Enum option with discrete choices
+    Enum {
+        default: u32,
+        choices: Vec<CfrEnumChoice>,
+    },
+
+    /// Variable-length string option
+    Varchar { default: String },
+
+    /// Comment (informational, not editable)
+    Comment,
+}
+
+/// A single CFR option
+#[derive(Debug, Clone)]
+pub struct CfrOption {
+    /// Unique object ID
+    pub object_id: u64,
+    /// Dependency on another option's object_id (0 = none)
+    pub dependency_id: u64,
+    /// Variable name (for storage)
+    pub opt_name: String,
+    /// Display name
+    pub ui_name: String,
+    /// Help text
+    pub ui_helptext: String,
+    /// Option flags
+    pub flags: u32,
+    /// Option type and type-specific data
+    pub option_type: CfrOptionType,
+    /// Dependency values: option is visible when the dependency's current value
+    /// matches one of these. Empty means visible when dependency value != 0.
+    pub dep_values: Vec<u32>,
+}
+
+impl CfrOption {
+    /// Check if this option is editable (ignoring dependency state)
+    pub fn is_editable(&self) -> bool {
+        (self.flags & CFR_OPTFLAG_READONLY) == 0
+            && (self.flags & CFR_OPTFLAG_INACTIVE) == 0
+            && (self.flags & CFR_OPTFLAG_VOLATILE) == 0
+            && !matches!(self.option_type, CfrOptionType::Comment)
+    }
+
+    /// Check if this option is visible (ignoring dependency state)
+    pub fn is_visible(&self) -> bool {
+        (self.flags & CFR_OPTFLAG_SUPPRESS) == 0
+    }
+}
+
+/// A CFR form (category/group of options)
+///
+/// Nested subforms are flattened during parsing: the subform's ui_name is
+/// inserted as a Comment option, then its options are inlined into the parent.
+#[derive(Debug, Clone)]
+pub struct CfrForm {
+    /// Unique object ID
+    pub object_id: u64,
+    /// Dependency on another option's object_id (0 = none)
+    pub dependency_id: u64,
+    /// Display name
+    pub ui_name: String,
+    /// Form flags
+    pub flags: u32,
+    /// Options in this form (including flattened subform options)
+    pub options: Vec<CfrOption>,
+    /// Dependency values for this form
+    pub dep_values: Vec<u32>,
+}
+
+impl CfrForm {
+    /// Check if this form is visible (ignoring dependency state)
+    pub fn is_visible(&self) -> bool {
+        (self.flags & CFR_OPTFLAG_SUPPRESS) == 0
+    }
+}
+
+/// Parsed CFR information
+#[derive(Debug, Clone)]
+pub struct CfrInfo {
+    /// CFR version
+    pub version: u32,
+    /// Top-level forms
+    pub forms: Vec<CfrForm>,
+}
+
+impl CfrInfo {
+    pub fn new() -> Self {
+        Self {
+            version: CFR_VERSION,
+            forms: Vec::new(),
+        }
+    }
+
+    /// Get total number of options across all forms
+    pub fn total_options(&self) -> usize {
+        self.forms.iter().map(|f| f.options.len()).sum()
+    }
+
+    /// Find an option by object_id across all forms and read its current numeric value.
+    /// Returns None if the option is not found or is not a numeric type.
+    pub fn find_numeric_value(&self, object_id: u64) -> Option<u32> {
+        if object_id == 0 {
+            return None;
+        }
+        for form in &self.forms {
+            for option in &form.options {
+                if option.object_id == object_id {
+                    let value = read_option_value(option);
+                    return match value {
+                        CfrValue::Bool(b) => Some(if b { 1 } else { 0 }),
+                        CfrValue::Number(n) => Some(n),
+                        _ => None,
+                    };
+                }
+            }
+        }
+        None
+    }
+
+    /// Evaluate whether an option/form with the given dependency is visible.
+    ///
+    /// Returns true if:
+    /// - dependency_id is 0 (no dependency)
+    /// - The dependency option's current value matches one of dep_values
+    /// - dep_values is empty and the dependency value != 0
+    pub fn is_dependency_met(&self, dependency_id: u64, dep_values: &[u32]) -> bool {
+        if dependency_id == 0 {
+            return true;
+        }
+        match self.find_numeric_value(dependency_id) {
+            Some(current) => {
+                if dep_values.is_empty() {
+                    current != 0
+                } else {
+                    dep_values.contains(&current)
+                }
+            }
+            None => true, // If we can't find the dependency, show the option
+        }
+    }
+}
+
+impl Default for CfrInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ============================================================================
+// CRC32 computation (matching coreboot's CRC32 used in lb_cfr.checksum)
+// ============================================================================
+
+/// Compute CRC32 matching coreboot's crc_byte implementation.
+/// This is the standard CRC-32 (ISO 3309, ITU-T V.42, Ethernet, PKZIP, etc.)
+fn compute_crc32(data: &[u8]) -> u32 {
+    // Use the same CRC32 as the rest of CrabEFI
+    crate::efi::boot_services::compute_crc32(data)
+}
+
+// ============================================================================
+// Parsing
+// ============================================================================
+
+/// Parse CFR data from coreboot tables
+///
+/// # Arguments
+///
+/// * `data` - Raw bytes starting from the CFR root record
+///
+/// # Returns
+///
+/// Parsed CFR info, or None if parsing fails
+pub fn parse_cfr(data: &[u8]) -> Option<CfrInfo> {
+    if data.len() < core::mem::size_of::<CbCfrRoot>() {
+        log::warn!("CFR data too small for header");
+        return None;
+    }
+
+    let Ok((root, _)) = CbCfrRoot::read_from_prefix(data) else {
+        log::warn!("Failed to parse CFR root header");
+        return None;
+    };
+
+    let tag = root.tag;
+    let size = root.size;
+    let version = root.version;
+    let checksum = root.checksum;
+
+    if tag != CB_TAG_CFR_ROOT {
+        log::warn!("Invalid CFR root tag: {:#x}", tag);
+        return None;
+    }
+
+    if version != CFR_VERSION {
+        log::warn!(
+            "Unsupported CFR version: {:#x} (expected {:#x})",
+            version,
+            CFR_VERSION
+        );
+        return None;
+    }
+
+    log::info!("Parsing CFR data: {} bytes", size);
+
+    // Validate CRC32 checksum over the data after the root header
+    let header_size = core::mem::size_of::<CbCfrRoot>();
+    let total_size = (size as usize).min(data.len());
+    if total_size > header_size {
+        let payload = &data[header_size..total_size];
+        let computed = compute_crc32(payload);
+        if computed != checksum {
+            log::warn!(
+                "CFR CRC32 mismatch: computed {:#x}, expected {:#x} (continuing anyway)",
+                computed,
+                checksum
+            );
+        }
+    }
+
+    let mut info = CfrInfo::new();
+
+    // Parse children (forms) after the root header
+    if total_size > header_size {
+        let children_data = &data[header_size..total_size];
+        parse_top_level_children(children_data, &mut info.forms);
+    }
+
+    log::info!(
+        "CFR parsed: {} forms, {} total options",
+        info.forms.len(),
+        info.total_options()
+    );
+
+    Some(info)
+}
+
+/// Parse top-level child records into forms
+fn parse_top_level_children(data: &[u8], forms: &mut Vec<CfrForm>) {
+    let mut offset = 0;
+
+    while offset + 8 <= data.len() {
+        let record_data = &data[offset..];
+
+        let Ok((header, _)) = CfrHeader::read_from_prefix(record_data) else {
+            break;
+        };
+
+        let tag = header.tag;
+        let size = header.size as usize;
+
+        if size < 8 || offset + size > data.len() {
+            log::debug!("Invalid CFR record size {} at offset {}", size, offset);
+            break;
+        }
+
+        let record_bytes = &data[offset..offset + size];
+
+        if tag == CFR_TAG_OPTION_FORM {
+            if let Some(form) = parse_form(record_bytes) {
+                forms.push(form);
+            }
+        } else {
+            log::trace!("Skipping non-form CFR record tag={}", tag);
+        }
+
+        offset += size;
+    }
+}
+
+/// Parse a CFR option form
+fn parse_form(data: &[u8]) -> Option<CfrForm> {
+    if data.len() < core::mem::size_of::<CfrOptionFormHeader>() {
+        return None;
+    }
+
+    let Ok((header, _)) = CfrOptionFormHeader::read_from_prefix(data) else {
+        return None;
+    };
+
+    let object_id = header.object_id;
+    let dependency_id = header.dependency_id;
+    let flags = header.flags;
+
+    let mut form = CfrForm {
+        object_id,
+        dependency_id,
+        ui_name: String::new(),
+        flags,
+        options: Vec::new(),
+        dep_values: Vec::new(),
+    };
+
+    let header_size = core::mem::size_of::<CfrOptionFormHeader>();
+    let size = header.size as usize;
+
+    if size > header_size && size <= data.len() {
+        let children_data = &data[header_size..size];
+        parse_form_children(children_data, &mut form);
+    }
+
+    Some(form)
+}
+
+/// Parse children of a form
+fn parse_form_children(data: &[u8], form: &mut CfrForm) {
+    let mut offset = 0;
+
+    while offset + 8 <= data.len() {
+        let record_data = &data[offset..];
+
+        let Ok((header, _)) = CfrHeader::read_from_prefix(record_data) else {
+            break;
+        };
+
+        let tag = header.tag;
+        let size = header.size as usize;
+
+        if size < 8 || offset + size > data.len() {
+            break;
+        }
+
+        let record_bytes = &data[offset..offset + size];
+
+        match tag {
+            CFR_TAG_VARCHAR_UI_NAME => {
+                if let Some(name) = parse_varbinary_string(record_bytes) {
+                    form.ui_name = name;
+                }
+            }
+            CFR_TAG_OPTION_FORM => {
+                // Nested form: flatten into parent.
+                // Insert the subform's ui_name as a section header comment,
+                // then inline all its options.
+                if let Some(subform) = parse_form(record_bytes) {
+                    // Add a comment with the subform name as section header
+                    let section_comment = CfrOption {
+                        object_id: subform.object_id,
+                        dependency_id: subform.dependency_id,
+                        opt_name: String::new(),
+                        ui_name: subform.ui_name,
+                        ui_helptext: String::new(),
+                        flags: subform.flags,
+                        option_type: CfrOptionType::Comment,
+                        dep_values: subform.dep_values,
+                    };
+                    form.options.push(section_comment);
+
+                    // Inline all options from the nested form
+                    form.options.extend(subform.options);
+                }
+            }
+            CFR_TAG_OPTION_BOOL | CFR_TAG_OPTION_NUMBER | CFR_TAG_OPTION_ENUM => {
+                if let Some(option) = parse_numeric_option(record_bytes, tag) {
+                    form.options.push(option);
+                }
+            }
+            CFR_TAG_OPTION_VARCHAR => {
+                if let Some(option) = parse_varchar_option(record_bytes) {
+                    form.options.push(option);
+                }
+            }
+            CFR_TAG_OPTION_COMMENT => {
+                if let Some(option) = parse_comment_option(record_bytes) {
+                    form.options.push(option);
+                }
+            }
+            CFR_TAG_DEP_VALUES => {
+                parse_dep_values_into(record_bytes, &mut form.dep_values);
+            }
+            _ => {
+                log::trace!("Unknown form child tag: {}", tag);
+            }
+        }
+
+        offset += size;
+    }
+}
+
+/// Parse a numeric option (BOOL, NUMBER, ENUM)
+fn parse_numeric_option(data: &[u8], tag: u32) -> Option<CfrOption> {
+    if data.len() < core::mem::size_of::<CfrNumericOptionHeader>() {
+        return None;
+    }
+
+    let Ok((header, _)) = CfrNumericOptionHeader::read_from_prefix(data) else {
+        return None;
+    };
+
+    let object_id = header.object_id;
+    let dependency_id = header.dependency_id;
+    let flags = header.flags;
+    let default_value = header.default_value;
+    let min = header.min;
+    let max = header.max;
+    let step = header.step;
+    let display_flags = header.display_flags;
+    let size = header.size as usize;
+
+    let option_type = match tag {
+        CFR_TAG_OPTION_BOOL => CfrOptionType::Bool {
+            default: default_value != 0,
+        },
+        CFR_TAG_OPTION_NUMBER => CfrOptionType::Number {
+            default: default_value,
+            min,
+            max,
+            step: if step > 0 { step } else { 1 },
+            hex_display: (display_flags & CFR_NUM_OPT_DISPFLAG_HEX) != 0,
+        },
+        CFR_TAG_OPTION_ENUM => CfrOptionType::Enum {
+            default: default_value,
+            choices: Vec::new(),
+        },
+        _ => return None,
+    };
+
+    let mut option = CfrOption {
+        object_id,
+        dependency_id,
+        opt_name: String::new(),
+        ui_name: String::new(),
+        ui_helptext: String::new(),
+        flags,
+        option_type,
+        dep_values: Vec::new(),
+    };
+
+    let header_size = core::mem::size_of::<CfrNumericOptionHeader>();
+    if size > header_size && size <= data.len() {
+        let children_data = &data[header_size..size];
+        parse_option_children(children_data, &mut option);
+    }
+
+    Some(option)
+}
+
+/// Parse a varchar option
+fn parse_varchar_option(data: &[u8]) -> Option<CfrOption> {
+    if data.len() < core::mem::size_of::<CfrVarcharOptionHeader>() {
+        return None;
+    }
+
+    let Ok((header, _)) = CfrVarcharOptionHeader::read_from_prefix(data) else {
+        return None;
+    };
+
+    let object_id = header.object_id;
+    let dependency_id = header.dependency_id;
+    let flags = header.flags;
+    let size = header.size as usize;
+
+    let mut option = CfrOption {
+        object_id,
+        dependency_id,
+        opt_name: String::new(),
+        ui_name: String::new(),
+        ui_helptext: String::new(),
+        flags,
+        option_type: CfrOptionType::Varchar {
+            default: String::new(),
+        },
+        dep_values: Vec::new(),
+    };
+
+    let header_size = core::mem::size_of::<CfrVarcharOptionHeader>();
+    if size > header_size && size <= data.len() {
+        let children_data = &data[header_size..size];
+        parse_option_children(children_data, &mut option);
+    }
+
+    Some(option)
+}
+
+/// Parse a comment option (informational)
+fn parse_comment_option(data: &[u8]) -> Option<CfrOption> {
+    if data.len() < core::mem::size_of::<CfrCommentHeader>() {
+        return None;
+    }
+
+    let Ok((header, _)) = CfrCommentHeader::read_from_prefix(data) else {
+        return None;
+    };
+
+    let object_id = header.object_id;
+    let dependency_id = header.dependency_id;
+    let flags = header.flags;
+    let size = header.size as usize;
+
+    let mut option = CfrOption {
+        object_id,
+        dependency_id,
+        opt_name: String::new(),
+        ui_name: String::new(),
+        ui_helptext: String::new(),
+        flags,
+        option_type: CfrOptionType::Comment,
+        dep_values: Vec::new(),
+    };
+
+    let header_size = core::mem::size_of::<CfrCommentHeader>();
+    if size > header_size && size <= data.len() {
+        let children_data = &data[header_size..size];
+        parse_option_children(children_data, &mut option);
+    }
+
+    Some(option)
+}
+
+/// Parse children of an option
+fn parse_option_children(data: &[u8], option: &mut CfrOption) {
+    let mut offset = 0;
+
+    while offset + 8 <= data.len() {
+        let record_data = &data[offset..];
+
+        let Ok((header, _)) = CfrHeader::read_from_prefix(record_data) else {
+            break;
+        };
+
+        let tag = header.tag;
+        let size = header.size as usize;
+
+        if size < 8 || offset + size > data.len() {
+            break;
+        }
+
+        let record_bytes = &data[offset..offset + size];
+
+        match tag {
+            CFR_TAG_VARCHAR_OPT_NAME => {
+                if let Some(name) = parse_varbinary_string(record_bytes) {
+                    option.opt_name = name;
+                }
+            }
+            CFR_TAG_VARCHAR_UI_NAME => {
+                if let Some(name) = parse_varbinary_string(record_bytes) {
+                    option.ui_name = name;
+                }
+            }
+            CFR_TAG_VARCHAR_UI_HELPTEXT => {
+                if let Some(help) = parse_varbinary_string(record_bytes) {
+                    option.ui_helptext = help;
+                }
+            }
+            CFR_TAG_VARCHAR_DEF_VALUE => {
+                if let CfrOptionType::Varchar { ref mut default } = option.option_type
+                    && let Some(def) = parse_varbinary_string(record_bytes) {
+                        *default = def;
+                    }
+            }
+            CFR_TAG_ENUM_VALUE => {
+                if let CfrOptionType::Enum {
+                    ref mut choices, ..
+                } = option.option_type
+                    && let Some(choice) = parse_enum_value(record_bytes) {
+                        choices.push(choice);
+                    }
+            }
+            CFR_TAG_DEP_VALUES => {
+                parse_dep_values_into(record_bytes, &mut option.dep_values);
+            }
+            _ => {
+                log::trace!("Unknown option child tag: {}", tag);
+            }
+        }
+
+        offset += size;
+    }
+}
+
+/// Parse a varbinary record as a UTF-8 string
+fn parse_varbinary_string(data: &[u8]) -> Option<String> {
+    if data.len() < core::mem::size_of::<CfrVarbinaryHeader>() {
+        return None;
+    }
+
+    let Ok((header, _)) = CfrVarbinaryHeader::read_from_prefix(data) else {
+        return None;
+    };
+
+    let data_length = header.data_length as usize;
+    let header_size = core::mem::size_of::<CfrVarbinaryHeader>();
+
+    if header_size + data_length > data.len() {
+        return None;
+    }
+
+    let string_data = &data[header_size..header_size + data_length];
+
+    let nul_pos = string_data.iter().position(|&b| b == 0).unwrap_or(string_data.len());
+    let result = String::from_utf8_lossy(&string_data[..nul_pos]).into_owned();
+
+    Some(result)
+}
+
+/// Parse dependency values from a CFR_TAG_DEP_VALUES varbinary record
+fn parse_dep_values_into(data: &[u8], dep_values: &mut Vec<u32>) {
+    if data.len() < core::mem::size_of::<CfrVarbinaryHeader>() {
+        return;
+    }
+
+    let Ok((header, _)) = CfrVarbinaryHeader::read_from_prefix(data) else {
+        return;
+    };
+
+    let data_length = header.data_length as usize;
+    let header_size = core::mem::size_of::<CfrVarbinaryHeader>();
+
+    if header_size + data_length > data.len() {
+        return;
+    }
+
+    let payload = &data[header_size..header_size + data_length];
+    // Dependency values are stored as an array of u32 (little-endian)
+    let num_values = data_length / 4;
+    for i in 0..num_values {
+        let offset = i * 4;
+        if offset + 4 <= payload.len() {
+            let value = u32::from_le_bytes([
+                payload[offset],
+                payload[offset + 1],
+                payload[offset + 2],
+                payload[offset + 3],
+            ]);
+            dep_values.push(value);
+        }
+    }
+}
+
+/// Parse an enum value record
+fn parse_enum_value(data: &[u8]) -> Option<CfrEnumChoice> {
+    if data.len() < core::mem::size_of::<CfrEnumValueHeader>() {
+        return None;
+    }
+
+    let Ok((header, _)) = CfrEnumValueHeader::read_from_prefix(data) else {
+        return None;
+    };
+
+    let value = header.value;
+    let size = header.size as usize;
+
+    let mut choice = CfrEnumChoice {
+        value,
+        ui_name: String::new(),
+    };
+
+    let header_size = core::mem::size_of::<CfrEnumValueHeader>();
+    if size > header_size && size <= data.len() {
+        let children_data = &data[header_size..size];
+        let mut offset = 0;
+
+        while offset + 8 <= children_data.len() {
+            let record_data = &children_data[offset..];
+
+            let Ok((child_header, _)) = CfrHeader::read_from_prefix(record_data) else {
+                break;
+            };
+
+            let child_tag = child_header.tag;
+            let child_size = child_header.size as usize;
+
+            if child_size < 8 || offset + child_size > children_data.len() {
+                break;
+            }
+
+            if child_tag == CFR_TAG_VARCHAR_UI_NAME
+                && let Some(name) =
+                    parse_varbinary_string(&children_data[offset..offset + child_size])
+                {
+                    choice.ui_name = name;
+                }
+
+            offset += child_size;
+        }
+    }
+
+    Some(choice)
+}
+
+// ============================================================================
+// CFR Variable Storage
+// ============================================================================
+
+/// GUID for coreboot CFR options: EficorebootNvDataGuid
+///
+/// {ceae4c1d-335b-4685-a4a0-fc4a94eea085}
+///
+/// This is the GUID used by coreboot's `get_uint_option()` / `set_uint_option()`
+/// in `src/drivers/efi/option.c`. It must match exactly for coreboot to find
+/// the variables we write.
+pub const COREBOOT_CFR_GUID: r_efi::efi::Guid = r_efi::efi::Guid::from_fields(
+    0xceae4c1d,
+    0x335b,
+    0x4685,
+    0xa4,
+    0xa0,
+    &[0xfc, 0x4a, 0x94, 0xee, 0xa0, 0x85],
+);
+
+/// Value types for CFR options
+#[derive(Debug, Clone, PartialEq)]
+pub enum CfrValue {
+    Bool(bool),
+    Number(u32),
+    Varchar(String),
+}
+
+impl CfrValue {
+    /// Get default value from an option type
+    pub fn from_option_type(opt_type: &CfrOptionType) -> Self {
+        match opt_type {
+            CfrOptionType::Bool { default } => CfrValue::Bool(*default),
+            CfrOptionType::Number { default, .. } | CfrOptionType::Enum { default, .. } => {
+                CfrValue::Number(*default)
+            }
+            CfrOptionType::Varchar { default } => CfrValue::Varchar(default.clone()),
+            CfrOptionType::Comment => CfrValue::Bool(false),
+        }
+    }
+}
+
+/// Convert ASCII string to UCS-2 (UTF-16LE) for UEFI variable names
+fn ascii_to_ucs2(s: &str) -> Vec<u16> {
+    let mut result = Vec::with_capacity(s.len() + 1);
+    for c in s.chars() {
+        result.push(c as u16);
+    }
+    result.push(0); // NULL terminator
+    result
+}
+
+/// Read a CFR option value from storage
+///
+/// Returns the stored value or falls back to the CFR default.
+pub fn read_option_value(option: &CfrOption) -> CfrValue {
+    use crate::state;
+
+    let name = ascii_to_ucs2(&option.opt_name);
+
+    let mut found_value = None;
+    state::with_efi_mut(|efi_state| {
+        for var in efi_state.variables.iter() {
+            if !var.in_use {
+                continue;
+            }
+            if var.vendor_guid != COREBOOT_CFR_GUID {
+                continue;
+            }
+            let var_name_len = var
+                .name
+                .iter()
+                .position(|&c| c == 0)
+                .unwrap_or(var.name.len());
+            let name_len = name.len().saturating_sub(1); // Exclude NULL terminator
+            if var_name_len != name_len {
+                continue;
+            }
+            if var.name[..var_name_len] != name[..name_len] {
+                continue;
+            }
+
+            // Found the variable - deserialize based on option type
+            // All numeric types (Bool, Number, Enum) are stored as 4-byte LE u32
+            // for compatibility with coreboot's get_uint_option()
+            found_value = Some(match &option.option_type {
+                CfrOptionType::Bool { .. } => {
+                    let val = if var.data_size >= 4 {
+                        u32::from_le_bytes([var.data[0], var.data[1], var.data[2], var.data[3]])
+                    } else if var.data_size >= 1 {
+                        var.data[0] as u32
+                    } else {
+                        0
+                    };
+                    CfrValue::Bool(val != 0)
+                }
+                CfrOptionType::Number { .. } | CfrOptionType::Enum { .. } => {
+                    let val = if var.data_size >= 4 {
+                        u32::from_le_bytes([var.data[0], var.data[1], var.data[2], var.data[3]])
+                    } else if var.data_size >= 1 {
+                        var.data[0] as u32
+                    } else {
+                        0
+                    };
+                    CfrValue::Number(val)
+                }
+                CfrOptionType::Varchar { .. } => {
+                    let raw = &var.data[..var.data_size];
+                    let nul_pos = raw.iter().position(|&b| b == 0).unwrap_or(raw.len());
+                    CfrValue::Varchar(String::from_utf8_lossy(&raw[..nul_pos]).into_owned())
+                }
+                CfrOptionType::Comment => CfrValue::Bool(false),
+            });
+            break;
+        }
+    });
+
+    found_value.unwrap_or_else(|| CfrValue::from_option_type(&option.option_type))
+}
+
+/// Write a CFR option value to storage
+///
+/// All numeric types (Bool, Number, Enum) are stored as 4-byte LE u32
+/// for compatibility with coreboot's get_uint_option() which returns unsigned int.
+pub fn write_option_value(option: &CfrOption, value: &CfrValue) -> Result<(), &'static str> {
+    use crate::efi::varstore;
+    use r_efi::efi;
+
+    let name = ascii_to_ucs2(&option.opt_name);
+
+    // Serialize value - all numeric types as 4-byte LE u32
+    let data: Vec<u8> = match value {
+        CfrValue::Bool(b) => {
+            let val: u32 = if *b { 1 } else { 0 };
+            val.to_le_bytes().to_vec()
+        }
+        CfrValue::Number(n) => n.to_le_bytes().to_vec(),
+        CfrValue::Varchar(s) => {
+            let mut v: Vec<u8> = s.as_bytes().to_vec();
+            v.push(0); // NULL terminator
+            v
+        }
+    };
+
+    // Always use NV|BS|RT (0x07) to match coreboot's convention.
+    // Coreboot's set_uint_option() in option.c always writes with these exact
+    // attributes, and while get_uint_option() doesn't check attributes when
+    // reading, consistency avoids potential issues with other consumers.
+    let attrs = efi::VARIABLE_NON_VOLATILE
+        | efi::VARIABLE_BOOTSERVICE_ACCESS
+        | efi::VARIABLE_RUNTIME_ACCESS;
+
+    varstore::persist_variable(&COREBOOT_CFR_GUID, &name, attrs, &data)
+        .map_err(|_| "Failed to persist CFR variable")
+}
+
+/// Delete a CFR option from storage (revert to default)
+pub fn delete_option_value(option: &CfrOption) -> Result<(), &'static str> {
+    use crate::efi::varstore;
+
+    let name = ascii_to_ucs2(&option.opt_name);
+
+    varstore::delete_variable(&COREBOOT_CFR_GUID, &name)
+        .map_err(|_| "Failed to delete CFR variable")
+}

--- a/src/efi/varstore/deferred.rs
+++ b/src/efi/varstore/deferred.rs
@@ -52,7 +52,7 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use super::{crc32, SerializedTime, VarStoreError, VariableRecord};
+use super::{SerializedTime, VarStoreError, VariableRecord, crc32};
 use crate::efi::auth;
 
 /// Magic value for the deferred buffer header: "CVBF" (CrabVariable Buffer)

--- a/src/efi/varstore/deferred.rs
+++ b/src/efi/varstore/deferred.rs
@@ -52,7 +52,7 @@
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use super::{SerializedTime, VarStoreError, VariableRecord, crc32};
+use super::{crc32, SerializedTime, VarStoreError, VariableRecord};
 use crate::efi::auth;
 
 /// Magic value for the deferred buffer header: "CVBF" (CrabVariable Buffer)

--- a/src/efi/varstore/edk2.rs
+++ b/src/efi/varstore/edk2.rs
@@ -1,0 +1,659 @@
+//! EDK2-compatible UEFI Firmware Volume variable store format
+//!
+//! This module implements the on-disk format used by UEFI firmware (EDK2/TianoCore)
+//! for storing UEFI variables, matching what coreboot's `get_uint_option()` reads.
+//!
+//! # On-disk layout
+//!
+//! ```text
+//! +--------------------------------------------+ offset 0x0000
+//! |  EFI_FIRMWARE_VOLUME_HEADER  (72 bytes)    |
+//! +--------------------------------------------+ offset 0x0048
+//! |  VARIABLE_STORE_HEADER       (28 bytes)    |
+//! +--------------------------------------------+ offset 0x0064
+//! |  Variable Record #1 (header + name + data) |
+//! |  (padded to 4-byte alignment)              |
+//! +--------------------------------------------+
+//! |  Variable Record #2                        |
+//! +--------------------------------------------+
+//! |  ...                                       |
+//! +--------------------------------------------+
+//! |  Free space (0xFF)                         |
+//! +--------------------------------------------+
+//! ```
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// EFI Firmware Volume Header signature: "_FVH"
+const FV_SIGNATURE: u32 = 0x4856_465F;
+
+/// FV header revision
+const FV_REVISION: u8 = 0x02;
+
+/// Firmware Volume header length (including one block map entry + terminator)
+pub const FV_HEADER_LENGTH: usize = 0x48; // 72 bytes
+
+/// Variable Store header length
+pub const VS_HEADER_LENGTH: usize = 0x1C; // 28 bytes
+
+/// Offset where variable records begin (FV header + VS header)
+pub const VARIABLE_DATA_OFFSET: u32 = (FV_HEADER_LENGTH + VS_HEADER_LENGTH) as u32;
+
+/// Variable record start marker
+const VARIABLE_DATA: u16 = 0x55AA;
+
+/// Variable record alignment
+const HEADER_ALIGNMENT: u32 = 4;
+
+/// Variable store format byte: formatted
+const VARIABLE_STORE_FORMATTED: u8 = 0x5A;
+
+/// Variable store state byte: healthy
+const VARIABLE_STORE_HEALTHY: u8 = 0xFE;
+
+// Variable states (bits cleared in 0xFF flash):
+/// Variable is fully valid (bits 7 and 6 cleared)
+pub const VAR_ADDED: u8 = 0x3F;
+/// Header written, data may not be complete (bit 7 cleared)
+const VAR_HEADER_VALID_ONLY: u8 = 0x7F;
+/// Variable is being deleted (bit 0 cleared from VAR_ADDED)
+const _VAR_IN_DELETED_TRANSITION: u8 = 0xFE;
+/// Variable is deleted
+const VAR_DELETED: u8 = 0xFD;
+
+/// Non-authenticated variable header size
+pub const VAR_HEADER_SIZE: usize = 32;
+
+/// Authenticated variable header size (not currently used for writing, but
+/// needed for reading stores created by EDK2 which uses auth format)
+pub const AUTH_VAR_HEADER_SIZE: usize = 60;
+
+// ============================================================================
+// GUID constants (as raw LE bytes, matching coreboot's layout)
+// ============================================================================
+
+/// EFI System NV Data FV GUID: {fff12b8d-7696-4c8b-a985-2747075b4f50}
+/// Used in the Firmware Volume header's FileSystemGuid field.
+const EFI_SYSTEM_NV_DATA_FV_GUID: [u8; 16] = [
+    0x8d, 0x2b, 0xf1, 0xff, 0x96, 0x76, 0x8b, 0x4c, 0xa9, 0x85, 0x27, 0x47, 0x07, 0x5b, 0x4f, 0x50,
+];
+
+/// EFI Variable GUID (non-authenticated format): {ddcf3616-3275-4164-98b6-fe85707ffe7d}
+/// Used in the Variable Store header's Signature field.
+const EFI_VARIABLE_GUID: [u8; 16] = [
+    0x16, 0x36, 0xcf, 0xdd, 0x75, 0x32, 0x64, 0x41, 0x98, 0xb6, 0xfe, 0x85, 0x70, 0x7f, 0xfe, 0x7d,
+];
+
+/// EFI Authenticated Variable GUID: {aaf32c78-947b-439a-a180-2e144ec37792}
+/// Indicates the variable store uses authenticated variable headers.
+const EFI_AUTH_VARIABLE_GUID: [u8; 16] = [
+    0x78, 0x2c, 0xf3, 0xaa, 0x7b, 0x94, 0x9a, 0x43, 0xa1, 0x80, 0x2e, 0x14, 0x4e, 0xc3, 0x77, 0x92,
+];
+
+// ============================================================================
+// FV header construction / validation
+// ============================================================================
+
+/// Build a complete EDK2 Firmware Volume header + Variable Store header.
+///
+/// `region_size` is the total SMMSTORE region size in bytes.
+/// Returns the header bytes (FV_HEADER_LENGTH + VS_HEADER_LENGTH).
+pub fn build_fv_headers(region_size: u32) -> [u8; FV_HEADER_LENGTH + VS_HEADER_LENGTH] {
+    let mut buf = [0u8; FV_HEADER_LENGTH + VS_HEADER_LENGTH];
+
+    // --- EFI_FIRMWARE_VOLUME_HEADER (72 bytes) ---
+    // ZeroVector[16] at offset 0x00: already zero
+    // FileSystemGuid at offset 0x10
+    buf[0x10..0x20].copy_from_slice(&EFI_SYSTEM_NV_DATA_FV_GUID);
+    // FvLength (u64 LE) at offset 0x20
+    buf[0x20..0x28].copy_from_slice(&(region_size as u64).to_le_bytes());
+    // Signature at offset 0x28
+    buf[0x28..0x2C].copy_from_slice(&FV_SIGNATURE.to_le_bytes());
+    // Attributes at offset 0x2C (standard NV variable store attributes)
+    buf[0x2C..0x30].copy_from_slice(&0x0004_FEFFu32.to_le_bytes());
+    // HeaderLength at offset 0x30
+    buf[0x30..0x32].copy_from_slice(&(FV_HEADER_LENGTH as u16).to_le_bytes());
+    // Checksum at offset 0x32: computed below
+    // ExtHeaderOffset at offset 0x34: 0
+    // Reserved at offset 0x36: 0
+    // Revision at offset 0x37
+    buf[0x37] = FV_REVISION;
+    // BlockMap[0]: {NumBlocks=1, Length=region_size} at offset 0x38
+    buf[0x38..0x3C].copy_from_slice(&1u32.to_le_bytes());
+    buf[0x3C..0x40].copy_from_slice(&region_size.to_le_bytes());
+    // BlockMap[1]: terminator {0, 0} at offset 0x40 — already zero
+
+    // Compute FV header checksum (sum of all u16 words over HeaderLength must be 0)
+    let checksum = compute_fv_checksum(&buf[..FV_HEADER_LENGTH]);
+    buf[0x32..0x34].copy_from_slice(&checksum.to_le_bytes());
+
+    // --- VARIABLE_STORE_HEADER (28 bytes) at offset 0x48 ---
+    let vs_off = FV_HEADER_LENGTH;
+    // Signature (GUID) — use non-authenticated format
+    buf[vs_off..vs_off + 16].copy_from_slice(&EFI_VARIABLE_GUID);
+    // Size (u32 LE): size of the variable data area (after both FV and VS headers).
+    //
+    // Coreboot's efivars.c:199 does:
+    //   rdev_chain(rdev, rdev, HeaderLength + sizeof(VS_HEADER), hdr.Size)
+    // For this to fit within the region: HeaderLength + sizeof(VS_HEADER) + Size <= region_size
+    // Therefore Size must be region_size - FV_HEADER - VS_HEADER.
+    let vs_size = region_size - FV_HEADER_LENGTH as u32 - VS_HEADER_LENGTH as u32;
+    buf[vs_off + 0x10..vs_off + 0x14].copy_from_slice(&vs_size.to_le_bytes());
+    // Format
+    buf[vs_off + 0x14] = VARIABLE_STORE_FORMATTED;
+    // State
+    buf[vs_off + 0x15] = VARIABLE_STORE_HEALTHY;
+    // Reserved (2 + 4 bytes): already zero
+
+    buf
+}
+
+/// Compute the 16-bit checksum for the FV header.
+///
+/// Returns the value to store at the Checksum field such that the sum of
+/// all u16 words across the header equals 0.
+fn compute_fv_checksum(header: &[u8]) -> u16 {
+    // First zero out the checksum field (at offset 0x32-0x33)
+    let mut sum: u16 = 0;
+    for i in (0..header.len()).step_by(2) {
+        if i == 0x32 {
+            continue; // skip the checksum field itself
+        }
+        let lo = header[i] as u16;
+        let hi = if i + 1 < header.len() {
+            header[i + 1] as u16
+        } else {
+            0
+        };
+        sum = sum.wrapping_add(lo | (hi << 8));
+    }
+    // Checksum must make the total 0
+    0u16.wrapping_sub(sum)
+}
+
+/// Validation result for an existing FV region
+pub struct FvValidation {
+    /// Whether the region has a valid FV + VS header
+    pub valid: bool,
+    /// Whether the variable store uses authenticated headers
+    pub auth_format: bool,
+    /// Size of the variable store data area (after VS header)
+    pub data_size: u32,
+}
+
+/// Validate an existing Firmware Volume in a flash region.
+///
+/// `header_bytes` must be at least `FV_HEADER_LENGTH + VS_HEADER_LENGTH` bytes,
+/// read from offset 0 of the SMMSTORE region.
+///
+/// Returns validation result with format details needed for reading.
+pub fn validate_fv(header_bytes: &[u8], region_size: u32) -> FvValidation {
+    let invalid = FvValidation {
+        valid: false,
+        auth_format: false,
+        data_size: 0,
+    };
+
+    if header_bytes.len() < FV_HEADER_LENGTH + VS_HEADER_LENGTH {
+        return invalid;
+    }
+
+    // Check FV signature at offset 0x28
+    let sig = u32::from_le_bytes([
+        header_bytes[0x28],
+        header_bytes[0x29],
+        header_bytes[0x2A],
+        header_bytes[0x2B],
+    ]);
+    if sig != FV_SIGNATURE {
+        log::debug!(
+            "FV signature mismatch: {:#x} (expected {:#x})",
+            sig,
+            FV_SIGNATURE
+        );
+        return invalid;
+    }
+
+    // Check revision at offset 0x37
+    if header_bytes[0x37] != FV_REVISION {
+        log::debug!("FV revision mismatch: {}", header_bytes[0x37]);
+        return invalid;
+    }
+
+    // Check FileSystemGuid at offset 0x10
+    if header_bytes[0x10..0x20] != EFI_SYSTEM_NV_DATA_FV_GUID {
+        log::debug!("FV FileSystemGuid mismatch");
+        return invalid;
+    }
+
+    // Check FV header checksum
+    let header_length = u16::from_le_bytes([header_bytes[0x30], header_bytes[0x31]]) as usize;
+    if header_length > header_bytes.len()
+        || header_length < 0x38
+        || !header_length.is_multiple_of(2)
+    {
+        log::debug!("FV header length invalid: {}", header_length);
+        return invalid;
+    }
+    let mut checksum: u16 = 0;
+    for i in (0..header_length).step_by(2) {
+        let lo = header_bytes[i] as u16;
+        let hi = header_bytes[i + 1] as u16;
+        checksum = checksum.wrapping_add(lo | (hi << 8));
+    }
+    if checksum != 0 {
+        log::debug!("FV header checksum failed: {:#x}", checksum);
+        return invalid;
+    }
+
+    // Check variable store header at FV_HEADER_LENGTH
+    let vs = &header_bytes[FV_HEADER_LENGTH..];
+
+    // Determine auth vs non-auth format from VS Signature GUID
+    let auth_format = if vs[..16] == EFI_VARIABLE_GUID {
+        false
+    } else if vs[..16] == EFI_AUTH_VARIABLE_GUID {
+        true
+    } else {
+        log::debug!("VS Signature GUID not recognized");
+        return invalid;
+    };
+
+    // Check Format and State
+    if vs[0x14] != VARIABLE_STORE_FORMATTED || vs[0x15] != VARIABLE_STORE_HEALTHY {
+        log::debug!(
+            "VS format/state invalid: format={:#x} state={:#x}",
+            vs[0x14],
+            vs[0x15]
+        );
+        return invalid;
+    }
+
+    let vs_size = u32::from_le_bytes([vs[0x10], vs[0x11], vs[0x12], vs[0x13]]);
+    if vs_size > region_size - FV_HEADER_LENGTH as u32 {
+        log::debug!("VS size exceeds region");
+        return invalid;
+    }
+
+    // In coreboot's convention (efivars.c:199), the VS Size field represents the
+    // size of the variable data area — i.e., the space AFTER both the FV header
+    // and VS header. This is what coreboot passes directly to rdev_chain as the
+    // size of the child region.
+    //
+    // For stores created by EDK2 (where Size may include the VS header per the
+    // spec comment), vs_size could be slightly larger than the actual data area.
+    // This is harmless because walk_variables stops at 0xFF (erased flash).
+    let data_size = vs_size;
+
+    FvValidation {
+        valid: true,
+        auth_format,
+        data_size,
+    }
+}
+
+// ============================================================================
+// Variable record reading
+// ============================================================================
+
+/// A parsed variable from the FV store
+pub struct FvVariable {
+    /// EFI_GUID as raw 16-byte LE (mixed-endian)
+    pub guid: [u8; 16],
+    /// Variable name (UTF-16LE, with null terminator)
+    pub name: Vec<u16>,
+    /// Variable attributes
+    pub attributes: u32,
+    /// Variable data
+    pub data: Vec<u8>,
+    /// Variable state
+    pub state: u8,
+    /// Offset of this record's State byte in the storage region
+    /// (relative to storage base, i.e., absolute within the region)
+    pub state_offset: u32,
+}
+
+/// Walk all variable records in the FV data area.
+///
+/// `read_fn` reads bytes from the storage region at the given offset.
+/// `auth_format` indicates whether to use authenticated variable headers.
+/// `data_size` is the size of the variable data area (from `FvValidation`).
+///
+/// Returns all parsed variables (including deleted ones — caller filters).
+pub fn walk_variables<F>(read_fn: &mut F, auth_format: bool, data_size: u32) -> Vec<FvVariable>
+where
+    F: FnMut(u32, &mut [u8]) -> bool,
+{
+    let mut vars = Vec::new();
+    let hdr_size = if auth_format {
+        AUTH_VAR_HEADER_SIZE
+    } else {
+        VAR_HEADER_SIZE
+    } as u32;
+
+    let mut offset = VARIABLE_DATA_OFFSET;
+    let end = VARIABLE_DATA_OFFSET + data_size;
+
+    while offset + hdr_size <= end {
+        // Read the variable header
+        let mut hdr_buf = vec![0u8; hdr_size as usize];
+        if !read_fn(offset, &mut hdr_buf) {
+            break;
+        }
+
+        // Check StartId
+        let start_id = u16::from_le_bytes([hdr_buf[0], hdr_buf[1]]);
+        if start_id != VARIABLE_DATA {
+            break; // End of variable records (free space)
+        }
+
+        let state = hdr_buf[2];
+
+        // Check for erased/corrupt entry
+        if state == 0xFF {
+            break;
+        }
+
+        // Parse fields based on format
+        let (attributes, name_size, data_size_field, guid_offset) = if auth_format {
+            // Authenticated: attributes at 0x04, name_size at 0x24, data_size at 0x28,
+            // guid at 0x2C
+            let attrs =
+                u32::from_le_bytes([hdr_buf[0x04], hdr_buf[0x05], hdr_buf[0x06], hdr_buf[0x07]]);
+            let ns =
+                u32::from_le_bytes([hdr_buf[0x24], hdr_buf[0x25], hdr_buf[0x26], hdr_buf[0x27]]);
+            let ds =
+                u32::from_le_bytes([hdr_buf[0x28], hdr_buf[0x29], hdr_buf[0x2A], hdr_buf[0x2B]]);
+            (attrs, ns, ds, 0x2Cu32)
+        } else {
+            // Non-auth: attributes at 0x04, name_size at 0x08, data_size at 0x0C,
+            // guid at 0x10
+            let attrs =
+                u32::from_le_bytes([hdr_buf[0x04], hdr_buf[0x05], hdr_buf[0x06], hdr_buf[0x07]]);
+            let ns =
+                u32::from_le_bytes([hdr_buf[0x08], hdr_buf[0x09], hdr_buf[0x0A], hdr_buf[0x0B]]);
+            let ds =
+                u32::from_le_bytes([hdr_buf[0x0C], hdr_buf[0x0D], hdr_buf[0x0E], hdr_buf[0x0F]]);
+            (attrs, ns, ds, 0x10u32)
+        };
+
+        // Sanity check sizes — 0xFFFFFFFF means uninitialized
+        if name_size == 0xFFFFFFFF || data_size_field == 0xFFFFFFFF || attributes == 0xFFFFFFFF {
+            // Corrupt/uninitialized — skip with zero sizes
+            let var_size = align_up(hdr_size, HEADER_ALIGNMENT);
+            offset += var_size;
+            continue;
+        }
+
+        // Read GUID
+        let mut guid = [0u8; 16];
+        guid.copy_from_slice(&hdr_buf[guid_offset as usize..guid_offset as usize + 16]);
+
+        // Read name (UTF-16LE)
+        let name_offset = offset + hdr_size;
+        if name_offset + name_size > end {
+            break;
+        }
+        let mut name_bytes = vec![0u8; name_size as usize];
+        if !read_fn(name_offset, &mut name_bytes) {
+            break;
+        }
+        // Convert to Vec<u16>
+        let name: Vec<u16> = name_bytes
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+
+        // Read data
+        let data_offset = name_offset + name_size;
+        if data_offset + data_size_field > end {
+            break;
+        }
+        let mut data = vec![0u8; data_size_field as usize];
+        if !read_fn(data_offset, &mut data) {
+            break;
+        }
+
+        // State byte offset (relative to storage region base)
+        let state_offset = offset + 2; // State is at offset 2 within the header
+
+        vars.push(FvVariable {
+            guid,
+            name,
+            attributes,
+            data,
+            state,
+            state_offset,
+        });
+
+        // Advance to next record (aligned)
+        let total_size = hdr_size + name_size + data_size_field;
+        offset += align_up(total_size, HEADER_ALIGNMENT);
+    }
+
+    vars
+}
+
+/// Find the write offset (first free byte) in the variable data area.
+pub fn find_write_offset<F>(read_fn: &mut F, auth_format: bool, data_size: u32) -> u32
+where
+    F: FnMut(u32, &mut [u8]) -> bool,
+{
+    let hdr_size = if auth_format {
+        AUTH_VAR_HEADER_SIZE
+    } else {
+        VAR_HEADER_SIZE
+    } as u32;
+
+    let mut offset = VARIABLE_DATA_OFFSET;
+    let end = VARIABLE_DATA_OFFSET + data_size;
+
+    while offset + hdr_size <= end {
+        let mut start_id_buf = [0u8; 2];
+        if !read_fn(offset, &mut start_id_buf) {
+            break;
+        }
+        let start_id = u16::from_le_bytes(start_id_buf);
+        if start_id != VARIABLE_DATA {
+            break;
+        }
+
+        // Read header to get sizes
+        let mut hdr_buf = vec![0u8; hdr_size as usize];
+        if !read_fn(offset, &mut hdr_buf) {
+            break;
+        }
+
+        let state = hdr_buf[2];
+        if state == 0xFF {
+            break;
+        }
+
+        let (name_size, data_size_field) = if auth_format {
+            let ns =
+                u32::from_le_bytes([hdr_buf[0x24], hdr_buf[0x25], hdr_buf[0x26], hdr_buf[0x27]]);
+            let ds =
+                u32::from_le_bytes([hdr_buf[0x28], hdr_buf[0x29], hdr_buf[0x2A], hdr_buf[0x2B]]);
+            (ns, ds)
+        } else {
+            let ns =
+                u32::from_le_bytes([hdr_buf[0x08], hdr_buf[0x09], hdr_buf[0x0A], hdr_buf[0x0B]]);
+            let ds =
+                u32::from_le_bytes([hdr_buf[0x0C], hdr_buf[0x0D], hdr_buf[0x0E], hdr_buf[0x0F]]);
+            (ns, ds)
+        };
+
+        if name_size == 0xFFFFFFFF || data_size_field == 0xFFFFFFFF {
+            let var_size = align_up(hdr_size, HEADER_ALIGNMENT);
+            offset += var_size;
+            continue;
+        }
+
+        let total_size = hdr_size + name_size + data_size_field;
+        offset += align_up(total_size, HEADER_ALIGNMENT);
+    }
+
+    offset
+}
+
+// ============================================================================
+// Variable record writing
+// ============================================================================
+
+/// Build a non-authenticated variable record (header + name bytes + data).
+///
+/// `guid_bytes` is the 16-byte mixed-endian EFI_GUID.
+/// `name` is the UTF-16LE variable name including null terminator.
+/// `data` is the raw variable data.
+///
+/// The returned bytes include the full record, aligned to HEADER_ALIGNMENT.
+/// The State byte is initially 0xFF (will be written in stages).
+pub fn build_variable_record(
+    guid_bytes: &[u8; 16],
+    name: &[u16],
+    attributes: u32,
+    data: &[u8],
+) -> Vec<u8> {
+    let name_bytes_len = name.len() * 2; // UTF-16LE
+    let total_raw = VAR_HEADER_SIZE + name_bytes_len + data.len();
+    let total_aligned = align_up(total_raw as u32, HEADER_ALIGNMENT) as usize;
+
+    let mut buf = vec![0xFF; total_aligned]; // Start with 0xFF (erased flash pattern)
+
+    // VARIABLE_HEADER (32 bytes):
+    // StartId at 0x00
+    buf[0..2].copy_from_slice(&VARIABLE_DATA.to_le_bytes());
+    // State at 0x02: leave as 0xFF (written separately in stages)
+    // Reserved at 0x03: leave as 0xFF (or 0x00 — doesn't matter)
+    buf[0x03] = 0x00;
+    // Attributes at 0x04
+    buf[0x04..0x08].copy_from_slice(&attributes.to_le_bytes());
+    // NameSize at 0x08
+    buf[0x08..0x0C].copy_from_slice(&(name_bytes_len as u32).to_le_bytes());
+    // DataSize at 0x0C
+    buf[0x0C..0x10].copy_from_slice(&(data.len() as u32).to_le_bytes());
+    // VendorGuid at 0x10
+    buf[0x10..0x20].copy_from_slice(guid_bytes);
+
+    // Name (UTF-16LE) at offset VAR_HEADER_SIZE
+    let name_offset = VAR_HEADER_SIZE;
+    for (i, &ch) in name.iter().enumerate() {
+        let off = name_offset + i * 2;
+        buf[off..off + 2].copy_from_slice(&ch.to_le_bytes());
+    }
+
+    // Data at offset VAR_HEADER_SIZE + name_bytes_len
+    let data_offset = name_offset + name_bytes_len;
+    buf[data_offset..data_offset + data.len()].copy_from_slice(data);
+
+    // Padding bytes between end of data and total_aligned remain 0xFF
+
+    buf
+}
+
+/// Write a new variable record to the FV store using the multi-stage protocol.
+///
+/// `write_fn` writes bytes at the given offset in the storage region.
+/// `write_offset` is where the new record will be written.
+///
+/// The protocol:
+/// 1. Write full header + name + data (State byte = 0xFF)
+/// 2. Write State = VAR_HEADER_VALID_ONLY (0x7F)
+/// 3. (Name + data already written in step 1)
+/// 4. Write State = VAR_ADDED (0x3F)
+///
+/// Returns the new write_offset after the record, or None on failure.
+pub fn write_variable<F>(
+    write_fn: &mut F,
+    write_offset: u32,
+    guid_bytes: &[u8; 16],
+    name: &[u16],
+    attributes: u32,
+    data: &[u8],
+) -> Option<u32>
+where
+    F: FnMut(u32, &[u8]) -> bool,
+{
+    let record = build_variable_record(guid_bytes, name, attributes, data);
+    let record_len = record.len() as u32;
+
+    // Step 1: Write entire record (State = 0xFF from build)
+    if !write_fn(write_offset, &record) {
+        return None;
+    }
+
+    // Step 2: Write State = VAR_HEADER_VALID_ONLY
+    let state_offset = write_offset + 2;
+    if !write_fn(state_offset, &[VAR_HEADER_VALID_ONLY]) {
+        return None;
+    }
+
+    // Step 3: Name + data already written in step 1
+
+    // Step 4: Write State = VAR_ADDED
+    if !write_fn(state_offset, &[VAR_ADDED]) {
+        return None;
+    }
+
+    Some(write_offset + record_len)
+}
+
+/// Mark an existing variable as deleted by writing to its State byte.
+///
+/// On NOR flash, writes can only clear bits (1→0). The current state is
+/// `VAR_ADDED` (0x3F). Writing `VAR_DELETED` (0xFD) results in the flash
+/// performing `0x3F & 0xFD = 0x3D`, which clears bit 1. The result (0x3D)
+/// is neither `VAR_ADDED` (0x3F) nor `VAR_IN_DELETED_TRANSITION & VAR_ADDED`
+/// (0x3E), so coreboot's `match()` correctly skips it.
+///
+/// Note: coreboot's own `efi_fv_set_option()` uses a two-step deletion
+/// (first 0xFE → 0x3E, then 0xFD → 0x3C) for power-failure robustness.
+/// Our single-step approach is functionally equivalent for the reader.
+pub fn mark_deleted<F>(write_fn: &mut F, state_offset: u32) -> bool
+where
+    F: FnMut(u32, &[u8]) -> bool,
+{
+    write_fn(state_offset, &[VAR_DELETED])
+}
+
+/// Check if a variable is in the "added" (valid) state.
+pub fn is_var_added(state: u8) -> bool {
+    state == VAR_ADDED
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Align a value up to the given alignment (must be a power of 2).
+fn align_up(value: u32, alignment: u32) -> u32 {
+    (value + alignment - 1) & !(alignment - 1)
+}
+
+/// Convert an `r_efi::efi::Guid` to the 16-byte mixed-endian representation
+/// used in EDK2 on-disk format.
+pub fn guid_to_bytes(guid: &r_efi::efi::Guid) -> [u8; 16] {
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(guid.as_bytes());
+    bytes
+}
+
+/// Compare a 16-byte GUID from a variable record against an `r_efi::efi::Guid`.
+pub fn guid_matches(on_disk: &[u8; 16], guid: &r_efi::efi::Guid) -> bool {
+    *on_disk == guid_to_bytes(guid)
+}
+
+/// Compare variable names (UTF-16, case-sensitive, including null terminator).
+pub fn name_matches(on_disk: &[u16], name: &[u16]) -> bool {
+    // Strip trailing nulls for comparison
+    fn strip(n: &[u16]) -> &[u16] {
+        let len = n.iter().position(|&c| c == 0).unwrap_or(n.len());
+        &n[..len]
+    }
+    strip(on_disk) == strip(name)
+}

--- a/src/efi/varstore/persistence.rs
+++ b/src/efi/varstore/persistence.rs
@@ -29,9 +29,9 @@ use crate::coreboot;
 use crate::drivers::spi::{self, SpiController};
 use crate::state::{self, MAX_VARIABLE_DATA_SIZE, MAX_VARIABLE_NAME_LEN};
 
+use super::VarStoreError;
 use super::edk2;
 use super::storage::{SpiStorageBackend, StorageBackend};
-use super::VarStoreError;
 
 /// Default variable store base address in SPI flash
 /// This is typically at the end of the flash region

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,14 +289,15 @@ pub fn init(coreboot_table_ptr: u64) -> ! {
     // Parse and store CFR data now that the heap is available.
     // The raw data pointer was saved during coreboot table parsing.
     if let Some(cfr_raw) = cb_info.cfr_raw
-        && let Some(cfr) = coreboot::cfr::parse_cfr(cfr_raw) {
-            log::info!(
-                "CFR: {} forms, {} options",
-                cfr.forms.len(),
-                cfr.total_options()
-            );
-            coreboot::store_cfr(cfr);
-        }
+        && let Some(cfr) = coreboot::cfr::parse_cfr(cfr_raw)
+    {
+        log::info!(
+            "CFR: {} forms, {} options",
+            cfr.forms.len(),
+            cfr.total_options()
+        );
+        coreboot::store_cfr(cfr);
+    }
 
     log::info!("CrabEFI initialized successfully!");
     log::info!("EFI System Table at: {:p}", efi::get_system_table());

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -37,7 +37,7 @@ const DEFAULT_TIMEOUT_SECONDS: u32 = 5;
 const MENU_TITLE: &str = "CrabEFI Boot Menu";
 
 /// Help text
-const HELP_TEXT: &str = "Arrows: Select | Enter: Boot | C: Cmdline | S: Secure Boot | R: Reset";
+const HELP_TEXT: &str = "Arrows: Select | Enter: Boot | F: Firmware | C: Cmdline | S: Secure Boot | R: Reset";
 
 /// Storage device type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -990,6 +990,13 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
                 KeyPress::Char('s') | KeyPress::Char('S') => {
                     // Open Secure Boot settings menu
                     crate::secure_boot_menu::show_secure_boot_menu();
+                    // Redraw boot menu after returning
+                    clear_screen(&mut fb_console);
+                    draw_menu(menu, &mut fb_console);
+                }
+                KeyPress::Char('f') | KeyPress::Char('F') => {
+                    // Open Firmware Settings menu (CFR)
+                    crate::cfr_menu::show_cfr_menu();
                     // Redraw boot menu after returning
                     clear_screen(&mut fb_console);
                     draw_menu(menu, &mut fb_console);

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -37,7 +37,8 @@ const DEFAULT_TIMEOUT_SECONDS: u32 = 5;
 const MENU_TITLE: &str = "CrabEFI Boot Menu";
 
 /// Help text
-const HELP_TEXT: &str = "Arrows: Select | Enter: Boot | F: Firmware | C: Cmdline | S: Secure Boot | R: Reset";
+const HELP_TEXT: &str =
+    "Arrows: Select | Enter: Boot | F: Firmware | C: Cmdline | S: Secure Boot | R: Reset";
 
 /// Storage device type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -418,13 +418,19 @@ pub struct VarStoreState {
     pub initialized: bool,
     /// Next free location for appending records (relative to store start)
     pub write_offset: u32,
+    /// Whether the EDK2 FV uses authenticated variable headers (60 bytes vs 32)
+    pub auth_format: bool,
+    /// Size of the variable data area (after FV + VS headers)
+    pub data_size: u32,
 }
 
 impl VarStoreState {
     pub const fn new() -> Self {
         Self {
             initialized: false,
-            write_offset: 16, // STORE_HEADER_SIZE
+            write_offset: 0,
+            auth_format: false,
+            data_size: 0,
         }
     }
 }


### PR DESCRIPTION
This PR adds a new interactive menu for viewing and modifying coreboot firmware configuration options through CFR (Coreboot Form Representation). It also converts the variable store from a custom postcard-serialized format to the EDK2-compatible Firmware Volume format that coreboot's SMMSTORE reader expects.

## Key Changes

**CFR Menu (`src/cfr_menu.rs`)**
- Full-featured TUI for browsing and editing firmware options (booleans, numbers, enums, strings)
- Dynamic dependency evaluation: options appear/disappear based on other options' values
- Multi-stage write protocol for safe SPI flash updates
- Keyboard navigation: arrow keys, +/- for numeric values, Enter/Space to toggle, ? for help
- Changes are batched and only written on exit (reduces flash wear)
- Accessed via 'F' key from the boot menu

**CFR Parser (`src/coreboot/cfr.rs`)**
- Parses coreboot's CFR data structure (forms, options, dependencies, enums)
- Validates CRC32 checksum
- Supports bool, number, enum, varchar, and comment option types
- Reads/writes option values via UEFI variables using coreboot's GUID
- Flattens nested subforms for simpler menu rendering

**Variable Store Migration to EDK2 FV Format**
- `src/efi/varstore/edk2.rs`: EDK2 Firmware Volume reader/writer
- `src/efi/varstore/persistence.rs`: Updated to use EDK2 format instead of postcard
- Multi-stage write protocol (State byte: 0xFF → 0x7F → 0x3F) for power-loss safety
- Compatible with coreboot's `get_uint_option()` / `set_uint_option()`
- Validates existing stores (supports both auth and non-auth formats for reading)
- Always writes non-auth format (32-byte headers) for new stores

**Integration**
- CFR parsing deferred until after heap initialization (requires `alloc::String`/`alloc::Vec`)
- Raw CFR data pointer saved during coreboot table parsing
- CFR info stored in a heap-allocated `Box` via `AtomicPtr` (avoids stack overflow)
- Menu accessible via 'F' key in boot menu

## Testing Notes

- Tested on hardware with CFR-enabled coreboot firmware
- Variable store migration tested with existing SMMSTORE regions
- Compaction tested by filling store and triggering erase/rewrite