### PR TITLE
refactor: convert all menus to ratatui with custom dual backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +54,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +100,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +148,7 @@ dependencies = [
  "log",
  "postcard",
  "r-efi",
+ "ratatui",
  "rsa",
  "serde",
  "sha1",
@@ -126,6 +156,7 @@ dependencies = [
  "signature",
  "spin",
  "spki",
+ "talc",
  "tock-registers",
  "x509-cert",
  "x86_64",
@@ -140,6 +171,40 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -167,6 +232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +250,12 @@ dependencies = [
  "const-oid",
  "crypto-common",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embedded-io"
@@ -190,6 +270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +286,12 @@ name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "generic-array"
@@ -221,6 +313,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +331,65 @@ checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "kasuari"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+dependencies = [
+ "hashbrown",
+ "thiserror",
 ]
 
 [[package]]
@@ -252,6 +414,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "line-clipping"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +436,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "num-bigint-dig"
@@ -281,6 +461,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -355,6 +541,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +606,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags",
+ "compact_str",
+ "hashbrown",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags",
+ "hashbrown",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +680,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -545,6 +793,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +840,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "talc"
+version = "4.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -582,6 +872,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
 name = "tock-registers"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +906,29 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ bitflags = "2"
 heapless = "0.8"
 atomic_refcell = "0.1"
 spin = "0.9"
+talc = { version = "4.4", default-features = false, features = ["lock_api"] }
+ratatui = { version = "0.30", default-features = false }
 tock-registers = "0.10"
 zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
 

--- a/src/cfr_menu.rs
+++ b/src/cfr_menu.rs
@@ -13,15 +13,16 @@ use crate::coreboot::{
     self,
     cfr::{self, CfrInfo, CfrOption, CfrOptionType, CfrValue},
 };
-use crate::drivers::serial as serial_driver;
-use crate::framebuffer_console::{
-    Color, DEFAULT_BG, DEFAULT_FG, FramebufferConsole, HIGHLIGHT_BG, HIGHLIGHT_FG,
-};
-use crate::menu_common::{self, KeyPress, SerialWriter};
+use crate::menu_common::{self, KeyPress};
 use crate::time::delay_ms;
+use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::fmt::Write;
+use ratatui::Terminal;
+use ratatui::layout::{Alignment, Constraint, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, HighlightSpacing, List, ListItem, ListState, Paragraph};
 
 /// Menu title
 const MENU_TITLE: &str = "Firmware Settings";
@@ -71,45 +72,44 @@ pub fn show_cfr_menu() {
     let cfr_info = match coreboot::get_cfr() {
         Some(cfr) => cfr,
         None => {
-            show_no_cfr_message();
+            show_message_screen("Firmware settings not available",
+                "This firmware does not expose CFR configuration options.");
             return;
         }
     };
 
     let fb_info = coreboot::get_framebuffer();
-    let mut fb_console = fb_info.as_ref().map(FramebufferConsole::new);
+    let backend = crate::tui::DualBackend::new(fb_info.as_ref());
+    let mut terminal = match Terminal::new(backend) {
+        Ok(t) => t,
+        Err(_) => {
+            log::error!("Failed to create ratatui terminal");
+            return;
+        }
+    };
+    let _ = terminal.clear();
+    let _ = terminal.hide_cursor();
 
     let mut items = build_menu_items(cfr_info);
 
     if items.is_empty() {
-        show_no_options_message(&mut fb_console);
+        show_message_screen("No configurable options found", "");
         return;
     }
 
     let mut selected = find_first_selectable(cfr_info, &items, 0);
-    let mut status_message: Option<(&str, bool)> = None;
-    let mut scroll_offset = 0usize;
+    let mut status_message: Option<(String, bool)> = None;
 
     loop {
-        menu_common::clear_screen(&mut fb_console);
         let modified = has_changes(&items);
-        // Ensure scroll keeps selected item visible
-        let vis = visible_indices(cfr_info, &items);
-        let sel_vis_pos = vis.iter().position(|&i| i == selected).unwrap_or(0);
-        let screen_rows = get_visible_rows(&fb_console);
-        if sel_vis_pos < scroll_offset {
-            scroll_offset = sel_vis_pos;
-        } else if sel_vis_pos >= scroll_offset + screen_rows {
-            scroll_offset = sel_vis_pos - screen_rows + 1;
-        }
-        draw_menu(
+
+        render_menu(
+            &mut terminal,
             cfr_info,
             &items,
             selected,
-            scroll_offset,
             modified,
-            status_message,
-            &mut fb_console,
+            &status_message,
         );
 
         status_message = None;
@@ -126,7 +126,6 @@ pub fn show_cfr_menu() {
                         break;
                     }
                     KeyPress::Enter | KeyPress::Char(' ') => {
-                        // Check visibility/editability before taking a mutable borrow
                         let can_edit = if let Some(
                             item @ MenuItem::Option {
                                 form_idx,
@@ -155,7 +154,7 @@ pub fn show_cfr_menu() {
                                 }
                             }
                         } else if matches!(items.get(selected), Some(MenuItem::Option { .. })) {
-                            status_message = Some(("Option is read-only", false));
+                            status_message = Some(("Option is read-only".into(), false));
                         }
                         break;
                     }
@@ -168,9 +167,30 @@ pub fn show_cfr_menu() {
                         break;
                     }
                     KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
-                        if has_changes(&items) && confirm_save(&mut fb_console) {
+                        if has_changes(&items)
+                            && confirm_dialog(
+                                &mut terminal,
+                                "Save changes? (takes effect after reset)",
+                                "Press Y to save, N to discard",
+                            )
+                        {
                             let (saved, failed) = save_all_changes(cfr_info, &items);
-                            show_save_result(saved, failed, &mut fb_console);
+                            let msg = if failed == 0 {
+                                format!("Saved {} option(s).", saved)
+                            } else {
+                                format!("Saved {}, {} failed to write.", saved, failed)
+                            };
+                            let is_ok = failed == 0;
+                            status_message = Some((msg, is_ok));
+                            render_menu(
+                                &mut terminal,
+                                cfr_info,
+                                &items,
+                                selected,
+                                false,
+                                &status_message,
+                            );
+                            delay_ms(1500);
                         }
                         return;
                     }
@@ -182,7 +202,7 @@ pub fn show_cfr_menu() {
                         }) = items.get(selected)
                             && let Some(option) = get_option(cfr_info, *form_idx, *option_idx)
                         {
-                            show_help(option, &mut fb_console);
+                            show_help_screen(&mut terminal, option);
                         }
                         break;
                     }
@@ -193,6 +213,355 @@ pub fn show_cfr_menu() {
         }
     }
 }
+
+// ============================================================================
+// Rendering
+// ============================================================================
+
+/// Render the complete menu with ratatui
+fn render_menu(
+    terminal: &mut Terminal<crate::tui::DualBackend>,
+    cfr: &CfrInfo,
+    items: &[MenuItem],
+    selected: usize,
+    modified: bool,
+    status_message: &Option<(String, bool)>,
+) {
+    let _ = terminal.draw(|frame| {
+        let area = frame.area();
+
+        let chunks = Layout::vertical([
+            Constraint::Length(3), // header
+            Constraint::Min(4),   // item list
+            Constraint::Length(3), // status + help
+        ])
+        .split(area);
+
+        // --- Header ---
+        let title = if modified {
+            "Firmware Settings (modified)"
+        } else {
+            MENU_TITLE
+        };
+        let header = Paragraph::new(Line::from(title).alignment(Alignment::Center))
+            .style(Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD))
+            .block(
+                Block::new()
+                    .borders(Borders::TOP | Borders::BOTTOM)
+                    .border_style(Style::new().fg(Color::Yellow)),
+            );
+        frame.render_widget(header, chunks[0]);
+
+        // --- Build visible item list ---
+        let vis = visible_indices(cfr, items);
+        let mut list_items: Vec<ListItem> = Vec::new();
+        let mut selected_list_pos: Option<usize> = None;
+
+        for &item_idx in &vis {
+            let item = &items[item_idx];
+            let list_pos = list_items.len();
+
+            match item {
+                MenuItem::FormHeader { name } => {
+                    let text = format!("--- {} ---", name);
+                    list_items.push(
+                        ListItem::new(Line::raw(text))
+                            .style(Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+                    );
+                }
+                MenuItem::SubformHeader { name } => {
+                    let text = format!("  {}", name);
+                    list_items.push(
+                        ListItem::new(Line::raw(text))
+                            .style(Style::new().fg(Color::Magenta).add_modifier(Modifier::BOLD)),
+                    );
+                }
+                MenuItem::Comment { text } => {
+                    list_items.push(
+                        ListItem::new(Line::raw(text.as_str()))
+                            .style(Style::new().fg(Color::DarkGray)),
+                    );
+                }
+                MenuItem::Option {
+                    form_idx,
+                    option_idx,
+                    current_value,
+                    ..
+                } => {
+                    if let Some(option) = get_option(cfr, *form_idx, *option_idx) {
+                        let value_str = format_value(option, current_value);
+                        let is_editable = option.is_editable();
+
+                        // Pad name to align values
+                        let name = &option.ui_name;
+                        let cols = area.width as usize;
+                        let pad_to = 40.min(cols.saturating_sub(value_str.len() + 8));
+                        let name_display_len = name.len();
+                        let padding = if pad_to > name_display_len {
+                            pad_to - name_display_len
+                        } else {
+                            1
+                        };
+                        let pad: String = core::iter::repeat(' ').take(padding).collect();
+                        let text = format!("{}{}{}", name, pad, value_str);
+
+                        let style = if !is_editable {
+                            Style::new().fg(Color::DarkGray)
+                        } else {
+                            Style::new().fg(Color::Gray)
+                        };
+
+                        list_items.push(ListItem::new(Line::raw(text)).style(style));
+                    }
+
+                    if item_idx == selected {
+                        selected_list_pos = Some(list_pos);
+                    }
+                }
+            }
+        }
+
+        let list = List::new(list_items)
+            .highlight_style(
+                Style::new()
+                    .fg(Color::Black)
+                    .bg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol(">> ")
+            .highlight_spacing(HighlightSpacing::Always)
+            .scroll_padding(2);
+
+        let mut list_state = ListState::default().with_selected(selected_list_pos);
+        frame.render_stateful_widget(list, chunks[1], &mut list_state);
+
+        // --- Footer ---
+        let footer_chunks = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(chunks[2]);
+
+        if let Some((msg, is_success)) = status_message {
+            let color = if *is_success { Color::Green } else { Color::Red };
+            let line = Line::from(Span::styled(msg.as_str(), Style::new().fg(color)))
+                .alignment(Alignment::Center);
+            frame.render_widget(Paragraph::new(line), footer_chunks[0]);
+        }
+
+        let help = Paragraph::new(
+            Line::from(HELP_TEXT)
+                .style(Style::new().fg(Color::Cyan))
+                .alignment(Alignment::Center),
+        );
+        frame.render_widget(help, footer_chunks[2]);
+    });
+}
+
+/// Format an option value for display
+fn format_value(option: &CfrOption, value: &CfrValue) -> String {
+    match (&option.option_type, value) {
+        (CfrOptionType::Bool { .. }, CfrValue::Bool(b)) => {
+            if *b {
+                "[Enabled]".into()
+            } else {
+                "[Disabled]".into()
+            }
+        }
+        (CfrOptionType::Enum { choices, .. }, CfrValue::Number(n)) => {
+            if let Some(choice) = choices.iter().find(|c| c.value == *n) {
+                format!("[{}]", choice.ui_name)
+            } else {
+                format!("[{}]", n)
+            }
+        }
+        (CfrOptionType::Number { hex_display, .. }, CfrValue::Number(n)) => {
+            if *hex_display {
+                format!("[0x{:X}]", n)
+            } else {
+                format!("[{}]", n)
+            }
+        }
+        (CfrOptionType::Varchar { .. }, CfrValue::Varchar(s)) => {
+            if s.len() > 20 {
+                format!("[{}...]", &s[..20])
+            } else {
+                format!("[{}]", s)
+            }
+        }
+        _ => "[-]".into(),
+    }
+}
+
+/// Show a help screen for an option
+fn show_help_screen(
+    terminal: &mut Terminal<crate::tui::DualBackend>,
+    option: &CfrOption,
+) {
+    let name = option.ui_name.clone();
+    let helptext = if !option.ui_helptext.is_empty() {
+        option.ui_helptext.clone()
+    } else {
+        "No help available for this option.".into()
+    };
+
+    let _ = terminal.draw(|frame| {
+        let area = frame.area();
+        let chunks = Layout::vertical([
+            Constraint::Length(3),
+            Constraint::Length(2),
+            Constraint::Min(3),
+            Constraint::Length(2),
+        ])
+        .split(area);
+
+        let header = Paragraph::new(
+            Line::from(Span::styled(
+                name.as_str(),
+                Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            ))
+            .alignment(Alignment::Center),
+        )
+        .block(
+            Block::new()
+                .borders(Borders::TOP | Borders::BOTTOM)
+                .border_style(Style::new().fg(Color::Cyan)),
+        );
+        frame.render_widget(header, chunks[0]);
+
+        let body = Paragraph::new(format!("    {}", helptext));
+        frame.render_widget(body, chunks[2]);
+
+        let footer = Paragraph::new(
+            Line::from("Press any key to continue...")
+                .alignment(Alignment::Center)
+                .style(Style::new().fg(Color::DarkGray)),
+        );
+        frame.render_widget(footer, chunks[3]);
+    });
+
+    loop {
+        if menu_common::read_key().is_some() {
+            break;
+        }
+        delay_ms(10);
+    }
+}
+
+/// Show a simple confirmation dialog. Returns true if user pressed Y.
+fn confirm_dialog(
+    terminal: &mut Terminal<crate::tui::DualBackend>,
+    message: &str,
+    help: &str,
+) -> bool {
+    let msg = String::from(message);
+    let hlp = String::from(help);
+    let _ = terminal.draw(|frame| {
+        let area = frame.area();
+        let chunks = Layout::vertical([
+            Constraint::Percentage(40),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(0),
+        ])
+        .split(area);
+
+        let prompt = Paragraph::new(
+            Line::from(Span::styled(
+                msg.as_str(),
+                Style::new()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ))
+            .alignment(Alignment::Center),
+        );
+        frame.render_widget(prompt, chunks[1]);
+
+        let hint = Paragraph::new(
+            Line::from(hlp.as_str())
+                .alignment(Alignment::Center)
+                .style(Style::new().fg(Color::Gray)),
+        );
+        frame.render_widget(hint, chunks[3]);
+    });
+
+    loop {
+        if let Some(key) = menu_common::read_key() {
+            match key {
+                KeyPress::Char('y') | KeyPress::Char('Y') => return true,
+                KeyPress::Char('n') | KeyPress::Char('N') | KeyPress::Escape => return false,
+                _ => {}
+            }
+        }
+        delay_ms(10);
+    }
+}
+
+/// Show a simple message screen (for errors / "not available" messages)
+fn show_message_screen(title: &str, body: &str) {
+    let fb_info = coreboot::get_framebuffer();
+    let backend = crate::tui::DualBackend::new(fb_info.as_ref());
+    let mut terminal = match Terminal::new(backend) {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+    let _ = terminal.clear();
+
+    let title_s = String::from(title);
+    let body_s = String::from(body);
+    let _ = terminal.draw(|frame| {
+        let area = frame.area();
+        let chunks = Layout::vertical([
+            Constraint::Percentage(40),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(0),
+        ])
+        .split(area);
+
+        let t = Paragraph::new(
+            Line::from(Span::styled(
+                title_s.as_str(),
+                Style::new()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ))
+            .alignment(Alignment::Center),
+        );
+        frame.render_widget(t, chunks[1]);
+
+        if !body_s.is_empty() {
+            let b = Paragraph::new(
+                Line::from(body_s.as_str())
+                    .alignment(Alignment::Center)
+                    .style(Style::new().fg(Color::Gray)),
+            );
+            frame.render_widget(b, chunks[3]);
+        }
+
+        let footer = Paragraph::new(
+            Line::from("Press any key to continue...")
+                .alignment(Alignment::Center)
+                .style(Style::new().fg(Color::DarkGray)),
+        );
+        frame.render_widget(footer, chunks[4]);
+    });
+
+    loop {
+        if menu_common::read_key().is_some() {
+            break;
+        }
+        delay_ms(10);
+    }
+}
+
+// ============================================================================
+// Business logic (unchanged)
+// ============================================================================
 
 /// Build menu items from CFR info.
 ///
@@ -218,7 +587,6 @@ fn build_menu_items(cfr: &CfrInfo) -> Vec<MenuItem> {
 
             match &option.option_type {
                 CfrOptionType::Comment => {
-                    // Check if this is a flattened subform header (has object_id, no opt_name)
                     let is_subform = option.opt_name.is_empty() && option.object_id != 0;
                     if is_subform {
                         items.push(MenuItem::SubformHeader {
@@ -248,13 +616,11 @@ fn build_menu_items(cfr: &CfrInfo) -> Vec<MenuItem> {
 
 /// Look up the current in-flight numeric value for an option identified by
 /// `object_id`, checking the menu items first (which reflect the user's
-/// uncommitted edits) and falling back to persistent storage via
-/// `CfrInfo::find_numeric_value`.
+/// uncommitted edits) and falling back to persistent storage.
 fn find_live_numeric_value(cfr: &CfrInfo, items: &[MenuItem], object_id: u64) -> Option<u32> {
     if object_id == 0 {
         return None;
     }
-    // Search menu items for an option whose CfrOption::object_id matches
     for item in items {
         if let MenuItem::Option {
             form_idx,
@@ -272,7 +638,6 @@ fn find_live_numeric_value(cfr: &CfrInfo, items: &[MenuItem], object_id: u64) ->
             };
         }
     }
-    // Fallback to stored value
     cfr.find_numeric_value(object_id)
 }
 
@@ -299,21 +664,15 @@ fn is_dep_met_live(
 }
 
 /// Check if a menu item is currently visible based on live dependency state.
-///
-/// Form headers are visible if the form's dependency is met. Options, comments,
-/// and subform headers are visible if the owning form's dependency AND the
-/// item's own dependency are both met.
 fn is_item_visible(cfr: &CfrInfo, items: &[MenuItem], item: &MenuItem) -> bool {
     match item {
-        MenuItem::FormHeader { name } => {
-            // Find the form by name and check its dependency
-            cfr.forms
-                .iter()
-                .find(|f| f.ui_name == *name)
-                .is_none_or(|form| {
-                    is_dep_met_live(cfr, items, form.dependency_id, &form.dep_values)
-                })
-        }
+        MenuItem::FormHeader { name } => cfr
+            .forms
+            .iter()
+            .find(|f| f.ui_name == *name)
+            .is_none_or(|form| {
+                is_dep_met_live(cfr, items, form.dependency_id, &form.dep_values)
+            }),
         MenuItem::Option {
             form_idx,
             option_idx,
@@ -326,20 +685,16 @@ fn is_item_visible(cfr: &CfrInfo, items: &[MenuItem], item: &MenuItem) -> bool {
                 .is_none_or(|opt| is_dep_met_live(cfr, items, opt.dependency_id, &opt.dep_values));
             form_ok && opt_ok
         }
-        // Comments and subform headers don't carry their own indices, so
-        // they stay visible (their parent form header hides the section).
         MenuItem::Comment { .. } | MenuItem::SubformHeader { .. } => true,
     }
 }
 
-/// Get an option by form and option index
 fn get_option(cfr: &CfrInfo, form_idx: usize, option_idx: usize) -> Option<&CfrOption> {
     cfr.forms
         .get(form_idx)
         .and_then(|f| f.options.get(option_idx))
 }
 
-/// Find the first selectable and visible item starting from index
 fn find_first_selectable(cfr: &CfrInfo, items: &[MenuItem], start: usize) -> usize {
     for (i, item) in items.iter().enumerate().skip(start) {
         if is_selectable(item) && is_item_visible(cfr, items, item) {
@@ -376,7 +731,6 @@ fn is_selectable(item: &MenuItem) -> bool {
     matches!(item, MenuItem::Option { .. })
 }
 
-/// Check if the item at `index` is an editable, visible option (immutable borrow).
 fn can_edit_item(cfr: &CfrInfo, items: &[MenuItem], index: usize) -> bool {
     if let Some(
         item @ MenuItem::Option {
@@ -393,15 +747,16 @@ fn can_edit_item(cfr: &CfrInfo, items: &[MenuItem], index: usize) -> bool {
     }
 }
 
-fn get_visible_rows(fb_console: &Option<FramebufferConsole>) -> usize {
-    fb_console
-        .as_ref()
-        .map(|c| c.rows() as usize)
-        .unwrap_or(20)
-        .saturating_sub(10)
+/// Collect the indices of items that are currently visible (dependency-aware).
+fn visible_indices(cfr: &CfrInfo, items: &[MenuItem]) -> Vec<usize> {
+    items
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| is_item_visible(cfr, items, item))
+        .map(|(i, _)| i)
+        .collect()
 }
 
-/// Toggle/cycle a value (Enter/Space)
 fn toggle_value(option: &CfrOption, value: &mut CfrValue) -> bool {
     match (&option.option_type, value) {
         (CfrOptionType::Bool { .. }, CfrValue::Bool(b)) => {
@@ -425,7 +780,7 @@ fn toggle_value(option: &CfrOption, value: &mut CfrValue) -> bool {
             if new_val <= *max {
                 *n = new_val;
             } else {
-                *n = *min; // Wrap around
+                *n = *min;
             }
             true
         }
@@ -433,9 +788,7 @@ fn toggle_value(option: &CfrOption, value: &mut CfrValue) -> bool {
     }
 }
 
-/// Increment a numeric/enum option in-place
 fn increment_option(cfr: &CfrInfo, items: &mut [MenuItem], index: usize) -> bool {
-    // Check editability with live dependencies before taking a mutable borrow
     if !can_edit_item(cfr, items, index) {
         return false;
     }
@@ -476,7 +829,6 @@ fn increment_option(cfr: &CfrInfo, items: &mut [MenuItem], index: usize) -> bool
                 *n = new_val;
                 true
             } else if *n < *max {
-                // Unaligned: clamp to max
                 *n = *max;
                 true
             } else {
@@ -487,9 +839,7 @@ fn increment_option(cfr: &CfrInfo, items: &mut [MenuItem], index: usize) -> bool
     }
 }
 
-/// Decrement a numeric/enum option in-place
 fn decrement_option(cfr: &CfrInfo, items: &mut [MenuItem], index: usize) -> bool {
-    // Check editability with live dependencies before taking a mutable borrow
     if !can_edit_item(cfr, items, index) {
         return false;
     }
@@ -533,7 +883,6 @@ fn decrement_option(cfr: &CfrInfo, items: &mut [MenuItem], index: usize) -> bool
                 *n -= *step;
                 true
             } else if *n > *min {
-                // Unaligned: clamp to min
                 *n = *min;
                 true
             } else {
@@ -544,10 +893,6 @@ fn decrement_option(cfr: &CfrInfo, items: &mut [MenuItem], index: usize) -> bool
     }
 }
 
-/// Save modified option values to persistent storage.
-///
-/// Only writes options that were actually changed by the user, reducing
-/// unnecessary SPI flash wear. Returns `(saved, failed)` counts.
 fn save_all_changes(cfr: &CfrInfo, items: &[MenuItem]) -> (usize, usize) {
     let mut saved = 0usize;
     let mut failed = 0usize;
@@ -571,537 +916,4 @@ fn save_all_changes(cfr: &CfrInfo, items: &[MenuItem]) -> (usize, usize) {
         }
     }
     (saved, failed)
-}
-
-/// Show confirmation dialog for saving on exit
-fn confirm_save(fb_console: &mut Option<FramebufferConsole>) -> bool {
-    serial_driver::write_str("\x1b[2J\x1b[H");
-    serial_driver::write_str("\r\n\r\n");
-    serial_driver::write_str("\x1b[1;33m");
-    serial_driver::write_str("  Save changes? (takes effect after reset)\r\n");
-    serial_driver::write_str("\x1b[0m\r\n");
-    serial_driver::write_str("  Press Y to save, N to discard\r\n");
-
-    if let Some(console) = fb_console {
-        console.clear();
-        let rows = console.rows();
-        let confirm_row = rows / 2;
-        console.set_fg_color(Color::new(255, 255, 0));
-        console.write_centered(confirm_row, "Save changes? (takes effect after reset)");
-        console.reset_colors();
-        console.write_centered(confirm_row + 2, "Press Y to save, N to discard");
-    }
-
-    loop {
-        if let Some(key) = menu_common::read_key() {
-            match key {
-                KeyPress::Char('y') | KeyPress::Char('Y') => return true,
-                KeyPress::Char('n') | KeyPress::Char('N') | KeyPress::Escape => return false,
-                _ => {}
-            }
-        }
-        delay_ms(10);
-    }
-}
-
-/// Show a brief save result message (displayed on the confirm screen)
-fn show_save_result(saved: usize, failed: usize, fb_console: &mut Option<FramebufferConsole>) {
-    if failed == 0 {
-        let _ = write!(
-            SerialWriter,
-            "\r\n\x1b[1;32m  Saved {} option(s).\x1b[0m\r\n",
-            saved
-        );
-        if let Some(console) = fb_console {
-            let rows = console.rows();
-            console.set_fg_color(Color::new(0, 255, 0));
-            let mut buf = [0u8; 64];
-            let msg = fmt_save_msg(&mut buf, saved, 0);
-            console.write_centered(rows / 2 + 4, msg);
-            console.reset_colors();
-        }
-    } else {
-        let _ = write!(
-            SerialWriter,
-            "\r\n\x1b[1;31m  Saved {} option(s), {} failed to write.\x1b[0m\r\n",
-            saved, failed
-        );
-        if let Some(console) = fb_console {
-            let rows = console.rows();
-            console.set_fg_color(Color::new(255, 64, 64));
-            let mut buf = [0u8; 64];
-            let msg = fmt_save_msg(&mut buf, saved, failed);
-            console.write_centered(rows / 2 + 4, msg);
-            console.reset_colors();
-        }
-    }
-    // Brief pause so the user can read the message
-    delay_ms(1500);
-}
-
-/// Format save result into a stack buffer (no alloc needed for a short message)
-fn fmt_save_msg(buf: &mut [u8; 64], saved: usize, failed: usize) -> &str {
-    use core::fmt::Write;
-    struct BufWriter<'a> {
-        buf: &'a mut [u8],
-        pos: usize,
-    }
-    impl<'a> core::fmt::Write for BufWriter<'a> {
-        fn write_str(&mut self, s: &str) -> core::fmt::Result {
-            let bytes = s.as_bytes();
-            let end = (self.pos + bytes.len()).min(self.buf.len());
-            let count = end - self.pos;
-            self.buf[self.pos..end].copy_from_slice(&bytes[..count]);
-            self.pos = end;
-            Ok(())
-        }
-    }
-    let mut w = BufWriter {
-        buf: buf.as_mut_slice(),
-        pos: 0,
-    };
-    if failed == 0 {
-        let _ = write!(w, "Saved {} option(s).", saved);
-    } else {
-        let _ = write!(w, "Saved {}, {} failed to write.", saved, failed);
-    }
-    let len = w.pos;
-    core::str::from_utf8(&buf[..len]).unwrap_or("Save complete.")
-}
-
-/// Show help for an option
-fn show_help(option: &CfrOption, fb_console: &mut Option<FramebufferConsole>) {
-    serial_driver::write_str("\x1b[2J\x1b[H");
-    serial_driver::write_str("\r\n");
-    serial_driver::write_str("\x1b[1;36m");
-    serial_driver::write_str("  ");
-    serial_driver::write_str(&option.ui_name);
-    serial_driver::write_str("\x1b[0m\r\n\r\n");
-
-    if !option.ui_helptext.is_empty() {
-        serial_driver::write_str("  ");
-        serial_driver::write_str(&option.ui_helptext);
-        serial_driver::write_str("\r\n");
-    } else {
-        serial_driver::write_str("  No help available for this option.\r\n");
-    }
-
-    serial_driver::write_str("\r\n  Press any key to continue...\r\n");
-
-    if let Some(console) = fb_console {
-        console.clear();
-        let rows = console.rows();
-        console.set_fg_color(Color::new(0, 192, 192));
-        console.write_centered(4, &option.ui_name);
-        console.reset_colors();
-
-        if !option.ui_helptext.is_empty() {
-            console.set_position(4, 7);
-            let _ = console.write_str(&option.ui_helptext);
-        } else {
-            console.write_centered(7, "No help available for this option.");
-        }
-
-        console.write_centered(rows - 3, "Press any key to continue...");
-    }
-
-    loop {
-        if menu_common::read_key().is_some() {
-            break;
-        }
-        delay_ms(10);
-    }
-}
-
-/// Show message that CFR is not available
-fn show_no_cfr_message() {
-    let fb_info = coreboot::get_framebuffer();
-    let mut fb_console = fb_info.as_ref().map(FramebufferConsole::new);
-
-    serial_driver::write_str("\r\n");
-    serial_driver::write_str("\x1b[1;33m");
-    serial_driver::write_str("  Firmware settings not available\r\n");
-    serial_driver::write_str("\x1b[0m");
-    serial_driver::write_str("  This firmware does not expose CFR configuration options.\r\n");
-    serial_driver::write_str("\r\n  Press any key to continue...\r\n");
-
-    if let Some(console) = &mut fb_console {
-        console.clear();
-        let rows = console.rows();
-        console.set_fg_color(Color::new(255, 255, 0));
-        console.write_centered(rows / 2 - 1, "Firmware settings not available");
-        console.reset_colors();
-        console.write_centered(
-            rows / 2 + 1,
-            "This firmware does not expose CFR configuration options.",
-        );
-        console.write_centered(rows / 2 + 3, "Press any key to continue...");
-    }
-
-    loop {
-        if menu_common::read_key().is_some() {
-            break;
-        }
-        delay_ms(10);
-    }
-}
-
-/// Show message that no options are available
-fn show_no_options_message(fb_console: &mut Option<FramebufferConsole>) {
-    serial_driver::write_str("\r\n");
-    serial_driver::write_str("\x1b[1;33m");
-    serial_driver::write_str("  No configurable options found\r\n");
-    serial_driver::write_str("\x1b[0m");
-    serial_driver::write_str("\r\n  Press any key to continue...\r\n");
-
-    if let Some(console) = fb_console {
-        console.clear();
-        let rows = console.rows();
-        console.set_fg_color(Color::new(255, 255, 0));
-        console.write_centered(rows / 2, "No configurable options found");
-        console.reset_colors();
-        console.write_centered(rows / 2 + 2, "Press any key to continue...");
-    }
-
-    loop {
-        if menu_common::read_key().is_some() {
-            break;
-        }
-        delay_ms(10);
-    }
-}
-
-// ============================================================================
-// Drawing
-// ============================================================================
-
-/// Collect the indices of items that are currently visible (dependency-aware).
-fn visible_indices(cfr: &CfrInfo, items: &[MenuItem]) -> Vec<usize> {
-    items
-        .iter()
-        .enumerate()
-        .filter(|(_, item)| is_item_visible(cfr, items, item))
-        .map(|(i, _)| i)
-        .collect()
-}
-
-/// Draw the complete menu
-fn draw_menu(
-    cfr: &CfrInfo,
-    items: &[MenuItem],
-    selected: usize,
-    scroll_offset: usize,
-    modified: bool,
-    status_message: Option<(&str, bool)>,
-    fb_console: &mut Option<FramebufferConsole>,
-) {
-    let cols = fb_console.as_ref().map(|c| c.cols()).unwrap_or(80) as usize;
-    let rows = fb_console.as_ref().map(|c| c.rows()).unwrap_or(25) as usize;
-
-    // Draw header
-    let title = if modified {
-        "Firmware Settings (modified)"
-    } else {
-        MENU_TITLE
-    };
-    menu_common::draw_header(title, fb_console, cols);
-
-    // Build list of visible item indices (dependency-aware)
-    let vis = visible_indices(cfr, items);
-
-    // Calculate visible area
-    let start_row = 4;
-    let visible_rows = rows.saturating_sub(8);
-
-    // Draw items — only the visible ones, respecting scroll_offset
-    for (screen_idx, &item_idx) in vis
-        .iter()
-        .enumerate()
-        .skip(scroll_offset)
-        .take(visible_rows)
-    {
-        let row = start_row + (screen_idx - scroll_offset);
-        let is_selected = item_idx == selected;
-        draw_item(cfr, &items[item_idx], is_selected, row, fb_console, cols);
-    }
-
-    // Draw scroll indicators
-    if scroll_offset > 0 {
-        draw_scroll_indicator(start_row - 1, "^", fb_console);
-    }
-    if scroll_offset + visible_rows < vis.len() {
-        draw_scroll_indicator(start_row + visible_rows, "v", fb_console);
-    }
-
-    // Draw help text
-    let help_row = rows.saturating_sub(3);
-    draw_help(help_row, fb_console, cols);
-
-    // Draw status message if any
-    if let Some((msg, is_success)) = status_message {
-        draw_status_message(rows.saturating_sub(2), msg, is_success, fb_console);
-    }
-}
-
-/// Draw a single menu item
-fn draw_item(
-    cfr: &CfrInfo,
-    item: &MenuItem,
-    is_selected: bool,
-    row: usize,
-    fb_console: &mut Option<FramebufferConsole>,
-    cols: usize,
-) {
-    match item {
-        MenuItem::FormHeader { name } => {
-            draw_form_header(name, row, fb_console);
-        }
-        MenuItem::SubformHeader { name } => {
-            draw_subform_header(name, row, fb_console);
-        }
-        MenuItem::Option {
-            form_idx,
-            option_idx,
-            current_value,
-            ..
-        } => {
-            if let Some(option) = get_option(cfr, *form_idx, *option_idx) {
-                draw_option_item(option, current_value, is_selected, row, fb_console, cols);
-            }
-        }
-        MenuItem::Comment { text } => {
-            draw_comment(text, row, fb_console);
-        }
-    }
-}
-
-/// Draw a form header (category separator)
-fn draw_form_header(name: &str, row: usize, fb_console: &mut Option<FramebufferConsole>) {
-    let ansi_row = row + 1;
-    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
-    serial_driver::write_str("\x1b[1;36m");
-    serial_driver::write_str("--- ");
-    serial_driver::write_str(name);
-    serial_driver::write_str(" ---");
-    serial_driver::write_str("\x1b[0m\x1b[K\r\n");
-
-    if let Some(console) = fb_console {
-        console.set_position(0, row as u32);
-        console.set_fg_color(Color::new(0, 192, 192));
-        let _ = console.write_str("--- ");
-        let _ = console.write_str(name);
-        let _ = console.write_str(" ---");
-        clear_line_remainder(console);
-        console.reset_colors();
-    }
-}
-
-/// Draw a subform header (indented section within a form)
-fn draw_subform_header(name: &str, row: usize, fb_console: &mut Option<FramebufferConsole>) {
-    let ansi_row = row + 1;
-    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
-    serial_driver::write_str("\x1b[1;35m"); // Magenta bold
-    serial_driver::write_str("     ");
-    serial_driver::write_str(name);
-    serial_driver::write_str("\x1b[0m\x1b[K\r\n");
-
-    if let Some(console) = fb_console {
-        console.set_position(0, row as u32);
-        console.set_fg_color(Color::new(192, 0, 192)); // Magenta
-        let _ = console.write_str("     ");
-        let _ = console.write_str(name);
-        clear_line_remainder(console);
-        console.reset_colors();
-    }
-}
-
-/// Draw an option item
-fn draw_option_item(
-    option: &CfrOption,
-    value: &CfrValue,
-    is_selected: bool,
-    row: usize,
-    fb_console: &mut Option<FramebufferConsole>,
-    cols: usize,
-) {
-    let is_editable = option.is_editable();
-
-    // Format the value for display
-    let mut value_str = String::new();
-    match (&option.option_type, value) {
-        (CfrOptionType::Bool { .. }, CfrValue::Bool(b)) => {
-            value_str.push_str(if *b { "[Enabled]" } else { "[Disabled]" });
-        }
-        (CfrOptionType::Enum { choices, .. }, CfrValue::Number(n)) => {
-            if let Some(choice) = choices.iter().find(|c| c.value == *n) {
-                value_str.push('[');
-                value_str.push_str(&choice.ui_name);
-                value_str.push(']');
-            } else {
-                let _ = write!(value_str, "[{}]", n);
-            }
-        }
-        (CfrOptionType::Number { hex_display, .. }, CfrValue::Number(n)) => {
-            if *hex_display {
-                let _ = write!(value_str, "[0x{:X}]", n);
-            } else {
-                let _ = write!(value_str, "[{}]", n);
-            }
-        }
-        (CfrOptionType::Varchar { .. }, CfrValue::Varchar(s)) => {
-            value_str.push('[');
-            let max_len = 20;
-            if s.len() > max_len {
-                value_str.push_str(&s[..max_len]);
-                value_str.push_str("...");
-            } else {
-                value_str.push_str(s);
-            }
-            value_str.push(']');
-        }
-        _ => {
-            value_str.push_str("[-]");
-        }
-    }
-
-    // Serial output
-    let ansi_row = row + 1;
-    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
-
-    if is_selected {
-        serial_driver::write_str("\x1b[7m");
-    }
-    if !is_editable {
-        serial_driver::write_str("\x1b[90m");
-    }
-
-    serial_driver::write_str("   ");
-    serial_driver::write_str(&option.ui_name);
-
-    let name_len = option.ui_name.len();
-    let pad_to = 40.min(cols.saturating_sub(value_str.len() + 5));
-    for _ in name_len + 3..pad_to {
-        serial_driver::write_str(" ");
-    }
-    serial_driver::write_str(&value_str);
-
-    serial_driver::write_str("\x1b[0m\x1b[K\r\n");
-
-    // Framebuffer output
-    if let Some(console) = fb_console {
-        console.set_position(0, row as u32);
-
-        if is_selected {
-            console.set_colors(HIGHLIGHT_FG, HIGHLIGHT_BG);
-        } else if !is_editable {
-            console.set_fg_color(Color::new(128, 128, 128));
-        } else {
-            console.set_colors(DEFAULT_FG, DEFAULT_BG);
-        }
-
-        let _ = console.write_str("   ");
-        let _ = console.write_str(&option.ui_name);
-
-        let name_len = option.ui_name.len();
-        let term_cols = console.cols() as usize;
-        let pad_to = 40.min(term_cols.saturating_sub(value_str.len() + 5));
-        for _ in name_len + 3..pad_to {
-            let _ = console.write_str(" ");
-        }
-        let _ = console.write_str(&value_str);
-
-        clear_line_remainder(console);
-        console.reset_colors();
-    }
-}
-
-/// Draw a comment item
-fn draw_comment(text: &str, row: usize, fb_console: &mut Option<FramebufferConsole>) {
-    let ansi_row = row + 1;
-    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
-    serial_driver::write_str("\x1b[90m");
-    serial_driver::write_str("   ");
-    serial_driver::write_str(text);
-    serial_driver::write_str("\x1b[0m\x1b[K\r\n");
-
-    if let Some(console) = fb_console {
-        console.set_position(0, row as u32);
-        console.set_fg_color(Color::new(128, 128, 128));
-        let _ = console.write_str("   ");
-        let _ = console.write_str(text);
-        clear_line_remainder(console);
-        console.reset_colors();
-    }
-}
-
-/// Draw scroll indicator
-fn draw_scroll_indicator(row: usize, indicator: &str, fb_console: &mut Option<FramebufferConsole>) {
-    let ansi_row = row + 1;
-    let _ = write!(SerialWriter, "\x1b[{};40H{}", ansi_row, indicator);
-
-    if let Some(console) = fb_console {
-        let cols = console.cols();
-        console.set_position(cols / 2, row as u32);
-        console.set_fg_color(Color::new(128, 128, 128));
-        let _ = console.write_str(indicator);
-        console.reset_colors();
-    }
-}
-
-/// Draw help text
-fn draw_help(row: usize, fb_console: &mut Option<FramebufferConsole>, cols: usize) {
-    let ansi_row = row + 1;
-    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
-    serial_driver::write_str("\x1b[36m");
-    let help_pad = (cols.saturating_sub(HELP_TEXT.len())) / 2;
-    for _ in 0..help_pad {
-        serial_driver::write_str(" ");
-    }
-    serial_driver::write_str(HELP_TEXT);
-    serial_driver::write_str("\x1b[0m");
-
-    if let Some(console) = fb_console {
-        console.set_fg_color(Color::new(0, 192, 192));
-        console.write_centered(row as u32, HELP_TEXT);
-        console.reset_colors();
-    }
-}
-
-/// Draw a status message
-fn draw_status_message(
-    row: usize,
-    message: &str,
-    is_success: bool,
-    fb_console: &mut Option<FramebufferConsole>,
-) {
-    let color = if is_success {
-        Color::new(0, 255, 0)
-    } else {
-        Color::new(255, 0, 0)
-    };
-
-    let ansi_row = row + 1;
-    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
-    if is_success {
-        serial_driver::write_str("\x1b[32m");
-    } else {
-        serial_driver::write_str("\x1b[31m");
-    }
-    serial_driver::write_str("  ");
-    serial_driver::write_str(message);
-    serial_driver::write_str("\x1b[0m");
-
-    if let Some(console) = fb_console {
-        console.set_fg_color(color);
-        console.write_centered(row as u32, message);
-        console.reset_colors();
-    }
-}
-
-/// Clear remaining characters on the current line of a framebuffer console
-fn clear_line_remainder(console: &mut FramebufferConsole) {
-    let (col, _) = console.position();
-    for _ in col..console.cols() {
-        let _ = console.write_str(" ");
-    }
 }

--- a/src/framebuffer_console.rs
+++ b/src/framebuffer_console.rs
@@ -326,13 +326,89 @@ pub fn render_glyph(fb: &FramebufferInfo, c: char, x: u32, y: u32, fg: Color, bg
 /// Get the glyph data for a character
 ///
 /// Returns a reference to 16 bytes representing the 8x16 bitmap for the character.
+/// Handles Unicode box-drawing and block-element characters by mapping them to
+/// their CP437 equivalents in the VGA font.
 fn get_glyph(c: char) -> &'static [u8; 16] {
-    let index = c as usize;
-    if index < 256 {
-        &VGA_FONT_8X16[index]
+    let index = if (c as usize) < 256 {
+        c as usize
+    } else if let Some(cp437) = unicode_to_cp437(c) {
+        cp437 as usize
     } else {
-        // Return '?' for non-ASCII characters
-        &VGA_FONT_8X16[b'?' as usize]
+        b'?' as usize
+    };
+    &VGA_FONT_8X16[index]
+}
+
+/// Map Unicode characters to their CP437 font indices
+///
+/// The VGA font uses CP437 encoding where box-drawing characters live at
+/// 0xB3-0xDA and block elements at 0xB0-0xDF. Unicode places these same
+/// glyphs at U+2500-U+257F (box drawing) and U+2580-U+2593 (block elements).
+fn unicode_to_cp437(c: char) -> Option<u8> {
+    match c {
+        // Box drawing — single line
+        '─' => Some(0xC4),
+        '│' => Some(0xB3),
+        '┌' => Some(0xDA),
+        '┐' => Some(0xBF),
+        '└' => Some(0xC0),
+        '┘' => Some(0xD9),
+        '├' => Some(0xC3),
+        '┤' => Some(0xB4),
+        '┬' => Some(0xC2),
+        '┴' => Some(0xC1),
+        '┼' => Some(0xC5),
+
+        // Box drawing — double line
+        '═' => Some(0xCD),
+        '║' => Some(0xBA),
+        '╔' => Some(0xC9),
+        '╗' => Some(0xBB),
+        '╚' => Some(0xC8),
+        '╝' => Some(0xBC),
+        '╠' => Some(0xCC),
+        '╣' => Some(0xB9),
+        '╦' => Some(0xCB),
+        '╩' => Some(0xCA),
+        '╬' => Some(0xCE),
+
+        // Box drawing — mixed single/double
+        '╒' => Some(0xD5),
+        '╓' => Some(0xD6),
+        '╕' => Some(0xB8),
+        '╖' => Some(0xB7),
+        '╘' => Some(0xD4),
+        '╙' => Some(0xD3),
+        '╛' => Some(0xBE),
+        '╜' => Some(0xBD),
+        '╞' => Some(0xC6),
+        '╟' => Some(0xC7),
+        '╡' => Some(0xB5),
+        '╢' => Some(0xB6),
+        '╤' => Some(0xD1),
+        '╥' => Some(0xD2),
+        '╧' => Some(0xCF),
+        '╨' => Some(0xD0),
+        '╪' => Some(0xD8),
+        '╫' => Some(0xD7),
+
+        // Rounded corners → regular corners (no rounded glyphs in CP437)
+        '╭' => Some(0xDA),
+        '╮' => Some(0xBF),
+        '╯' => Some(0xD9),
+        '╰' => Some(0xC0),
+
+        // Block elements
+        '▀' => Some(0xDF),
+        '▄' => Some(0xDC),
+        '█' => Some(0xDB),
+        '▌' => Some(0xDD),
+        '▐' => Some(0xDE),
+        '░' => Some(0xB0),
+        '▒' => Some(0xB1),
+        '▓' => Some(0xB2),
+
+        _ => None,
     }
 }
 

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -2,12 +2,13 @@
 //!
 //! This module provides a global allocator implementation that enables the use of
 //! the `alloc` crate for heap allocations. This is required for cryptographic
-//! operations in the RustCrypto crates (RSA, X.509, etc.).
+//! operations in the RustCrypto crates (RSA, X.509, etc.) and for ratatui's
+//! terminal UI rendering.
 //!
 //! # Design
 //!
-//! We use a simple bump allocator backed by a pre-allocated heap region. The heap
-//! is allocated from the EFI memory allocator during initialization.
+//! We use `talc`, a lightweight allocator with proper deallocation support,
+//! backed by a pre-allocated heap region from the EFI page allocator.
 //!
 //! # Memory Management
 //!
@@ -15,15 +16,11 @@
 //! - This ensures the OS preserves the heap after ExitBootServices, so runtime
 //!   services (SetVariable, etc.) can continue to use heap allocations for
 //!   authenticated variable verification, varstore persistence, etc.
-//! - Allocations are bump-pointer style (fast allocation)
-//! - Deallocation is a no-op (bump allocator never frees)
+//! - Proper alloc/dealloc via talc's bucketed linked-list algorithm
 
-use core::alloc::{GlobalAlloc, Layout};
-use core::cell::UnsafeCell;
-use core::ptr::null_mut;
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use talc::{ErrOnOom, Span, Talc, Talck};
 
-/// Heap size (2 MB should be sufficient for crypto operations)
+/// Heap size (2 MB should be sufficient for crypto operations + UI)
 const HEAP_SIZE: usize = 2 * 1024 * 1024;
 
 /// Page size (4KB)
@@ -32,119 +29,13 @@ const PAGE_SIZE: usize = 4096;
 /// Number of pages for the heap
 const HEAP_PAGES: u64 = (HEAP_SIZE / PAGE_SIZE) as u64;
 
-/// Global heap state
-struct BumpAllocator {
-    /// Start of the heap
-    heap_start: UnsafeCell<usize>,
-    /// Current allocation pointer (offset from heap_start)
-    offset: AtomicUsize,
-    /// Heap size (written once during init)
-    heap_size: UnsafeCell<usize>,
-    /// Whether the allocator has been initialized
-    initialized: AtomicBool,
-}
-
-// SAFETY: BumpAllocator is thread-safe because:
-// 1. CrabEFI is single-threaded firmware
-// 2. We use atomic operations for offset updates
-// 3. heap_start is only written once during initialization
-unsafe impl Sync for BumpAllocator {}
-
-impl BumpAllocator {
-    const fn new() -> Self {
-        Self {
-            heap_start: UnsafeCell::new(0),
-            offset: AtomicUsize::new(0),
-            heap_size: UnsafeCell::new(0),
-            initialized: AtomicBool::new(false),
-        }
-    }
-
-    /// Initialize the allocator with a heap region
-    ///
-    /// # Safety
-    ///
-    /// Must be called only once, before any allocations.
-    unsafe fn init(&self, heap_start: usize, heap_size: usize) {
-        // Store the heap start address
-        *self.heap_start.get() = heap_start;
-
-        *self.heap_size.get() = heap_size;
-
-        // Reset the offset
-        self.offset.store(0, Ordering::Release);
-        self.initialized.store(true, Ordering::Release);
-
-        log::info!(
-            "Global allocator initialized: heap at {:#x}, size {} KB",
-            heap_start,
-            heap_size / 1024
-        );
-    }
-
-    /// Check if the allocator is initialized
-    fn is_initialized(&self) -> bool {
-        self.initialized.load(Ordering::Acquire)
-    }
-}
-
-unsafe impl GlobalAlloc for BumpAllocator {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        if !self.is_initialized() {
-            // Allocator not initialized yet - this shouldn't happen in normal operation
-            return null_mut();
-        }
-
-        let heap_start = *self.heap_start.get();
-        let size = layout.size();
-        let align = layout.align();
-
-        // Use a CAS loop to atomically bump the offset
-        loop {
-            let current_offset = self.offset.load(Ordering::Acquire);
-
-            // Calculate aligned offset
-            let alloc_start = heap_start + current_offset;
-            let aligned_start = (alloc_start + align - 1) & !(align - 1);
-            let padding = aligned_start - alloc_start;
-            let new_offset = current_offset + padding + size;
-
-            // Check if we have enough space
-            // Safety: heap_size is only written once during init, before any allocations
-            let heap_size = unsafe { *self.heap_size.get() };
-            if new_offset > heap_size {
-                log::error!(
-                    "Heap exhausted: requested {} bytes, offset {}, heap_size {}",
-                    size,
-                    current_offset,
-                    heap_size
-                );
-                return null_mut();
-            }
-
-            // Try to update the offset atomically
-            match self.offset.compare_exchange_weak(
-                current_offset,
-                new_offset,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => return aligned_start as *mut u8,
-                Err(_) => continue, // Another allocation happened, retry
-            }
-        }
-    }
-
-    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {
-        // Bump allocator doesn't deallocate individual allocations.
-        // The heap is RuntimeServicesData, so it persists after ExitBootServices
-        // and remains available for runtime service calls.
-    }
-}
-
 /// Global allocator instance
+///
+/// Uses `spin::Mutex` for locking (CrabEFI is single-threaded but GlobalAlloc
+/// requires Sync). `ErrOnOom` causes allocation failure to return null rather
+/// than panic.
 #[global_allocator]
-static ALLOCATOR: BumpAllocator = BumpAllocator::new();
+static ALLOCATOR: Talck<spin::Mutex<()>, ErrOnOom> = Talc::new(ErrOnOom).lock();
 
 /// Initialize the global allocator
 ///
@@ -155,7 +46,7 @@ static ALLOCATOR: BumpAllocator = BumpAllocator::new();
 ///
 /// `true` if initialization succeeded, `false` otherwise.
 pub fn init() -> bool {
-    use crate::efi::allocator::{AllocateType, MemoryType, allocate_pages};
+    use crate::efi::allocator::{allocate_pages, AllocateType, MemoryType};
     use r_efi::efi::Status;
 
     // Allocate heap pages as RuntimeServicesData so the OS preserves them
@@ -175,24 +66,22 @@ pub fn init() -> bool {
         return false;
     }
 
-    // Initialize the bump allocator
-    // SAFETY: Called once before any allocations
+    let heap_start = heap_addr as *mut u8;
+    // Safety: heap_start is a valid pointer to HEAP_SIZE bytes of EFI-allocated memory.
+    // This is called once before any allocations.
     unsafe {
-        ALLOCATOR.init(heap_addr as usize, HEAP_SIZE);
+        let heap_span = Span::new(heap_start, heap_start.add(HEAP_SIZE));
+        ALLOCATOR
+            .lock()
+            .claim(heap_span)
+            .expect("Failed to claim heap memory for allocator");
     }
 
+    log::info!(
+        "Global allocator initialized: heap at {:#x}, size {} KB",
+        heap_addr,
+        HEAP_SIZE / 1024
+    );
+
     true
-}
-
-/// Check if the allocator is initialized
-pub fn is_initialized() -> bool {
-    ALLOCATOR.is_initialized()
-}
-
-/// Get heap usage statistics
-pub fn stats() -> (usize, usize) {
-    let used = ALLOCATOR.offset.load(Ordering::Acquire);
-    // Safety: heap_size is only written once during init
-    let total = unsafe { *ALLOCATOR.heap_size.get() };
-    (used, total)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod pe;
 pub mod secure_boot_menu;
 pub mod state;
 pub mod time;
+pub mod tui;
 
 use crate::drivers::block::{AhciDisk, NvmeDisk, SdhciDisk, UsbDisk};
 use core::panic::PanicInfo;
@@ -71,46 +72,56 @@ fn panic(info: &PanicInfo) -> ! {
 /// when Secure Boot verification fails. It also outputs to the serial console.
 /// The display persists for a few seconds so the user can see it.
 pub fn display_secure_boot_error() {
-    use framebuffer_console::{Color, DEFAULT_BG, FramebufferConsole};
+    use ratatui::Terminal;
+    use ratatui::layout::{Alignment, Constraint, Layout};
+    use ratatui::style::{Color, Modifier, Style};
+    use ratatui::text::Line;
+    use ratatui::widgets::{Block, Borders, Paragraph};
 
     const ERROR_MESSAGE: &str = "SECURE BOOT VIOLATION: Image not authorized";
 
-    // Output to serial console with red color (ANSI escape codes)
-    drivers::serial::write_str("\r\n\x1b[1;31m"); // Bold red
-    drivers::serial::write_str(
-        "================================================================================\r\n",
-    );
-    drivers::serial::write_str(
-        "                    SECURE BOOT VIOLATION: Image not authorized                 \r\n",
-    );
-    drivers::serial::write_str(
-        "================================================================================\r\n",
-    );
-    drivers::serial::write_str("\x1b[0m\r\n"); // Reset color
+    let fb_info = coreboot::get_framebuffer();
+    let backend = tui::DualBackend::new(fb_info.as_ref());
+    let mut terminal = match Terminal::new(backend) {
+        Ok(t) => t,
+        Err(_) => {
+            // Fallback: at least print to serial
+            drivers::serial::write_str("\r\n*** SECURE BOOT VIOLATION ***\r\n");
+            time::delay_ms(3000);
+            return;
+        }
+    };
+    let _ = terminal.clear();
+    let _ = terminal.hide_cursor();
 
-    // Output to framebuffer if available
-    if let Some(fb_info) = coreboot::get_framebuffer() {
-        let mut console = FramebufferConsole::new(&fb_info);
+    let error_style = Style::default()
+        .fg(Color::Red)
+        .add_modifier(Modifier::BOLD);
 
-        // Calculate center position
-        let rows = console.rows();
-        let center_row = rows / 2;
+    let _ = terminal.draw(|frame| {
+        let area = frame.area();
 
-        // Set red foreground color
-        let error_color = Color::new(255, 0, 0); // Bright red
+        // Center the error box vertically
+        let vertical = Layout::vertical([
+            Constraint::Fill(1),
+            Constraint::Length(5),
+            Constraint::Fill(1),
+        ])
+        .split(area);
 
-        // Draw a border above the message
-        console.set_colors(error_color, DEFAULT_BG);
-        console.write_centered(center_row - 2, "========================================");
+        let border = Block::default()
+            .borders(Borders::ALL)
+            .border_style(error_style)
+            .title(" Secure Boot Error ")
+            .title_alignment(Alignment::Center);
 
-        // Draw the error message
-        console.write_centered(center_row, ERROR_MESSAGE);
+        let paragraph = Paragraph::new(Line::from(ERROR_MESSAGE))
+            .style(error_style)
+            .alignment(Alignment::Center)
+            .block(border);
 
-        // Draw a border below the message
-        console.write_centered(center_row + 2, "========================================");
-
-        console.reset_colors();
-    }
+        frame.render_widget(paragraph, vertical[1]);
+    });
 
     // Wait 3 seconds so the user can see the message
     time::delay_ms(3000);

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -17,10 +17,6 @@
 
 use crate::coreboot;
 use crate::drivers::block::BlockDevice;
-use crate::drivers::serial as serial_driver;
-use crate::framebuffer_console::{
-    Color, DEFAULT_BG, DEFAULT_FG, FramebufferConsole, HIGHLIGHT_BG, HIGHLIGHT_FG, TITLE_COLOR,
-};
 use crate::fs::{fat::FatFilesystem, gpt, iso9660};
 use crate::time::{Timeout, delay_ms};
 use core::fmt::Write;
@@ -912,41 +908,165 @@ fn scan_partition_for_entries(
 ///
 /// The index of the selected boot entry, or `None` if no selection was made.
 pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
+    use alloc::format;
+    use alloc::string::ToString;
+    use ratatui::Terminal;
+    use ratatui::layout::{Alignment, Constraint, Layout};
+    use ratatui::style::{Color as TuiColor, Modifier, Style};
+    use ratatui::text::{Line, Span};
+    use ratatui::widgets::{
+        Block, Borders, HighlightSpacing, List, ListItem, ListState, Paragraph,
+    };
+
     if menu.entry_count() == 0 {
         log::error!("No boot entries to display");
         return None;
     }
 
-    // Get framebuffer for rendering
+    // Create the dual backend (serial + framebuffer)
     let fb_info = coreboot::get_framebuffer();
+    let backend = crate::tui::DualBackend::new(fb_info.as_ref());
+    let mut terminal = match Terminal::new(backend) {
+        Ok(t) => t,
+        Err(_) => {
+            log::error!("Failed to create ratatui terminal");
+            return None;
+        }
+    };
+    let _ = terminal.clear();
+    let _ = terminal.hide_cursor();
 
-    // Create framebuffer console if available
-    let mut fb_console = fb_info.as_ref().map(FramebufferConsole::new);
-
-    // Clear screen
-    clear_screen(&mut fb_console);
-
-    // Initial display
-    draw_menu(menu, &mut fb_console);
+    // Status message shown at the bottom (cleared on next redraw)
+    let mut status_msg: Option<alloc::string::String> = None;
 
     // Handle input with timeout
     let mut remaining_seconds = menu.timeout_seconds;
     let mut last_second_check = Timeout::from_ms(1000);
 
-    // Show initial countdown
-    draw_countdown(remaining_seconds, &mut fb_console);
+    // Render helper closure -- builds the ratatui frame
+    let render = |terminal: &mut Terminal<crate::tui::DualBackend>,
+                  menu: &BootMenu,
+                  remaining_seconds: u32,
+                  status_msg: &Option<alloc::string::String>| {
+        let _ = terminal.draw(|frame| {
+            let area = frame.area();
+
+            // Vertical layout: header(3) | entries(fill) | footer(3)
+            let chunks = Layout::vertical([
+                Constraint::Length(3),  // header
+                Constraint::Min(4),    // entry list
+                Constraint::Length(3), // countdown + help + status
+            ])
+            .split(area);
+
+            // --- Header ---
+            let header = Paragraph::new(Line::from(MENU_TITLE).alignment(Alignment::Center))
+                .style(Style::new().fg(TuiColor::Yellow).add_modifier(Modifier::BOLD))
+                .block(
+                    Block::new()
+                        .borders(Borders::TOP | Borders::BOTTOM)
+                        .border_style(Style::new().fg(TuiColor::Yellow)),
+                );
+            frame.render_widget(header, chunks[0]);
+
+            // --- Build list items with category separators ---
+            let mut items: alloc::vec::Vec<ListItem> = alloc::vec::Vec::new();
+            let mut entry_index_map: alloc::vec::Vec<Option<usize>> = alloc::vec::Vec::new();
+            let mut current_category: Option<BootCategory> = None;
+
+            for (i, entry) in menu.entries.iter().enumerate() {
+                // Category separator
+                if current_category != Some(entry.category) {
+                    if current_category.is_some() {
+                        items.push(ListItem::new(Line::raw("")));
+                        entry_index_map.push(None);
+                    }
+                    let label = entry.category.display_name();
+                    let sep = format!("--- {label} ---");
+                    items.push(
+                        ListItem::new(Line::from(sep).alignment(Alignment::Center))
+                            .style(Style::new().fg(TuiColor::DarkGray)),
+                    );
+                    entry_index_map.push(None);
+                    current_category = Some(entry.category);
+                }
+
+                let mut desc: String<128> = String::new();
+                entry.format_description(&mut desc);
+                let line_text = format!("  {}. {}", i + 1, desc);
+
+                items.push(
+                    ListItem::new(Line::raw(line_text)).style(Style::new().fg(TuiColor::Gray)),
+                );
+                entry_index_map.push(Some(i));
+            }
+
+            // Find which list position corresponds to menu.selected
+            let selected_list_idx = entry_index_map
+                .iter()
+                .position(|e| *e == Some(menu.selected));
+
+            let list = List::new(items)
+                .highlight_style(
+                    Style::new()
+                        .fg(TuiColor::Black)
+                        .bg(TuiColor::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                )
+                .highlight_symbol(">> ")
+                .highlight_spacing(HighlightSpacing::Always)
+                .scroll_padding(1);
+
+            let mut list_state = ListState::default().with_selected(selected_list_idx);
+            frame.render_stateful_widget(list, chunks[1], &mut list_state);
+
+            // --- Footer: countdown, status, help ---
+            let footer_chunks = Layout::vertical([
+                Constraint::Length(1), // countdown or status
+                Constraint::Length(1), // blank
+                Constraint::Length(1), // help
+            ])
+            .split(chunks[2]);
+
+            // Countdown or status message
+            let footer_line = if let Some(msg) = status_msg {
+                Line::from(Span::styled(
+                    msg.as_str().to_string(),
+                    Style::new().fg(TuiColor::Red),
+                ))
+                .alignment(Alignment::Center)
+            } else if remaining_seconds > 0 {
+                let msg = format!("Booting in {} seconds...", remaining_seconds);
+                Line::from(Span::styled(msg, Style::new().fg(TuiColor::Yellow)))
+                    .alignment(Alignment::Center)
+            } else {
+                Line::raw("")
+            };
+            frame.render_widget(Paragraph::new(footer_line), footer_chunks[0]);
+
+            // Help text
+            let help = Paragraph::new(
+                Line::from(HELP_TEXT)
+                    .style(Style::new().fg(TuiColor::Cyan))
+                    .alignment(Alignment::Center),
+            );
+            frame.render_widget(help, footer_chunks[2]);
+        });
+    };
+
+    // Initial render
+    render(&mut terminal, menu, remaining_seconds, &status_msg);
 
     loop {
         // Check for timeout (first tick fires after 1 real second)
         if remaining_seconds > 0 && last_second_check.is_expired() {
             remaining_seconds -= 1;
             last_second_check = Timeout::from_ms(1000);
+            status_msg = None;
 
-            // Update countdown display
-            draw_countdown(remaining_seconds, &mut fb_console);
+            render(&mut terminal, menu, remaining_seconds, &status_msg);
 
             if remaining_seconds == 0 {
-                // Timeout - boot selected entry
                 return Some(menu.selected);
             }
         }
@@ -955,56 +1075,54 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
         if let Some(key) = read_key() {
             // Any key resets the timeout
             remaining_seconds = menu.timeout_seconds;
+            status_msg = None;
 
             match key {
                 KeyPress::Up | KeyPress::Char('k') => {
                     menu.select_previous();
-                    draw_menu(menu, &mut fb_console);
+                    render(&mut terminal, menu, remaining_seconds, &status_msg);
                 }
                 KeyPress::Down | KeyPress::Char('j') => {
                     menu.select_next();
-                    draw_menu(menu, &mut fb_console);
+                    render(&mut terminal, menu, remaining_seconds, &status_msg);
                 }
                 KeyPress::Enter => {
-                    // Show booting message before returning
                     if let Some(entry) = menu.entries.get(menu.selected) {
                         log::info!(
                             "Selected entry: name='{}', path='{}'",
                             entry.name,
                             entry.path
                         );
-                        let mut msg: String<64> = String::new();
-                        let _ = msg.push_str("Booting ");
-                        let _ = msg.push_str(&entry.name);
-                        let _ = msg.push_str("...");
-                        draw_status(&msg, &mut fb_console);
+                        status_msg = Some(format!("Booting {}...", entry.name));
                     } else {
                         log::error!("No entry at selected index {}", menu.selected);
-                        draw_status("Error: No entry selected", &mut fb_console);
+                        status_msg = Some("Error: No entry selected".into());
                     }
+                    render(&mut terminal, menu, remaining_seconds, &status_msg);
                     return Some(menu.selected);
                 }
                 KeyPress::Escape => {
-                    // Future: file browser
-                    draw_status("File browser not yet implemented", &mut fb_console);
+                    status_msg = Some("File browser not yet implemented".into());
+                    render(&mut terminal, menu, remaining_seconds, &status_msg);
                 }
                 KeyPress::Char('s') | KeyPress::Char('S') => {
                     // Open Secure Boot settings menu
+                    let _ = terminal.clear();
                     crate::secure_boot_menu::show_secure_boot_menu();
                     // Redraw boot menu after returning
-                    clear_screen(&mut fb_console);
-                    draw_menu(menu, &mut fb_console);
+                    let _ = terminal.clear();
+                    render(&mut terminal, menu, remaining_seconds, &status_msg);
                 }
                 KeyPress::Char('f') | KeyPress::Char('F') => {
-                    // Open Firmware Settings menu (CFR)
+                    // Open Firmware Settings menu
+                    let _ = terminal.clear();
                     crate::cfr_menu::show_cfr_menu();
-                    // Redraw boot menu after returning
-                    clear_screen(&mut fb_console);
-                    draw_menu(menu, &mut fb_console);
+                    let _ = terminal.clear();
+                    render(&mut terminal, menu, remaining_seconds, &status_msg);
                 }
                 KeyPress::Char('r') | KeyPress::Char('R') => {
-                    // Reset the system
-                    draw_status("Resetting system...", &mut fb_console);
+                    status_msg = Some("Resetting system...".into());
+                    render(&mut terminal, menu, remaining_seconds, &status_msg);
                     delay_ms(500);
                     perform_system_reset();
                 }
@@ -1012,39 +1130,34 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
                     // Edit kernel command line
                     if let Some(entry) = menu.entries.get_mut(menu.selected) {
                         if entry.has_cmdline() {
-                            match edit_cmdline(entry, &mut fb_console) {
+                            match edit_cmdline(entry, &mut terminal) {
                                 EditResult::Boot => {
-                                    // Boot immediately with the edited command line
-                                    let mut msg: String<64> = String::new();
-                                    let _ = msg.push_str("Booting ");
-                                    let _ = msg.push_str(&entry.name);
-                                    let _ = msg.push_str("...");
-                                    clear_screen(&mut fb_console);
-                                    draw_status(&msg, &mut fb_console);
+                                    status_msg = Some(format!("Booting {}...", entry.name));
+                                    let _ = terminal.clear();
+                                    render(&mut terminal, menu, remaining_seconds, &status_msg);
                                     return Some(menu.selected);
                                 }
                                 EditResult::Confirmed => {
-                                    draw_status("Command line updated", &mut fb_console);
+                                    status_msg = Some("Command line updated".into());
                                 }
                                 EditResult::Cancelled => {
-                                    draw_status("Edit cancelled", &mut fb_console);
+                                    status_msg = Some("Edit cancelled".into());
                                 }
                             }
                         } else {
-                            draw_status("This entry has no editable command line", &mut fb_console);
+                            status_msg =
+                                Some("This entry has no editable command line".into());
                         }
                     }
-                    // Redraw menu after editing (unless we're booting)
                     delay_ms(500);
-                    clear_screen(&mut fb_console);
-                    draw_menu(menu, &mut fb_console);
+                    let _ = terminal.clear();
+                    render(&mut terminal, menu, remaining_seconds, &status_msg);
                 }
                 KeyPress::Char(c) if c.is_ascii_digit() => {
-                    // Direct selection by number
                     let num = (c as u8 - b'0') as usize;
                     if num > 0 && num <= menu.entry_count() {
                         menu.selected = num - 1;
-                        draw_menu(menu, &mut fb_console);
+                        render(&mut terminal, menu, remaining_seconds, &status_msg);
                     }
                 }
                 _ => {}
@@ -1056,230 +1169,10 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
     }
 }
 
-use crate::menu_common::{self, KeyPress, SerialWriter};
+use crate::menu_common::{self, KeyPress};
 
 fn read_key() -> Option<KeyPress> {
     menu_common::read_key()
-}
-
-fn clear_screen(fb_console: &mut Option<FramebufferConsole>) {
-    menu_common::clear_screen(fb_console);
-}
-
-/// Draw the menu on both outputs
-fn draw_menu(menu: &BootMenu, fb_console: &mut Option<FramebufferConsole>) {
-    let cols = fb_console.as_ref().map(|c| c.cols()).unwrap_or(80) as usize;
-
-    // Draw header
-    draw_header(fb_console, cols);
-
-    // Draw entries with category separators
-    let start_row = 4;
-    let mut current_row = start_row;
-    let mut current_category: Option<BootCategory> = None;
-
-    for (i, entry) in menu.entries.iter().enumerate() {
-        // Check if we need a category separator
-        if current_category != Some(entry.category) {
-            // Add blank line before separator (except for first category)
-            if current_category.is_some() {
-                current_row += 1;
-            }
-            draw_category_separator(entry.category, current_row, fb_console, cols);
-            current_row += 1;
-            current_category = Some(entry.category);
-        }
-
-        let is_selected = i == menu.selected;
-        draw_entry(i, entry, is_selected, current_row, fb_console, cols);
-        current_row += 1;
-    }
-
-    // Draw help text
-    let help_row = current_row + 2;
-    draw_help(help_row, fb_console, cols);
-}
-
-/// Draw a category separator line
-fn draw_category_separator(
-    category: BootCategory,
-    row: usize,
-    fb_console: &mut Option<FramebufferConsole>,
-    cols: usize,
-) {
-    let label = category.display_name();
-
-    // Build separator: "--- Category Name ---" style
-    let dashes_total = cols.saturating_sub(label.len() + 2); // 2 for spaces around label
-    let dashes_left = dashes_total / 2;
-    let dashes_right = dashes_total - dashes_left;
-
-    // Serial output
-    let ansi_row = row + 1; // ANSI is 1-based
-    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
-    serial_driver::write_str("\x1b[90m"); // Dark gray
-
-    for _ in 0..dashes_left.min(40) {
-        serial_driver::write_str("-");
-    }
-    serial_driver::write_str(" ");
-    serial_driver::write_str(label);
-    serial_driver::write_str(" ");
-    for _ in 0..dashes_right.min(40) {
-        serial_driver::write_str("-");
-    }
-
-    serial_driver::write_str("\x1b[0m\x1b[K\r\n");
-
-    // Framebuffer output
-    if let Some(console) = fb_console {
-        console.set_position(0, row as u32);
-        console.set_fg_color(Color::new(128, 128, 128)); // Gray
-
-        for _ in 0..dashes_left.min(40) {
-            let _ = console.write_str("-");
-        }
-        let _ = console.write_str(" ");
-        let _ = console.write_str(label);
-        let _ = console.write_str(" ");
-        for _ in 0..dashes_right.min(40) {
-            let _ = console.write_str("-");
-        }
-
-        // Clear rest of line
-        let (col, _) = console.position();
-        let term_cols = console.cols();
-        for _ in col..term_cols {
-            let _ = console.write_str(" ");
-        }
-
-        console.reset_colors();
-    }
-}
-
-fn draw_header(fb_console: &mut Option<FramebufferConsole>, cols: usize) {
-    menu_common::draw_header(MENU_TITLE, fb_console, cols);
-}
-
-/// Draw a single boot entry
-fn draw_entry(
-    index: usize,
-    entry: &BootEntry,
-    is_selected: bool,
-    row: usize,
-    fb_console: &mut Option<FramebufferConsole>,
-    _cols: usize,
-) {
-    let mut desc: String<128> = String::new();
-    entry.format_description(&mut desc);
-
-    // Build the line
-    let marker = if is_selected { "[*]" } else { "[ ]" };
-
-    // Serial output
-    let ansi_row = row + 1; // ANSI is 1-based
-    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row); // Position cursor
-
-    if is_selected {
-        serial_driver::write_str("\x1b[7m"); // Inverse video
-    }
-
-    let _ = write!(SerialWriter, "   {}. {} {}", index + 1, marker, desc);
-
-    if is_selected {
-        serial_driver::write_str("\x1b[0m"); // Reset
-    }
-
-    // Clear rest of line
-    serial_driver::write_str("\x1b[K\r\n");
-
-    // Framebuffer output
-    if let Some(console) = fb_console {
-        console.set_position(3, row as u32);
-
-        if is_selected {
-            console.set_colors(HIGHLIGHT_FG, HIGHLIGHT_BG);
-        } else {
-            console.set_colors(DEFAULT_FG, DEFAULT_BG);
-        }
-
-        let _ = write!(console, "{}. {} {}", index + 1, marker, desc);
-
-        // Clear rest of line with spaces
-        let (col, _) = console.position();
-        let cols = console.cols();
-        for _ in col..cols {
-            let _ = console.write_str(" ");
-        }
-
-        console.reset_colors();
-    }
-}
-
-/// Draw the help text
-fn draw_help(row: usize, fb_console: &mut Option<FramebufferConsole>, cols: usize) {
-    // Serial output
-    let ansi_row = row + 1;
-    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
-    serial_driver::write_str("\x1b[36m"); // Cyan
-
-    // Center help text
-    let help_pad = (cols.saturating_sub(HELP_TEXT.len())) / 2;
-    for _ in 0..help_pad {
-        serial_driver::write_str(" ");
-    }
-    serial_driver::write_str(HELP_TEXT);
-    serial_driver::write_str("\x1b[0m\r\n");
-
-    // Framebuffer output
-    if let Some(console) = fb_console {
-        console.set_fg_color(Color::new(0, 192, 192)); // Cyan
-        console.write_centered(row as u32, HELP_TEXT);
-        console.reset_colors();
-    }
-}
-
-/// Draw the countdown timer
-fn draw_countdown(seconds: u32, fb_console: &mut Option<FramebufferConsole>) {
-    let mut msg: String<64> = String::new();
-    if seconds > 0 {
-        let _ = write!(msg, "Booting in {} seconds...", seconds);
-    } else {
-        let _ = write!(msg, "Booting now...");
-    }
-
-    // Serial output - position at bottom area
-    serial_driver::write_str("\x1b[20;1H"); // Row 20
-    serial_driver::write_str("\x1b[33m"); // Yellow
-    serial_driver::write_str(&msg);
-    serial_driver::write_str("\x1b[K"); // Clear rest of line
-    serial_driver::write_str("\x1b[0m");
-
-    // Framebuffer output
-    if let Some(console) = fb_console {
-        let row = console.rows().saturating_sub(3);
-        console.set_fg_color(Color::new(255, 255, 0)); // Yellow
-        console.write_centered(row, &msg);
-        console.reset_colors();
-    }
-}
-
-/// Draw a status message
-fn draw_status(message: &str, fb_console: &mut Option<FramebufferConsole>) {
-    // Serial output
-    serial_driver::write_str("\x1b[22;1H"); // Row 22
-    serial_driver::write_str("\x1b[31m"); // Red
-    serial_driver::write_str(message);
-    serial_driver::write_str("\x1b[K"); // Clear rest of line
-    serial_driver::write_str("\x1b[0m");
-
-    // Framebuffer output
-    if let Some(console) = fb_console {
-        let row = console.rows().saturating_sub(1);
-        console.set_fg_color(Color::new(255, 0, 0)); // Red
-        console.write_centered(row, message);
-        console.reset_colors();
-    }
 }
 
 /// Result of command line editing
@@ -1293,72 +1186,184 @@ enum EditResult {
     Boot,
 }
 
-/// Edit the command line of a boot entry
+/// Edit the command line of a boot entry using ratatui
 ///
 /// Displays a full-screen editor for the kernel command line.
 ///
 /// # Arguments
 ///
 /// * `entry` - The boot entry to edit
-/// * `fb_console` - Optional framebuffer console for display
+/// * `terminal` - The ratatui terminal for rendering
 ///
 /// # Returns
 ///
 /// `EditResult::Cancelled` if the user pressed Escape (cmdline unchanged)
 /// `EditResult::Confirmed` if the user pressed Enter (cmdline updated, return to menu)
 /// `EditResult::Boot` if the user pressed Ctrl+X (cmdline updated, boot immediately)
-fn edit_cmdline(entry: &mut BootEntry, fb_console: &mut Option<FramebufferConsole>) -> EditResult {
+fn edit_cmdline(
+    entry: &mut BootEntry,
+    terminal: &mut ratatui::Terminal<crate::tui::DualBackend>,
+) -> EditResult {
+    use alloc::format;
+    use alloc::string::ToString;
+    use alloc::vec;
+    use ratatui::layout::{Alignment, Constraint, Layout};
+    use ratatui::style::{Color as TuiColor, Modifier, Style};
+    use ratatui::text::{Line, Span};
+    use ratatui::widgets::{Block, Borders, Paragraph};
+
     // Check if entry has cmdline and extract initial value
     let initial_cmdline = match entry.get_cmdline() {
         Some(c) => c.clone(),
-        None => {
-            draw_status("This entry has no command line to edit", fb_console);
-            delay_ms(1500);
-            return EditResult::Cancelled;
-        }
+        None => return EditResult::Cancelled,
     };
 
-    // Copy entry name for display (to avoid borrow issues)
-    let entry_name: String<64> = entry.name.clone();
-
-    // Create a working buffer for editing
+    let entry_name: alloc::string::String = entry.name.to_string();
     let mut buffer: String<512> = initial_cmdline;
     let mut cursor_pos = buffer.len();
 
-    // Calculate scroll offset for long command lines
-    let cols = fb_console.as_ref().map(|c| c.cols()).unwrap_or(80) as usize;
-    let edit_width = cols.saturating_sub(4); // Leave margin for decoration
+    let help1 = "Enter: Confirm | Esc: Cancel | Ctrl+X: Boot | Left/Right: Move cursor";
+    let help2 = "Ctrl+A: Start | Ctrl+E: End | Ctrl+K: Delete to end | Ctrl+U: Delete to start";
 
-    // Draw static parts once
-    draw_cmdline_editor_static(&entry_name, fb_console, cols);
+    let _ = terminal.clear();
 
-    // Track if display needs updating
-    let mut needs_redraw = true;
+    let render = |terminal: &mut ratatui::Terminal<crate::tui::DualBackend>,
+                  buffer: &str,
+                  cursor_pos: usize| {
+        let _ = terminal.draw(|frame| {
+            let area = frame.area();
+            let width = area.width.saturating_sub(4) as usize;
+
+            // Calculate visible window for long command lines
+            let buf_len = buffer.len();
+            let (vis_start, vis_end, disp_cursor) = if buf_len <= width {
+                (0, buf_len, cursor_pos)
+            } else if cursor_pos < width / 2 {
+                (0, width, cursor_pos)
+            } else if cursor_pos > buf_len.saturating_sub(width / 2) {
+                let start = buf_len.saturating_sub(width);
+                (start, buf_len, cursor_pos - start)
+            } else {
+                let start = cursor_pos - width / 2;
+                (start, (start + width).min(buf_len), width / 2)
+            };
+            let visible = &buffer[vis_start..vis_end];
+
+            // Build the edit line with cursor highlighting
+            let left_indicator = if vis_start > 0 { "<" } else { " " };
+            let right_indicator = if vis_end < buf_len { ">" } else { " " };
+
+            let before = &visible[..disp_cursor];
+            let cursor_ch = if disp_cursor < visible.len() {
+                &visible[disp_cursor..disp_cursor + 1]
+            } else {
+                " "
+            };
+            let after = if disp_cursor < visible.len() {
+                &visible[disp_cursor + 1..]
+            } else {
+                ""
+            };
+
+            // Pad to fill the edit area width
+            let content_len = before.len() + 1 + after.len();
+            let padding = width.saturating_sub(content_len);
+            let pad_str: alloc::string::String =
+                core::iter::repeat(' ').take(padding).collect();
+
+            let edit_line = Line::from(vec![
+                Span::raw(left_indicator),
+                Span::styled(
+                    before.to_string(),
+                    Style::new().bg(TuiColor::Blue),
+                ),
+                Span::styled(
+                    cursor_ch.to_string(),
+                    Style::new()
+                        .fg(TuiColor::Black)
+                        .bg(TuiColor::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("{}{}", after, pad_str),
+                    Style::new().bg(TuiColor::Blue),
+                ),
+                Span::raw(right_indicator),
+            ]);
+
+            let length_line = Line::from(Span::styled(
+                format!("Length: {}/512", buf_len),
+                Style::new().fg(TuiColor::Yellow),
+            ));
+
+            // Layout: header(3), entry(2), label(1), edit(1), gap(1), length(1), gap(1), help(2), fill
+            let chunks = Layout::vertical([
+                Constraint::Length(3),  // header
+                Constraint::Length(2),  // entry name
+                Constraint::Length(1),  // "Command line:" label
+                Constraint::Length(1),  // edit line
+                Constraint::Length(1),  // gap
+                Constraint::Length(1),  // length indicator
+                Constraint::Length(1),  // gap
+                Constraint::Length(2),  // help text
+                Constraint::Min(0),    // fill
+            ])
+            .split(area);
+
+            // Header
+            let header =
+                Paragraph::new(Line::from("Edit Kernel Command Line").alignment(Alignment::Center))
+                    .style(
+                        Style::new()
+                            .fg(TuiColor::Yellow)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                    .block(
+                        Block::new()
+                            .borders(Borders::TOP | Borders::BOTTOM)
+                            .border_style(Style::new().fg(TuiColor::Yellow)),
+                    );
+            frame.render_widget(header, chunks[0]);
+
+            // Entry name
+            let entry_line = Line::from(vec![
+                Span::styled("Entry: ", Style::new().fg(TuiColor::Cyan)),
+                Span::raw(entry_name.as_str()),
+            ]);
+            frame.render_widget(Paragraph::new(entry_line), chunks[1]);
+
+            // Label
+            frame.render_widget(Paragraph::new("Command line:"), chunks[2]);
+
+            // Edit line
+            frame.render_widget(Paragraph::new(edit_line), chunks[3]);
+
+            // Length
+            frame.render_widget(Paragraph::new(length_line), chunks[5]);
+
+            // Help
+            let help = Paragraph::new(vec![
+                Line::from(Span::styled(help1, Style::new().fg(TuiColor::Cyan))),
+                Line::from(Span::styled(help2, Style::new().fg(TuiColor::Cyan))),
+            ]);
+            frame.render_widget(help, chunks[7]);
+        });
+    };
+
+    render(terminal, &buffer, cursor_pos);
 
     loop {
-        // Only redraw if something changed
-        if needs_redraw {
-            draw_cmdline_editor_line(&buffer, cursor_pos, edit_width, fb_console);
-            needs_redraw = false;
-        }
-
-        // Wait for input
         if let Some(key) = read_key() {
             match key {
                 KeyPress::Enter => {
-                    // Confirm - update the cmdline
                     if let Some(cmdline) = entry.get_cmdline_mut() {
                         cmdline.clear();
                         let _ = cmdline.push_str(&buffer);
                     }
                     return EditResult::Confirmed;
                 }
-                KeyPress::Escape => {
-                    // Cancel - don't modify
-                    return EditResult::Cancelled;
-                }
+                KeyPress::Escape => return EditResult::Cancelled,
                 KeyPress::Char(c) => {
-                    // Handle special characters
                     match c {
                         '\x18' => {
                             // Ctrl+X - boot immediately
@@ -1371,7 +1376,6 @@ fn edit_cmdline(entry: &mut BootEntry, fb_console: &mut Option<FramebufferConsol
                         '\x08' | '\x7f' => {
                             // Backspace
                             if cursor_pos > 0 {
-                                // Remove character before cursor
                                 let mut new_buffer: String<512> = String::new();
                                 for (i, ch) in buffer.chars().enumerate() {
                                     if i != cursor_pos - 1 {
@@ -1380,25 +1384,12 @@ fn edit_cmdline(entry: &mut BootEntry, fb_console: &mut Option<FramebufferConsol
                                 }
                                 buffer = new_buffer;
                                 cursor_pos -= 1;
-                                needs_redraw = true;
                             }
                         }
-                        '\x01' => {
-                            // Ctrl+A - move to beginning
-                            if cursor_pos != 0 {
-                                cursor_pos = 0;
-                                needs_redraw = true;
-                            }
-                        }
-                        '\x05' => {
-                            // Ctrl+E - move to end
-                            if cursor_pos != buffer.len() {
-                                cursor_pos = buffer.len();
-                                needs_redraw = true;
-                            }
-                        }
+                        '\x01' => cursor_pos = 0,       // Ctrl+A
+                        '\x05' => cursor_pos = buffer.len(), // Ctrl+E
                         '\x0b' => {
-                            // Ctrl+K - delete to end of line
+                            // Ctrl+K - delete to end
                             if cursor_pos < buffer.len() {
                                 let mut new_buffer: String<512> = String::new();
                                 for (i, ch) in buffer.chars().enumerate() {
@@ -1407,11 +1398,10 @@ fn edit_cmdline(entry: &mut BootEntry, fb_console: &mut Option<FramebufferConsol
                                     }
                                 }
                                 buffer = new_buffer;
-                                needs_redraw = true;
                             }
                         }
                         '\x15' => {
-                            // Ctrl+U - delete to beginning of line
+                            // Ctrl+U - delete to start
                             if cursor_pos > 0 {
                                 let mut new_buffer: String<512> = String::new();
                                 for (i, ch) in buffer.chars().enumerate() {
@@ -1421,11 +1411,9 @@ fn edit_cmdline(entry: &mut BootEntry, fb_console: &mut Option<FramebufferConsol
                                 }
                                 buffer = new_buffer;
                                 cursor_pos = 0;
-                                needs_redraw = true;
                             }
                         }
                         _ if c.is_ascii_graphic() || c == ' ' => {
-                            // Regular printable character - insert at cursor (ASCII only)
                             if buffer.len() < 511 {
                                 let mut new_buffer: String<512> = String::new();
                                 for (i, ch) in buffer.chars().enumerate() {
@@ -1439,257 +1427,24 @@ fn edit_cmdline(entry: &mut BootEntry, fb_console: &mut Option<FramebufferConsol
                                 }
                                 buffer = new_buffer;
                                 cursor_pos += 1;
-                                needs_redraw = true;
                             }
                         }
-                        _ => {}
+                        _ => continue,
                     }
+                    render(terminal, &buffer, cursor_pos);
                 }
-                KeyPress::Left => {
-                    // Move cursor left
-                    if cursor_pos > 0 {
-                        cursor_pos -= 1;
-                        needs_redraw = true;
-                    }
+                KeyPress::Left if cursor_pos > 0 => {
+                    cursor_pos -= 1;
+                    render(terminal, &buffer, cursor_pos);
                 }
-                KeyPress::Right => {
-                    // Move cursor right
-                    if cursor_pos < buffer.len() {
-                        cursor_pos += 1;
-                        needs_redraw = true;
-                    }
+                KeyPress::Right if cursor_pos < buffer.len() => {
+                    cursor_pos += 1;
+                    render(terminal, &buffer, cursor_pos);
                 }
-                // Ignore Up/Down in editor
-                KeyPress::Up | KeyPress::Down => {}
+                _ => {}
             }
         }
-
         delay_ms(10);
-    }
-}
-
-/// Draw the static parts of the command line editor UI (header, title, help)
-/// This is called once when entering the editor.
-fn draw_cmdline_editor_static(
-    entry_name: &str,
-    fb_console: &mut Option<FramebufferConsole>,
-    cols: usize,
-) {
-    let title = "Edit Kernel Command Line";
-
-    // Serial output - clear and draw static content
-    serial_driver::write_str("\x1b[2J\x1b[H"); // Clear and home
-    serial_driver::write_str("\x1b[1;33m"); // Yellow, bold
-
-    // Draw header
-    let header_line = [b'='; 128];
-    let header_len = cols.min(128);
-    serial_driver::write_str(core::str::from_utf8(&header_line[..header_len]).unwrap_or(""));
-    serial_driver::write_str("\r\n");
-
-    // Title
-    let title_pad = (cols.saturating_sub(title.len())) / 2;
-    for _ in 0..title_pad {
-        serial_driver::write_str(" ");
-    }
-    serial_driver::write_str(title);
-    serial_driver::write_str("\r\n");
-
-    serial_driver::write_str(core::str::from_utf8(&header_line[..header_len]).unwrap_or(""));
-    serial_driver::write_str("\r\n\x1b[0m");
-
-    // Entry name
-    serial_driver::write_str("\x1b[36m"); // Cyan
-    serial_driver::write_str("Entry: ");
-    serial_driver::write_str(entry_name);
-    serial_driver::write_str("\x1b[0m\r\n\r\n");
-
-    // Command line label
-    serial_driver::write_str("Command line:\r\n");
-
-    // Leave space for edit line (row 7)
-    serial_driver::write_str("\r\n\r\n");
-
-    // Help text (row 9-10)
-    serial_driver::write_str("\x1b[36m"); // Cyan
-    serial_driver::write_str(
-        "Enter: Confirm | Esc: Cancel | Ctrl+X: Boot | Left/Right: Move cursor\r\n",
-    );
-    serial_driver::write_str(
-        "Ctrl+A: Start | Ctrl+E: End | Ctrl+K: Delete to end | Ctrl+U: Delete to start",
-    );
-    serial_driver::write_str("\x1b[0m\r\n");
-
-    // Framebuffer output
-    if let Some(console) = fb_console {
-        console.clear();
-
-        // Header
-        console.set_fg_color(TITLE_COLOR);
-        let mut header: String<128> = String::new();
-        for _ in 0..cols {
-            let _ = header.push('=');
-        }
-        console.set_position(0, 0);
-        let _ = console.write_str(&header);
-        console.write_centered(1, title);
-        console.set_position(0, 2);
-        let _ = console.write_str(&header);
-        console.reset_colors();
-
-        // Entry name
-        console.set_position(0, 4);
-        console.set_fg_color(Color::new(0, 192, 192)); // Cyan
-        let _ = console.write_str("Entry: ");
-        console.reset_colors();
-        let _ = console.write_str(entry_name);
-
-        // Command line label
-        console.set_position(0, 6);
-        let _ = console.write_str("Command line:");
-
-        // Help text
-        console.set_position(0, 9);
-        console.set_fg_color(Color::new(0, 192, 192));
-        let _ = console
-            .write_str("Enter: Confirm | Esc: Cancel | Ctrl+X: Boot | Left/Right: Move cursor");
-        console.set_position(0, 10);
-        let _ = console.write_str(
-            "Ctrl+A: Start | Ctrl+E: End | Ctrl+K: Delete to end | Ctrl+U: Delete to start",
-        );
-        console.reset_colors();
-    }
-}
-
-/// Draw just the edit line and length indicator (called on each change)
-fn draw_cmdline_editor_line(
-    buffer: &str,
-    cursor_pos: usize,
-    edit_width: usize,
-    fb_console: &mut Option<FramebufferConsole>,
-) {
-    // Calculate visible portion of the buffer (scroll if needed)
-    let buffer_len = buffer.len();
-    let (visible_start, visible_end, display_cursor) = if buffer_len <= edit_width {
-        (0, buffer_len, cursor_pos)
-    } else if cursor_pos < edit_width / 2 {
-        // Cursor near start - show from beginning
-        (0, edit_width, cursor_pos)
-    } else if cursor_pos > buffer_len.saturating_sub(edit_width / 2) {
-        // Cursor near end - show end portion
-        let start = buffer_len.saturating_sub(edit_width);
-        (start, buffer_len, cursor_pos - start)
-    } else {
-        // Cursor in middle - center the view
-        let start = cursor_pos - edit_width / 2;
-        let end = start + edit_width;
-        (start, end.min(buffer_len), edit_width / 2)
-    };
-
-    let visible_text = &buffer[visible_start..visible_end];
-
-    // Serial output - position cursor at edit line (row 7)
-    serial_driver::write_str("\x1b[7;1H"); // Row 7, column 1
-    serial_driver::write_str("\x1b[K"); // Clear line
-    serial_driver::write_str("\x1b[44m"); // Blue background
-
-    // Show scroll indicators
-    if visible_start > 0 {
-        serial_driver::write_str("<");
-    } else {
-        serial_driver::write_str(" ");
-    }
-
-    // Draw text before cursor
-    if display_cursor > 0 {
-        serial_driver::write_str(&visible_text[..display_cursor]);
-    }
-
-    // Draw cursor position with inverse video
-    serial_driver::write_str("\x1b[7m"); // Inverse
-    if display_cursor < visible_text.len() {
-        let cursor_char = &visible_text[display_cursor..display_cursor + 1];
-        serial_driver::write_str(cursor_char);
-    } else {
-        serial_driver::write_str(" ");
-    }
-    serial_driver::write_str("\x1b[27m"); // Normal (but still blue bg)
-
-    // Draw text after cursor
-    if display_cursor < visible_text.len() {
-        serial_driver::write_str(&visible_text[display_cursor + 1..]);
-    }
-
-    // Pad to width and show scroll indicator
-    let displayed_len = visible_text.len() + 2; // +2 for scroll indicators
-    for _ in displayed_len..edit_width {
-        serial_driver::write_str(" ");
-    }
-
-    if visible_end < buffer_len {
-        serial_driver::write_str(">");
-    } else {
-        serial_driver::write_str(" ");
-    }
-
-    serial_driver::write_str("\x1b[0m"); // Reset colors
-
-    // Length indicator (row 12)
-    serial_driver::write_str("\x1b[12;1H"); // Row 12
-    serial_driver::write_str("\x1b[K"); // Clear line
-    let _ = write!(SerialWriter, "\x1b[33mLength: {}/512\x1b[0m", buffer_len);
-
-    // Framebuffer output - only update edit line and length
-    if let Some(console) = fb_console {
-        // Edit area with blue background (row 7)
-        console.set_position(0, 7);
-        console.set_colors(DEFAULT_FG, Color::new(0, 0, 128)); // Blue bg
-
-        // Scroll indicator left
-        if visible_start > 0 {
-            let _ = console.write_str("<");
-        } else {
-            let _ = console.write_str(" ");
-        }
-
-        // Text before cursor
-        if display_cursor > 0 {
-            let _ = console.write_str(&visible_text[..display_cursor]);
-        }
-
-        // Cursor with highlight
-        console.set_colors(HIGHLIGHT_FG, HIGHLIGHT_BG);
-        if display_cursor < visible_text.len() {
-            let _ = console.write_str(&visible_text[display_cursor..display_cursor + 1]);
-        } else {
-            let _ = console.write_str(" ");
-        }
-        console.set_colors(DEFAULT_FG, Color::new(0, 0, 128));
-
-        // Text after cursor
-        if display_cursor < visible_text.len() {
-            let _ = console.write_str(&visible_text[display_cursor + 1..]);
-        }
-
-        // Pad and right scroll indicator
-        let displayed_len = visible_text.len() + 2;
-        for _ in displayed_len..edit_width {
-            let _ = console.write_str(" ");
-        }
-        if visible_end < buffer_len {
-            let _ = console.write_str(">");
-        } else {
-            let _ = console.write_str(" ");
-        }
-        console.reset_colors();
-
-        // Length indicator (row 12)
-        console.set_position(0, 12);
-        console.set_fg_color(Color::new(255, 255, 0)); // Yellow
-        let mut len_str: String<32> = String::new();
-        let _ = write!(len_str, "Length: {}/512    ", buffer_len); // Extra spaces to clear old longer values
-        let _ = console.write_str(&len_str);
-        console.reset_colors();
     }
 }
 

--- a/src/menu_common.rs
+++ b/src/menu_common.rs
@@ -1,13 +1,11 @@
 //! Shared utilities for menu modules
 //!
-//! Contains keyboard input handling, screen control, and serial output helpers
-//! shared by both the boot menu and the Secure Boot settings menu.
+//! Contains keyboard input handling shared by the boot menu, Secure Boot
+//! settings menu, and CFR firmware settings menu.
 
 use crate::drivers::keyboard;
 use crate::drivers::serial as serial_driver;
-use crate::framebuffer_console::{FramebufferConsole, TITLE_COLOR};
 use crate::time::delay_ms;
-use core::fmt::Write;
 
 /// Key press types for menu navigation
 #[derive(Debug, Clone, Copy)]
@@ -75,60 +73,4 @@ pub fn read_key() -> Option<KeyPress> {
     }
 
     None
-}
-
-/// Clear both serial and framebuffer screens
-pub fn clear_screen(fb_console: &mut Option<FramebufferConsole>) {
-    serial_driver::write_str("\x1b[2J\x1b[H");
-    if let Some(console) = fb_console {
-        console.clear();
-    }
-}
-
-/// Draw a menu header with a title on both serial and framebuffer
-pub fn draw_header(title: &str, fb_console: &mut Option<FramebufferConsole>, cols: usize) {
-    // Build horizontal line
-    let mut line = [0u8; 128];
-    let line_len = cols.min(line.len());
-    line[..line_len].fill(b'=');
-    let line_str = core::str::from_utf8(&line[..line_len]).unwrap_or("");
-
-    // Serial output
-    serial_driver::write_str("\x1b[H"); // Home cursor
-    serial_driver::write_str("\x1b[1;33m"); // Yellow, bold
-    serial_driver::write_str(line_str);
-    serial_driver::write_str("\r\n");
-
-    // Center title
-    let title_pad = (cols.saturating_sub(title.len())) / 2;
-    for _ in 0..title_pad {
-        serial_driver::write_str(" ");
-    }
-    serial_driver::write_str(title);
-    serial_driver::write_str("\r\n");
-
-    serial_driver::write_str(line_str);
-    serial_driver::write_str("\r\n\x1b[0m"); // Reset attributes
-
-    // Framebuffer output
-    if let Some(console) = fb_console {
-        console.set_position(0, 0);
-        console.set_fg_color(TITLE_COLOR);
-        let _ = console.write_str(line_str);
-        console.set_position(0, 1);
-        console.write_centered(1, title);
-        console.set_position(0, 2);
-        let _ = console.write_str(line_str);
-        console.reset_colors();
-    }
-}
-
-/// Helper for serial formatted output
-pub struct SerialWriter;
-
-impl core::fmt::Write for SerialWriter {
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        serial_driver::write_str(s);
-        Ok(())
-    }
 }

--- a/src/secure_boot_menu.rs
+++ b/src/secure_boot_menu.rs
@@ -4,18 +4,24 @@
 //! including viewing status, enabling/disabling Secure Boot, and managing keys.
 
 use crate::coreboot;
-use crate::drivers::serial as serial_driver;
 use crate::efi::auth::{self, boot as secure_boot};
-use crate::framebuffer_console::{
-    Color, DEFAULT_BG, DEFAULT_FG, FramebufferConsole, HIGHLIGHT_BG, HIGHLIGHT_FG,
-};
-use crate::menu_common::{self, KeyPress, SerialWriter};
+use crate::menu_common::{self, KeyPress};
 use crate::time::delay_ms;
-use core::fmt::Write;
-use heapless::String;
+
+use alloc::format;
+use alloc::string::String;
+use alloc::vec;
+use ratatui::layout::{Alignment, Constraint, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, HighlightSpacing, List, ListItem, ListState, Paragraph};
+use ratatui::Terminal;
 
 /// Menu title
 const MENU_TITLE: &str = "Secure Boot Settings";
+
+/// Help text
+const HELP_TEXT: &str = "Up/Down: Navigate | Enter: Select | Esc/Q: Back";
 
 /// Menu options
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -85,12 +91,20 @@ const MENU_OPTIONS: [MenuOption; 6] = [
 ///
 /// This displays Secure Boot status and allows the user to manage settings.
 pub fn show_secure_boot_menu() {
-    // Get framebuffer for rendering
     let fb_info = coreboot::get_framebuffer();
-    let mut fb_console = fb_info.as_ref().map(FramebufferConsole::new);
+    let backend = crate::tui::DualBackend::new(fb_info.as_ref());
+    let mut terminal = match Terminal::new(backend) {
+        Ok(t) => t,
+        Err(_) => {
+            log::error!("Failed to create ratatui terminal");
+            return;
+        }
+    };
+    let _ = terminal.clear();
+    let _ = terminal.hide_cursor();
 
     let mut selected = 0usize;
-    let mut status_message: Option<(&str, bool)> = None; // (message, is_success)
+    let mut status_message: Option<(String, bool)> = None; // (message, is_success)
 
     loop {
         // Get current state
@@ -98,10 +112,9 @@ pub fn show_secure_boot_menu() {
         let secure_boot_enabled = auth::is_secure_boot_enabled();
         let (pk_count, kek_count, db_count, dbx_count) = secure_boot::get_enrollment_summary();
 
-        // Clear and draw
-        clear_screen(&mut fb_console);
-        draw_menu(
-            &mut fb_console,
+        // Render
+        render_menu(
+            &mut terminal,
             selected,
             setup_mode,
             secure_boot_enabled,
@@ -109,7 +122,7 @@ pub fn show_secure_boot_menu() {
             kek_count,
             db_count,
             dbx_count,
-            status_message,
+            &status_message,
         );
 
         // Clear status message after displaying
@@ -137,7 +150,8 @@ pub fn show_secure_boot_menu() {
                         }
 
                         if !option.is_enabled(secure_boot_enabled, setup_mode) {
-                            status_message = Some(("Option not available in current mode", false));
+                            status_message =
+                                Some(("Option not available in current mode".into(), false));
                             break;
                         }
 
@@ -146,20 +160,17 @@ pub fn show_secure_boot_menu() {
                             MenuOption::ToggleSecureBoot => {
                                 if secure_boot_enabled {
                                     auth::disable_secure_boot();
-                                    status_message = Some(("Secure Boot disabled", true));
+                                    status_message = Some(("Secure Boot disabled".into(), true));
                                 } else {
                                     auth::enable_secure_boot();
-                                    status_message = Some(("Secure Boot enabled", true));
+                                    status_message = Some(("Secure Boot enabled".into(), true));
                                 }
-                                // Update status variables
                                 let _ = secure_boot::update_status_variables();
                             }
                             MenuOption::EnrollDefaultKeys => {
-                                status_message = Some(("Enrolling keys...", true));
-                                // Redraw to show "enrolling" message
-                                clear_screen(&mut fb_console);
-                                draw_menu(
-                                    &mut fb_console,
+                                status_message = Some(("Enrolling keys...".into(), true));
+                                render_menu(
+                                    &mut terminal,
                                     selected,
                                     setup_mode,
                                     secure_boot_enabled,
@@ -167,25 +178,25 @@ pub fn show_secure_boot_menu() {
                                     kek_count,
                                     db_count,
                                     dbx_count,
-                                    status_message,
+                                    &status_message,
                                 );
 
                                 match enroll_default_keys() {
                                     Ok(()) => {
-                                        status_message =
-                                            Some(("Default keys enrolled successfully!", true));
+                                        status_message = Some((
+                                            "Default keys enrolled successfully!".into(),
+                                            true,
+                                        ));
                                     }
                                     Err(msg) => {
-                                        status_message = Some((msg, false));
+                                        status_message = Some((msg.into(), false));
                                     }
                                 }
                             }
                             MenuOption::EnrollCustomPK => {
-                                status_message = Some(("Searching for PK on ESP...", true));
-                                // Redraw to show "searching" message
-                                clear_screen(&mut fb_console);
-                                draw_menu(
-                                    &mut fb_console,
+                                status_message = Some(("Searching for PK on ESP...".into(), true));
+                                render_menu(
+                                    &mut terminal,
                                     selected,
                                     setup_mode,
                                     secure_boot_enabled,
@@ -193,24 +204,22 @@ pub fn show_secure_boot_menu() {
                                     kek_count,
                                     db_count,
                                     dbx_count,
-                                    status_message,
+                                    &status_message,
                                 );
 
                                 match enroll_custom_pk() {
                                     Ok(source) => {
-                                        status_message = Some((source, true));
+                                        status_message = Some((source.into(), true));
                                     }
                                     Err(msg) => {
-                                        status_message = Some((msg, false));
+                                        status_message = Some((msg.into(), false));
                                     }
                                 }
                             }
                             MenuOption::ImportDbxUpdate => {
-                                status_message = Some(("Searching for dbx on ESP...", true));
-                                // Redraw to show "searching" message
-                                clear_screen(&mut fb_console);
-                                draw_menu(
-                                    &mut fb_console,
+                                status_message = Some(("Searching for dbx on ESP...".into(), true));
+                                render_menu(
+                                    &mut terminal,
                                     selected,
                                     setup_mode,
                                     secure_boot_enabled,
@@ -218,31 +227,32 @@ pub fn show_secure_boot_menu() {
                                     kek_count,
                                     db_count,
                                     dbx_count,
-                                    status_message,
+                                    &status_message,
                                 );
 
                                 match import_dbx_update() {
                                     Ok(msg) => {
-                                        status_message = Some((msg, true));
+                                        status_message = Some((msg.into(), true));
                                     }
                                     Err(msg) => {
-                                        status_message = Some((msg, false));
+                                        status_message = Some((msg.into(), false));
                                     }
                                 }
                             }
                             MenuOption::ClearAllKeys => {
-                                // Confirm before clearing
-                                if confirm_action(&mut fb_console, "Clear ALL Secure Boot keys?") {
+                                if confirm_action(&mut terminal, "Clear ALL Secure Boot keys?") {
                                     match secure_boot::clear_all_keys() {
                                         Ok(()) => {
-                                            status_message = Some(("All keys cleared", true));
+                                            status_message =
+                                                Some(("All keys cleared".into(), true));
                                         }
                                         Err(_) => {
-                                            status_message = Some(("Failed to clear keys", false));
+                                            status_message =
+                                                Some(("Failed to clear keys".into(), false));
                                         }
                                     }
                                 } else {
-                                    status_message = Some(("Cancelled", true));
+                                    status_message = Some(("Cancelled".into(), true));
                                 }
                             }
                             MenuOption::ReturnToBootMenu => unreachable!(),
@@ -260,22 +270,203 @@ pub fn show_secure_boot_menu() {
     }
 }
 
+/// Render the complete menu with ratatui
+fn render_menu(
+    terminal: &mut Terminal<crate::tui::DualBackend>,
+    selected: usize,
+    setup_mode: bool,
+    secure_boot_enabled: bool,
+    pk_count: usize,
+    kek_count: usize,
+    db_count: usize,
+    dbx_count: usize,
+    status_message: &Option<(String, bool)>,
+) {
+    let _ = terminal.draw(|frame| {
+        let area = frame.area();
+
+        let chunks = Layout::vertical([
+            Constraint::Length(3), // header
+            Constraint::Length(7), // status section
+            Constraint::Min(8),    // options list
+            Constraint::Length(3), // status msg + help
+        ])
+        .split(area);
+
+        // --- Header ---
+        let header = Paragraph::new(Line::from(MENU_TITLE).alignment(Alignment::Center))
+            .style(Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD))
+            .block(
+                Block::new()
+                    .borders(Borders::TOP | Borders::BOTTOM)
+                    .border_style(Style::new().fg(Color::Yellow)),
+            );
+        frame.render_widget(header, chunks[0]);
+
+        // --- Status section ---
+        let mode_str = if setup_mode {
+            "Setup Mode"
+        } else {
+            "User Mode"
+        };
+        let mode_color = if setup_mode {
+            Color::Yellow
+        } else {
+            Color::Green
+        };
+        let sb_str = if secure_boot_enabled {
+            "ENABLED"
+        } else {
+            "Disabled"
+        };
+        let sb_color = if secure_boot_enabled {
+            Color::Green
+        } else {
+            Color::LightRed
+        };
+
+        let status_lines = vec![
+            Line::from(Span::styled(
+                "  Current Status:",
+                Style::new().add_modifier(Modifier::BOLD),
+            )),
+            Line::raw(""),
+            Line::from(vec![
+                Span::raw("    Mode:        "),
+                Span::styled(mode_str, Style::new().fg(mode_color)),
+            ]),
+            Line::from(vec![
+                Span::raw("    Secure Boot: "),
+                Span::styled(sb_str, Style::new().fg(sb_color)),
+            ]),
+            Line::raw(""),
+            Line::from(Span::raw(format!(
+                "    Enrolled Keys: PK={}, KEK={}, db={}, dbx={}",
+                pk_count, kek_count, db_count, dbx_count
+            ))),
+        ];
+        frame.render_widget(Paragraph::new(status_lines), chunks[1]);
+
+        // --- Options list ---
+        let header_items: [ListItem; 2] = [
+            ListItem::new(Line::from(Span::styled(
+                "  Actions:",
+                Style::new().add_modifier(Modifier::BOLD),
+            ))),
+            ListItem::new(Line::raw("")),
+        ];
+
+        let option_items = MENU_OPTIONS.iter().map(|option| {
+            let is_enabled = option.is_enabled(secure_boot_enabled, setup_mode);
+            let label = option.label(secure_boot_enabled, setup_mode);
+
+            let style = if !is_enabled {
+                Style::new().fg(Color::DarkGray)
+            } else {
+                Style::new().fg(Color::Gray)
+            };
+
+            ListItem::new(Line::raw(format!("  {}", label))).style(style)
+        });
+
+        let items: alloc::vec::Vec<ListItem> =
+            header_items.into_iter().chain(option_items).collect();
+
+        let list = List::new(items)
+            .highlight_style(
+                Style::new()
+                    .fg(Color::Black)
+                    .bg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol(" > ")
+            .highlight_spacing(HighlightSpacing::Always);
+
+        // Offset by 2 to skip the "Actions:" header and blank line
+        let mut list_state = ListState::default().with_selected(Some(selected + 2));
+        frame.render_stateful_widget(list, chunks[2], &mut list_state);
+
+        // --- Footer: status message + help ---
+        let footer_chunks = Layout::vertical([
+            Constraint::Length(1), // status or blank
+            Constraint::Length(1), // blank
+            Constraint::Length(1), // help
+        ])
+        .split(chunks[3]);
+
+        if let Some((msg, is_success)) = status_message {
+            let color = if *is_success {
+                Color::Green
+            } else {
+                Color::Red
+            };
+            let line = Line::from(Span::styled(msg.as_str(), Style::new().fg(color)))
+                .alignment(Alignment::Center);
+            frame.render_widget(Paragraph::new(line), footer_chunks[0]);
+        }
+
+        let help = Paragraph::new(
+            Line::from(HELP_TEXT)
+                .style(Style::new().fg(Color::Cyan))
+                .alignment(Alignment::Center),
+        );
+        frame.render_widget(help, footer_chunks[2]);
+    });
+}
+
+/// Show a confirmation dialog
+fn confirm_action(terminal: &mut Terminal<crate::tui::DualBackend>, message: &str) -> bool {
+    let msg = String::from(message);
+    let _ = terminal.draw(|frame| {
+        let area = frame.area();
+        let chunks = Layout::vertical([
+            Constraint::Percentage(40),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(0),
+        ])
+        .split(area);
+
+        let prompt = Paragraph::new(
+            Line::from(Span::styled(
+                msg.as_str(),
+                Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            ))
+            .alignment(Alignment::Center),
+        );
+        frame.render_widget(prompt, chunks[1]);
+
+        let help = Paragraph::new(
+            Line::from("Press Y to confirm, N to cancel")
+                .alignment(Alignment::Center)
+                .style(Style::new().fg(Color::Gray)),
+        );
+        frame.render_widget(help, chunks[3]);
+    });
+
+    loop {
+        if let Some(key) = read_key() {
+            match key {
+                KeyPress::Char('y') | KeyPress::Char('Y') => return true,
+                KeyPress::Char('n') | KeyPress::Char('N') | KeyPress::Escape => return false,
+                _ => {}
+            }
+        }
+        delay_ms(10);
+    }
+}
+
+// --- Business logic (unchanged) ---
+
 /// Enroll default keys
 fn enroll_default_keys() -> Result<(), &'static str> {
     use crate::efi::auth::enrollment;
 
-    // Enroll in memory
     enrollment::enroll_default_keys().map_err(|_| "Failed to enroll keys")?;
-
-    // Enter user mode
     auth::enter_user_mode();
-
-    // Persist to storage
     secure_boot::persist_key_databases().map_err(|_| "Failed to persist keys")?;
-
-    // Update status variables
     secure_boot::update_status_variables().map_err(|_| "Failed to update status")?;
-
     Ok(())
 }
 
@@ -284,15 +475,12 @@ fn enroll_custom_pk() -> Result<&'static str, &'static str> {
     use crate::efi::auth::key_files;
 
     match key_files::enroll_pk_from_file() {
-        Ok(source) => {
-            // Return a success message with the source
-            match source {
-                "NVMe" => Ok("Custom PK enrolled from NVMe ESP!"),
-                "SATA" => Ok("Custom PK enrolled from SATA ESP!"),
-                "SD" => Ok("Custom PK enrolled from SD card ESP!"),
-                _ => Ok("Custom PK enrolled successfully!"),
-            }
-        }
+        Ok(source) => match source {
+            "NVMe" => Ok("Custom PK enrolled from NVMe ESP!"),
+            "SATA" => Ok("Custom PK enrolled from SATA ESP!"),
+            "SD" => Ok("Custom PK enrolled from SD card ESP!"),
+            _ => Ok("Custom PK enrolled successfully!"),
+        },
         Err(auth::AuthError::NoSuitableKey) => {
             Err("No PK file found (place PK.cer in EFI\\keys\\)")
         }
@@ -307,7 +495,6 @@ fn import_dbx_update() -> Result<&'static str, &'static str> {
 
     match dbx_update::enroll_dbx_from_file() {
         Ok(result) => {
-            // Log the details
             log::info!(
                 "dbx update imported: {} SHA-256 hashes, {} certificates from {}",
                 result.sha256_count,
@@ -315,7 +502,6 @@ fn import_dbx_update() -> Result<&'static str, &'static str> {
                 result.source
             );
 
-            // Return a success message with the source
             match result.source {
                 "NVMe" => Ok("dbx update imported from NVMe ESP!"),
                 "SATA" => Ok("dbx update imported from SATA ESP!"),
@@ -329,307 +515,6 @@ fn import_dbx_update() -> Result<&'static str, &'static str> {
         Err(auth::AuthError::InvalidHeader) => Err("Invalid dbx file format"),
         Err(_) => Err("Failed to import dbx update"),
     }
-}
-
-/// Show a confirmation dialog
-fn confirm_action(fb_console: &mut Option<FramebufferConsole>, message: &str) -> bool {
-    // Draw confirmation
-    let rows = fb_console.as_ref().map(|c| c.rows()).unwrap_or(25);
-    let confirm_row = rows / 2;
-
-    // Serial
-    serial_driver::write_str("\x1b[2J\x1b[H"); // Clear
-    serial_driver::write_str("\r\n\r\n");
-    serial_driver::write_str("\x1b[1;33m"); // Yellow bold
-    serial_driver::write_str("  ");
-    serial_driver::write_str(message);
-    serial_driver::write_str("\x1b[0m\r\n\r\n");
-    serial_driver::write_str("  Press Y to confirm, N to cancel\r\n");
-
-    // Framebuffer
-    if let Some(console) = fb_console {
-        console.clear();
-        console.set_fg_color(Color::new(255, 255, 0)); // Yellow
-        console.write_centered(confirm_row, message);
-        console.reset_colors();
-        console.write_centered(confirm_row + 2, "Press Y to confirm, N to cancel");
-    }
-
-    // Wait for response
-    loop {
-        if let Some(key) = read_key() {
-            match key {
-                KeyPress::Char('y') | KeyPress::Char('Y') => return true,
-                KeyPress::Char('n') | KeyPress::Char('N') | KeyPress::Escape => return false,
-                _ => {}
-            }
-        }
-        delay_ms(10);
-    }
-}
-
-/// Draw the complete menu
-fn draw_menu(
-    fb_console: &mut Option<FramebufferConsole>,
-    selected: usize,
-    setup_mode: bool,
-    secure_boot_enabled: bool,
-    pk_count: usize,
-    kek_count: usize,
-    db_count: usize,
-    dbx_count: usize,
-    status_message: Option<(&str, bool)>,
-) {
-    let cols = fb_console.as_ref().map(|c| c.cols()).unwrap_or(80) as usize;
-
-    // Draw header
-    draw_header(fb_console, cols);
-
-    // Draw status section
-    let status_start_row = 4;
-    draw_status(
-        fb_console,
-        status_start_row,
-        setup_mode,
-        secure_boot_enabled,
-        pk_count,
-        kek_count,
-        db_count,
-        dbx_count,
-    );
-
-    // Draw menu options
-    let options_start_row = status_start_row + 8;
-    draw_options(
-        fb_console,
-        options_start_row,
-        selected,
-        setup_mode,
-        secure_boot_enabled,
-    );
-
-    // Draw help text
-    let help_row = options_start_row + MENU_OPTIONS.len() + 2;
-    draw_help(fb_console, help_row, cols);
-
-    // Draw status message if any
-    if let Some((msg, is_success)) = status_message {
-        draw_status_message(fb_console, help_row + 2, msg, is_success);
-    }
-}
-
-fn draw_header(fb_console: &mut Option<FramebufferConsole>, cols: usize) {
-    menu_common::draw_header(MENU_TITLE, fb_console, cols);
-}
-
-/// Draw the status section
-fn draw_status(
-    fb_console: &mut Option<FramebufferConsole>,
-    start_row: usize,
-    setup_mode: bool,
-    secure_boot_enabled: bool,
-    pk_count: usize,
-    kek_count: usize,
-    db_count: usize,
-    dbx_count: usize,
-) {
-    let mode_str = if setup_mode {
-        "Setup Mode"
-    } else {
-        "User Mode"
-    };
-    let sb_str = if secure_boot_enabled {
-        "ENABLED"
-    } else {
-        "Disabled"
-    };
-
-    // Mode color: yellow for setup, green for user
-    let mode_color = if setup_mode {
-        Color::new(255, 255, 0)
-    } else {
-        Color::new(0, 255, 0)
-    };
-
-    // Secure boot color: green if enabled, red if disabled
-    let sb_color = if secure_boot_enabled {
-        Color::new(0, 255, 0)
-    } else {
-        Color::new(255, 100, 100)
-    };
-
-    // Serial output
-    let _ = write!(SerialWriter, "\x1b[{};1H", start_row + 1);
-    serial_driver::write_str("\x1b[1m  Current Status:\x1b[0m\r\n\r\n");
-
-    serial_driver::write_str("    Mode:        ");
-    if setup_mode {
-        serial_driver::write_str("\x1b[33m"); // Yellow
-    } else {
-        serial_driver::write_str("\x1b[32m"); // Green
-    }
-    serial_driver::write_str(mode_str);
-    serial_driver::write_str("\x1b[0m\r\n");
-
-    serial_driver::write_str("    Secure Boot: ");
-    if secure_boot_enabled {
-        serial_driver::write_str("\x1b[32m"); // Green
-    } else {
-        serial_driver::write_str("\x1b[31m"); // Red
-    }
-    serial_driver::write_str(sb_str);
-    serial_driver::write_str("\x1b[0m\r\n\r\n");
-
-    let _ = write!(
-        SerialWriter,
-        "    Enrolled Keys: PK={}, KEK={}, db={}, dbx={}\r\n",
-        pk_count, kek_count, db_count, dbx_count
-    );
-
-    // Framebuffer output
-    if let Some(console) = fb_console {
-        console.set_position(2, start_row as u32);
-        console.set_fg_color(Color::white());
-        let _ = console.write_str("Current Status:");
-
-        console.set_position(4, (start_row + 2) as u32);
-        console.reset_colors();
-        let _ = console.write_str("Mode:        ");
-        console.set_fg_color(mode_color);
-        let _ = console.write_str(mode_str);
-
-        console.set_position(4, (start_row + 3) as u32);
-        console.reset_colors();
-        let _ = console.write_str("Secure Boot: ");
-        console.set_fg_color(sb_color);
-        let _ = console.write_str(sb_str);
-
-        console.set_position(4, (start_row + 5) as u32);
-        console.reset_colors();
-        let mut key_info: String<64> = String::new();
-        let _ = write!(
-            key_info,
-            "Enrolled Keys: PK={}, KEK={}, db={}, dbx={}",
-            pk_count, kek_count, db_count, dbx_count
-        );
-        let _ = console.write_str(&key_info);
-    }
-}
-
-/// Draw menu options
-fn draw_options(
-    fb_console: &mut Option<FramebufferConsole>,
-    start_row: usize,
-    selected: usize,
-    setup_mode: bool,
-    secure_boot_enabled: bool,
-) {
-    // Serial: position cursor
-    let _ = write!(SerialWriter, "\x1b[{};1H", start_row + 1);
-    serial_driver::write_str("\x1b[1m  Actions:\x1b[0m\r\n\r\n");
-
-    for (i, option) in MENU_OPTIONS.iter().enumerate() {
-        let is_selected = i == selected;
-        let is_enabled = option.is_enabled(secure_boot_enabled, setup_mode);
-        let label = option.label(secure_boot_enabled, setup_mode);
-
-        // Serial output
-        if is_selected {
-            serial_driver::write_str("\x1b[7m"); // Inverse
-        }
-        if !is_enabled {
-            serial_driver::write_str("\x1b[90m"); // Gray
-        }
-
-        let marker = if is_selected { " > " } else { "   " };
-        let _ = write!(SerialWriter, "  {} {}", marker, label);
-
-        serial_driver::write_str("\x1b[0m"); // Reset
-        serial_driver::write_str("\x1b[K\r\n"); // Clear to EOL
-
-        // Framebuffer output
-        if let Some(console) = fb_console {
-            let row = (start_row + 2 + i) as u32;
-            console.set_position(2, row);
-
-            if is_selected {
-                console.set_colors(HIGHLIGHT_FG, HIGHLIGHT_BG);
-            } else if !is_enabled {
-                console.set_fg_color(Color::new(128, 128, 128)); // Gray
-            } else {
-                console.set_colors(DEFAULT_FG, DEFAULT_BG);
-            }
-
-            let _ = write!(console, " {} {} ", marker, label);
-
-            // Fill rest of line
-            let (col, _) = console.position();
-            let cols = console.cols();
-            for _ in col..cols.saturating_sub(2) {
-                let _ = console.write_str(" ");
-            }
-
-            console.reset_colors();
-        }
-    }
-}
-
-/// Draw help text
-fn draw_help(fb_console: &mut Option<FramebufferConsole>, row: usize, cols: usize) {
-    let help_text = "Up/Down: Navigate | Enter: Select | Esc/Q: Back";
-
-    // Serial
-    let _ = write!(SerialWriter, "\x1b[{};1H", row + 1);
-    serial_driver::write_str("\x1b[36m"); // Cyan
-    let help_pad = (cols.saturating_sub(help_text.len())) / 2;
-    for _ in 0..help_pad {
-        serial_driver::write_str(" ");
-    }
-    serial_driver::write_str(help_text);
-    serial_driver::write_str("\x1b[0m");
-
-    // Framebuffer
-    if let Some(console) = fb_console {
-        console.set_fg_color(Color::new(0, 192, 192)); // Cyan
-        console.write_centered(row as u32, help_text);
-        console.reset_colors();
-    }
-}
-
-/// Draw a status message
-fn draw_status_message(
-    fb_console: &mut Option<FramebufferConsole>,
-    row: usize,
-    message: &str,
-    is_success: bool,
-) {
-    let color = if is_success {
-        Color::new(0, 255, 0) // Green
-    } else {
-        Color::new(255, 0, 0) // Red
-    };
-
-    // Serial
-    let _ = write!(SerialWriter, "\x1b[{};1H", row + 1);
-    if is_success {
-        serial_driver::write_str("\x1b[32m"); // Green
-    } else {
-        serial_driver::write_str("\x1b[31m"); // Red
-    }
-    serial_driver::write_str("  ");
-    serial_driver::write_str(message);
-    serial_driver::write_str("\x1b[0m");
-
-    // Framebuffer
-    if let Some(console) = fb_console {
-        console.set_fg_color(color);
-        console.write_centered(row as u32, message);
-        console.reset_colors();
-    }
-}
-
-fn clear_screen(fb_console: &mut Option<FramebufferConsole>) {
-    menu_common::clear_screen(fb_console);
 }
 
 fn read_key() -> Option<KeyPress> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,0 +1,548 @@
+//! Ratatui backends for CrabEFI
+//!
+//! Provides custom [`Backend`] implementations for rendering ratatui UIs
+//! to CrabEFI's serial console and framebuffer simultaneously.
+//!
+//! - [`SerialBackend`]: Renders via ANSI escape codes over the serial port
+//! - [`FramebufferBackend`]: Renders to the coreboot framebuffer using the VGA font
+//! - [`DualBackend`]: Renders to both serial and framebuffer at once
+
+use crate::coreboot::framebuffer::FramebufferInfo;
+use crate::drivers::serial as serial_driver;
+use crate::framebuffer_console::{self, Color as FbColor, FramebufferConsole};
+use core::fmt::Write;
+use ratatui::backend::{Backend, ClearType, WindowSize};
+use ratatui::buffer::Cell;
+use ratatui::layout::{Position, Size};
+use ratatui::style::Color;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Infallible error type for CrabEFI backends.
+///
+/// Our backends write directly to hardware registers / memory-mapped framebuffer
+/// and cannot fail in a recoverable way, so we use an infallible error.
+#[derive(Debug)]
+pub enum BackendError {}
+
+impl core::fmt::Display for BackendError {
+    fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match *self {}
+    }
+}
+
+impl core::error::Error for BackendError {}
+
+// ---------------------------------------------------------------------------
+// Color conversion
+// ---------------------------------------------------------------------------
+
+/// Convert a ratatui [`Color`] to a framebuffer [`FbColor`].
+fn ratatui_color_to_fb(color: Color, default: FbColor) -> FbColor {
+    match color {
+        Color::Reset => default,
+        Color::Black => FbColor::new(0, 0, 0),
+        Color::Red => FbColor::new(170, 0, 0),
+        Color::Green => FbColor::new(0, 170, 0),
+        Color::Yellow => FbColor::new(170, 170, 0),
+        Color::Blue => FbColor::new(0, 0, 170),
+        Color::Magenta => FbColor::new(170, 0, 170),
+        Color::Cyan => FbColor::new(0, 170, 170),
+        Color::Gray => FbColor::new(170, 170, 170),
+        Color::DarkGray => FbColor::new(85, 85, 85),
+        Color::LightRed => FbColor::new(255, 85, 85),
+        Color::LightGreen => FbColor::new(85, 255, 85),
+        Color::LightYellow => FbColor::new(255, 255, 85),
+        Color::LightBlue => FbColor::new(85, 85, 255),
+        Color::LightMagenta => FbColor::new(255, 85, 255),
+        Color::LightCyan => FbColor::new(85, 255, 255),
+        Color::White => FbColor::new(255, 255, 255),
+        Color::Rgb(r, g, b) => FbColor::new(r, g, b),
+        Color::Indexed(idx) => ansi256_to_fb(idx),
+    }
+}
+
+/// Map an 8-bit ANSI color index to an RGB [`FbColor`].
+fn ansi256_to_fb(idx: u8) -> FbColor {
+    match idx {
+        // Standard 16 colors
+        0 => FbColor::new(0, 0, 0),
+        1 => FbColor::new(170, 0, 0),
+        2 => FbColor::new(0, 170, 0),
+        3 => FbColor::new(170, 170, 0),
+        4 => FbColor::new(0, 0, 170),
+        5 => FbColor::new(170, 0, 170),
+        6 => FbColor::new(0, 170, 170),
+        7 => FbColor::new(170, 170, 170),
+        8 => FbColor::new(85, 85, 85),
+        9 => FbColor::new(255, 85, 85),
+        10 => FbColor::new(85, 255, 85),
+        11 => FbColor::new(255, 255, 85),
+        12 => FbColor::new(85, 85, 255),
+        13 => FbColor::new(255, 85, 255),
+        14 => FbColor::new(85, 255, 255),
+        15 => FbColor::new(255, 255, 255),
+        // 216-color cube (indices 16..=231)
+        16..=231 => {
+            let idx = idx - 16;
+            let r = (idx / 36) * 51;
+            let g = ((idx % 36) / 6) * 51;
+            let b = (idx % 6) * 51;
+            FbColor::new(r, g, b)
+        }
+        // Grayscale ramp (indices 232..=255)
+        232..=255 => {
+            let v = 8 + (idx - 232) * 10;
+            FbColor::new(v, v, v)
+        }
+    }
+}
+
+/// Write the ANSI SGR (Select Graphic Rendition) escape sequence for a cell's
+/// foreground and background colors to the serial port.
+fn write_serial_sgr(fg: Color, bg: Color) {
+    // Reset first, then set colors
+    serial_driver::write_str("\x1b[0");
+
+    // Foreground
+    match fg {
+        Color::Reset => {}
+        Color::Black => serial_driver::write_str(";30"),
+        Color::Red => serial_driver::write_str(";31"),
+        Color::Green => serial_driver::write_str(";32"),
+        Color::Yellow => serial_driver::write_str(";33"),
+        Color::Blue => serial_driver::write_str(";34"),
+        Color::Magenta => serial_driver::write_str(";35"),
+        Color::Cyan => serial_driver::write_str(";36"),
+        Color::Gray => serial_driver::write_str(";37"),
+        Color::DarkGray => serial_driver::write_str(";90"),
+        Color::LightRed => serial_driver::write_str(";91"),
+        Color::LightGreen => serial_driver::write_str(";92"),
+        Color::LightYellow => serial_driver::write_str(";93"),
+        Color::LightBlue => serial_driver::write_str(";94"),
+        Color::LightMagenta => serial_driver::write_str(";95"),
+        Color::LightCyan => serial_driver::write_str(";96"),
+        Color::White => serial_driver::write_str(";97"),
+        Color::Rgb(r, g, b) => {
+            let mut buf = SerialBuf::new();
+            let _ = write!(buf, ";38;2;{};{};{}", r, g, b);
+            serial_driver::write_str(buf.as_str());
+        }
+        Color::Indexed(idx) => {
+            let mut buf = SerialBuf::new();
+            let _ = write!(buf, ";38;5;{}", idx);
+            serial_driver::write_str(buf.as_str());
+        }
+    }
+
+    // Background
+    match bg {
+        Color::Reset => {}
+        Color::Black => serial_driver::write_str(";40"),
+        Color::Red => serial_driver::write_str(";41"),
+        Color::Green => serial_driver::write_str(";42"),
+        Color::Yellow => serial_driver::write_str(";43"),
+        Color::Blue => serial_driver::write_str(";44"),
+        Color::Magenta => serial_driver::write_str(";45"),
+        Color::Cyan => serial_driver::write_str(";46"),
+        Color::Gray => serial_driver::write_str(";47"),
+        Color::DarkGray => serial_driver::write_str(";100"),
+        Color::LightRed => serial_driver::write_str(";101"),
+        Color::LightGreen => serial_driver::write_str(";102"),
+        Color::LightYellow => serial_driver::write_str(";103"),
+        Color::LightBlue => serial_driver::write_str(";104"),
+        Color::LightMagenta => serial_driver::write_str(";105"),
+        Color::LightCyan => serial_driver::write_str(";106"),
+        Color::White => serial_driver::write_str(";107"),
+        Color::Rgb(r, g, b) => {
+            let mut buf = SerialBuf::new();
+            let _ = write!(buf, ";48;2;{};{};{}", r, g, b);
+            serial_driver::write_str(buf.as_str());
+        }
+        Color::Indexed(idx) => {
+            let mut buf = SerialBuf::new();
+            let _ = write!(buf, ";48;5;{}", idx);
+            serial_driver::write_str(buf.as_str());
+        }
+    }
+
+    serial_driver::write_str("m");
+}
+
+/// Small stack buffer for formatting ANSI sequences without allocation.
+struct SerialBuf {
+    buf: [u8; 32],
+    pos: usize,
+}
+
+impl SerialBuf {
+    fn new() -> Self {
+        Self {
+            buf: [0; 32],
+            pos: 0,
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        // Safety: we only write ASCII via core::fmt::Write
+        unsafe { core::str::from_utf8_unchecked(&self.buf[..self.pos]) }
+    }
+}
+
+impl core::fmt::Write for SerialBuf {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let bytes = s.as_bytes();
+        let remaining = &mut self.buf[self.pos..];
+        if bytes.len() > remaining.len() {
+            return Err(core::fmt::Error);
+        }
+        remaining[..bytes.len()].copy_from_slice(bytes);
+        self.pos += bytes.len();
+        Ok(())
+    }
+}
+
+// ===========================================================================
+// SerialBackend
+// ===========================================================================
+
+/// Backend that renders to the serial console via ANSI escape codes.
+pub struct SerialBackend {
+    width: u16,
+    height: u16,
+    cursor: Position,
+}
+
+impl SerialBackend {
+    /// Create a new serial backend with the given terminal dimensions.
+    pub fn new(width: u16, height: u16) -> Self {
+        Self {
+            width,
+            height,
+            cursor: Position::ORIGIN,
+        }
+    }
+}
+
+impl Backend for SerialBackend {
+    type Error = BackendError;
+
+    fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
+    where
+        I: Iterator<Item = (u16, u16, &'a Cell)>,
+    {
+        let mut last_fg = Color::Reset;
+        let mut last_bg = Color::Reset;
+        let mut last_pos: Option<(u16, u16)> = None;
+
+        for (x, y, cell) in content {
+            // Only reposition cursor if not contiguous with previous cell
+            let need_move = match last_pos {
+                Some((lx, ly)) => !(ly == y && lx + 1 == x),
+                None => true,
+            };
+            if need_move {
+                let mut buf = SerialBuf::new();
+                // ANSI cursor position is 1-based
+                let _ = write!(buf, "\x1b[{};{}H", y + 1, x + 1);
+                serial_driver::write_str(buf.as_str());
+            }
+
+            // Only emit SGR if colors changed
+            if cell.fg != last_fg || cell.bg != last_bg {
+                write_serial_sgr(cell.fg, cell.bg);
+                last_fg = cell.fg;
+                last_bg = cell.bg;
+            }
+
+            serial_driver::write_str(cell.symbol());
+            last_pos = Some((x, y));
+        }
+
+        // Reset attributes after drawing
+        serial_driver::write_str("\x1b[0m");
+        Ok(())
+    }
+
+    fn hide_cursor(&mut self) -> Result<(), Self::Error> {
+        serial_driver::write_str("\x1b[?25l");
+        Ok(())
+    }
+
+    fn show_cursor(&mut self) -> Result<(), Self::Error> {
+        serial_driver::write_str("\x1b[?25h");
+        Ok(())
+    }
+
+    fn get_cursor_position(&mut self) -> Result<Position, Self::Error> {
+        Ok(self.cursor)
+    }
+
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> Result<(), Self::Error> {
+        self.cursor = position.into();
+        let mut buf = SerialBuf::new();
+        let _ = write!(buf, "\x1b[{};{}H", self.cursor.y + 1, self.cursor.x + 1);
+        serial_driver::write_str(buf.as_str());
+        Ok(())
+    }
+
+    fn clear(&mut self) -> Result<(), Self::Error> {
+        serial_driver::write_str("\x1b[2J\x1b[H");
+        Ok(())
+    }
+
+    fn clear_region(&mut self, clear_type: ClearType) -> Result<(), Self::Error> {
+        match clear_type {
+            ClearType::All => serial_driver::write_str("\x1b[2J"),
+            ClearType::AfterCursor => serial_driver::write_str("\x1b[J"),
+            ClearType::BeforeCursor => serial_driver::write_str("\x1b[1J"),
+            ClearType::CurrentLine => serial_driver::write_str("\x1b[2K"),
+            ClearType::UntilNewLine => serial_driver::write_str("\x1b[K"),
+        }
+        Ok(())
+    }
+
+    fn size(&self) -> Result<Size, Self::Error> {
+        Ok(Size::new(self.width, self.height))
+    }
+
+    fn window_size(&mut self) -> Result<WindowSize, Self::Error> {
+        Ok(WindowSize {
+            columns_rows: Size::new(self.width, self.height),
+            pixels: Size::new(self.width * 8, self.height * 16),
+        })
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+// ===========================================================================
+// FramebufferBackend
+// ===========================================================================
+
+/// Backend that renders to the coreboot framebuffer using the VGA bitmap font.
+pub struct FramebufferBackend<'a> {
+    console: FramebufferConsole<'a>,
+}
+
+impl<'a> FramebufferBackend<'a> {
+    /// Create a new framebuffer backend wrapping the given framebuffer info.
+    pub fn new(fb: &'a FramebufferInfo) -> Self {
+        Self {
+            console: FramebufferConsole::new(fb),
+        }
+    }
+}
+
+impl Backend for FramebufferBackend<'_> {
+    type Error = BackendError;
+
+    fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
+    where
+        I: Iterator<Item = (u16, u16, &'a Cell)>,
+    {
+        let default_fg = framebuffer_console::DEFAULT_FG;
+        let default_bg = framebuffer_console::DEFAULT_BG;
+
+        for (x, y, cell) in content {
+            let fg = ratatui_color_to_fb(cell.fg, default_fg);
+            let bg = ratatui_color_to_fb(cell.bg, default_bg);
+
+            // Use the first char of the symbol (our VGA font is single-byte)
+            let ch = cell.symbol().chars().next().unwrap_or(' ');
+            self.console.draw_char_at(ch, x as u32, y as u32, fg, bg);
+        }
+
+        Ok(())
+    }
+
+    fn hide_cursor(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn show_cursor(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn get_cursor_position(&mut self) -> Result<Position, Self::Error> {
+        let (col, row) = self.console.position();
+        Ok(Position::new(col as u16, row as u16))
+    }
+
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> Result<(), Self::Error> {
+        let pos = position.into();
+        self.console.set_position(pos.x as u32, pos.y as u32);
+        Ok(())
+    }
+
+    fn clear(&mut self) -> Result<(), Self::Error> {
+        self.console.clear();
+        Ok(())
+    }
+
+    fn clear_region(&mut self, clear_type: ClearType) -> Result<(), Self::Error> {
+        match clear_type {
+            ClearType::All => self.console.clear(),
+            ClearType::CurrentLine => {
+                let (_, row) = self.console.position();
+                self.console.clear_line(row);
+            }
+            // For other clear types, fall back to full clear
+            _ => self.console.clear(),
+        }
+        Ok(())
+    }
+
+    fn size(&self) -> Result<Size, Self::Error> {
+        Ok(Size::new(
+            self.console.cols() as u16,
+            self.console.rows() as u16,
+        ))
+    }
+
+    fn window_size(&mut self) -> Result<WindowSize, Self::Error> {
+        let cols = self.console.cols() as u16;
+        let rows = self.console.rows() as u16;
+        Ok(WindowSize {
+            columns_rows: Size::new(cols, rows),
+            pixels: Size::new(
+                cols * framebuffer_console::CHAR_WIDTH as u16,
+                rows * framebuffer_console::CHAR_HEIGHT as u16,
+            ),
+        })
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+// ===========================================================================
+// DualBackend
+// ===========================================================================
+
+/// Backend that renders to both serial and framebuffer simultaneously.
+///
+/// Uses the smaller of the two terminal sizes so widgets lay out correctly
+/// on both outputs.
+pub struct DualBackend<'a> {
+    serial: SerialBackend,
+    fb: Option<FramebufferBackend<'a>>,
+}
+
+impl<'a> DualBackend<'a> {
+    /// Create a dual backend.
+    ///
+    /// If `fb_info` is `None`, this degrades to serial-only output.
+    /// The serial dimensions are automatically matched to the framebuffer
+    /// when available, or default to 80x25.
+    pub fn new(fb_info: Option<&'a FramebufferInfo>) -> Self {
+        match fb_info {
+            Some(fb) => {
+                let fb_backend = FramebufferBackend::new(fb);
+                let cols = fb_backend.console.cols() as u16;
+                let rows = fb_backend.console.rows() as u16;
+                // Use the min of framebuffer and a generous serial assumption
+                let width = cols.min(120);
+                let height = rows.min(50);
+                Self {
+                    serial: SerialBackend::new(width, height),
+                    fb: Some(fb_backend),
+                }
+            }
+            None => Self {
+                serial: SerialBackend::new(80, 25),
+                fb: None,
+            },
+        }
+    }
+}
+
+impl Backend for DualBackend<'_> {
+    type Error = BackendError;
+
+    fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
+    where
+        I: Iterator<Item = (u16, u16, &'a Cell)>,
+    {
+        // Collect into a Vec so we can iterate twice (once per backend).
+        // This is acceptable because draw() is only called with the diff
+        // between frames, which is typically small.
+        let cells: alloc::vec::Vec<(u16, u16, Cell)> =
+            content.map(|(x, y, c)| (x, y, c.clone())).collect();
+
+        self.serial
+            .draw(cells.iter().map(|(x, y, c)| (*x, *y, c)))?;
+
+        if let Some(fb) = &mut self.fb {
+            fb.draw(cells.iter().map(|(x, y, c)| (*x, *y, c)))?;
+        }
+
+        Ok(())
+    }
+
+    fn hide_cursor(&mut self) -> Result<(), Self::Error> {
+        self.serial.hide_cursor()?;
+        if let Some(fb) = &mut self.fb {
+            fb.hide_cursor()?;
+        }
+        Ok(())
+    }
+
+    fn show_cursor(&mut self) -> Result<(), Self::Error> {
+        self.serial.show_cursor()?;
+        if let Some(fb) = &mut self.fb {
+            fb.show_cursor()?;
+        }
+        Ok(())
+    }
+
+    fn get_cursor_position(&mut self) -> Result<Position, Self::Error> {
+        self.serial.get_cursor_position()
+    }
+
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> Result<(), Self::Error> {
+        let pos: Position = position.into();
+        self.serial.set_cursor_position(pos)?;
+        if let Some(fb) = &mut self.fb {
+            fb.set_cursor_position(pos)?;
+        }
+        Ok(())
+    }
+
+    fn clear(&mut self) -> Result<(), Self::Error> {
+        self.serial.clear()?;
+        if let Some(fb) = &mut self.fb {
+            fb.clear()?;
+        }
+        Ok(())
+    }
+
+    fn clear_region(&mut self, clear_type: ClearType) -> Result<(), Self::Error> {
+        self.serial.clear_region(clear_type)?;
+        if let Some(fb) = &mut self.fb {
+            fb.clear_region(clear_type)?;
+        }
+        Ok(())
+    }
+
+    fn size(&self) -> Result<Size, Self::Error> {
+        self.serial.size()
+    }
+
+    fn window_size(&mut self) -> Result<WindowSize, Self::Error> {
+        self.serial.window_size()
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.serial.flush()?;
+        if let Some(fb) = &mut self.fb {
+            fb.flush()?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Replace hand-rolled dual-output rendering (serial ANSI + framebuffer) with
ratatui no_std using custom Backend implementations. This eliminates the
duplicated rendering codepaths where every menu function had to write ANSI
escape sequences to serial AND call FramebufferConsole methods separately.

Key changes:
- Replace bump allocator with talc (proper dealloc for ratatui allocs)
- Add ratatui 0.30 (default-features=false) for no_std support
- Implement SerialBackend, FramebufferBackend, and DualBackend in src/tui.rs
- Convert boot menu, cmdline editor, secure boot menu, CFR firmware settings
  menu, and secure boot error banner to ratatui Terminal::draw()
- Use ListState with highlight_style/highlight_symbol for idiomatic selection
- Add Unicode-to-CP437 mapping so box-drawing characters render correctly on
  the VGA framebuffer font
- Strip menu_common.rs down to just KeyPress enum and read_key()
- Remove ~600 lines of old dual-output draw_* functions