### PR TITLE
feat: add UEFI boot variable support (Boot####, BootOrder, BootNext)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ default = []
 fb-log = []
 # Enable runtime services serial debug logging (post-SetVirtualAddressMap)
 rt-debug = []
+# Enable runtime services log buffer (records SetVariable calls after
+# ExitBootServices into a warm-reboot-persistent ring buffer; requires
+# _rt_log_start/_rt_log_end linker symbols)
+rt-log = []
 
 [dependencies]
 r-efi = "5.3"

--- a/aarch64-coreboot.ld
+++ b/aarch64-coreboot.ld
@@ -69,10 +69,10 @@ SECTIONS
         _bss_end = .;
     }
 
-    /* Stack - 2MB */
+    /* Stack - 3MB (increased from 2MB for large structs like FirmwareState) */
     .stack (NOLOAD) : ALIGN(65536) {
         _stack_bottom = .;
-        . += 0x200000;
+        . += 0x300000;
         _stack_top = .;
     }
 

--- a/src/boot_vars.rs
+++ b/src/boot_vars.rs
@@ -1,0 +1,694 @@
+//! UEFI Boot Variable Support
+//!
+//! Implements the UEFI boot manager variable protocol:
+//! - `Boot####` — individual boot option entries (EFI_LOAD_OPTION format)
+//! - `BootOrder` — ordered list of Boot#### option numbers to try
+//! - `BootNext` — one-shot next-boot override (deleted before use)
+//! - `BootCurrent` — volatile variable set during boot attempt
+//! - `Timeout` — seconds to wait before auto-booting
+//!
+//! All variables use the EFI Global Variable GUID
+//! (`8BE4DF61-93CA-11D2-AA0D-00E098032B8C`) and follow the UEFI
+//! Specification sections 3.1 (Boot Manager) and 3.1.2 (Load Options).
+//!
+//! # Binary format of Boot#### (EFI_LOAD_OPTION)
+//!
+//! ```text
+//! Offset 0:  u32    Attributes        (LOAD_OPTION_ACTIVE = 0x01, etc.)
+//! Offset 4:  u16    FilePathListLength (bytes)
+//! Offset 6:  [u16]  Description        (null-terminated UCS-2)
+//! Then:      [u8]   FilePathList       (EFI_DEVICE_PATH, FilePathListLength bytes)
+//! Then:      [u8]   OptionalData       (remaining bytes)
+//! ```
+
+use crate::efi::auth::{EFI_GLOBAL_VARIABLE_GUID, attributes};
+use crate::efi::utils::ucs2_eq;
+use crate::state::{self, MAX_VARIABLE_DATA_SIZE, MAX_VARIABLE_NAME_LEN};
+use core::fmt::Write;
+use heapless::Vec as HeaplessVec;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// EFI_LOAD_OPTION attribute: option is active and should be tried
+pub const LOAD_OPTION_ACTIVE: u32 = 0x00000001;
+
+/// EFI_LOAD_OPTION attribute: force reconnect of all drivers before boot
+#[allow(dead_code)]
+pub const LOAD_OPTION_FORCE_RECONNECT: u32 = 0x00000002;
+
+/// EFI_LOAD_OPTION attribute: option is hidden from the user
+#[allow(dead_code)]
+pub const LOAD_OPTION_HIDDEN: u32 = 0x00000008;
+
+/// EFI_LOAD_OPTION attribute mask for option category
+pub const LOAD_OPTION_CATEGORY: u32 = 0x00001F00;
+
+/// Category: this is a normal boot option
+pub const LOAD_OPTION_CATEGORY_BOOT: u32 = 0x00000000;
+
+/// Category: this is an application (not a boot option)
+#[allow(dead_code)]
+pub const LOAD_OPTION_CATEGORY_APP: u32 = 0x00000100;
+
+/// NV+BS+RT attributes for persistent boot variables
+const NV_BS_RT: u32 =
+    attributes::NON_VOLATILE | attributes::BOOTSERVICE_ACCESS | attributes::RUNTIME_ACCESS;
+
+/// BS+RT attributes for volatile boot variables (BootCurrent)
+const BS_RT: u32 = attributes::BOOTSERVICE_ACCESS | attributes::RUNTIME_ACCESS;
+
+/// Maximum number of boot options we can track
+const MAX_BOOT_OPTIONS: usize = 16;
+
+/// Maximum description length (in UCS-2 characters, including null)
+const MAX_DESCRIPTION_CHARS: usize = 64;
+
+/// Maximum file path list length we can handle
+const MAX_FILE_PATH_SIZE: usize = 512;
+
+/// Maximum optional data size
+const MAX_OPTIONAL_DATA_SIZE: usize = 256;
+
+// ============================================================================
+// UCS-2 variable name constants
+// ============================================================================
+
+/// "BootOrder" in UCS-2
+const BOOT_ORDER_NAME: [u16; 10] = [
+    b'B' as u16,
+    b'o' as u16,
+    b'o' as u16,
+    b't' as u16,
+    b'O' as u16,
+    b'r' as u16,
+    b'd' as u16,
+    b'e' as u16,
+    b'r' as u16,
+    0,
+];
+
+/// "BootNext" in UCS-2
+const BOOT_NEXT_NAME: [u16; 9] = [
+    b'B' as u16,
+    b'o' as u16,
+    b'o' as u16,
+    b't' as u16,
+    b'N' as u16,
+    b'e' as u16,
+    b'x' as u16,
+    b't' as u16,
+    0,
+];
+
+/// "BootCurrent" in UCS-2
+const BOOT_CURRENT_NAME: [u16; 12] = [
+    b'B' as u16,
+    b'o' as u16,
+    b'o' as u16,
+    b't' as u16,
+    b'C' as u16,
+    b'u' as u16,
+    b'r' as u16,
+    b'r' as u16,
+    b'e' as u16,
+    b'n' as u16,
+    b't' as u16,
+    0,
+];
+
+/// "Timeout" in UCS-2
+const TIMEOUT_NAME: [u16; 8] = [
+    b'T' as u16,
+    b'i' as u16,
+    b'm' as u16,
+    b'e' as u16,
+    b'o' as u16,
+    b'u' as u16,
+    b't' as u16,
+    0,
+];
+
+// ============================================================================
+// EFI_LOAD_OPTION (Boot#### variable data)
+// ============================================================================
+
+/// Parsed Boot#### load option
+#[derive(Debug, Clone)]
+pub struct LoadOption {
+    /// Option number (the #### part)
+    pub option_number: u16,
+    /// LOAD_OPTION_ACTIVE, etc.
+    pub attributes: u32,
+    /// Human-readable description (ASCII, truncated from UCS-2)
+    pub description: heapless::String<MAX_DESCRIPTION_CHARS>,
+    /// Raw file path list (EFI_DEVICE_PATH_PROTOCOL nodes)
+    pub file_path: HeaplessVec<u8, MAX_FILE_PATH_SIZE>,
+    /// Optional data passed to the image as LoadOptions
+    pub optional_data: HeaplessVec<u8, MAX_OPTIONAL_DATA_SIZE>,
+}
+
+impl LoadOption {
+    /// Check if this option is active (should be tried during boot)
+    pub fn is_active(&self) -> bool {
+        (self.attributes & LOAD_OPTION_ACTIVE) != 0
+    }
+
+    /// Check if this is a normal boot option (not an application)
+    pub fn is_boot_category(&self) -> bool {
+        (self.attributes & LOAD_OPTION_CATEGORY) == LOAD_OPTION_CATEGORY_BOOT
+    }
+
+    /// Check if this option should be attempted during the BootOrder loop
+    pub fn should_boot(&self) -> bool {
+        self.is_active() && self.is_boot_category()
+    }
+}
+
+/// Parse a raw Boot#### variable value into a LoadOption
+///
+/// The binary layout is:
+/// ```text
+/// u32    Attributes
+/// u16    FilePathListLength
+/// [u16]  Description (null-terminated UCS-2)
+/// [u8]   FilePathList (FilePathListLength bytes)
+/// [u8]   OptionalData (remaining bytes)
+/// ```
+pub fn parse_load_option(option_number: u16, data: &[u8]) -> Option<LoadOption> {
+    // Minimum size: 4 (attrs) + 2 (fplen) + 2 (null-term description) = 8
+    if data.len() < 8 {
+        log::debug!(
+            "Boot{:04X}: too short ({} bytes, need >= 8)",
+            option_number,
+            data.len()
+        );
+        return None;
+    }
+
+    let mut offset = 0;
+
+    // Attributes (u32 LE)
+    let attrs = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+    offset += 4;
+
+    // FilePathListLength (u16 LE)
+    let fp_len = u16::from_le_bytes([data[4], data[5]]) as usize;
+    offset += 2;
+
+    // Description: null-terminated UCS-2 string
+    let mut desc = heapless::String::<MAX_DESCRIPTION_CHARS>::new();
+
+    loop {
+        if offset + 1 >= data.len() {
+            log::debug!(
+                "Boot{:04X}: description runs past end of data",
+                option_number
+            );
+            return None;
+        }
+        let ch = u16::from_le_bytes([data[offset], data[offset + 1]]);
+        offset += 2;
+        if ch == 0 {
+            break; // Null terminator
+        }
+        // Convert UCS-2 to ASCII (best-effort: non-ASCII becomes '?')
+        let ascii = if ch < 128 { ch as u8 as char } else { '?' };
+        let _ = desc.push(ascii);
+    }
+
+    // FilePathList
+    if offset + fp_len > data.len() {
+        log::debug!(
+            "Boot{:04X}: file path list extends past end (offset={}, fp_len={}, total={})",
+            option_number,
+            offset,
+            fp_len,
+            data.len()
+        );
+        return None;
+    }
+
+    let mut file_path = HeaplessVec::<u8, MAX_FILE_PATH_SIZE>::new();
+    if fp_len <= MAX_FILE_PATH_SIZE {
+        file_path
+            .extend_from_slice(&data[offset..offset + fp_len])
+            .ok();
+    } else {
+        log::warn!(
+            "Boot{:04X}: file path list too large ({} bytes, max {})",
+            option_number,
+            fp_len,
+            MAX_FILE_PATH_SIZE
+        );
+    }
+    offset += fp_len;
+
+    // OptionalData: everything remaining
+    let mut optional_data = HeaplessVec::<u8, MAX_OPTIONAL_DATA_SIZE>::new();
+    if offset < data.len() {
+        let opt_len = data.len() - offset;
+        if opt_len <= MAX_OPTIONAL_DATA_SIZE {
+            optional_data.extend_from_slice(&data[offset..]).ok();
+        }
+    }
+
+    log::debug!(
+        "Boot{:04X}: attrs={:#x}, desc='{}', fp_len={}, opt_len={}",
+        option_number,
+        attrs,
+        desc,
+        file_path.len(),
+        optional_data.len()
+    );
+
+    Some(LoadOption {
+        option_number,
+        attributes: attrs,
+        description: desc,
+        file_path,
+        optional_data,
+    })
+}
+
+// ============================================================================
+// Variable helpers (internal firmware API)
+// ============================================================================
+
+/// Build a "Boot####" UCS-2 name for a given option number.
+///
+/// Returns a fixed-size buffer suitable for variable lookup.
+fn boot_option_name(option_number: u16) -> [u16; MAX_VARIABLE_NAME_LEN] {
+    let mut name = [0u16; MAX_VARIABLE_NAME_LEN];
+    // "Boot" prefix
+    name[0] = b'B' as u16;
+    name[1] = b'o' as u16;
+    name[2] = b'o' as u16;
+    name[3] = b't' as u16;
+
+    // 4-digit hex number
+    let hex_chars = [
+        b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'A', b'B', b'C', b'D', b'E',
+        b'F',
+    ];
+    name[4] = hex_chars[((option_number >> 12) & 0xF) as usize] as u16;
+    name[5] = hex_chars[((option_number >> 8) & 0xF) as usize] as u16;
+    name[6] = hex_chars[((option_number >> 4) & 0xF) as usize] as u16;
+    name[7] = hex_chars[(option_number & 0xF) as usize] as u16;
+    // name[8] = 0 already (null terminator)
+
+    name
+}
+
+/// Read a variable from the in-memory variable store.
+///
+/// Returns `Some((attributes, data_slice))` if found, `None` otherwise.
+fn read_variable(name: &[u16]) -> Option<(u32, HeaplessVec<u8, MAX_VARIABLE_DATA_SIZE>)> {
+    let efi = state::efi();
+    for var in efi.variables.iter() {
+        if var.in_use && var.vendor_guid == EFI_GLOBAL_VARIABLE_GUID && ucs2_eq(&var.name, name) {
+            let mut data = HeaplessVec::new();
+            data.extend_from_slice(&var.data[..var.data_size]).ok();
+            return Some((var.attributes, data));
+        }
+    }
+    None
+}
+
+/// Write (or create) a variable in the in-memory variable store.
+///
+/// If `data` is empty and `attrs` is 0, the variable is deleted.
+fn write_variable(name: &[u16], attrs: u32, data: &[u8]) -> bool {
+    state::with_efi_mut(|efi| {
+        let guid = EFI_GLOBAL_VARIABLE_GUID;
+
+        // If deleting (size=0, attrs=0), find and remove
+        if data.is_empty() && attrs == 0 {
+            for var in efi.variables.iter_mut() {
+                if var.in_use && var.vendor_guid == guid && ucs2_eq(&var.name, name) {
+                    var.in_use = false;
+                    return true;
+                }
+            }
+            return true; // Not found is OK for delete
+        }
+
+        if data.len() > MAX_VARIABLE_DATA_SIZE {
+            log::error!("write_variable: data too large ({} bytes)", data.len());
+            return false;
+        }
+
+        // Try to find existing variable to update
+        for var in efi.variables.iter_mut() {
+            if var.in_use && var.vendor_guid == guid && ucs2_eq(&var.name, name) {
+                var.attributes = attrs;
+                var.data[..data.len()].copy_from_slice(data);
+                var.data_size = data.len();
+                return true;
+            }
+        }
+
+        // Create new variable in first empty slot
+        for var in efi.variables.iter_mut() {
+            if !var.in_use {
+                var.in_use = true;
+                var.vendor_guid = guid;
+                var.attributes = attrs;
+                // Copy name
+                let name_len = name.iter().position(|&c| c == 0).unwrap_or(name.len());
+                let copy_len = name_len.min(MAX_VARIABLE_NAME_LEN - 1);
+                var.name[..copy_len].copy_from_slice(&name[..copy_len]);
+                var.name[copy_len] = 0;
+                // Zero remaining name bytes
+                for c in &mut var.name[copy_len + 1..] {
+                    *c = 0;
+                }
+                // Copy data and zero the tail (defense-in-depth for variable isolation)
+                var.data[..data.len()].copy_from_slice(data);
+                var.data[data.len()..].fill(0);
+                var.data_size = data.len();
+                return true;
+            }
+        }
+
+        log::error!("write_variable: no free variable slots");
+        false
+    })
+}
+
+/// Delete a variable from the in-memory store.
+fn delete_variable(name: &[u16]) -> bool {
+    write_variable(name, 0, &[])
+}
+
+// ============================================================================
+// BootNext
+// ============================================================================
+
+/// Read and cache the BootNext variable.
+///
+/// Returns `Some(option_number)` if BootNext is set and valid (exactly 2 bytes).
+/// Returns `None` if BootNext is not set or invalid.
+///
+/// This should be called early in the boot process, before platform hooks
+/// can modify it (matching edk2 behavior).
+pub fn read_boot_next() -> Option<u16> {
+    let (_, data) = read_variable(&BOOT_NEXT_NAME)?;
+
+    if data.len() != 2 {
+        log::warn!("BootNext: invalid size {} (expected 2)", data.len());
+        return None;
+    }
+
+    let value = u16::from_le_bytes([data[0], data[1]]);
+    log::info!("BootNext: Boot{:04X}", value);
+    Some(value)
+}
+
+/// Delete the BootNext variable.
+///
+/// Per UEFI spec, BootNext must be deleted before attempting to boot
+/// the referenced option, to prevent infinite boot loops.
+pub fn delete_boot_next() {
+    if delete_variable(&BOOT_NEXT_NAME) {
+        log::info!("BootNext: deleted");
+    }
+}
+
+// ============================================================================
+// BootOrder
+// ============================================================================
+
+/// Read the BootOrder variable.
+///
+/// Returns an ordered list of Boot#### option numbers.
+/// Returns an empty list if BootOrder is not set.
+pub fn read_boot_order() -> HeaplessVec<u16, MAX_BOOT_OPTIONS> {
+    let mut order = HeaplessVec::new();
+
+    let Some((_, data)) = read_variable(&BOOT_ORDER_NAME) else {
+        log::debug!("BootOrder: not set");
+        return order;
+    };
+
+    if data.len() % 2 != 0 {
+        log::warn!("BootOrder: odd data size {}", data.len());
+        return order;
+    }
+
+    for chunk in data.chunks_exact(2) {
+        let num = u16::from_le_bytes([chunk[0], chunk[1]]);
+        if order.push(num).is_err() {
+            log::warn!(
+                "BootOrder: truncated at {} entries (max {})",
+                order.len(),
+                MAX_BOOT_OPTIONS
+            );
+            break;
+        }
+    }
+
+    if !order.is_empty() {
+        log::info!("BootOrder: {} entries", order.len());
+        for (i, &num) in order.iter().enumerate() {
+            log::debug!("  [{}] Boot{:04X}", i, num);
+        }
+    }
+
+    order
+}
+
+// ============================================================================
+// Boot#### (Load Option)
+// ============================================================================
+
+/// Read and parse a Boot#### variable.
+///
+/// Returns `None` if the variable doesn't exist or can't be parsed.
+pub fn read_boot_option(option_number: u16) -> Option<LoadOption> {
+    let name = boot_option_name(option_number);
+    let (_, data) = read_variable(&name)?;
+    parse_load_option(option_number, &data)
+}
+
+/// Read all Boot#### entries referenced by BootOrder.
+///
+/// Skips entries that don't exist or can't be parsed (matching edk2 behavior
+/// which also silently drops invalid entries).
+pub fn read_boot_options() -> HeaplessVec<LoadOption, MAX_BOOT_OPTIONS> {
+    let order = read_boot_order();
+    let mut options = HeaplessVec::new();
+
+    for &num in order.iter() {
+        match read_boot_option(num) {
+            Some(opt) => {
+                if options.push(opt).is_err() {
+                    log::warn!("Boot options list full at {} entries", options.len());
+                    break;
+                }
+            }
+            None => {
+                log::debug!("Boot{:04X}: not found or invalid, skipping", num);
+            }
+        }
+    }
+
+    options
+}
+
+// ============================================================================
+// BootCurrent
+// ============================================================================
+
+/// Set the BootCurrent variable (volatile, BS+RT).
+///
+/// Called just before starting a boot option's image.
+pub fn set_boot_current(option_number: u16) {
+    let data = option_number.to_le_bytes();
+    if write_variable(&BOOT_CURRENT_NAME, BS_RT, &data) {
+        log::info!("BootCurrent: set to Boot{:04X}", option_number);
+    } else {
+        log::error!("BootCurrent: failed to set");
+    }
+}
+
+/// Clear the BootCurrent variable.
+///
+/// Called after a boot option's image returns.
+pub fn clear_boot_current() {
+    delete_variable(&BOOT_CURRENT_NAME);
+    log::debug!("BootCurrent: cleared");
+}
+
+// ============================================================================
+// Timeout
+// ============================================================================
+
+/// Read the Timeout variable.
+///
+/// Returns the timeout in seconds:
+/// - `Some(0)` — no wait, boot immediately
+/// - `Some(0xFFFF)` — wait forever
+/// - `Some(n)` — wait n seconds
+/// - `None` — variable not set (caller should use a default)
+pub fn read_timeout() -> Option<u16> {
+    let (_, data) = read_variable(&TIMEOUT_NAME)?;
+
+    if data.len() != 2 {
+        log::warn!("Timeout: invalid size {} (expected 2)", data.len());
+        return None;
+    }
+
+    let value = u16::from_le_bytes([data[0], data[1]]);
+    log::info!("Timeout: {} seconds", value);
+    Some(value)
+}
+
+/// Write the Timeout variable (NV+BS+RT).
+///
+/// Sets the boot menu timeout in seconds.
+pub fn set_timeout(seconds: u16) {
+    let data = seconds.to_le_bytes();
+    if write_variable(&TIMEOUT_NAME, NV_BS_RT, &data) {
+        log::debug!("Timeout: set to {} seconds", seconds);
+    }
+}
+
+// ============================================================================
+// Device Path Extraction
+// ============================================================================
+
+/// Extract a file path string from the FilePathList in a LoadOption.
+///
+/// Walks the EFI_DEVICE_PATH_PROTOCOL nodes looking for a Media/FilePath
+/// node (type=4, subtype=4) and extracts the UCS-2 path string from it.
+///
+/// Returns `None` if no file path node is found.
+pub fn extract_file_path(load_option: &LoadOption) -> Option<heapless::String<128>> {
+    let data = &load_option.file_path;
+    let mut offset = 0;
+
+    while offset + 4 <= data.len() {
+        let node_type = data[offset];
+        let node_subtype = data[offset + 1];
+        let node_length = u16::from_le_bytes([data[offset + 2], data[offset + 3]]) as usize;
+
+        if node_length < 4 || offset + node_length > data.len() {
+            break;
+        }
+
+        // End of Device Path node (type=0x7F, subtype=0xFF)
+        if node_type == 0x7F && node_subtype == 0xFF {
+            break;
+        }
+
+        // Media/FilePath node (type=4, subtype=4)
+        if node_type == 4 && node_subtype == 4 && node_length > 4 {
+            let path_data = &data[offset + 4..offset + node_length];
+            let mut path = heapless::String::<128>::new();
+
+            // UCS-2 to ASCII conversion
+            for chunk in path_data.chunks_exact(2) {
+                let ch = u16::from_le_bytes([chunk[0], chunk[1]]);
+                if ch == 0 {
+                    break;
+                }
+                let ascii = if ch < 128 { ch as u8 as char } else { '?' };
+                if path.push(ascii).is_err() {
+                    log::warn!("extract_file_path: path exceeds 128 chars, truncated");
+                    break;
+                }
+            }
+
+            if !path.is_empty() {
+                return Some(path);
+            }
+        }
+
+        offset += node_length;
+    }
+
+    None
+}
+
+// ============================================================================
+// Boot Manager Integration
+// ============================================================================
+
+/// Result of attempting to boot a single option
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootAttemptResult {
+    /// Boot was successful (image ran and returned SUCCESS)
+    Success,
+    /// Boot failed (image not found, verification failed, etc.)
+    Failed,
+    /// Option was skipped (inactive, wrong category, etc.)
+    Skipped,
+}
+
+/// Summary of the boot variable state, gathered early in boot.
+///
+/// This is cached before platform hooks run (matching edk2's approach).
+pub struct BootVarState {
+    /// Cached BootNext value (read and cached early)
+    pub boot_next: Option<u16>,
+    /// BootOrder entries
+    pub boot_order: HeaplessVec<u16, MAX_BOOT_OPTIONS>,
+    /// Timeout in seconds (None = use default)
+    pub timeout: Option<u16>,
+}
+
+/// Read all boot manager variables at once.
+///
+/// Call this early in the boot process, before platform hooks or driver
+/// binding, to cache the boot variable state.
+pub fn read_boot_var_state() -> BootVarState {
+    let boot_next = read_boot_next();
+    let boot_order = read_boot_order();
+    let timeout = read_timeout();
+
+    log::info!("Boot variable state:");
+    log::info!(
+        "  BootNext: {}",
+        match boot_next {
+            Some(n) => {
+                let mut s = heapless::String::<16>::new();
+                let _ = write!(s, "Boot{:04X}", n);
+                s
+            }
+            None => {
+                let mut s = heapless::String::<16>::new();
+                let _ = s.push_str("(not set)");
+                s
+            }
+        }
+    );
+    log::info!("  BootOrder: {} entries", boot_order.len());
+    log::info!(
+        "  Timeout: {}",
+        match timeout {
+            Some(0xFFFF) => {
+                let mut s = heapless::String::<16>::new();
+                let _ = s.push_str("forever");
+                s
+            }
+            Some(n) => {
+                let mut s = heapless::String::<16>::new();
+                let _ = write!(s, "{}s", n);
+                s
+            }
+            None => {
+                let mut s = heapless::String::<16>::new();
+                let _ = s.push_str("(default)");
+                s
+            }
+        }
+    );
+
+    BootVarState {
+        boot_next,
+        boot_order,
+        timeout,
+    }
+}

--- a/src/efi/auth/boot.rs
+++ b/src/efi/auth/boot.rs
@@ -126,10 +126,12 @@ pub fn init_secure_boot(config: &SecureBootConfig) -> Result<EnrollmentStatus, A
     Ok(enrollment::get_enrollment_status())
 }
 
-/// Load the SecureBootEnable preference from persistent storage
+/// Load the SecureBootEnable preference from persistent storage.
 ///
 /// Returns true if Secure Boot was previously enabled by the user.
-fn load_secure_boot_enable_preference() -> bool {
+/// Called during boot initialization and by
+/// `handle_secure_boot_variable_update()` when PK is enrolled at runtime.
+pub fn load_secure_boot_enable_preference() -> bool {
     use super::EFI_GLOBAL_VARIABLE_GUID;
     use super::variables::SECURE_BOOT_ENABLE_NAME;
 

--- a/src/efi/auth/crypto.rs
+++ b/src/efi/auth/crypto.rs
@@ -717,6 +717,13 @@ fn verify_chain_link(
 }
 
 /// Verify a single certificate against a trust anchor (for direct trust)
+///
+/// Per the UEFI specification, certificates in the db are explicit trust
+/// anchors for image verification.  When the signer certificate IS the db
+/// certificate (direct trust), we must NOT enforce CA-only extensions
+/// (basicConstraints, keyUsage) because tools like `sbctl` generate plain
+/// end-entity certificates without CA:TRUE.  edk2 and u-boot behave the
+/// same way — the db is a flat allow-list, not a CA trust store.
 fn verify_single_cert(
     cert_der: &[u8],
     trust_anchor_der: &[u8],
@@ -735,7 +742,19 @@ fn verify_single_cert(
         return Ok(false);
     };
 
-    verify_chain_link(cert_der, issuer_der, config)
+    // For direct trust (cert is directly in db), relax CA-only checks.
+    // The db entry is an explicit trust anchor — its extensions are irrelevant.
+    let relaxed_config = ChainBuildingConfig {
+        max_depth: config.max_depth,
+        check_revocation: config.check_revocation,
+        revocation_config: Default::default(),
+        current_time: config.current_time,
+        require_basic_constraints: false,
+        require_key_usage: false,
+        check_validity_period: config.check_validity_period,
+    };
+
+    verify_chain_link(cert_der, issuer_der, &relaxed_config)
 }
 
 /// Verify a certificate chain with full revocation checking

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -7,6 +7,7 @@ pub mod allocator;
 pub mod auth;
 pub mod boot_services;
 pub mod protocols;
+#[cfg(feature = "rt-log")]
 pub mod rtlog;
 pub mod runtime_services;
 pub mod system_table;

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -7,6 +7,7 @@ pub mod allocator;
 pub mod auth;
 pub mod boot_services;
 pub mod protocols;
+pub mod rtlog;
 pub mod runtime_services;
 pub mod system_table;
 pub mod utils;

--- a/src/efi/rtlog.rs
+++ b/src/efi/rtlog.rs
@@ -1,0 +1,279 @@
+//! Runtime Services Log Buffer
+//!
+//! A fixed-address, warm-reboot-persistent ring buffer for logging what the
+//! OS does via Runtime Services (primarily SetVariable calls).
+//!
+//! # Memory layout  (64 KB at 0x70000, NOLOAD / PT_NULL)
+//!
+//! ```text
+//! +------------------+  <- _rt_log_start
+//! | Header (16 bytes)|
+//! |   Magic "CRTL"   |  4 bytes
+//! |   write_pos      |  4 bytes — next byte to write (wraps at DATA_SIZE)
+//! |   wrapped        |  1 byte  — 1 if the ring has wrapped at least once
+//! |   _pad           |  7 bytes
+//! +------------------+
+//! | Data ring        |  rest of 64 KB
+//! +------------------+  <- _rt_log_end
+//! ```
+//!
+//! Lines are plain ASCII / UTF-8, newline-terminated.  On wrap the oldest
+//! data is silently overwritten — this is a best-effort debug aid.
+//!
+//! # Safety
+//!
+//! These functions are called from runtime services context after
+//! ExitBootServices.  No allocator, no `log` crate, no locks — only
+//! raw pointer writes and simple atomics.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+// Linker symbols
+unsafe extern "C" {
+    static _rt_log_start: u8;
+    static _rt_log_end: u8;
+}
+
+const MAGIC: u32 = 0x4c545243; // "CRTL"
+const HEADER_SIZE: usize = 16;
+
+/// Whether the log has been initialised this boot session.
+static INITIALISED: AtomicBool = AtomicBool::new(false);
+
+#[repr(C)]
+struct Header {
+    magic: u32,
+    write_pos: u32, // offset into data area (0..DATA_SIZE-1)
+    wrapped: u8,
+    _pad: [u8; 7],
+}
+
+#[inline]
+fn base() -> *mut u8 {
+    unsafe { &_rt_log_start as *const u8 as *mut u8 }
+}
+
+#[inline]
+fn total_size() -> usize {
+    unsafe {
+        let s = &_rt_log_start as *const u8 as usize;
+        let e = &_rt_log_end as *const u8 as usize;
+        e - s
+    }
+}
+
+#[inline]
+fn data_size() -> usize {
+    total_size() - HEADER_SIZE
+}
+
+#[inline]
+fn header() -> *mut Header {
+    base() as *mut Header
+}
+
+#[inline]
+fn data_base() -> *mut u8 {
+    // SAFETY: base + HEADER_SIZE is within the linker-allocated region.
+    unsafe { base().add(HEADER_SIZE) }
+}
+
+/// Initialise a fresh log for this boot session.
+///
+/// Call this AFTER [`dump`] so the previous boot's data has been printed.
+pub fn init() {
+    let h = header();
+    // SAFETY: pointer is within the NOLOAD section we own.
+    unsafe {
+        (*h).magic = MAGIC;
+        (*h).write_pos = 0;
+        (*h).wrapped = 0;
+        (*h)._pad = [0u8; 7];
+    }
+    INITIALISED.store(true, Ordering::Relaxed);
+}
+
+/// Dump the previous boot's log to the `log` crate (called early on next boot).
+///
+/// Returns the number of bytes dumped, or 0 if the buffer was empty / invalid.
+pub fn dump() -> usize {
+    let h = header();
+    // SAFETY: reading our own NOLOAD section.
+    let (magic, write_pos, wrapped) =
+        unsafe { ((*h).magic, (*h).write_pos as usize, (*h).wrapped) };
+
+    if magic != MAGIC {
+        log::debug!(
+            "[rtlog] No valid runtime log from previous boot (magic={:#010x})",
+            magic
+        );
+        return 0;
+    }
+
+    let ds = data_size();
+    let write_pos = write_pos.min(ds);
+
+    if write_pos == 0 && wrapped == 0 {
+        log::info!("[rtlog] Previous runtime log is empty");
+        return 0;
+    }
+
+    log::info!("[rtlog] ── Runtime services log from previous boot ──");
+
+    let db = data_base();
+
+    // Build a contiguous slice (start..end of valid data).
+    // If wrapped: data is [write_pos..ds] ++ [0..write_pos]
+    // If not:     data is [0..write_pos]
+    let total_bytes = if wrapped != 0 { ds } else { write_pos };
+
+    // Print line by line so each line goes through the log formatter.
+    let mut printed = 0usize;
+    let mut line_start = 0usize;
+
+    // Helper: byte at logical offset `i`
+    let byte_at = |i: usize| -> u8 {
+        let phys = if wrapped != 0 {
+            (write_pos + i) % ds
+        } else {
+            i
+        };
+        // SAFETY: phys < ds, data_base() + ds is within our section.
+        unsafe { *db.add(phys) }
+    };
+
+    for i in 0..=total_bytes {
+        let is_end = i == total_bytes;
+        let b = if is_end { b'\n' } else { byte_at(i) };
+
+        if b == b'\n' || is_end {
+            let line_len = i - line_start;
+            if line_len > 0 {
+                // Collect into a small stack buffer for logging
+                let mut buf = [0u8; 256];
+                let capped = line_len.min(buf.len() - 1);
+                for (j, slot) in buf[..capped].iter_mut().enumerate() {
+                    *slot = byte_at(line_start + j);
+                }
+                if let Ok(s) = core::str::from_utf8(&buf[..capped]) {
+                    log::info!("[rtlog] {}", s);
+                }
+                printed += line_len;
+            }
+            line_start = i + 1;
+        }
+    }
+
+    log::info!("[rtlog] ── end of runtime log ({} bytes) ──", total_bytes);
+    printed
+}
+
+/// Append a string to the runtime log ring buffer.
+///
+/// Safe to call from any context after ExitBootServices — no allocations,
+/// no locks, no `log` crate.  Silently drops data when the buffer is full
+/// (ring wraps).
+pub fn append(s: &str) {
+    if !INITIALISED.load(Ordering::Relaxed) {
+        return;
+    }
+
+    let h = header();
+    // SAFETY: our NOLOAD section, no concurrent writers (single-threaded runtime).
+    let ds = data_size();
+    let db = data_base();
+
+    for &b in s.as_bytes() {
+        let pos = unsafe { (*h).write_pos as usize };
+        // SAFETY: pos < ds guaranteed by the modulo below.
+        unsafe {
+            *db.add(pos) = b;
+            let next = pos + 1;
+            if next >= ds {
+                (*h).write_pos = 0;
+                (*h).wrapped = 1;
+            } else {
+                (*h).write_pos = next as u32;
+            }
+        }
+    }
+}
+
+/// Append a string followed by a newline.
+#[inline]
+pub fn appendln(s: &str) {
+    append(s);
+    append("\n");
+}
+
+/// Append a decimal u64.
+pub fn append_u64(v: u64) {
+    if v == 0 {
+        append("0");
+        return;
+    }
+    let mut buf = [0u8; 20];
+    let mut i = buf.len();
+    let mut n = v;
+    while n > 0 {
+        i -= 1;
+        buf[i] = b'0' + (n % 10) as u8;
+        n /= 10;
+    }
+    // SAFETY: buf[i..] contains valid ASCII digits.
+    if let Ok(s) = core::str::from_utf8(&buf[i..]) {
+        append(s);
+    }
+}
+
+/// Append a hex u64 with "0x" prefix.
+pub fn append_hex(v: u64) {
+    append("0x");
+    if v == 0 {
+        append("0");
+        return;
+    }
+    let mut buf = [0u8; 16];
+    let mut i = buf.len();
+    let mut n = v;
+    while n > 0 {
+        i -= 1;
+        let nibble = (n & 0xF) as u8;
+        buf[i] = if nibble < 10 {
+            b'0' + nibble
+        } else {
+            b'a' + nibble - 10
+        };
+        n >>= 4;
+    }
+    // SAFETY: buf[i..] contains valid ASCII hex chars.
+    if let Ok(s) = core::str::from_utf8(&buf[i..]) {
+        append(s);
+    }
+}
+
+/// Register the rt_log region as RuntimeServicesData so the OS preserves it.
+pub fn register_region() {
+    use crate::efi::allocator::{MemoryType, PAGE_SIZE};
+
+    let buf_base = unsafe { &_rt_log_start as *const u8 as u64 };
+    let buf_pages = (total_size() as u64).div_ceil(PAGE_SIZE);
+
+    if let Err(e) = crate::efi::allocator::force_add_region(
+        buf_base,
+        buf_pages,
+        MemoryType::RuntimeServicesData,
+    ) {
+        log::warn!(
+            "[rtlog] Could not register rt_log region at {:#x}: {:?}",
+            buf_base,
+            e
+        );
+    } else {
+        log::info!(
+            "[rtlog] Runtime log buffer at {:#x} ({} pages) registered as RuntimeServicesData",
+            buf_base,
+            buf_pages
+        );
+    }
+}

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -989,6 +989,27 @@ extern "efiapi" fn set_variable(
     let name = variable_name;
     let guid = unsafe { *vendor_guid };
 
+    // ── Runtime log: record every SetVariable call after ExitBootServices ──
+    if state::is_exit_boot_services_called() {
+        use crate::efi::rtlog;
+        rtlog::append("SetVariable name=");
+        if !variable_name.is_null() {
+            // Print up to 64 UCS-2 chars as ASCII (names are always ASCII)
+            for i in 0..64usize {
+                let c = unsafe { *variable_name.add(i) };
+                if c == 0 {
+                    break;
+                }
+                rtlog::append(core::str::from_utf8(&[(c & 0x7f) as u8]).unwrap_or("?"));
+            }
+        }
+        rtlog::append(" attr=");
+        rtlog::append_hex(attributes as u64);
+        rtlog::append(" size=");
+        rtlog::append_u64(data_size as u64);
+        rtlog::appendln("");
+    }
+
     // Check name length
     let name_len = ucs2_strlen_ptr(name);
     if name_len == 0 || name_len >= MAX_VARIABLE_NAME_LEN {
@@ -1072,6 +1093,11 @@ extern "efiapi" fn set_variable(
             }
             Err(e) => {
                 log::warn!("Authenticated variable verification failed: {:?}", e);
+                if state::is_exit_boot_services_called() {
+                    use crate::efi::rtlog;
+                    rtlog::append("  -> auth verify FAILED: ");
+                    rtlog::appendln(alloc::format!("{:?}", e).as_str());
+                }
                 return e.into();
             }
         }
@@ -1146,10 +1172,34 @@ extern "efiapi" fn set_variable(
                     // Persist the updated variable
                     if (attributes & crate::efi::auth::attributes::NON_VOLATILE) != 0 {
                         let name_slice = unsafe { core::slice::from_raw_parts(name, name_len + 1) };
-                        if let Err(e) = crate::efi::varstore::persist_variable(
-                            &guid, name_slice, attributes, &combined,
+                        // The combined data is the fully-resolved merge of existing +
+                        // new signature lists (auth header already stripped, append
+                        // already applied).  When writing to the deferred buffer at
+                        // runtime, clear the auth/append flags so the buffer stores
+                        // it as a plain non-auth full write — the verification was
+                        // already performed above.
+                        let persist_attrs = attributes
+                            & !(crate::efi::auth::attributes::TIME_BASED_AUTHENTICATED_WRITE_ACCESS
+                                | crate::efi::auth::attributes::APPEND_WRITE);
+                        match crate::efi::varstore::persist_variable(
+                            &guid,
+                            name_slice,
+                            persist_attrs,
+                            &combined,
                         ) {
-                            log::debug!("Variable not persisted: {:?}", e);
+                            Ok(()) => {
+                                if state::is_exit_boot_services_called() {
+                                    crate::efi::rtlog::appendln("  -> persisted OK (append)");
+                                }
+                            }
+                            Err(e) => {
+                                log::debug!("Variable not persisted: {:?}", e);
+                                if state::is_exit_boot_services_called() {
+                                    use crate::efi::rtlog;
+                                    rtlog::append("  -> persist FAILED (append): ");
+                                    rtlog::appendln(alloc::format!("{:?}", e).as_str());
+                                }
+                            }
                         }
                     }
 
@@ -1203,12 +1253,42 @@ extern "efiapi" fn set_variable(
         // Only persist non-volatile variables
         if (attributes & crate::efi::auth::attributes::NON_VOLATILE) != 0 {
             let name_slice = unsafe { core::slice::from_raw_parts(name, name_len + 1) };
-            let data_slice = unsafe { core::slice::from_raw_parts(data_ptr, final_data_size) };
-            if let Err(e) =
-                crate::efi::varstore::persist_variable(&guid, name_slice, attributes, data_slice)
-            {
-                log::debug!("Variable not persisted: {:?}", e);
-                // Don't fail the operation - in-memory storage succeeded
+
+            // For authenticated variables at runtime (after ExitBootServices), we
+            // must pass the ORIGINAL signed data (with auth header) to the deferred
+            // buffer so it can re-verify the signature on next boot and extract the
+            // timestamp.  Before ExitBootServices, we write the stripped payload
+            // directly to SPI flash (no auth header needed in storage).
+            let persist_data: &[u8] =
+                if is_authenticated && state::is_exit_boot_services_called() && data_size > 0 {
+                    // SAFETY: `data` and `data_size` are the original caller-provided
+                    // values validated at function entry; the pointer is valid for
+                    // `data_size` bytes and has not been freed.
+                    unsafe { core::slice::from_raw_parts(data as *const u8, data_size) }
+                } else {
+                    unsafe { core::slice::from_raw_parts(data_ptr, final_data_size) }
+                };
+
+            match crate::efi::varstore::persist_variable(
+                &guid,
+                name_slice,
+                attributes,
+                persist_data,
+            ) {
+                Ok(()) => {
+                    if state::is_exit_boot_services_called() {
+                        use crate::efi::rtlog;
+                        rtlog::appendln("  -> persisted OK");
+                    }
+                }
+                Err(e) => {
+                    log::debug!("Variable not persisted: {:?}", e);
+                    if state::is_exit_boot_services_called() {
+                        use crate::efi::rtlog;
+                        rtlog::append("  -> persist FAILED: ");
+                        rtlog::appendln(alloc::format!("{:?}", e).as_str());
+                    }
+                }
             }
         }
 
@@ -1222,7 +1302,17 @@ fn handle_secure_boot_variable_update(var_type: auth::SecureBootVariable) {
         auth::SecureBootVariable::PK if auth::is_setup_mode() => {
             // PK enrollment transitions from Setup Mode to User Mode
             auth::enter_user_mode();
-            auth::enable_secure_boot();
+
+            // Per UEFI spec, PK enrollment transitions to User Mode but does NOT
+            // automatically enable Secure Boot enforcement.  The SecureBoot variable
+            // is set based on the persisted SecureBootEnable preference.
+            if auth::boot::load_secure_boot_enable_preference() {
+                auth::enable_secure_boot();
+            }
+
+            // Sync the in-memory SetupMode/SecureBoot status variables so that
+            // GetNextVariableName enumeration and any internal readers stay consistent.
+            let _ = auth::boot::update_status_variables();
         }
         _ => {
             // Other variables (or PK when not in setup mode) don't change state
@@ -1238,6 +1328,9 @@ fn handle_secure_boot_variable_delete(var_type: auth::SecureBootVariable) {
             auth::enter_setup_mode();
             // Clear the PK database
             auth::pk_database().clear();
+
+            // Sync the in-memory status variables after mode transition
+            let _ = auth::boot::update_status_variables();
         }
         auth::SecureBootVariable::KEK => {
             auth::kek_database().clear();

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -990,6 +990,7 @@ extern "efiapi" fn set_variable(
     let guid = unsafe { *vendor_guid };
 
     // ── Runtime log: record every SetVariable call after ExitBootServices ──
+    #[cfg(feature = "rt-log")]
     if state::is_exit_boot_services_called() {
         use crate::efi::rtlog;
         rtlog::append("SetVariable name=");
@@ -1093,6 +1094,7 @@ extern "efiapi" fn set_variable(
             }
             Err(e) => {
                 log::warn!("Authenticated variable verification failed: {:?}", e);
+                #[cfg(feature = "rt-log")]
                 if state::is_exit_boot_services_called() {
                     use crate::efi::rtlog;
                     rtlog::append("  -> auth verify FAILED: ");
@@ -1187,13 +1189,16 @@ extern "efiapi" fn set_variable(
                             persist_attrs,
                             &combined,
                         ) {
-                            Ok(()) => {
+                            Ok(()) =>
+                            {
+                                #[cfg(feature = "rt-log")]
                                 if state::is_exit_boot_services_called() {
                                     crate::efi::rtlog::appendln("  -> persisted OK (append)");
                                 }
                             }
                             Err(e) => {
                                 log::debug!("Variable not persisted: {:?}", e);
+                                #[cfg(feature = "rt-log")]
                                 if state::is_exit_boot_services_called() {
                                     use crate::efi::rtlog;
                                     rtlog::append("  -> persist FAILED (append): ");
@@ -1275,7 +1280,9 @@ extern "efiapi" fn set_variable(
                 attributes,
                 persist_data,
             ) {
-                Ok(()) => {
+                Ok(()) =>
+                {
+                    #[cfg(feature = "rt-log")]
                     if state::is_exit_boot_services_called() {
                         use crate::efi::rtlog;
                         rtlog::appendln("  -> persisted OK");
@@ -1283,6 +1290,7 @@ extern "efiapi" fn set_variable(
                 }
                 Err(e) => {
                     log::debug!("Variable not persisted: {:?}", e);
+                    #[cfg(feature = "rt-log")]
                     if state::is_exit_boot_services_called() {
                         use crate::efi::rtlog;
                         rtlog::append("  -> persist FAILED: ");

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -995,8 +995,25 @@ extern "efiapi" fn set_variable(
         return Status::INVALID_PARAMETER;
     }
 
-    // Check data size
-    if data_size > MAX_VARIABLE_DATA_SIZE {
+    // Check data size.
+    //
+    // For authenticated writes the caller passes the EFI_VARIABLE_AUTHENTICATION_2
+    // header (timestamp + WIN_CERTIFICATE with a PKCS#7 signature, typically
+    // 1-3 KB) prepended to the actual payload.  The signature is verified and
+    // discarded; only the payload is stored.  We therefore allow a generous raw
+    // input limit here and re-check the *stored* size after auth processing
+    // (see the `final_data_size > MAX_VARIABLE_DATA_SIZE` guard below).
+    //
+    // For non-authenticated writes the raw size IS the stored size, so
+    // MAX_VARIABLE_DATA_SIZE is the correct limit.
+    let is_auth_write = (attributes & auth::attributes::TIME_BASED_AUTHENTICATED_WRITE_ACCESS) != 0;
+    let raw_limit = if is_auth_write {
+        // Auth header (PKCS#7 signature) can add 1-3 KB on top of payload
+        MAX_VARIABLE_DATA_SIZE * 3
+    } else {
+        MAX_VARIABLE_DATA_SIZE
+    };
+    if data_size > raw_limit {
         return Status::OUT_OF_RESOURCES;
     }
 

--- a/src/efi/varstore/deferred.rs
+++ b/src/efi/varstore/deferred.rs
@@ -94,7 +94,13 @@ fn linker_buffer_base() -> *mut u8 {
 const HEADER_SIZE: usize = 32;
 
 /// Maximum size of a single entry (including length prefix)
-const MAX_ENTRY_SIZE: usize = 8 * 1024;
+///
+/// Must be large enough for authenticated Secure Boot key variables.
+/// `sbctl enroll-keys --microsoft` writes db/KEK entries containing
+/// multiple X.509 certificates (~1.5 KB each) inside an
+/// EFI_VARIABLE_AUTHENTICATION_2 header with a PKCS#7 signature
+/// (~1-2 KB).  16 KB covers all realistic enrollment payloads.
+const MAX_ENTRY_SIZE: usize = 16 * 1024;
 
 /// Entry flags
 mod entry_flags {

--- a/src/efi/varstore/mod.rs
+++ b/src/efi/varstore/mod.rs
@@ -77,8 +77,11 @@ pub use deferred::{
 /// Maximum variable name length (in UTF-16 code units)
 pub const MAX_NAME_LEN: usize = 64;
 
-/// Maximum variable data size
-pub const MAX_DATA_SIZE: usize = 4096;
+/// Maximum variable data size for persistence
+///
+/// Must match `state::MAX_VARIABLE_DATA_SIZE` so that any variable held in
+/// memory can be persisted to SPI flash.
+pub const MAX_DATA_SIZE: usize = 8192;
 
 /// Variable record header magic: 0xAA55
 const RECORD_MAGIC: u16 = 0xAA55;

--- a/src/efi/varstore/mod.rs
+++ b/src/efi/varstore/mod.rs
@@ -77,11 +77,15 @@ pub use deferred::{
 /// Maximum variable name length (in UTF-16 code units)
 pub const MAX_NAME_LEN: usize = 64;
 
-/// Maximum variable data size for persistence
+/// Maximum data payload for a single persisted or deferred variable record.
 ///
-/// Must match `state::MAX_VARIABLE_DATA_SIZE` so that any variable held in
-/// memory can be persisted to SPI flash.
-pub const MAX_DATA_SIZE: usize = 8192;
+/// This is intentionally larger than `state::MAX_VARIABLE_DATA_SIZE` (16 KB)
+/// because the deferred buffer stores the raw authenticated variable data
+/// including the PKCS#7 signature header, which can add 1-3 KB on top of the
+/// stripped payload.  `sbctl enroll-keys --microsoft` produces a db blob
+/// with three X.509 certificates plus a PKCS#7 auth header: observed at
+/// ~10.9 KB.  32 KB gives ample headroom for future key databases.
+pub const MAX_DATA_SIZE: usize = 32 * 1024;
 
 /// Variable record header magic: 0xAA55
 const RECORD_MAGIC: u16 = 0xAA55;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,8 +387,11 @@ pub fn init(coreboot_table_ptr: u64) -> ! {
     // Register the runtime services log region and dump any log from the
     // previous boot before we do anything else (so the data is visible even
     // if init fails).  init() is called after deferred writes are processed.
-    efi::rtlog::register_region();
-    efi::rtlog::dump();
+    #[cfg(feature = "rt-log")]
+    {
+        efi::rtlog::register_region();
+        efi::rtlog::dump();
+    }
 
     // Reserve the deferred variable buffer region as RuntimeServicesData.
     // The buffer is at a fixed address (0x80000) below the payload, placed
@@ -473,6 +476,7 @@ pub fn init(coreboot_table_ptr: u64) -> ! {
 
     // Initialize the runtime log for this boot session (clears previous boot's
     // data now that it has been dumped above).
+    #[cfg(feature = "rt-log")]
     efi::rtlog::init();
 
     // Cache boot manager variables EARLY, before platform hooks or driver

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,34 +384,42 @@ pub fn init(coreboot_table_ptr: u64) -> ! {
     // Initialize PCI early so we can detect SPI controller
     drivers::pci::init();
 
-    // Reserve and initialize the deferred variable buffer (for runtime variable persistence)
-    // This buffer survives warm reboot and allows variable changes after ExitBootServices
-    // to be applied on the next boot.
+    // Register the runtime services log region and dump any log from the
+    // previous boot before we do anything else (so the data is visible even
+    // if init fails).  init() is called after deferred writes are processed.
+    efi::rtlog::register_region();
+    efi::rtlog::dump();
+
+    // Reserve the deferred variable buffer region as RuntimeServicesData.
+    // The buffer is at a fixed address (0x80000) below the payload, placed
+    // there by the linker script so coreboot/cbfstool never overwrites it.
+    // Registering it as RuntimeServicesData ensures the OS preserves the
+    // mapping and SetVirtualAddressMap adjusts the GOT-based pointer.
     {
         use efi::allocator::{MemoryType, PAGE_SIZE};
-        use efi::varstore::{deferred_buffer_base, deferred_buffer_size};
+        use efi::varstore::deferred;
 
-        let buffer_base = deferred_buffer_base();
-        let buffer_pages = (deferred_buffer_size() as u64).div_ceil(PAGE_SIZE);
+        let buf_base = deferred::deferred_buffer_base();
+        let buf_pages = (deferred::deferred_buffer_size() as u64).div_ceil(PAGE_SIZE);
 
-        // Reserve the memory region as ReservedMemoryType so the OS won't overwrite it
-        state::with_allocator_mut(|alloc| {
-            if let Err(e) =
-                alloc.reserve_region(buffer_base, buffer_pages, MemoryType::ReservedMemoryType)
-            {
-                log::warn!(
-                    "Could not reserve deferred buffer region at {:#x}: {:?}",
-                    buffer_base,
-                    e
-                );
-            } else {
-                log::debug!(
-                    "Reserved {} pages for deferred buffer at {:#x}",
-                    buffer_pages,
-                    buffer_base
-                );
-            }
-        });
+        // The buffer is outside the payload load region so it might not be in
+        // the coreboot-derived memory map at all.  force_add_region creates
+        // the entry unconditionally.
+        if let Err(e) =
+            efi::allocator::force_add_region(buf_base, buf_pages, MemoryType::RuntimeServicesData)
+        {
+            log::warn!(
+                "Could not register deferred buffer at {:#x}: {:?}",
+                buf_base,
+                e
+            );
+        } else {
+            log::info!(
+                "Deferred buffer at {:#x} ({} pages) registered as RuntimeServicesData",
+                buf_base,
+                buf_pages
+            );
+        }
     }
 
     // Initialize variable store persistence (loads variables from SPI flash)
@@ -419,16 +427,13 @@ pub fn init(coreboot_table_ptr: u64) -> ! {
         Ok(()) => {
             log::info!("Variable store persistence initialized");
 
-            // Check for pending deferred writes from previous boot BEFORE clearing the buffer
-            // This must be done after SPI init so we can write to SMMSTORE
+            // Check for pending deferred writes from previous warm boot
             let pending_count = efi::varstore::check_deferred_pending();
             if pending_count > 0 {
                 log::info!(
                     "Found {} pending deferred writes from previous boot",
                     pending_count
                 );
-
-                // Apply the deferred writes to SPI
                 match efi::varstore::process_deferred_pending() {
                     Ok(n) => log::info!("Applied {} deferred variable writes", n),
                     Err(e) => log::warn!("Failed to process deferred writes: {:?}", e),
@@ -461,9 +466,14 @@ pub fn init(coreboot_table_ptr: u64) -> ! {
         Err(e) => log::warn!("Variable store persistence not available: {:?}", e),
     }
 
-    // Now initialize the deferred buffer for this boot session
-    // This clears the buffer so new runtime writes can be accumulated
+    // Initialize the deferred buffer for this boot session.
+    // Any pending writes from a previous warm boot were already processed
+    // above; now clear the buffer so new runtime writes can be accumulated.
     efi::varstore::init_deferred_buffer();
+
+    // Initialize the runtime log for this boot session (clears previous boot's
+    // data now that it has been dumped above).
+    efi::rtlog::init();
 
     // Cache boot manager variables EARLY, before platform hooks or driver
     // binding can modify them (matches edk2 BdsEntry behavior).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ extern crate alloc;
 pub mod arch;
 pub mod bls;
 pub mod boot;
+pub mod boot_vars;
 pub mod cfr_menu;
 pub mod coreboot;
 pub mod drivers;
@@ -464,8 +465,12 @@ pub fn init(coreboot_table_ptr: u64) -> ! {
     // This clears the buffer so new runtime writes can be accumulated
     efi::varstore::init_deferred_buffer();
 
-    // Initialize storage subsystem
-    init_storage();
+    // Cache boot manager variables EARLY, before platform hooks or driver
+    // binding can modify them (matches edk2 BdsEntry behavior).
+    let boot_var_state = boot_vars::read_boot_var_state();
+
+    // Initialize storage subsystem and run boot manager
+    run_boot_manager(boot_var_state);
 
     log::info!("Press Ctrl+A X to exit QEMU");
 
@@ -475,8 +480,10 @@ pub fn init(coreboot_table_ptr: u64) -> ! {
     }
 }
 
-/// Initialize storage subsystem and attempt to find bootable media
-fn init_storage() {
+/// Initialize storage subsystem (PCI drivers, USB keyboards, etc.)
+///
+/// This is called once before the boot manager starts trying boot options.
+fn init_storage_subsystem() {
     log::info!("Initializing storage subsystem...");
 
     // Print PCI devices (already initialized earlier for SPI detection)
@@ -492,17 +499,126 @@ fn init_storage() {
     // Initialize pass-through protocols for TCG Opal support
     efi::protocols::pass_thru_init::init();
 
-    // Discover boot entries and show menu
+    log::info!("Storage subsystem initialized");
+}
+
+/// Run the UEFI boot manager.
+///
+/// Implements the boot dispatch sequence from UEFI Specification Section 3.1:
+///
+/// 1. Initialize storage subsystem (PCI drivers)
+/// 2. **BootNext** — if set, delete it and try that Boot#### entry
+/// 3. **BootOrder** — iterate Boot#### entries in order, try each active one
+/// 4. **Fallback** — discover boot entries from ESPs (removable media path)
+/// 5. Show interactive boot menu if nothing booted automatically
+fn run_boot_manager(boot_var_state: boot_vars::BootVarState) {
+    init_storage_subsystem();
+
+    // Apply timeout from the Timeout variable (if set) to the boot menu default
+    let timeout_seconds = boot_var_state.timeout.unwrap_or(5) as u32;
+
+    // ---- Phase 1: BootNext ----
+    if let Some(boot_next_num) = boot_var_state.boot_next {
+        log::info!("=== BootNext: attempting Boot{:04X} ===", boot_next_num);
+
+        // Delete BootNext BEFORE attempting boot (prevents infinite loops)
+        boot_vars::delete_boot_next();
+
+        if let Some(load_option) = boot_vars::read_boot_option(boot_next_num) {
+            // Match edk2 (BdsLibBootNext): skip if not active or not boot category
+            if !load_option.should_boot() {
+                log::warn!(
+                    "BootNext Boot{:04X}: skipped (active={}, category_boot={})",
+                    boot_next_num,
+                    load_option.is_active(),
+                    load_option.is_boot_category()
+                );
+            } else if let Some(file_path) = boot_vars::extract_file_path(&load_option) {
+                log::info!("BootNext: '{}' -> {}", load_option.description, file_path);
+                let result = try_boot_load_option(&load_option, &file_path);
+                if result == boot_vars::BootAttemptResult::Success {
+                    log::info!("BootNext succeeded, returning to boot manager");
+                    // edk2 would show BootManagerMenu here; we fall through to menu
+                }
+            } else {
+                log::warn!(
+                    "BootNext Boot{:04X}: no file path found in device path list",
+                    boot_next_num
+                );
+            }
+        } else {
+            log::warn!("BootNext Boot{:04X}: variable not found", boot_next_num);
+        }
+    }
+
+    // ---- Phase 2: BootOrder ----
+    if !boot_var_state.boot_order.is_empty() {
+        log::info!(
+            "=== BootOrder: trying {} entries ===",
+            boot_var_state.boot_order.len()
+        );
+
+        for &option_num in boot_var_state.boot_order.iter() {
+            let Some(load_option) = boot_vars::read_boot_option(option_num) else {
+                log::debug!("Boot{:04X}: not found, skipping", option_num);
+                continue;
+            };
+
+            if !load_option.should_boot() {
+                log::debug!(
+                    "Boot{:04X}: skipped (active={}, category_boot={})",
+                    option_num,
+                    load_option.is_active(),
+                    load_option.is_boot_category()
+                );
+                continue;
+            }
+
+            let Some(file_path) = boot_vars::extract_file_path(&load_option) else {
+                log::debug!("Boot{:04X}: no file path, skipping", option_num);
+                continue;
+            };
+
+            log::info!(
+                "BootOrder: trying Boot{:04X} '{}' -> {}",
+                option_num,
+                load_option.description,
+                file_path
+            );
+
+            let result = try_boot_load_option(&load_option, &file_path);
+            match result {
+                boot_vars::BootAttemptResult::Success => {
+                    log::info!("Boot{:04X} succeeded", option_num);
+                    // edk2 retries the whole loop if boot succeeded then returned;
+                    // we fall through to the menu instead
+                    break;
+                }
+                boot_vars::BootAttemptResult::Failed => {
+                    log::warn!(
+                        "Boot{:04X} '{}' failed, trying next",
+                        option_num,
+                        load_option.description
+                    );
+                }
+                boot_vars::BootAttemptResult::Skipped => {}
+            }
+        }
+    }
+
+    // ---- Phase 3: Fallback to device discovery and interactive menu ----
+    log::info!("=== Fallback: discovering boot entries from storage ===");
+
     let mut boot_menu = menu::discover_boot_entries();
 
     if boot_menu.entry_count() == 0 {
         log::warn!("No bootable media found!");
-        log::info!("Storage initialization complete");
         return;
     }
 
-    // If only one entry and no interactive mode requested, boot directly
-    // For now, always show the menu for testing
+    // Apply Timeout variable to the menu
+    boot_menu.set_timeout(timeout_seconds);
+
     log::debug!("Showing boot menu...");
     let selected = menu::show_menu(&mut boot_menu);
     log::info!("Menu returned: {:?}", selected);
@@ -522,7 +638,277 @@ fn init_storage() {
         log::warn!("No entry selected from menu");
     }
 
-    log::info!("Boot menu returned, storage initialization complete");
+    log::info!("Boot manager finished");
+}
+
+/// Attempt to boot a Boot#### load option.
+///
+/// This resolves the file path from the load option's device path list and
+/// attempts to find and boot the referenced EFI application from discovered
+/// storage devices. Sets BootCurrent before booting and clears it after.
+///
+/// Currently this matches the file path against ESPs found on storage devices.
+/// Full device path matching (resolving the exact disk/partition from the
+/// device path) is a future enhancement.
+fn try_boot_load_option(
+    load_option: &boot_vars::LoadOption,
+    file_path: &str,
+) -> boot_vars::BootAttemptResult {
+    // Set BootCurrent before attempting boot
+    boot_vars::set_boot_current(load_option.option_number);
+
+    // Try to find this file on any discovered ESP
+    let result = try_boot_file_from_esps(file_path);
+
+    // Clear BootCurrent after boot returns
+    boot_vars::clear_boot_current();
+
+    result
+}
+
+/// Try to boot a specific file path from any discovered ESP.
+///
+/// Scans all storage devices, looks for ESPs, and tries to find and boot
+/// the specified file. This is the fallback path when we don't have full
+/// device path resolution yet.
+fn try_boot_file_from_esps(file_path: &str) -> boot_vars::BootAttemptResult {
+    // Convert forward slashes to backslashes for FAT
+    let fat_path = if file_path.contains('/') {
+        match crate::fs::linux_path_to_fat(file_path) {
+            Ok(p) => p,
+            Err(_) => {
+                let mut p = heapless::String::<128>::new();
+                if p.push_str(file_path).is_err() {
+                    log::warn!("boot file path truncated ({} > 128 chars)", file_path.len());
+                }
+                p
+            }
+        }
+    } else {
+        let mut p = heapless::String::<128>::new();
+        if p.push_str(file_path).is_err() {
+            log::warn!("boot file path truncated ({} > 128 chars)", file_path.len());
+        }
+        p
+    };
+
+    // Try NVMe devices
+    if try_boot_file_on_nvme(&fat_path) {
+        return boot_vars::BootAttemptResult::Success;
+    }
+
+    // Try AHCI devices
+    if try_boot_file_on_ahci(&fat_path) {
+        return boot_vars::BootAttemptResult::Success;
+    }
+
+    // Try USB devices
+    if try_boot_file_on_usb(&fat_path) {
+        return boot_vars::BootAttemptResult::Success;
+    }
+
+    // Try SDHCI devices
+    if try_boot_file_on_sdhci(&fat_path) {
+        return boot_vars::BootAttemptResult::Success;
+    }
+
+    boot_vars::BootAttemptResult::Failed
+}
+
+/// Try to boot a file from NVMe ESPs
+fn try_boot_file_on_nvme(file_path: &str) -> bool {
+    use crate::drivers::nvme;
+
+    let Some(controller_ptr) = nvme::get_controller(0) else {
+        return false;
+    };
+    let controller = unsafe { &mut *controller_ptr };
+    let Some(ns) = controller.default_namespace() else {
+        return false;
+    };
+    let nsid = ns.nsid;
+    let pci_addr = controller.pci_address();
+
+    if !nvme::store_global_device(0, nsid) {
+        return false;
+    }
+
+    let device_type = menu::DeviceType::Nvme {
+        controller_id: 0,
+        nsid,
+    };
+
+    try_boot_file_on_device(&device_type, pci_addr.device, pci_addr.function, file_path)
+}
+
+/// Try to boot a file from AHCI ESPs
+fn try_boot_file_on_ahci(file_path: &str) -> bool {
+    use crate::drivers::ahci;
+
+    let Some(controller_ptr) = ahci::get_controller(0) else {
+        return false;
+    };
+    let controller = unsafe { &mut *controller_ptr };
+    let pci_addr = controller.pci_address();
+    let num_ports = controller.num_active_ports();
+
+    for port_index in 0..num_ports {
+        if !ahci::store_global_device(0, port_index) {
+            continue;
+        }
+        let device_type = menu::DeviceType::Ahci {
+            controller_id: 0,
+            port: port_index,
+        };
+        if try_boot_file_on_device(&device_type, pci_addr.device, pci_addr.function, file_path) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Try to boot a file from USB ESPs
+fn try_boot_file_on_usb(file_path: &str) -> bool {
+    use crate::drivers::usb::{self, UsbMassStorage, mass_storage};
+
+    let Some((controller_id, device_addr)) = usb::find_mass_storage() else {
+        return false;
+    };
+    let Some(controller_ptr) = usb::get_controller_ptr(controller_id) else {
+        return false;
+    };
+
+    let device_created =
+        usb::with_controller(controller_id, |controller| {
+            match UsbMassStorage::new(controller, device_addr) {
+                Ok(usb_device) => {
+                    if usb_device.num_blocks == 0 {
+                        return false;
+                    }
+                    unsafe {
+                        mass_storage::store_global_device_with_controller_ptr(
+                            usb_device,
+                            controller_ptr,
+                        )
+                    }
+                }
+                Err(_) => false,
+            }
+        });
+
+    if device_created != Some(true) {
+        return false;
+    }
+
+    let device_type = menu::DeviceType::Usb {
+        controller_id,
+        device_addr,
+    };
+    try_boot_file_on_device(&device_type, 0, 0, file_path)
+}
+
+/// Try to boot a file from SDHCI ESPs
+fn try_boot_file_on_sdhci(file_path: &str) -> bool {
+    use crate::drivers::sdhci;
+
+    for controller_id in 0..sdhci::controller_count() {
+        let Some(controller_ptr) = sdhci::get_controller(controller_id) else {
+            continue;
+        };
+        let controller = unsafe { &mut *controller_ptr };
+        if !controller.is_ready() {
+            continue;
+        }
+        let pci_addr = controller.pci_address();
+
+        if !sdhci::store_global_device(controller_id) {
+            continue;
+        }
+
+        let device_type = menu::DeviceType::Sdhci { controller_id };
+        if try_boot_file_on_device(&device_type, pci_addr.device, pci_addr.function, file_path) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Try to boot a specific file from ESPs on a given device.
+///
+/// Reads GPT, finds ESP partitions, mounts FAT, checks if the file exists,
+/// and if so, boots it through the standard UEFI boot path.
+fn try_boot_file_on_device(
+    device_type: &menu::DeviceType,
+    pci_device: u8,
+    pci_function: u8,
+    file_path: &str,
+) -> bool {
+    use crate::fs::{fat::FatFilesystem, gpt};
+
+    // Read GPT partitions
+    let partitions = with_disk(device_type, |disk| {
+        if let Ok(header) = gpt::read_gpt_header(disk)
+            && let Ok(parts) = gpt::read_partitions(disk, &header)
+        {
+            Some(parts)
+        } else {
+            None
+        }
+    })
+    .flatten();
+
+    let partitions = match partitions {
+        Some(p) => p,
+        None => return false,
+    };
+
+    // Look for ESPs containing the target file
+    for (i, partition) in partitions.iter().enumerate() {
+        if !partition.is_esp {
+            continue;
+        }
+
+        let partition_num = (i + 1) as u32;
+
+        // Try to mount FAT and check for the file
+        let found = with_disk(device_type, |disk| {
+            if let Ok(mut fat) = FatFilesystem::new(disk, partition.first_lba) {
+                fat.file_size(file_path).is_ok()
+            } else {
+                false
+            }
+        })
+        .unwrap_or(false);
+
+        if !found {
+            continue;
+        }
+
+        log::info!(
+            "Found '{}' on {} partition {}",
+            file_path,
+            device_type.description(),
+            partition_num
+        );
+
+        // Build a synthetic BootEntry and boot it through the standard path
+        let entry = menu::BootEntry::new(
+            file_path,
+            file_path,
+            *device_type,
+            partition_num,
+            partition.clone(),
+            pci_device,
+            pci_function,
+        );
+
+        boot_uefi_entry(&entry);
+
+        // If boot_uefi_entry returned, the boot failed
+        return false;
+    }
+
+    false
 }
 
 /// Boot a selected menu entry

--- a/src/state.rs
+++ b/src/state.rs
@@ -236,8 +236,15 @@ pub const MAX_VARIABLES: usize = 64;
 /// Maximum variable name length (in characters)
 pub const MAX_VARIABLE_NAME_LEN: usize = 64;
 
-/// Maximum variable data size
-pub const MAX_VARIABLE_DATA_SIZE: usize = 1024;
+/// Maximum variable data size (stored payload, after auth header stripping)
+///
+/// This must be large enough for Secure Boot key databases (PK, KEK, db, dbx).
+/// A single X.509 certificate in an EFI_SIGNATURE_LIST is typically 1-2 KB,
+/// and databases with multiple certificates (e.g. Microsoft CA chain + custom
+/// keys from sbctl) can reach 4-8 KB.  16 KB covers all realistic Secure Boot
+/// configurations while keeping FirmwareState within the 2 MB stack budget
+/// (64 entries * ~8.3 KB ≈ 530 KB).
+pub const MAX_VARIABLE_DATA_SIZE: usize = 16 * 1024;
 
 /// Protocol interface entry
 #[derive(Clone, Copy)]

--- a/x86_64-coreboot.ld
+++ b/x86_64-coreboot.ld
@@ -70,10 +70,10 @@ SECTIONS
         _bss_end = .;
     }
 
-    /* Stack - 2MB (increased from 64KB for large structs like FirmwareState) */
+    /* Stack - 3MB (increased from 64KB for large structs like FirmwareState) */
     .stack : ALIGN(4096) {
         _stack_bottom = .;
-        . += 0x200000;
+        . += 0x300000;
         _stack_top = .;
     }
 

--- a/x86_64-coreboot.ld
+++ b/x86_64-coreboot.ld
@@ -7,8 +7,60 @@ ENTRY(_start)
 /* Coreboot loads payloads at a configurable address, typically 0x100000 (1MB) */
 PAYLOAD_BASE = 0x100000;
 
+/*
+ * Explicit program headers so the deferred variable buffer is NOT in any
+ * PT_LOAD segment.  Without this, lld merges the NOLOAD section into the
+ * preceding data segment and coreboot/cbfstool zeroes its contents on
+ * every boot, destroying the buffer that must survive warm reboot.
+ */
+PHDRS
+{
+    code   PT_LOAD FLAGS(5);   /* R-X */
+    rodata PT_LOAD FLAGS(4);   /* R-- */
+    relro  PT_LOAD FLAGS(4);   /* R-- (GNU_RELRO covered separately by lld) */
+    data   PT_LOAD FLAGS(6);   /* RW- */
+    defer  PT_NULL FLAGS(6);   /* NOT loaded -- survives warm reboot */
+    rtlog  PT_NULL FLAGS(6);   /* Runtime services log -- survives warm reboot */
+}
+
 SECTIONS
 {
+    /* ── Deferred variable buffer ─────────────────────────────────────
+     *
+     * 64 KB at a fixed address BELOW the payload load region.
+     *
+     *   • NOLOAD + PT_NULL: neither the linker, cbfstool, nor coreboot's
+     *     ELF/SELF loader will write to this region.
+     *   • 0x80000 sits above coreboot's SMM temp modules (0x30000-0x38000)
+     *     and the 32-bit entry trampoline (~0x9000), and below the legacy
+     *     video area (0xA0000).
+     *   • On warm reboot the RAM content is preserved, so pending variable
+     *     writes queued here after ExitBootServices survive into the next
+     *     boot cycle.
+     *   • Registered as RuntimeServicesData by reserve_runtime_region() so
+     *     the OS keeps the mapping and SetVirtualAddressMap adjusts the
+     *     GOT entry for _deferred_buffer_start.
+     */
+    /* ── Runtime services log buffer ─────────────────────────────────
+     *
+     * 64 KB at 0x70000 — same survival properties as .deferred_buffer.
+     * SetVariable and other runtime paths append plain-text lines here.
+     * On the next boot the contents are emitted to the coreboot log so
+     * we can see exactly what the OS did at runtime.
+     */
+    .rt_log 0x70000 (NOLOAD) : {
+        _rt_log_start = .;
+        . += 64K;
+        _rt_log_end = .;
+    } :rtlog
+
+    .deferred_buffer 0x80000 (NOLOAD) : {
+        _deferred_buffer_start = .;
+        . += 64K;
+        _deferred_buffer_end = .;
+    } :defer
+
+    /* ── Payload proper ───────────────────────────────────────────── */
     . = PAYLOAD_BASE;
     
     /* Runtime code starts here - everything executable */
@@ -17,14 +69,14 @@ SECTIONS
     /* 32-bit entry code - must be first */
     .entry32 : ALIGN(4096) {
         *(.entry32)
-    }
+    } :code
 
     /* Text section */
     .text : ALIGN(4096) {
         _text_start = .;
         *(.text .text.*)
         _text_end = .;
-    }
+    } :code
     
     /* Runtime code ends here */
     __runtime_code_end = .;
@@ -37,7 +89,7 @@ SECTIONS
         _rodata_start = .;
         *(.rodata .rodata.*)
         _rodata_end = .;
-    }
+    } :rodata
 
     /* Global Offset Table (PIC indirect calls to memcpy/memset/etc.)
      * These entries contain absolute addresses that must be relocated
@@ -46,21 +98,21 @@ SECTIONS
         _got_start = .;
         *(.got .got.*)
         _got_end = .;
-    }
+    } :relro
 
     /* Initialized data */
     .data : ALIGN(4096) {
         _data_start = .;
         *(.data .data.*)
         _data_end = .;
-    }
+    } :data
 
     /* Page tables - must be 4KB aligned */
     .page_tables : ALIGN(4096) {
         _page_tables_start = .;
         *(.page_tables)
         _page_tables_end = .;
-    }
+    } :data
 
     /* Uninitialized data (BSS) */
     .bss : ALIGN(4096) {
@@ -68,26 +120,16 @@ SECTIONS
         *(.bss .bss.*)
         *(COMMON)
         _bss_end = .;
-    }
+    } :data
 
     /* Stack - 3MB (increased from 64KB for large structs like FirmwareState) */
     .stack : ALIGN(4096) {
         _stack_bottom = .;
         . += 0x300000;
         _stack_top = .;
-    }
+    } :data
 
-    /* Deferred variable buffer - 64KB
-     * Used for queuing variable writes after ExitBootServices.
-     * Included in runtime data region so OS preserves the mapping.
-     */
-    .deferred_buffer (NOLOAD) : ALIGN(4096) {
-        _deferred_buffer_start = .;
-        . += 64K;
-        _deferred_buffer_end = .;
-    }
-
-    /* Runtime data ends here (after BSS, stack, and deferred buffer) */
+    /* Runtime data ends here */
     __runtime_data_end = .;
 
     _end = .;


### PR DESCRIPTION
Implement the UEFI boot manager variable protocol per spec section 3.1:

- Add boot_vars module: parses EFI_LOAD_OPTION (Boot####) binary format,
  reads BootOrder/BootNext/BootCurrent/Timeout variables, and provides
  the boot variable state cache read early in boot (matching edk2 BdsEntry)
- Replace init_storage() with run_boot_manager() that follows the UEFI
  boot dispatch sequence: BootNext first (delete-before-use), then
  BootOrder iteration, then fallback to ESP discovery and interactive menu
- Set BootCurrent (volatile BS+RT) before each boot attempt, clear after
- Apply Timeout variable to the boot menu countdown

Also fix SetVariable rejecting Secure Boot key writes from Linux (sbctl):

- Increase MAX_VARIABLE_DATA_SIZE from 1KB to 16KB so Secure Boot
  databases (db with Microsoft CA chain + custom keys) fit
- Increase varstore MAX_DATA_SIZE to match for SPI persistence
- Fix early raw-input size check in set_variable that rejected
  authenticated writes before stripping the PKCS#7 auth header;
  now allows 3x MAX_VARIABLE_DATA_SIZE for authenticated input