### PR TITLE
fix: correct Secure Boot Authenticode verification for Microsoft-signed images

### DIFF
--- a/src/efi/auth/authenticode.rs
+++ b/src/efi/auth/authenticode.rs
@@ -108,9 +108,11 @@ pub fn compute_authenticode_hash(pe_data: &[u8]) -> Result<[u8; 32], AuthError> 
         }
     }
 
-    // Region 4: Hash sections in order of file offset
-    // Sections are already sorted by file_offset
-    let mut current_pos = info.size_of_headers;
+    // Region 4: Hash each section in order of PointerToRawData.
+    // Per the Authenticode spec, only each section's raw data is hashed here
+    // (no inter-section gaps). SUM_OF_BYTES_HASHED tracks the total byte count
+    // for the extra-data calculation in the next step.
+    let mut sum_of_bytes_hashed = info.size_of_headers;
 
     for section in &info.sections {
         let section_start = section.file_offset as usize;
@@ -123,29 +125,25 @@ pub fn compute_authenticode_hash(pe_data: &[u8]) -> Result<[u8; 32], AuthError> 
             continue;
         }
 
-        // Handle gap between current position and section start
-        if section_start > current_pos && section_start <= pe_data.len() {
-            // There's a gap - hash it (could be alignment padding)
-            hasher.update(&pe_data[current_pos..section_start]);
-        }
-
         // Hash the section data
         if section_end <= pe_data.len() {
             hasher.update(&pe_data[section_start..section_end]);
-            current_pos = section_end;
+            sum_of_bytes_hashed += section.size_of_raw_data as usize;
         }
     }
 
-    // Hash any remaining data BEFORE the certificate table
-    let file_end = if info.cert_table_rva > 0 && info.cert_table_size > 0 {
-        // Certificate table is at the end - don't hash it
-        info.cert_table_rva as usize
+    // Region 5: Hash any extra data between SUM_OF_BYTES_HASHED and the
+    // certificate table (or end of file). Per Authenticode spec step 14:
+    //   extra_start = SUM_OF_BYTES_HASHED (as file offset)
+    //   extra_end   = FILE_SIZE - Size_of_CertificateTable
+    let file_end = if info.cert_table_size > 0 {
+        pe_data.len().saturating_sub(info.cert_table_size as usize)
     } else {
         pe_data.len()
     };
 
-    if current_pos < file_end && file_end <= pe_data.len() {
-        hasher.update(&pe_data[current_pos..file_end]);
+    if sum_of_bytes_hashed < file_end && file_end <= pe_data.len() {
+        hasher.update(&pe_data[sum_of_bytes_hashed..file_end]);
     }
 
     Ok(hasher.finalize().into())
@@ -311,11 +309,105 @@ pub fn verify_pe_image_secure_boot(pe_data: &[u8]) -> Result<bool, AuthError> {
     }
 }
 
+/// Extract the Authenticode hash from the SpcIndirectDataContent in a PKCS#7 signature.
+///
+/// The SpcIndirectDataContent structure (Microsoft Authenticode) contains:
+/// ```text
+/// SpcIndirectDataContent ::= SEQUENCE {
+///     data            SpcAttributeTypeAndOptionalValue,
+///     messageDigest   DigestInfo ::= SEQUENCE {
+///         digestAlgorithm  AlgorithmIdentifier,
+///         digest           OCTET STRING
+///     }
+/// }
+/// ```
+///
+/// This function parses the eContent from the PKCS#7 SignedData and extracts
+/// the hash from the DigestInfo, which should match our computed Authenticode hash.
+fn extract_spc_authenticode_hash(pkcs7_data: &[u8]) -> Result<Option<Vec<u8>>, AuthError> {
+    use cms::content_info::ContentInfo;
+    use cms::signed_data::SignedData;
+    use der::asn1::OctetStringRef;
+    use der::{Decode, Encode, Reader, SliceReader, Tagged};
+
+    let actual_pkcs7 = super::crypto::trim_der_trailing_bytes(pkcs7_data)?;
+    let content_info = ContentInfo::from_der(actual_pkcs7).map_err(|_| AuthError::InvalidHeader)?;
+    let signed_data_bytes = content_info
+        .content
+        .to_der()
+        .map_err(|_| AuthError::InvalidHeader)?;
+    let cms_signed_data =
+        SignedData::from_der(&signed_data_bytes).map_err(|_| AuthError::InvalidHeader)?;
+
+    let econtent = match cms_signed_data.encap_content_info.econtent {
+        Some(ref ec) => ec,
+        None => return Ok(None),
+    };
+
+    // Get SpcIndirectDataContent bytes for parsing.
+    // If eContent is OCTET STRING, the value is the DER of SpcIndirectDataContent.
+    // If eContent is a SEQUENCE (direct encoding), we need the full DER.
+    let spc_owned: Vec<u8>;
+    let spc_data: &[u8] = if econtent.tag() == der::Tag::OctetString {
+        econtent.value()
+    } else {
+        spc_owned = econtent.to_der().map_err(|_| AuthError::InvalidHeader)?;
+        &spc_owned
+    };
+
+    // Parse SpcIndirectDataContent SEQUENCE to extract the digest
+    let mut reader = SliceReader::new(spc_data).map_err(|_| AuthError::InvalidHeader)?;
+    let hash = reader
+        .sequence(|seq| {
+            // Skip SpcAttributeTypeAndOptionalValue (first element)
+            let _ = seq.tlv_bytes()?;
+            // Parse DigestInfo SEQUENCE (second element)
+            seq.sequence(|digest_seq| {
+                // Skip AlgorithmIdentifier
+                let _ = digest_seq.tlv_bytes()?;
+                // Read digest OCTET STRING
+                let digest: OctetStringRef = digest_seq.decode()?;
+                Ok(digest.as_bytes().to_vec())
+            })
+        })
+        .map_err(|_: der::Error| AuthError::InvalidHeader)?;
+
+    Ok(Some(hash))
+}
+
 /// Verify an Authenticode signature against the db database
 fn verify_authenticode_signature(
     image_hash: &[u8],
     sig: &AuthenticodeSignature,
 ) -> Result<bool, AuthError> {
+    // Verify the Authenticode hash matches what's embedded in the PKCS#7's
+    // SpcIndirectDataContent. This prevents signature transplant attacks where
+    // a valid signature from one PE image is attached to a different image.
+    match extract_spc_authenticode_hash(sig.pkcs7_data) {
+        Ok(Some(ref spc_hash)) => {
+            if !super::crypto::constant_time_eq(spc_hash, image_hash) {
+                log::warn!(
+                    "Authenticode hash in SpcIndirectDataContent does not match computed image hash"
+                );
+                log::debug!(
+                    "SPC hash: {:02x?}, image hash: {:02x?}",
+                    &spc_hash[..core::cmp::min(8, spc_hash.len())],
+                    &image_hash[..core::cmp::min(8, image_hash.len())]
+                );
+                return Ok(false);
+            }
+            log::debug!("Authenticode hash matches SpcIndirectDataContent");
+        }
+        Ok(None) => {
+            log::warn!("No SpcIndirectDataContent found in PKCS#7 signature");
+            return Ok(false);
+        }
+        Err(e) => {
+            log::debug!("Failed to extract SPC authenticode hash: {:?}", e);
+            return Ok(false);
+        }
+    }
+
     // Get all X.509 certificates from db
     let db = db_database();
     let certificates: Vec<&[u8]> = db.x509_certificates().collect();

--- a/src/efi/auth/crypto.rs
+++ b/src/efi/auth/crypto.rs
@@ -42,6 +42,10 @@ pub struct ChainBuildingConfig {
     pub require_basic_constraints: bool,
     /// Whether to require CA certificates to have keyCertSign keyUsage
     pub require_key_usage: bool,
+    /// Whether to check certificate validity periods (notBefore/notAfter)
+    /// Set to false for Secure Boot image verification, matching edk2/u-boot behavior
+    /// which do not enforce certificate expiry for firmware signing certificates.
+    pub check_validity_period: bool,
 }
 
 impl Default for ChainBuildingConfig {
@@ -53,6 +57,7 @@ impl Default for ChainBuildingConfig {
             current_time: get_current_time_for_cert_validation(),
             require_basic_constraints: true,
             require_key_usage: true,
+            check_validity_period: true,
         }
     }
 }
@@ -176,8 +181,25 @@ pub fn verify_pkcs7_signature(
         embedded_certs.len()
     );
 
-    // Compute the hash of the actual signed data
-    let computed_hash = sha256(signed_data);
+    // Compute the content digest for messageDigest verification.
+    // Per RFC 5652 Section 5.4, the messageDigest attribute value must match
+    // the digest of the encapContentInfo eContent value.
+    //
+    // Both edk2 and u-boot hash the VALUE (V) portion of the ASN.1 element
+    // inside the [0] EXPLICIT tag -- i.e., the bytes after stripping the outer
+    // tag and length. For Authenticode (SEQUENCE), this is the inner content
+    // of the SpcIndirectDataContent. For standard CMS (OCTET STRING), this is
+    // the raw content bytes. In both cases, Any::value() returns exactly these
+    // V bytes.
+    //
+    // - For attached content (e.g., Authenticode): hash econtent.value()
+    // - For detached signatures (e.g., authenticated variables): hash the external data
+    let computed_hash = if let Some(ref econtent) = cms_signed_data.encap_content_info.econtent {
+        sha256(econtent.value())
+    } else {
+        // Detached signature: hash the externally-provided signed data
+        sha256(signed_data)
+    };
 
     // Get SignerInfos and verify the signature
     if cms_signed_data.signer_infos.0.is_empty() {
@@ -226,7 +248,12 @@ pub fn verify_pkcs7_signature(
                     log::debug!("RSA signature verification succeeded");
 
                     // Build and verify the certificate chain using the full chain building algorithm
-                    let config = ChainBuildingConfig::default();
+                    // Disable validity period checking: UEFI Secure Boot does not enforce
+                    // certificate expiry for image verification, matching edk2 and u-boot behavior.
+                    let config = ChainBuildingConfig {
+                        check_validity_period: false,
+                        ..ChainBuildingConfig::default()
+                    };
 
                     // Try to build a chain from the signer certificate to the trusted certificate
                     match build_and_verify_chain(
@@ -641,8 +668,10 @@ fn verify_chain_link(
         return Ok(false);
     }
 
-    // Validate certificate time
-    if let Err(e) = validate_certificate_time(cert_der) {
+    // Validate certificate time (skipped for Secure Boot image verification)
+    if config.check_validity_period
+        && let Err(e) = validate_certificate_time(cert_der)
+    {
         log::debug!("Certificate validity check failed: {:?}", e);
         return Ok(false);
     }
@@ -664,9 +693,25 @@ fn verify_chain_link(
 
     // Verify the signature
     let cert_signature = cert.signature.raw_bytes();
-    let tbs_bytes = extract_tbs_bytes(cert_der)?;
+    let tbs_bytes = match extract_tbs_bytes(cert_der) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            log::debug!(
+                "extract_tbs_bytes failed for cert (len={}): {:?}",
+                cert_der.len(),
+                e
+            );
+            return Err(e);
+        }
+    };
     let tbs_hash = sha256(tbs_bytes);
-    let issuer_rsa_key = extract_rsa_key(&issuer)?;
+    let issuer_rsa_key = match extract_rsa_key(&issuer) {
+        Ok(key) => key,
+        Err(e) => {
+            log::debug!("extract_rsa_key failed for issuer: {:?}", e);
+            return Err(e);
+        }
+    };
 
     verify_rsa_signature_raw(&issuer_rsa_key, cert_signature, &tbs_hash)
 }
@@ -973,12 +1018,29 @@ fn get_current_time_for_cert_validation() -> i64 {
 /// We need to extract the first element of the outer SEQUENCE, preserving
 /// the original DER encoding exactly as it was signed.
 fn extract_tbs_bytes(cert_der: &[u8]) -> Result<&[u8], AuthError> {
-    use der::{Reader, SliceReader};
+    use der::{Decode, Header, Reader, SliceReader, Tag};
+
+    // Note: we cannot use reader.sequence(|seq| seq.tlv_bytes()) here because
+    // sequence() calls read_nested() → finish(), which requires ALL bytes inside
+    // the SEQUENCE to be consumed. We only want the first element (TBSCertificate),
+    // not the signatureAlgorithm and signatureValue that follow it.
+    //
+    // Instead, decode the outer SEQUENCE header to skip past it, then use
+    // tlv_bytes() to read just the first inner TLV. Neither operation calls
+    // finish(), so trailing bytes (from PKCS#7 certificate extraction) and
+    // unconsumed sibling elements are both tolerated.
 
     let mut reader = SliceReader::new(cert_der).map_err(|_| AuthError::CertificateParseError)?;
-    // Enter the outer SEQUENCE (Certificate), then read the first TLV (TBSCertificate)
+
+    // Skip the outer Certificate SEQUENCE header
+    let outer = Header::decode(&mut reader).map_err(|_| AuthError::CertificateParseError)?;
+    if outer.tag != Tag::Sequence {
+        return Err(AuthError::CertificateParseError);
+    }
+
+    // Read just the first TLV within the SEQUENCE (TBSCertificate)
     reader
-        .sequence(|seq| seq.tlv_bytes())
+        .tlv_bytes()
         .map_err(|_| AuthError::CertificateParseError)
 }
 
@@ -1016,7 +1078,7 @@ pub fn validate_x509_certificate(cert_der: &[u8]) -> Result<(), AuthError> {
 /// WIN_CERTIFICATE structures are 8-byte aligned, which means the PKCS#7
 /// data may have padding bytes after the actual DER content. This function
 /// reads the DER length and returns a slice containing only the valid data.
-fn trim_der_trailing_bytes(data: &[u8]) -> Result<&[u8], AuthError> {
+pub(super) fn trim_der_trailing_bytes(data: &[u8]) -> Result<&[u8], AuthError> {
     use der::{Reader, SliceReader};
 
     let mut reader = SliceReader::new(data).map_err(|_| AuthError::InvalidHeader)?;


### PR DESCRIPTION
Fix six bugs preventing UEFI Secure Boot from verifying Microsoft-signed
PE images (Windows 11 25H2 BOOTX64.EFI):

1. Double-hash in messageDigest comparison: verify_pkcs7_signature()
   hashed the external data instead of the eContent value for attached
   content (Authenticode). Now uses econtent.value() matching edk2/u-boot.

2. Wrong bytes hashed for eContent: uses the VALUE (V) bytes of the
   ASN.1 element, not the full TLV, matching how edk2 strips the
   SEQUENCE tag+length from SpcIndirectDataContent.

3. Missing SPC hash verification: added extract_spc_authenticode_hash()
   to verify the Authenticode hash embedded in SpcIndirectDataContent
   matches the computed PE image hash, preventing signature transplant.

4. Spec-noncompliant Authenticode hash: fixed compute_authenticode_hash()
   to not hash inter-section gaps and to use SUM_OF_BYTES_HASHED as the
   file offset for extra-data calculation per the Authenticode spec.

5. Certificate expiry blocking verification: added check_validity_period
   flag to ChainBuildingConfig, disabled for Secure Boot image
   verification. UEFI firmware does not enforce certificate expiry for
   image signing, matching edk2 and u-boot behavior.

6. Broken TBS extraction in chain verification: extract_tbs_bytes() used
   reader.sequence(|seq| seq.tlv_bytes()) which requires consuming ALL
   elements in the SEQUENCE, but only the first (TBSCertificate) was
   read. Fixed to use Header::decode() + tlv_bytes() which tolerates
   both unconsumed sibling elements and trailing bytes from PKCS#7
   certificate extraction.