### PR TITLE
refactor(state): consolidate scattered statics into FirmwareState

### DIFF
--- a/src/arch/aarch64/rng.rs
+++ b/src/arch/aarch64/rng.rs
@@ -127,9 +127,7 @@ pub fn init() {
     if has_rndr() {
         // Verify RNDR actually works
         if rndr64().is_some() {
-            unsafe {
-                (*crate::state::drivers_mut_ptr()).rng_available = true;
-            }
+            crate::state::with_drivers_mut(|d| d.rng_available = true);
             RNG_METHOD.store(RngMethod::Rndr as u8, Ordering::Release);
             log::info!("RNG: RNDR instruction available (FEAT_RNG)");
             return;
@@ -137,9 +135,7 @@ pub fn init() {
     }
 
     if check_smccc_trng() {
-        unsafe {
-            (*crate::state::drivers_mut_ptr()).rng_available = true;
-        }
+        crate::state::with_drivers_mut(|d| d.rng_available = true);
         RNG_METHOD.store(RngMethod::SmcccTrng as u8, Ordering::Release);
         log::info!("RNG: SMCCC TRNG available");
         return;

--- a/src/arch/aarch64/rng.rs
+++ b/src/arch/aarch64/rng.rs
@@ -7,19 +7,32 @@
 //! Falls back to SMCCC TRNG (ARM True Random Number Generator)
 //! interface via HVC/SMC if RNDR is not available.
 
+use core::sync::atomic::{AtomicU8, Ordering};
+
 /// SMCCC TRNG function IDs
 const SMCCC_TRNG_VERSION: u32 = 0xC400_0050;
 const SMCCC_TRNG_RND64: u32 = 0xC400_0053;
 
-/// Static flag indicating RNG is supported and functional
-static mut RNG_AVAILABLE: bool = false;
-static mut RNG_METHOD: RngMethod = RngMethod::None;
+/// RNG method selector (written once during init, read many times).
+/// Stored as AtomicU8 to avoid `static mut` unsoundness.
+static RNG_METHOD: AtomicU8 = AtomicU8::new(RngMethod::None as u8);
 
 #[derive(Clone, Copy, PartialEq)]
+#[repr(u8)]
 enum RngMethod {
-    None,
-    Rndr,
-    SmcccTrng,
+    None = 0,
+    Rndr = 1,
+    SmcccTrng = 2,
+}
+
+impl RngMethod {
+    fn from_u8(v: u8) -> Self {
+        match v {
+            1 => Self::Rndr,
+            2 => Self::SmcccTrng,
+            _ => Self::None,
+        }
+    }
 }
 
 /// Check if RNDR instruction is available via ID_AA64ISAR0_EL1
@@ -111,31 +124,33 @@ fn smccc_trng_rnd64() -> Option<u64> {
 ///
 /// Checks for RNDR instruction support and SMCCC TRNG availability.
 pub fn init() {
-    unsafe {
-        if has_rndr() {
-            // Verify RNDR actually works
-            if rndr64().is_some() {
-                RNG_AVAILABLE = true;
-                RNG_METHOD = RngMethod::Rndr;
-                log::info!("RNG: RNDR instruction available (FEAT_RNG)");
-                return;
+    if has_rndr() {
+        // Verify RNDR actually works
+        if rndr64().is_some() {
+            unsafe {
+                (*crate::state::drivers_mut_ptr()).rng_available = true;
             }
-        }
-
-        if check_smccc_trng() {
-            RNG_AVAILABLE = true;
-            RNG_METHOD = RngMethod::SmcccTrng;
-            log::info!("RNG: SMCCC TRNG available");
+            RNG_METHOD.store(RngMethod::Rndr as u8, Ordering::Release);
+            log::info!("RNG: RNDR instruction available (FEAT_RNG)");
             return;
         }
-
-        log::warn!("RNG: No hardware RNG available");
     }
+
+    if check_smccc_trng() {
+        unsafe {
+            (*crate::state::drivers_mut_ptr()).rng_available = true;
+        }
+        RNG_METHOD.store(RngMethod::SmcccTrng as u8, Ordering::Release);
+        log::info!("RNG: SMCCC TRNG available");
+        return;
+    }
+
+    log::warn!("RNG: No hardware RNG available");
 }
 
 /// Check if hardware RNG is available and functional
 pub fn is_supported() -> bool {
-    unsafe { RNG_AVAILABLE }
+    crate::state::drivers().rng_available
 }
 
 /// Fill a byte buffer with random data
@@ -143,7 +158,7 @@ pub fn is_supported() -> bool {
 /// # Returns
 /// `true` if the buffer was filled, `false` if RNG is not available
 pub fn fill_random(buffer: &mut [u8]) -> bool {
-    let method = unsafe { RNG_METHOD };
+    let method = RngMethod::from_u8(RNG_METHOD.load(Ordering::Acquire));
     let get_random = match method {
         RngMethod::Rndr => rndr64,
         RngMethod::SmcccTrng => smccc_trng_rnd64,

--- a/src/arch/x86_64/rng.rs
+++ b/src/arch/x86_64/rng.rs
@@ -88,9 +88,8 @@ fn test_rdrand() -> bool {
 /// Checks CPUID for RDRAND support and runs the broken RDRAND test.
 /// Must be called before `is_supported()` or `rdrand64()`.
 pub fn init() {
-    unsafe {
-        (*crate::state::drivers_mut_ptr()).rng_available = cpuid_has_rdrand() && test_rdrand();
-    }
+    let available = cpuid_has_rdrand() && test_rdrand();
+    crate::state::with_drivers_mut(|d| d.rng_available = available);
 
     if is_supported() {
         log::info!("RDRAND available (SP800-90 CTR-256)");

--- a/src/arch/x86_64/rng.rs
+++ b/src/arch/x86_64/rng.rs
@@ -12,9 +12,6 @@ const RDRAND_TEST_SAMPLES: usize = 8;
 /// Minimum number of different values required to pass broken RDRAND test
 const RDRAND_MIN_CHANGE: usize = 5;
 
-/// Static flag indicating RDRAND is supported and functional
-static mut RDRAND_AVAILABLE: bool = false;
-
 /// Check if RDRAND is supported via CPUID
 ///
 /// Returns true if CPUID reports RDRAND support (ECX bit 30, leaf 1)
@@ -92,7 +89,7 @@ fn test_rdrand() -> bool {
 /// Must be called before `is_supported()` or `rdrand64()`.
 pub fn init() {
     unsafe {
-        RDRAND_AVAILABLE = cpuid_has_rdrand() && test_rdrand();
+        (*crate::state::drivers_mut_ptr()).rng_available = cpuid_has_rdrand() && test_rdrand();
     }
 
     if is_supported() {
@@ -104,7 +101,7 @@ pub fn init() {
 
 /// Check if RDRAND is available and functional
 pub fn is_supported() -> bool {
-    unsafe { RDRAND_AVAILABLE }
+    crate::state::drivers().rng_available
 }
 
 /// Fill a byte buffer with random data from RDRAND

--- a/src/coreboot/cbmem_console.rs
+++ b/src/coreboot/cbmem_console.rs
@@ -67,8 +67,13 @@ pub fn init(addr: u64) {
 }
 
 /// Check if CBMEM console is available
+///
+/// Uses raw-pointer read (see *Log-Path Contract* in [`crate::state`]) to
+/// avoid creating a shared reference that would alias with a live `&mut`
+/// from `with_*_mut()` closures.
 pub fn is_available() -> bool {
-    crate::state::try_get().is_some_and(|s| s.drivers.platform.cbmem_console_addr != 0)
+    crate::state::try_get_mut_ptr()
+        .is_some_and(|ptr| unsafe { (*ptr).drivers.platform.cbmem_console_addr != 0 })
 }
 
 /// Disable the CBMEM console
@@ -94,7 +99,14 @@ pub fn disable() {
 /// - Bits 0-27: Current write position (CURSOR_MASK)
 /// - Bit 31: Overflow flag (set when buffer has wrapped at least once)
 pub fn write_bytes(data: &[u8]) {
-    let addr = crate::state::drivers().platform.cbmem_console_addr;
+    // SAFETY: single-threaded firmware; raw-pointer read avoids aliasing
+    // with a live &mut from with_*_mut() closures (see Log-Path Contract
+    // in crate::state).
+    let addr = unsafe {
+        (*crate::state::drivers_mut_ptr())
+            .platform
+            .cbmem_console_addr
+    };
     if addr == 0 {
         return;
     }

--- a/src/coreboot/cbmem_console.rs
+++ b/src/coreboot/cbmem_console.rs
@@ -7,7 +7,6 @@
 //! Reference: coreboot/payloads/libpayload/drivers/cbmem_console.c
 
 use core::fmt::{self, Write};
-use core::sync::atomic::{AtomicU64, Ordering};
 use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
 
 /// CBMEM console structure header
@@ -29,9 +28,6 @@ const CURSOR_MASK: u32 = (1 << 28) - 1;
 /// Overflow flag (bit 31) - set when buffer has wrapped around
 const OVERFLOW: u32 = 1 << 31;
 
-/// Global CBMEM console address (0 = not initialized)
-static CBMEM_CONSOLE_ADDR: AtomicU64 = AtomicU64::new(0);
-
 /// Initialize the CBMEM console with the given physical address
 ///
 /// # Arguments
@@ -52,7 +48,9 @@ pub fn init(addr: u64) {
         let size = header.size;
         // Sanity check: size should be reasonable (at least 1KB, at most 1MB)
         if (1024..=1024 * 1024).contains(&size) {
-            CBMEM_CONSOLE_ADDR.store(addr, Ordering::Release);
+            (*crate::state::drivers_mut_ptr())
+                .platform
+                .cbmem_console_addr = addr;
             log::debug!(
                 "CBMEM console initialized: addr={:#x}, size={} bytes",
                 addr,
@@ -70,7 +68,7 @@ pub fn init(addr: u64) {
 
 /// Check if CBMEM console is available
 pub fn is_available() -> bool {
-    CBMEM_CONSOLE_ADDR.load(Ordering::Acquire) != 0
+    crate::state::try_get().is_some_and(|s| s.drivers.platform.cbmem_console_addr != 0)
 }
 
 /// Disable the CBMEM console
@@ -79,7 +77,11 @@ pub fn is_available() -> bool {
 /// cbmem buffer, which lives in a coreboot Reserved region that the OS
 /// does not map for EFI runtime use.
 pub fn disable() {
-    CBMEM_CONSOLE_ADDR.store(0, Ordering::Release);
+    unsafe {
+        (*crate::state::drivers_mut_ptr())
+            .platform
+            .cbmem_console_addr = 0;
+    }
 }
 
 /// Write bytes to the CBMEM console (ring buffer)
@@ -92,7 +94,7 @@ pub fn disable() {
 /// - Bits 0-27: Current write position (CURSOR_MASK)
 /// - Bit 31: Overflow flag (set when buffer has wrapped at least once)
 pub fn write_bytes(data: &[u8]) {
-    let addr = CBMEM_CONSOLE_ADDR.load(Ordering::Acquire);
+    let addr = crate::state::drivers().platform.cbmem_console_addr;
     if addr == 0 {
         return;
     }

--- a/src/coreboot/mod.rs
+++ b/src/coreboot/mod.rs
@@ -28,14 +28,14 @@ pub use tables::{
 /// Store framebuffer info in global state
 pub fn store_framebuffer(fb: FramebufferInfo) {
     crate::state::with_drivers_mut(|drivers| {
-        drivers.framebuffer = Some(fb);
+        drivers.platform.framebuffer = Some(fb);
     });
 }
 
 /// Store the coreboot framebuffer record address for later invalidation
 pub fn store_framebuffer_record_addr(addr: u64) {
     crate::state::with_drivers_mut(|drivers| {
-        drivers.coreboot_fb_record_addr = Some(addr);
+        drivers.platform.coreboot_fb_record_addr = Some(addr);
     });
 }
 
@@ -43,13 +43,13 @@ pub fn store_framebuffer_record_addr(addr: u64) {
 ///
 /// Returns the framebuffer info if available.
 pub fn get_framebuffer() -> Option<FramebufferInfo> {
-    crate::state::try_get().and_then(|state| state.drivers.framebuffer)
+    crate::state::try_get().and_then(|state| state.drivers.platform.framebuffer)
 }
 
 /// Store SMMSTORE v2 info in global state
 pub fn store_smmstorev2(smmstore: Smmstorev2Info) {
     crate::state::with_drivers_mut(|drivers| {
-        drivers.smmstorev2 = Some(smmstore);
+        drivers.platform.smmstorev2 = Some(smmstore);
     });
 }
 
@@ -57,13 +57,13 @@ pub fn store_smmstorev2(smmstore: Smmstorev2Info) {
 ///
 /// Returns the SMMSTORE v2 info if available.
 pub fn get_smmstorev2() -> Option<Smmstorev2Info> {
-    crate::state::try_get().and_then(|state| state.drivers.smmstorev2)
+    crate::state::try_get().and_then(|state| state.drivers.platform.smmstorev2)
 }
 
 /// Store SPI flash info in global state
 pub fn store_spi_flash(spi_flash: SpiFlashInfo) {
     crate::state::with_drivers_mut(|drivers| {
-        drivers.spi_flash = Some(spi_flash);
+        drivers.platform.spi_flash = Some(spi_flash);
     });
 }
 
@@ -71,13 +71,13 @@ pub fn store_spi_flash(spi_flash: SpiFlashInfo) {
 ///
 /// Returns a clone of the SPI flash info if available.
 pub fn get_spi_flash() -> Option<SpiFlashInfo> {
-    crate::state::try_get().and_then(|state| state.drivers.spi_flash.clone())
+    crate::state::try_get().and_then(|state| state.drivers.platform.spi_flash.clone())
 }
 
 /// Store boot media params in global state
 pub fn store_boot_media(boot_media: BootMediaInfo) {
     crate::state::with_drivers_mut(|drivers| {
-        drivers.boot_media = Some(boot_media);
+        drivers.platform.boot_media = Some(boot_media);
     });
 }
 
@@ -86,7 +86,7 @@ pub fn store_boot_media(boot_media: BootMediaInfo) {
 /// Returns the boot media info if available.
 /// This includes the FMAP offset which can be used to locate flash regions.
 pub fn get_boot_media() -> Option<BootMediaInfo> {
-    crate::state::try_get().and_then(|state| state.drivers.boot_media)
+    crate::state::try_get().and_then(|state| state.drivers.platform.boot_media)
 }
 
 // CFR info is stored separately because it can be very large with nested heapless::Vec.
@@ -142,7 +142,8 @@ pub fn get_cfr() -> Option<&'static CfrInfo> {
 /// This function modifies memory in the coreboot tables area. It must only
 /// be called when it's safe to modify that memory (at ExitBootServices).
 pub unsafe fn invalidate_framebuffer_record() {
-    let addr = crate::state::try_get().and_then(|state| state.drivers.coreboot_fb_record_addr);
+    let addr =
+        crate::state::try_get().and_then(|state| state.drivers.platform.coreboot_fb_record_addr);
 
     if let Some(record_addr) = addr {
         // The tag is the first 4 bytes of the record (u32)

--- a/src/drivers/pci/mod.rs
+++ b/src/drivers/pci/mod.rs
@@ -25,8 +25,7 @@
 pub mod access;
 pub mod driver;
 
-use access::{AnyPciAccess, IoCamAccess, PciAccess};
-use spin::Mutex;
+use access::{AnyPciAccess, PciAccess};
 
 use crate::state;
 
@@ -65,19 +64,13 @@ const HEADER_TYPE_MULTI_FUNCTION: u8 = 0x80;
 // Global PCI Access
 // ============================================================================
 
-/// Global PCI config space access method
-///
-/// Initialized during `init()` and used by all subsequent PCI operations.
-/// Defaults to legacy I/O CAM; upgraded to ECAM if available.
-static PCI_ACCESS: Mutex<AnyPciAccess> = Mutex::new(AnyPciAccess::IoCam(IoCamAccess));
-
 /// Helper: run a closure with the global PCI access method
 fn with_access<F, R>(f: F) -> R
 where
     F: FnOnce(&AnyPciAccess) -> R,
 {
-    let access = PCI_ACCESS.lock();
-    f(&access)
+    let access = &state::drivers().pci.access;
+    f(access)
 }
 
 // ============================================================================
@@ -381,19 +374,16 @@ pub fn init() {
     log::info!("Initializing PCI subsystem...");
 
     // Select access method based on ECAM availability
-    let ecam_base = state::drivers().ecam_base;
-    {
-        let new_access = access::create_access(ecam_base);
-        let mut access = PCI_ACCESS.lock();
-        *access = new_access;
-    }
+    let ecam_base = state::drivers().pci.ecam_base;
+    let new_access = access::create_access(ecam_base);
 
-    // Enumerate devices
-    let access = PCI_ACCESS.lock();
+    // Set access method and enumerate devices in one closure so we can
+    // borrow both `pci.access` and `pci.devices` without aliasing issues.
     state::with_drivers_mut(|drivers| {
-        let devices = &mut drivers.pci_devices;
-        devices.clear();
-        enumerate_devices(&access, devices);
+        drivers.pci.access = new_access;
+        let pci = &mut drivers.pci;
+        pci.devices.clear();
+        enumerate_devices(&pci.access, &mut pci.devices);
     });
 }
 
@@ -459,7 +449,7 @@ fn enumerate_devices(
 pub fn bind_drivers() {
     log::info!("Binding PCI drivers to devices...");
 
-    let devices = state::drivers().pci_devices.clone();
+    let devices = state::drivers().pci.devices.clone();
 
     let mut bound_count = 0;
     for device in devices.iter() {
@@ -486,7 +476,7 @@ pub fn shutdown_drivers() {
 /// Find all NVMe controllers
 pub fn find_nvme_controllers() -> heapless::Vec<PciDevice, 8> {
     let drivers = state::drivers();
-    let devices = &drivers.pci_devices;
+    let devices = &drivers.pci.devices;
     let mut result = heapless::Vec::new();
     for dev in devices.iter() {
         if dev.is_nvme() {
@@ -505,7 +495,7 @@ pub fn find_nvme_controllers() -> heapless::Vec<PciDevice, 8> {
 /// Find all AHCI controllers
 pub fn find_ahci_controllers() -> heapless::Vec<PciDevice, 8> {
     let drivers = state::drivers();
-    let devices = &drivers.pci_devices;
+    let devices = &drivers.pci.devices;
     let mut result = heapless::Vec::new();
     for dev in devices.iter() {
         if dev.is_ahci() {
@@ -524,7 +514,7 @@ pub fn find_ahci_controllers() -> heapless::Vec<PciDevice, 8> {
 /// Find all SDHCI controllers
 pub fn find_sdhci_controllers() -> heapless::Vec<PciDevice, 8> {
     let drivers = state::drivers();
-    let devices = &drivers.pci_devices;
+    let devices = &drivers.pci.devices;
     let mut result = heapless::Vec::new();
     for dev in devices.iter() {
         if dev.is_sdhci() {
@@ -542,13 +532,13 @@ pub fn find_sdhci_controllers() -> heapless::Vec<PciDevice, 8> {
 
 /// Get all enumerated PCI devices
 pub fn get_all_devices() -> heapless::Vec<PciDevice, { state::MAX_PCI_DEVICES }> {
-    state::drivers().pci_devices.clone()
+    state::drivers().pci.devices.clone()
 }
 
 /// Print information about all PCI devices
 pub fn print_devices() {
     let drivers = state::drivers();
-    let devices = &drivers.pci_devices;
+    let devices = &drivers.pci.devices;
 
     log::info!("PCI Devices:");
     for dev in devices.iter() {
@@ -580,7 +570,7 @@ pub fn print_devices() {
 /// Set ECAM base address (from ACPI MCFG table)
 pub fn set_ecam_base(base: u64) {
     state::with_drivers_mut(|drivers| {
-        drivers.ecam_base = Some(base);
+        drivers.pci.ecam_base = Some(base);
     });
     log::debug!("ECAM base set to {:#x}", base);
 }

--- a/src/drivers/serial.rs
+++ b/src/drivers/serial.rs
@@ -9,8 +9,6 @@
 
 use core::fmt::{self, Write};
 
-use spin::Mutex;
-
 // ============================================================================
 // Register offsets (16550-compatible)
 // ============================================================================
@@ -240,7 +238,7 @@ mod pl011 {
 /// PL011 serial port backend
 ///
 /// Separate from the 16550 backend because register layout differs significantly.
-struct Pl011Port {
+pub(crate) struct Pl011Port {
     base: u64,
     functional: bool,
 }
@@ -321,13 +319,11 @@ impl Write for Pl011Port {
 // ============================================================================
 
 /// Runtime-selected serial port type
-enum AnySerial {
+pub(crate) enum AnySerial {
     Uart16550(SerialPort),
     #[cfg(target_arch = "aarch64")]
     Pl011(Pl011Port),
 }
-
-static ANY_SERIAL: Mutex<Option<AnySerial>> = Mutex::new(None);
 
 // ============================================================================
 // Global API
@@ -352,7 +348,11 @@ pub fn init_from_coreboot(base_addr: u32, baud: u32, is_mmio: bool) {
             let mut port = Pl011Port::new(base_addr as u64);
             if port.functional {
                 let _ = port.write_str("\r\n[CrabEFI] PL011 serial initialized from coreboot\r\n");
-                *ANY_SERIAL.lock() = Some(AnySerial::Pl011(port));
+                // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
+                // issues since serial is called from log macros inside other state closures.
+                unsafe {
+                    (*crate::state::drivers_mut_ptr()).serial.driver = Some(AnySerial::Pl011(port));
+                }
                 return;
             }
         }
@@ -366,7 +366,12 @@ pub fn init_from_coreboot(base_addr: u32, baud: u32, is_mmio: bool) {
         };
         if serial.init_16550(baud) {
             let _ = serial.write_str("\r\n[CrabEFI] MMIO serial initialized from coreboot\r\n");
-            *ANY_SERIAL.lock() = Some(AnySerial::Uart16550(serial));
+            // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
+            // issues since serial is called from log macros inside other state closures.
+            unsafe {
+                (*crate::state::drivers_mut_ptr()).serial.driver =
+                    Some(AnySerial::Uart16550(serial));
+            }
         }
     } else {
         // I/O port UART (x86 only)
@@ -380,7 +385,12 @@ pub fn init_from_coreboot(base_addr: u32, baud: u32, is_mmio: bool) {
             };
             if serial.init_16550(baud) {
                 let _ = serial.write_str("\r\n[CrabEFI] Serial initialized from coreboot\r\n");
-                *ANY_SERIAL.lock() = Some(AnySerial::Uart16550(serial));
+                // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
+                // issues since serial is called from log macros inside other state closures.
+                unsafe {
+                    (*crate::state::drivers_mut_ptr()).serial.driver =
+                        Some(AnySerial::Uart16550(serial));
+                }
             }
         }
         #[cfg(not(target_arch = "x86_64"))]
@@ -393,7 +403,10 @@ pub fn init_from_coreboot(base_addr: u32, baud: u32, is_mmio: bool) {
 
 /// Write a string to the serial port
 pub fn write_str(s: &str) {
-    if let Some(serial) = &mut *ANY_SERIAL.lock() {
+    // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
+    // issues since serial is called from log macros inside other state closures.
+    let driver = unsafe { &mut (*crate::state::drivers_mut_ptr()).serial.driver };
+    if let Some(serial) = driver {
         match serial {
             AnySerial::Uart16550(uart) => {
                 let _ = uart.write_str(s);
@@ -408,7 +421,10 @@ pub fn write_str(s: &str) {
 
 /// Write formatted output to the serial port
 pub fn write_fmt(args: fmt::Arguments) {
-    if let Some(serial) = &mut *ANY_SERIAL.lock() {
+    // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
+    // issues since serial is called from log macros inside other state closures.
+    let driver = unsafe { &mut (*crate::state::drivers_mut_ptr()).serial.driver };
+    if let Some(serial) = driver {
         match serial {
             AnySerial::Uart16550(uart) => {
                 let _ = uart.write_fmt(args);
@@ -423,7 +439,10 @@ pub fn write_fmt(args: fmt::Arguments) {
 
 /// Write a single byte to the serial port
 pub fn write_byte(byte: u8) {
-    if let Some(serial) = &mut *ANY_SERIAL.lock() {
+    // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
+    // issues since serial is called from log macros inside other state closures.
+    let driver = unsafe { &mut (*crate::state::drivers_mut_ptr()).serial.driver };
+    if let Some(serial) = driver {
         match serial {
             AnySerial::Uart16550(uart) => uart.write_byte(byte),
             #[cfg(target_arch = "aarch64")]
@@ -434,7 +453,8 @@ pub fn write_byte(byte: u8) {
 
 /// Check if there is input available on the serial port
 pub fn has_input() -> bool {
-    if let Some(serial) = &*ANY_SERIAL.lock() {
+    // Read-only check -- use immutable access (no raw pointer needed).
+    if let Some(serial) = &crate::state::drivers().serial.driver {
         match serial {
             AnySerial::Uart16550(uart) => uart.can_receive(),
             #[cfg(target_arch = "aarch64")]
@@ -447,7 +467,10 @@ pub fn has_input() -> bool {
 
 /// Try to read a byte from the serial port (non-blocking)
 pub fn try_read() -> Option<u8> {
-    if let Some(serial) = &mut *ANY_SERIAL.lock() {
+    // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
+    // issues since serial is called from log macros inside other state closures.
+    let driver = unsafe { &mut (*crate::state::drivers_mut_ptr()).serial.driver };
+    if let Some(serial) = driver {
         match serial {
             AnySerial::Uart16550(uart) => uart.try_read_byte(),
             #[cfg(target_arch = "aarch64")]

--- a/src/drivers/storage.rs
+++ b/src/drivers/storage.rs
@@ -49,32 +49,32 @@ impl StorageRegistry {
 
 /// Register a storage device and get its device ID
 pub fn register_device(device_type: StorageType, num_blocks: u64, block_size: u32) -> Option<u32> {
-    // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy issues
-    // since storage registration may be called from contexts that already hold state.
-    let registry = unsafe { &mut (*crate::state::drivers_mut_ptr()).storage_registry };
+    crate::state::with_drivers_mut(|drivers| {
+        let registry = &mut drivers.storage_registry;
 
-    // Find a free slot index first
-    let slot_idx = registry.devices.iter().position(|slot| slot.is_none())?;
+        // Find a free slot index first
+        let slot_idx = registry.devices.iter().position(|slot| slot.is_none())?;
 
-    let device_id = registry.next_id;
-    registry.next_id += 1;
+        let device_id = registry.next_id;
+        registry.next_id += 1;
 
-    registry.devices[slot_idx] = Some(StorageDevice {
-        device_type,
-        num_blocks,
-        block_size,
-        device_id,
-    });
+        registry.devices[slot_idx] = Some(StorageDevice {
+            device_type,
+            num_blocks,
+            block_size,
+            device_id,
+        });
 
-    log::info!(
-        "Storage: registered {:?} as device {} ({} blocks x {} bytes)",
-        device_type,
-        device_id,
-        num_blocks,
-        block_size
-    );
+        log::info!(
+            "Storage: registered {:?} as device {} ({} blocks x {} bytes)",
+            device_type,
+            device_id,
+            num_blocks,
+            block_size
+        );
 
-    Some(device_id)
+        Some(device_id)
+    })
 }
 
 /// Get a storage device by ID

--- a/src/drivers/storage.rs
+++ b/src/drivers/storage.rs
@@ -3,8 +3,6 @@
 //! This module provides a common interface for all storage devices (USB, NVMe, AHCI)
 //! that can be used by the BlockIO protocol and filesystem code.
 
-use spin::Mutex;
-
 /// Maximum number of storage devices we can track
 const MAX_STORAGE_DEVICES: usize = 8;
 
@@ -35,13 +33,13 @@ pub struct StorageDevice {
 }
 
 /// Internal storage for registered devices
-struct StorageRegistry {
+pub(crate) struct StorageRegistry {
     devices: [Option<StorageDevice>; MAX_STORAGE_DEVICES],
     next_id: u32,
 }
 
 impl StorageRegistry {
-    const fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             devices: [const { None }; MAX_STORAGE_DEVICES],
             next_id: 0,
@@ -49,11 +47,11 @@ impl StorageRegistry {
     }
 }
 
-static STORAGE_REGISTRY: Mutex<StorageRegistry> = Mutex::new(StorageRegistry::new());
-
 /// Register a storage device and get its device ID
 pub fn register_device(device_type: StorageType, num_blocks: u64, block_size: u32) -> Option<u32> {
-    let mut registry = STORAGE_REGISTRY.lock();
+    // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy issues
+    // since storage registration may be called from contexts that already hold state.
+    let registry = unsafe { &mut (*crate::state::drivers_mut_ptr()).storage_registry };
 
     // Find a free slot index first
     let slot_idx = registry.devices.iter().position(|slot| slot.is_none())?;
@@ -81,7 +79,7 @@ pub fn register_device(device_type: StorageType, num_blocks: u64, block_size: u3
 
 /// Get a storage device by ID
 pub fn get_device(device_id: u32) -> Option<StorageDevice> {
-    let registry = STORAGE_REGISTRY.lock();
+    let registry = &crate::state::drivers().storage_registry;
     registry
         .devices
         .iter()

--- a/src/efi/auth/boot.rs
+++ b/src/efi/auth/boot.rs
@@ -115,7 +115,9 @@ pub fn init_secure_boot(config: &SecureBootConfig) -> Result<EnrollmentStatus, A
         let enable_from_storage = load_secure_boot_enable_preference();
         if enable_from_storage || config.enable_secure_boot {
             // Use internal function to avoid re-persisting what we just loaded
-            super::SECURE_BOOT_ENABLED.store(true, core::sync::atomic::Ordering::Release);
+            unsafe {
+                (*crate::state::efi_mut_ptr()).secure_boot_enabled = true;
+            }
             log::info!("Secure Boot: Enabled (from persisted preference)");
             // Update status variables to reflect the enabled state
             let _ = update_status_variables();

--- a/src/efi/auth/boot.rs
+++ b/src/efi/auth/boot.rs
@@ -115,9 +115,7 @@ pub fn init_secure_boot(config: &SecureBootConfig) -> Result<EnrollmentStatus, A
         let enable_from_storage = load_secure_boot_enable_preference();
         if enable_from_storage || config.enable_secure_boot {
             // Use internal function to avoid re-persisting what we just loaded
-            unsafe {
-                (*crate::state::efi_mut_ptr()).secure_boot_enabled = true;
-            }
+            crate::state::with_efi_mut(|efi| efi.secure_boot_enabled = true);
             log::info!("Secure Boot: Enabled (from persisted preference)");
             // Update status variables to reflect the enabled state
             let _ = update_status_variables();

--- a/src/efi/auth/mod.rs
+++ b/src/efi/auth/mod.rs
@@ -307,14 +307,6 @@ pub const WIN_CERT_TYPE_EFI_GUID: u16 = 0x0EF1;
 // Secure Boot State
 // ============================================================================
 
-use core::sync::atomic::{AtomicBool, Ordering};
-
-/// Whether Secure Boot is in Setup Mode (PK not enrolled)
-static SETUP_MODE: AtomicBool = AtomicBool::new(true);
-
-/// Whether Secure Boot is enabled
-static SECURE_BOOT_ENABLED: AtomicBool = AtomicBool::new(false);
-
 /// Variable attributes for the SecureBootEnable user preference variable
 /// This is non-volatile so it persists across resets
 const SECURE_BOOT_ENABLE_ATTRS: u32 =
@@ -322,31 +314,33 @@ const SECURE_BOOT_ENABLE_ATTRS: u32 =
 
 /// Check if we're in Setup Mode
 pub fn is_setup_mode() -> bool {
-    SETUP_MODE.load(Ordering::Acquire)
+    crate::state::efi().setup_mode
 }
 
 /// Check if Secure Boot is enabled
 pub fn is_secure_boot_enabled() -> bool {
-    SECURE_BOOT_ENABLED.load(Ordering::Acquire)
+    crate::state::efi().secure_boot_enabled
 }
 
 /// Enter User Mode (called when PK is enrolled)
 pub fn enter_user_mode() {
-    SETUP_MODE.store(false, Ordering::Release);
+    crate::state::with_efi_mut(|efi| efi.setup_mode = false);
     log::info!("Secure Boot: Entering User Mode");
 }
 
 /// Enter Setup Mode (called when PK is deleted)
 pub fn enter_setup_mode() {
-    SETUP_MODE.store(true, Ordering::Release);
-    SECURE_BOOT_ENABLED.store(false, Ordering::Release);
+    crate::state::with_efi_mut(|efi| {
+        efi.setup_mode = true;
+        efi.secure_boot_enabled = false;
+    });
     log::info!("Secure Boot: Entering Setup Mode");
 }
 
 /// Enable Secure Boot (only valid in User Mode)
 pub fn enable_secure_boot() {
     if !is_setup_mode() {
-        SECURE_BOOT_ENABLED.store(true, Ordering::Release);
+        crate::state::with_efi_mut(|efi| efi.secure_boot_enabled = true);
         log::info!("Secure Boot: Enabled");
         // Persist the user preference to SPI flash
         persist_secure_boot_enable_preference(true);
@@ -355,7 +349,7 @@ pub fn enable_secure_boot() {
 
 /// Disable Secure Boot
 pub fn disable_secure_boot() {
-    SECURE_BOOT_ENABLED.store(false, Ordering::Release);
+    crate::state::with_efi_mut(|efi| efi.secure_boot_enabled = false);
     log::info!("Secure Boot: Disabled");
     // Persist the user preference to SPI flash
     persist_secure_boot_enable_preference(false);

--- a/src/efi/protocols/console.rs
+++ b/src/efi/protocols/console.rs
@@ -18,9 +18,7 @@ use crate::state::{self, InputState};
 use core::ffi::c_void;
 use r_efi::efi::{Boolean, Event, Guid, Status};
 use r_efi::protocols::simple_text_input::{InputKey, Protocol as SimpleTextInputProtocol};
-use r_efi::protocols::simple_text_output::{
-    Mode as SimpleTextOutputMode, Protocol as SimpleTextOutputProtocol,
-};
+use r_efi::protocols::simple_text_output::Protocol as SimpleTextOutputProtocol;
 
 // ============================================================================
 // EFI Framebuffer Console State (stored in state::ConsoleState)
@@ -242,16 +240,6 @@ mod scan_codes {
 // Input Buffer for Escape Sequence Parsing (stored in state::ConsoleState.input)
 // ============================================================================
 
-/// Console output mode
-static mut CONSOLE_MODE: SimpleTextOutputMode = SimpleTextOutputMode {
-    max_mode: 1,
-    mode: 0,
-    attribute: 0x07, // Light gray on black
-    cursor_column: 0,
-    cursor_row: 0,
-    cursor_visible: Boolean::TRUE,
-};
-
 /// Static text input protocol
 /// Note: wait_for_key is set to KEYBOARD_EVENT_ID which is the special event
 /// used for keyboard input polling
@@ -282,8 +270,11 @@ pub fn get_text_input_protocol() -> *mut SimpleTextInputProtocol {
 
 /// Get the text output protocol
 pub fn get_text_output_protocol() -> *mut SimpleTextOutputProtocol {
+    // SAFETY: Single-threaded firmware. We point the protocol's mode field
+    // at the centralized console state so EFI callers can read it directly.
     unsafe {
-        TEXT_OUTPUT_PROTOCOL.mode = &raw mut CONSOLE_MODE;
+        TEXT_OUTPUT_PROTOCOL.mode =
+            core::ptr::addr_of_mut!((*crate::state::console_mut_ptr()).output_mode);
         &raw mut TEXT_OUTPUT_PROTOCOL
     }
 }
@@ -560,10 +551,12 @@ extern "efiapi" fn text_output_reset(
     _extended_verification: Boolean,
 ) -> Status {
     // Reset console state
+    // SAFETY: Single-threaded firmware; raw pointer to centralized console state.
     unsafe {
-        CONSOLE_MODE.cursor_column = 0;
-        CONSOLE_MODE.cursor_row = 0;
-        CONSOLE_MODE.attribute = 0x07;
+        let mode = &mut (*crate::state::console_mut_ptr()).output_mode;
+        mode.cursor_column = 0;
+        mode.cursor_row = 0;
+        mode.attribute = 0x07;
     }
 
     // Send reset sequence to serial
@@ -580,7 +573,15 @@ extern "efiapi" fn text_output_string(
         return Status::INVALID_PARAMETER;
     }
 
-    // Convert UCS-2 to ASCII and output to both serial and framebuffer
+    // Convert UCS-2 to ASCII and output to both serial and framebuffer.
+    //
+    // We use a raw *mut pointer (not &mut) to update `output_mode` fields
+    // because `fb_put_char()` internally calls `state::with_console_mut()`.
+    // Holding an `&mut ConsoleState.output_mode` across those calls would
+    // create aliasing &mut references (UB).  Raw pointer writes are fine
+    // in single-threaded firmware.
+    let mode_ptr =
+        unsafe { core::ptr::addr_of_mut!((*crate::state::console_mut_ptr()).output_mode) };
     let mut ptr = string;
     unsafe {
         while *ptr != 0 {
@@ -596,25 +597,25 @@ extern "efiapi" fn text_output_string(
                         serial::write_byte(b'\r');
                         serial::write_byte(b'\n');
                         fb_put_char('\n');
-                        CONSOLE_MODE.cursor_column = 0;
-                        CONSOLE_MODE.cursor_row += 1;
+                        (*mode_ptr).cursor_column = 0;
+                        (*mode_ptr).cursor_row += 1;
                     }
                     b'\r' => {
                         serial::write_byte(b'\r');
                         fb_put_char('\r');
-                        CONSOLE_MODE.cursor_column = 0;
+                        (*mode_ptr).cursor_column = 0;
                     }
                     _ => {
                         serial::write_byte(byte);
                         fb_put_char(c);
-                        CONSOLE_MODE.cursor_column += 1;
+                        (*mode_ptr).cursor_column += 1;
                     }
                 }
             } else {
                 // Non-ASCII: output '?'
                 serial::write_byte(b'?');
                 fb_put_char('?');
-                CONSOLE_MODE.cursor_column += 1;
+                (*mode_ptr).cursor_column += 1;
             }
 
             ptr = ptr.add(1);
@@ -683,8 +684,9 @@ extern "efiapi" fn text_output_set_mode(
         return Status::UNSUPPORTED;
     }
 
+    // SAFETY: Single-threaded firmware; raw pointer to centralized console state.
     unsafe {
-        CONSOLE_MODE.mode = mode_number as i32;
+        (*crate::state::console_mut_ptr()).output_mode.mode = mode_number as i32;
     }
 
     Status::SUCCESS
@@ -728,8 +730,9 @@ extern "efiapi" fn text_output_set_attribute(
     _this: *mut SimpleTextOutputProtocol,
     attribute: usize,
 ) -> Status {
+    // SAFETY: Single-threaded firmware; raw pointer to centralized console state.
     unsafe {
-        CONSOLE_MODE.attribute = attribute as i32;
+        (*crate::state::console_mut_ptr()).output_mode.attribute = attribute as i32;
     }
 
     let fg = attribute & 0x0F;
@@ -789,9 +792,11 @@ extern "efiapi" fn text_output_set_attribute(
 extern "efiapi" fn text_output_clear_screen(_this: *mut SimpleTextOutputProtocol) -> Status {
     serial::write_str("\x1b[2J\x1b[H");
 
+    // SAFETY: Single-threaded firmware; raw pointer to centralized console state.
     unsafe {
-        CONSOLE_MODE.cursor_column = 0;
-        CONSOLE_MODE.cursor_row = 0;
+        let mode = &mut (*crate::state::console_mut_ptr()).output_mode;
+        mode.cursor_column = 0;
+        mode.cursor_row = 0;
     }
 
     // Clear the ENTIRE framebuffer (bootloader expects full screen)
@@ -832,9 +837,11 @@ extern "efiapi" fn text_output_set_cursor_position(
         serial::write_byte(byte);
     }
 
+    // SAFETY: Single-threaded firmware; raw pointer to centralized console state.
     unsafe {
-        CONSOLE_MODE.cursor_column = column as i32;
-        CONSOLE_MODE.cursor_row = row as i32;
+        let mode = &mut (*crate::state::console_mut_ptr()).output_mode;
+        mode.cursor_column = column as i32;
+        mode.cursor_row = row as i32;
     }
 
     // Update framebuffer cursor position
@@ -852,8 +859,11 @@ extern "efiapi" fn text_output_enable_cursor(
     visible: Boolean,
 ) -> Status {
     let is_visible: bool = visible.into();
+    // SAFETY: Single-threaded firmware; raw pointer to centralized console state.
     unsafe {
-        CONSOLE_MODE.cursor_visible = visible;
+        (*crate::state::console_mut_ptr())
+            .output_mode
+            .cursor_visible = visible;
     }
 
     if is_visible {

--- a/src/efi/protocols/console_control.rs
+++ b/src/efi/protocols/console_control.rs
@@ -8,6 +8,7 @@ use core::ffi::c_void;
 use r_efi::efi::{Boolean, Guid, Status};
 
 use crate::efi::utils::allocate_protocol_with_log;
+use crate::state::ScreenMode;
 
 /// Console Control Protocol GUID
 /// {F42F7782-012E-4C12-9956-49F94304F721}
@@ -19,18 +20,6 @@ pub const CONSOLE_CONTROL_PROTOCOL_GUID: Guid = Guid::from_fields(
     0x56,
     &[0x49, 0xf9, 0x43, 0x04, 0xf7, 0x21],
 );
-
-/// Console screen mode
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ScreenMode {
-    /// Text mode
-    Text = 0,
-    /// Graphics mode
-    Graphics = 1,
-    /// Maximum mode value (for bounds checking)
-    MaxValue = 2,
-}
 
 /// Console Control Protocol structure
 #[repr(C)]
@@ -46,9 +35,6 @@ pub struct ConsoleControlProtocol {
         extern "efiapi" fn(this: *mut ConsoleControlProtocol, password: *mut u16) -> Status,
 }
 
-/// Current screen mode (we start in graphics mode since we have a framebuffer)
-static mut CURRENT_MODE: ScreenMode = ScreenMode::Graphics;
-
 /// Get the current console mode
 extern "efiapi" fn console_get_mode(
     _this: *mut ConsoleControlProtocol,
@@ -57,8 +43,9 @@ extern "efiapi" fn console_get_mode(
     std_in_locked: *mut Boolean,
 ) -> Status {
     if !mode.is_null() {
+        // SAFETY: mode is a non-null pointer from the caller; single-threaded firmware.
         unsafe {
-            *mode = CURRENT_MODE;
+            *mode = crate::state::console().screen_mode;
         }
     }
 
@@ -92,9 +79,10 @@ extern "efiapi" fn console_set_mode(
         return Status::INVALID_PARAMETER;
     }
 
-    let prev_mode = unsafe { CURRENT_MODE };
+    let prev_mode = crate::state::console().screen_mode;
+    // SAFETY: Single-threaded firmware; no aliasing &mut exists at this point.
     unsafe {
-        CURRENT_MODE = mode;
+        (*crate::state::console_mut_ptr()).screen_mode = mode;
     }
 
     log::debug!("ConsoleControl.SetMode({:?} -> {:?})", prev_mode, mode);

--- a/src/efi/protocols/serial_io.rs
+++ b/src/efi/protocols/serial_io.rs
@@ -273,24 +273,6 @@ extern "efiapi" fn serial_read(
     Status::SUCCESS
 }
 
-/// Static mode structure for the serial port
-static mut SERIAL_MODE: SerialIoMode = SerialIoMode {
-    control_mask: EFI_SERIAL_CLEAR_TO_SEND
-        | EFI_SERIAL_DATA_SET_READY
-        | EFI_SERIAL_RING_INDICATE
-        | EFI_SERIAL_CARRIER_DETECT
-        | EFI_SERIAL_INPUT_BUFFER_EMPTY
-        | EFI_SERIAL_OUTPUT_BUFFER_EMPTY
-        | EFI_SERIAL_REQUEST_TO_SEND
-        | EFI_SERIAL_DATA_TERMINAL_READY,
-    timeout: 1000000, // 1 second in microseconds
-    baud_rate: 115200,
-    receive_fifo_depth: 16,
-    data_bits: 8,
-    parity: 1,    // NoParity
-    stop_bits: 1, // OneStopBit
-};
-
 /// Create and initialize the Serial IO Protocol
 ///
 /// # Returns
@@ -305,7 +287,8 @@ pub fn create_protocol() -> *mut Protocol {
         p.get_control = serial_get_control;
         p.write = serial_write;
         p.read = serial_read;
-        p.mode = &raw mut SERIAL_MODE;
+        p.mode =
+            unsafe { core::ptr::addr_of_mut!((*crate::state::drivers_mut_ptr()).serial.io_mode) };
         p.device_type_guid = core::ptr::null();
     });
     if ptr.is_null() {

--- a/src/efi/varstore/persistence.rs
+++ b/src/efi/varstore/persistence.rs
@@ -87,7 +87,7 @@ pub fn init() -> Result<(), VarStoreError> {
 
     // Store the backend in global state
     state::with_mut(|s| {
-        s.drivers.storage = Some(backend);
+        s.drivers.platform.storage = Some(backend);
     });
 
     // Initialize the variable store region

--- a/src/fb_log.rs
+++ b/src/fb_log.rs
@@ -3,38 +3,27 @@
 //! This module provides logging output to the framebuffer. It is disabled by
 //! default as it is very slow. Enable with the `fb-log` feature flag.
 
-use core::fmt::Write;
-use log::Level;
-use spin::Mutex;
-
 use crate::coreboot::FramebufferInfo;
 use crate::framebuffer_console::{CHAR_HEIGHT, CHAR_WIDTH, Color, render_glyph};
-
-/// Global framebuffer info for logging
-static FB_INFO: Mutex<Option<FramebufferInfo>> = Mutex::new(None);
-
-/// Cursor position for framebuffer logging (row, col)
-static FB_CURSOR: Mutex<(u32, u32)> = Mutex::new((0, 0));
+use core::fmt::Write;
+use log::Level;
 
 /// Set the framebuffer for logging output
 ///
 /// Call this after parsing coreboot tables to enable framebuffer logging.
 /// Clears the screen to remove any stale content from bootloader.
 pub fn set_framebuffer(fb: FramebufferInfo) {
-    // Clear the entire screen first
     unsafe {
-        fb.clear(0, 0, 0); // Black background
+        fb.clear(0, 0, 0);
     }
-    *FB_INFO.lock() = Some(fb);
-    // Reset cursor to top-left
-    *FB_CURSOR.lock() = (0, 0);
+    let console = unsafe { &mut (*crate::state::console_mut_ptr()) };
+    console.logger_framebuffer = Some(fb);
+    console.logger_cursor = (0, 0);
 }
 
 /// Log a message to the framebuffer
 pub fn log_to_framebuffer(level: Level, ts: u64, args: &core::fmt::Arguments) {
-    // Copy fb_info out of the lock to avoid holding FB_INFO while acquiring
-    // FB_CURSOR, which would risk deadlock if the lock order were ever reversed.
-    let fb_info = match *FB_INFO.lock() {
+    let fb_info = match unsafe { (*crate::state::console_mut_ptr()).logger_framebuffer } {
         Some(fb) => fb,
         None => return,
     };
@@ -48,8 +37,7 @@ pub fn log_to_framebuffer(level: Level, ts: u64, args: &core::fmt::Arguments) {
         Level::Trace => ("TRACE", Color::new(192, 64, 192)), // Purple
     };
 
-    // Get cursor position (FB_INFO lock is already released)
-    let (mut row, mut col) = *FB_CURSOR.lock();
+    let (mut row, mut col) = unsafe { (*crate::state::console_mut_ptr()).logger_cursor };
     let cols = fb_info.x_resolution / CHAR_WIDTH;
     let rows = fb_info.y_resolution / CHAR_HEIGHT;
 
@@ -109,7 +97,9 @@ pub fn log_to_framebuffer(level: Level, ts: u64, args: &core::fmt::Arguments) {
     }
 
     // Update cursor
-    *FB_CURSOR.lock() = (row, col);
+    unsafe {
+        (*crate::state::console_mut_ptr()).logger_cursor = (row, col);
+    }
 }
 
 /// Clear a line on the framebuffer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub fn display_secure_boot_error() {
 /// Walks the XSDT/RSDT to find the MCFG table and extracts the first
 /// ECAM base address allocation entry.
 fn discover_ecam_from_acpi() -> Option<u64> {
-    let rsdp_addr = state::drivers().acpi_rsdp?;
+    let rsdp_addr = state::drivers().platform.acpi_rsdp?;
 
     // RSDP, SDT header structs are packed — safe to reference at any alignment
     #[repr(C, packed)]
@@ -251,10 +251,10 @@ pub fn init(coreboot_table_ptr: u64) -> ! {
     state::with_drivers_mut(|drivers| {
         // Copy memory regions
         for region in cb_info.memory_map.iter() {
-            let _ = drivers.memory_regions.push(*region);
+            let _ = drivers.platform.memory_regions.push(*region);
         }
         // Store ACPI RSDP
-        drivers.acpi_rsdp = cb_info.acpi_rsdp;
+        drivers.platform.acpi_rsdp = cb_info.acpi_rsdp;
     });
 
     // Initialize serial port from coreboot info (if available)
@@ -1233,10 +1233,10 @@ fn boot_linux_entry(
         let state = state::get();
         // Copy memory regions to a local buffer (we can't borrow across the disk operations)
         let mut regions = heapless::Vec::<crate::coreboot::memory::MemoryRegion, 64>::new();
-        for region in state.drivers.memory_regions.iter() {
+        for region in state.drivers.platform.memory_regions.iter() {
             let _ = regions.push(*region);
         }
-        (regions, state.drivers.acpi_rsdp)
+        (regions, state.drivers.platform.acpi_rsdp)
     };
 
     // Get framebuffer info for Linux console

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -12,9 +12,16 @@ use core::fmt::Write;
 use log::{Level, LevelFilter, Metadata, Record};
 
 /// Get relative counter ticks since boot (in thousands for readability)
+///
+/// Uses raw-pointer read (see *Log-Path Contract* in [`crate::state`]) to
+/// avoid creating a `&DriverState` reference that would alias with a live
+/// `&mut` from `with_*_mut()` closures.
 pub fn get_timestamp_k() -> u64 {
     let current = read_counter();
-    let boot = crate::state::drivers().timing.boot_counter;
+    // SAFETY: single-threaded firmware; field is written once at init,
+    // only read afterwards.  Raw pointer avoids aliasing with &mut held
+    // by with_*_mut() closures that may log.
+    let boot = unsafe { (*crate::state::drivers_mut_ptr()).timing.boot_counter };
     // Return delta in thousands (k-ticks) to keep numbers manageable
     current.saturating_sub(boot) / 1000
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -9,16 +9,12 @@
 use crate::coreboot::cbmem_console;
 use crate::time::read_counter;
 use core::fmt::Write;
-use core::sync::atomic::{AtomicU64, Ordering};
 use log::{Level, LevelFilter, Metadata, Record};
-
-/// Initial counter value at boot (set during init)
-static BOOT_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Get relative counter ticks since boot (in thousands for readability)
 pub fn get_timestamp_k() -> u64 {
     let current = read_counter();
-    let boot = BOOT_COUNTER.load(Ordering::Relaxed);
+    let boot = crate::state::drivers().timing.boot_counter;
     // Return delta in thousands (k-ticks) to keep numbers manageable
     current.saturating_sub(boot) / 1000
 }
@@ -83,7 +79,11 @@ static LOGGER: CombinedLogger = CombinedLogger;
 /// Initialize the logging subsystem
 pub fn init() {
     // Record the boot counter for relative timestamps
-    BOOT_COUNTER.store(read_counter(), Ordering::Relaxed);
+    // SAFETY: single-threaded init; raw pointer avoids re-entrancy
+    // issues with the state lock.
+    unsafe {
+        (*crate::state::drivers_mut_ptr()).timing.boot_counter = read_counter();
+    }
 
     log::set_logger(&LOGGER)
         .map(|()| log::set_max_level(LevelFilter::Debug))

--- a/src/state.rs
+++ b/src/state.rs
@@ -20,16 +20,19 @@
 //!   |
 //!   +-- efi: EfiState
 //!   |     +-- handles, events, loaded_images
-//!   |     +-- config_tables, variables
-//!   |     +-- allocator
+//!   |     +-- config_tables, variables, varstore
+//!   |     +-- allocator, secure boot flags
 //!   |
 //!   +-- drivers: DriverState
-//!   |     +-- pci, serial, keyboard
-//!   |     +-- storage controllers (nvme, ahci, usb)
+//!   |     +-- pci: PciState (devices, ecam, access method)
+//!   |     +-- serial: SerialState (driver, port, EFI mode)
+//!   |     +-- timing: TimingState (counter freq, boot timestamp)
+//!   |     +-- platform: PlatformInfo (framebuffer, SPI, coreboot info)
+//!   |     +-- keyboard, usb_keyboard, storage_registry, rng
 //!   |
 //!   +-- console: ConsoleState
-//!         +-- framebuffer, cursor, dimensions
-//!         +-- input state
+//!         +-- framebuffer, cursor, dimensions, colors
+//!         +-- input state, screen_mode, output_mode
 //! ```
 //!
 //! # Thread Safety
@@ -515,6 +518,12 @@ pub struct EfiState {
 
     /// Block device for filesystem access
     pub block_device: Option<crate::drivers::block::AnyBlockDevice>,
+
+    /// Secure Boot: whether in Setup Mode (PK not enrolled)
+    pub setup_mode: bool,
+
+    /// Secure Boot: whether Secure Boot is enabled
+    pub secure_boot_enabled: bool,
 }
 
 impl EfiState {
@@ -536,6 +545,8 @@ impl EfiState {
             exit_boot_services_called: false,
             filesystem: None,
             block_device: None,
+            setup_mode: true,
+            secure_boot_enabled: false,
         }
     }
 }
@@ -552,7 +563,15 @@ impl Default for EfiState {
 
 use crate::coreboot::FramebufferInfo;
 use crate::drivers::pci::PciDevice;
+use crate::drivers::pci::access::AnyPciAccess;
+use crate::drivers::serial::AnySerial;
+use crate::drivers::storage::StorageRegistry;
+use crate::drivers::usb::hid_keyboard::UsbHidKeyboard;
+use crate::efi::protocols::serial_io::SerialIoMode;
+use crate::time::Timeout;
 use heapless::Vec as HeaplessVec;
+use r_efi::efi::Boolean;
+use r_efi::protocols::simple_text_output::Mode as SimpleTextOutputMode;
 
 /// Maximum number of PCI devices
 pub const MAX_PCI_DEVICES: usize = 64;
@@ -566,72 +585,48 @@ pub const MAX_STORAGE_DEVICES: usize = 16;
 /// Maximum number of memory regions we can store
 pub const MAX_MEMORY_REGIONS: usize = 64;
 
-/// Hardware driver state
+/// Hardware driver state, organized into logical subsystems.
 pub struct DriverState {
-    /// PCI device list
-    pub pci_devices: HeaplessVec<PciDevice, MAX_PCI_DEVICES>,
-    /// PCIe ECAM base address
-    pub ecam_base: Option<u64>,
+    /// PCI bus subsystem
+    pub pci: PciState,
 
-    /// Serial port I/O base address
-    pub serial_port: Option<u16>,
+    /// Serial port (hardware driver + EFI protocol mode)
+    pub serial: SerialState,
 
-    /// PS/2 keyboard state
+    /// Timing calibration (TSC/ARM generic timer)
+    pub timing: TimingState,
+
+    /// Platform hardware info (from coreboot tables)
+    pub platform: PlatformInfo,
+
+    /// PS/2 keyboard state (x86 only, but always present for layout stability)
     pub keyboard: KeyboardState,
 
-    /// Global framebuffer info (from coreboot)
-    pub framebuffer: Option<FramebufferInfo>,
+    /// USB HID keyboard state
+    pub usb_keyboard: Option<UsbHidKeyboard>,
 
-    /// Address of the coreboot framebuffer record in the coreboot tables.
-    /// This is stored so we can invalidate it at ExitBootServices to prevent
-    /// Linux from trying to use both the coreboot framebuffer and the EFI GOP.
-    pub coreboot_fb_record_addr: Option<u64>,
+    /// USB keyboard next poll timeout
+    pub usb_keyboard_poll_timeout: Option<Timeout>,
 
-    /// SMMSTORE v2 info (from coreboot tables)
-    ///
-    /// Contains information for accessing UEFI variable storage through
-    /// coreboot's SMMSTORE v2 interface.
-    pub smmstorev2: Option<crate::coreboot::Smmstorev2Info>,
+    /// Storage device registry (tracks all block devices)
+    pub(crate) storage_registry: StorageRegistry,
 
-    /// SPI flash info (from coreboot tables)
-    ///
-    /// Contains information about the system's SPI flash chip.
-    pub spi_flash: Option<crate::coreboot::SpiFlashInfo>,
-
-    /// Boot media params (from coreboot tables)
-    ///
-    /// Contains information about the boot media layout including FMAP location.
-    pub boot_media: Option<crate::coreboot::BootMediaInfo>,
-
-    /// Storage backend for variable persistence (SPI flash, etc.)
-    ///
-    /// This is initialized during boot from detected SPI controller.
-    /// The storage handles offset translation so reads/writes are
-    /// relative to the variable store region.
-    pub storage: Option<crate::efi::varstore::SpiStorageBackend>,
-
-    /// Coreboot memory regions (for direct Linux boot)
-    pub memory_regions: HeaplessVec<crate::coreboot::memory::MemoryRegion, MAX_MEMORY_REGIONS>,
-
-    /// ACPI RSDP address (from coreboot)
-    pub acpi_rsdp: Option<u64>,
+    /// Hardware RNG available and functional
+    pub rng_available: bool,
 }
 
 impl DriverState {
     pub const fn new() -> Self {
         Self {
-            pci_devices: HeaplessVec::new(),
-            ecam_base: None,
-            serial_port: None,
+            pci: PciState::new(),
+            serial: SerialState::new(),
+            timing: TimingState::new(),
+            platform: PlatformInfo::new(),
             keyboard: KeyboardState::new(),
-            framebuffer: None,
-            coreboot_fb_record_addr: None,
-            smmstorev2: None,
-            spi_flash: None,
-            boot_media: None,
-            storage: None,
-            memory_regions: HeaplessVec::new(),
-            acpi_rsdp: None,
+            usb_keyboard: None,
+            usb_keyboard_poll_timeout: None,
+            storage_registry: StorageRegistry::new(),
+            rng_available: false,
         }
     }
 }
@@ -641,6 +636,192 @@ impl Default for DriverState {
         Self::new()
     }
 }
+
+// ----------------------------------------------------------------------------
+// PCI State
+// ----------------------------------------------------------------------------
+
+/// PCI bus subsystem state
+pub struct PciState {
+    /// Enumerated PCI device list
+    pub devices: HeaplessVec<PciDevice, MAX_PCI_DEVICES>,
+    /// PCIe ECAM base address (from ACPI MCFG or coreboot)
+    pub ecam_base: Option<u64>,
+    /// Config space access method (legacy I/O CAM or PCIe ECAM)
+    pub access: AnyPciAccess,
+}
+
+impl PciState {
+    pub const fn new() -> Self {
+        use crate::drivers::pci::access::IoCamAccess;
+        Self {
+            devices: HeaplessVec::new(),
+            ecam_base: None,
+            access: AnyPciAccess::IoCam(IoCamAccess),
+        }
+    }
+}
+
+impl Default for PciState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Serial State
+// ----------------------------------------------------------------------------
+
+/// Serial port state: hardware driver and EFI protocol mode.
+pub struct SerialState {
+    /// I/O base address (from coreboot serial info)
+    pub port: Option<u16>,
+    /// Active serial port driver (16550 UART or PL011)
+    pub(crate) driver: Option<AnySerial>,
+    /// EFI Serial IO protocol mode (current port settings).
+    ///
+    /// The Protocol.mode pointer is set to point here during init.
+    pub io_mode: SerialIoMode,
+}
+
+impl SerialState {
+    pub const fn new() -> Self {
+        use crate::efi::protocols::serial_io::{
+            EFI_SERIAL_CARRIER_DETECT, EFI_SERIAL_CLEAR_TO_SEND, EFI_SERIAL_DATA_SET_READY,
+            EFI_SERIAL_DATA_TERMINAL_READY, EFI_SERIAL_INPUT_BUFFER_EMPTY,
+            EFI_SERIAL_OUTPUT_BUFFER_EMPTY, EFI_SERIAL_REQUEST_TO_SEND, EFI_SERIAL_RING_INDICATE,
+        };
+
+        Self {
+            port: None,
+            driver: None,
+            io_mode: SerialIoMode {
+                control_mask: EFI_SERIAL_CLEAR_TO_SEND
+                    | EFI_SERIAL_DATA_SET_READY
+                    | EFI_SERIAL_RING_INDICATE
+                    | EFI_SERIAL_CARRIER_DETECT
+                    | EFI_SERIAL_INPUT_BUFFER_EMPTY
+                    | EFI_SERIAL_OUTPUT_BUFFER_EMPTY
+                    | EFI_SERIAL_REQUEST_TO_SEND
+                    | EFI_SERIAL_DATA_TERMINAL_READY,
+                timeout: 1000000,
+                baud_rate: 115200,
+                receive_fifo_depth: 16,
+                data_bits: 8,
+                parity: 1,    // NoParity
+                stop_bits: 1, // OneStopBit
+            },
+        }
+    }
+}
+
+impl Default for SerialState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Timing State
+// ----------------------------------------------------------------------------
+
+/// Timing calibration state.
+///
+/// On x86, the TSC is calibrated against the ACPI PM timer.
+/// On aarch64, the ARM Generic Timer frequency register is read directly.
+pub struct TimingState {
+    /// Counter frequency in Hz (set during calibration)
+    pub counter_freq_hz: u64,
+    /// Counter cycles per microsecond (cached for fast delay loops)
+    pub counter_cycles_per_us: u64,
+    /// Initial counter value at boot (for relative timestamps in log output)
+    pub boot_counter: u64,
+}
+
+impl TimingState {
+    pub const fn new() -> Self {
+        Self {
+            counter_freq_hz: 2_000_000_000, // Conservative 2 GHz fallback
+            counter_cycles_per_us: 2000,
+            boot_counter: 0,
+        }
+    }
+}
+
+impl Default for TimingState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Platform Info
+// ----------------------------------------------------------------------------
+
+/// Platform hardware info sourced from coreboot tables.
+///
+/// This groups all the hardware discovery data that comes from parsing
+/// coreboot's lb_record table entries during early boot.
+pub struct PlatformInfo {
+    /// Global framebuffer info
+    pub framebuffer: Option<FramebufferInfo>,
+
+    /// Address of the coreboot framebuffer record in the coreboot tables.
+    /// Stored so we can invalidate it at ExitBootServices to prevent
+    /// Linux from trying to use both the coreboot framebuffer and the EFI GOP.
+    pub coreboot_fb_record_addr: Option<u64>,
+
+    /// SMMSTORE v2 info for UEFI variable storage
+    pub smmstorev2: Option<crate::coreboot::Smmstorev2Info>,
+
+    /// SPI flash info
+    pub spi_flash: Option<crate::coreboot::SpiFlashInfo>,
+
+    /// Boot media params (FMAP location, etc.)
+    pub boot_media: Option<crate::coreboot::BootMediaInfo>,
+
+    /// Storage backend for variable persistence (SPI flash).
+    ///
+    /// Initialized during boot from detected SPI controller.
+    /// Handles offset translation so reads/writes are relative to
+    /// the variable store region.
+    pub storage: Option<crate::efi::varstore::SpiStorageBackend>,
+
+    /// Memory regions (for direct Linux boot)
+    pub memory_regions: HeaplessVec<crate::coreboot::memory::MemoryRegion, MAX_MEMORY_REGIONS>,
+
+    /// ACPI RSDP address
+    pub acpi_rsdp: Option<u64>,
+
+    /// CBMEM console address (0 = not initialized/disabled)
+    pub cbmem_console_addr: u64,
+}
+
+impl PlatformInfo {
+    pub const fn new() -> Self {
+        Self {
+            framebuffer: None,
+            coreboot_fb_record_addr: None,
+            smmstorev2: None,
+            spi_flash: None,
+            boot_media: None,
+            storage: None,
+            memory_regions: HeaplessVec::new(),
+            acpi_rsdp: None,
+            cbmem_console_addr: 0,
+        }
+    }
+}
+
+impl Default for PlatformInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Keyboard State
+// ----------------------------------------------------------------------------
 
 /// PS/2 keyboard state
 pub struct KeyboardState {
@@ -687,6 +868,20 @@ impl KeyboardState {
 // Console State
 // ============================================================================
 
+/// Console screen mode (Text or Graphics)
+///
+/// Used by the ConsoleControl protocol to track the current display mode.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScreenMode {
+    /// Text mode
+    Text = 0,
+    /// Graphics mode
+    Graphics = 1,
+    /// Maximum mode value (for bounds checking)
+    MaxValue = 2,
+}
+
 /// Console and display state
 pub struct ConsoleState {
     /// EFI console framebuffer info
@@ -711,13 +906,22 @@ pub struct ConsoleState {
     /// Input state for escape sequence parsing
     pub input: InputState,
 
-    /// Logger framebuffer info
+    /// Logger framebuffer info (used by fb_log for debug output)
     pub logger_framebuffer: Option<FramebufferInfo>,
-    /// Logger cursor position
+    /// Logger cursor position (row, col)
     pub logger_cursor: (u32, u32),
 
     /// GOP framebuffer for graphics output protocol Blt operations
     pub gop_framebuffer: Option<FramebufferInfo>,
+
+    /// Screen mode (Text or Graphics) for ConsoleControl protocol
+    pub screen_mode: ScreenMode,
+
+    /// EFI SimpleTextOutput mode structure
+    ///
+    /// The Protocol.mode pointer is set to point here during init.
+    /// This tracks cursor position, attribute, and mode for the EFI text console.
+    pub output_mode: SimpleTextOutputMode,
 }
 
 impl ConsoleState {
@@ -735,6 +939,15 @@ impl ConsoleState {
             logger_framebuffer: None,
             logger_cursor: (0, 0),
             gop_framebuffer: None,
+            screen_mode: ScreenMode::Graphics,
+            output_mode: SimpleTextOutputMode {
+                max_mode: 1,
+                mode: 0,
+                attribute: 0x07, // Light gray on black
+                cursor_column: 0,
+                cursor_row: 0,
+                cursor_visible: Boolean::TRUE,
+            },
         }
     }
 }
@@ -959,7 +1172,7 @@ pub fn with_storage_mut<F, R>(f: F) -> Option<R>
 where
     F: FnOnce(&mut crate::efi::varstore::SpiStorageBackend) -> R,
 {
-    with_mut(|state| state.drivers.storage.as_mut().map(f))
+    with_mut(|state| state.drivers.platform.storage.as_mut().map(f))
 }
 
 /// Get a reference to the varstore state.

--- a/src/state.rs
+++ b/src/state.rs
@@ -40,6 +40,35 @@
 //! CrabEFI is single-threaded firmware. We use `UnsafeCell` for interior
 //! mutability without the overhead of `Mutex`. The UEFI spec guarantees
 //! that Boot Services are not reentrant.
+//!
+//! # Log-Path Contract
+//!
+//! Functions called from the `log` crate macros — serial output
+//! ([`crate::drivers::serial`]), cbmem console ([`crate::coreboot::cbmem_console`]),
+//! framebuffer logging ([`crate::fb_log`]), and the timestamp helper
+//! ([`crate::logger::get_timestamp_k`]) — must **never** create Rust
+//! references (`&` or `&mut`) into `FirmwareState`.
+//!
+//! This is necessary because `log::info!()` and friends may fire *inside*
+//! a `with_mut()` / `with_drivers_mut()` closure, which holds a live
+//! `&mut FirmwareState`.  Creating any `&FirmwareState` (e.g. via
+//! [`drivers()`] or [`try_get()`]) would alias with that `&mut` — UB
+//! under Rust's reference rules.
+//!
+//! Instead, log-path code uses **raw-pointer field access**:
+//!
+//! - **Writes**: `(*drivers_mut_ptr()).serial.driver` (serial, fb_log)
+//! - **Reads**: `(*drivers_mut_ptr()).timing.boot_counter` (timestamps),
+//!   `(*drivers_mut_ptr()).platform.cbmem_console_addr` (CBMEM console)
+//!
+//! Raw-pointer access is sound here because:
+//!
+//! 1. The firmware is single-threaded — no data races.
+//! 2. The log-path functions only touch their own disjoint fields
+//!    (e.g. `serial.driver`, `platform.cbmem_console_addr`,
+//!    `console.logger_*`, `timing.boot_counter`).
+//! 3. They never read or write fields that the enclosing `with_mut()`
+//!    closure is currently modifying.
 
 use core::sync::atomic::{AtomicPtr, Ordering};
 
@@ -566,9 +595,7 @@ use crate::drivers::pci::PciDevice;
 use crate::drivers::pci::access::AnyPciAccess;
 use crate::drivers::serial::AnySerial;
 use crate::drivers::storage::StorageRegistry;
-use crate::drivers::usb::hid_keyboard::UsbHidKeyboard;
 use crate::efi::protocols::serial_io::SerialIoMode;
-use crate::time::Timeout;
 use heapless::Vec as HeaplessVec;
 use r_efi::efi::Boolean;
 use r_efi::protocols::simple_text_output::Mode as SimpleTextOutputMode;
@@ -599,15 +626,6 @@ pub struct DriverState {
     /// Platform hardware info (from coreboot tables)
     pub platform: PlatformInfo,
 
-    /// PS/2 keyboard state (x86 only, but always present for layout stability)
-    pub keyboard: KeyboardState,
-
-    /// USB HID keyboard state
-    pub usb_keyboard: Option<UsbHidKeyboard>,
-
-    /// USB keyboard next poll timeout
-    pub usb_keyboard_poll_timeout: Option<Timeout>,
-
     /// Storage device registry (tracks all block devices)
     pub(crate) storage_registry: StorageRegistry,
 
@@ -622,9 +640,6 @@ impl DriverState {
             serial: SerialState::new(),
             timing: TimingState::new(),
             platform: PlatformInfo::new(),
-            keyboard: KeyboardState::new(),
-            usb_keyboard: None,
-            usb_keyboard_poll_timeout: None,
             storage_registry: StorageRegistry::new(),
             rng_available: false,
         }
@@ -674,8 +689,6 @@ impl Default for PciState {
 
 /// Serial port state: hardware driver and EFI protocol mode.
 pub struct SerialState {
-    /// I/O base address (from coreboot serial info)
-    pub port: Option<u16>,
     /// Active serial port driver (16550 UART or PL011)
     pub(crate) driver: Option<AnySerial>,
     /// EFI Serial IO protocol mode (current port settings).
@@ -693,7 +706,6 @@ impl SerialState {
         };
 
         Self {
-            port: None,
             driver: None,
             io_mode: SerialIoMode {
                 control_mask: EFI_SERIAL_CLEAR_TO_SEND
@@ -816,51 +828,6 @@ impl PlatformInfo {
 impl Default for PlatformInfo {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-// ----------------------------------------------------------------------------
-// Keyboard State
-// ----------------------------------------------------------------------------
-
-/// PS/2 keyboard state
-pub struct KeyboardState {
-    /// Shift key pressed
-    pub shift_pressed: bool,
-    /// Control key pressed
-    pub ctrl_pressed: bool,
-    /// Alt key pressed
-    pub alt_pressed: bool,
-    /// Caps lock enabled
-    pub caps_lock: bool,
-    /// Key buffer for storing pending keys
-    pub key_buffer: [u8; 16],
-    /// Number of keys in buffer
-    pub key_count: usize,
-    /// Read position in buffer
-    pub read_pos: usize,
-    /// Write position in buffer
-    pub write_pos: usize,
-}
-
-impl Default for KeyboardState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl KeyboardState {
-    pub const fn new() -> Self {
-        Self {
-            shift_pressed: false,
-            ctrl_pressed: false,
-            alt_pressed: false,
-            caps_lock: false,
-            key_buffer: [0; 16],
-            key_count: 0,
-            read_pos: 0,
-            write_pos: 0,
-        }
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -4,8 +4,6 @@
 //! - **x86_64**: TSC (Time Stamp Counter) calibrated against the ACPI PM timer
 //! - **aarch64**: ARM Generic Timer (`CNTPCT_EL0` / `CNTFRQ_EL0`)
 
-use core::sync::atomic::{AtomicU64, Ordering};
-
 #[cfg(target_arch = "x86_64")]
 use crate::arch::x86_64::io;
 #[cfg(target_arch = "x86_64")]
@@ -14,13 +12,6 @@ use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
 // ============================================================================
 // Architecture-agnostic counter interface
 // ============================================================================
-
-/// Counter frequency in Hz (cycles per second)
-/// Default to 2 GHz as a conservative fallback for x86, or set by init for aarch64
-static COUNTER_FREQ_HZ: AtomicU64 = AtomicU64::new(2_000_000_000);
-
-/// Counter cycles per microsecond (cached for fast access)
-static COUNTER_CYCLES_PER_US: AtomicU64 = AtomicU64::new(2000);
 
 /// Read the monotonic counter value
 ///
@@ -39,7 +30,7 @@ pub fn read_counter() -> u64 {
 
 /// Get the counter frequency in Hz
 pub fn counter_frequency() -> u64 {
-    COUNTER_FREQ_HZ.load(Ordering::Relaxed)
+    crate::state::drivers().timing.counter_freq_hz
 }
 
 // Re-export read_counter as rdtsc on x86 for backwards compat with existing callers
@@ -55,7 +46,7 @@ pub fn rdtsc() -> u64 {
 
 // Re-export counter_frequency as tsc_frequency for backwards compat
 pub fn tsc_frequency() -> u64 {
-    COUNTER_FREQ_HZ.load(Ordering::Relaxed)
+    crate::state::drivers().timing.counter_freq_hz
 }
 
 // ============================================================================
@@ -65,6 +56,7 @@ pub fn tsc_frequency() -> u64 {
 #[cfg(target_arch = "x86_64")]
 mod x86_calibration {
     use super::*;
+    use core::sync::atomic::{AtomicU64, Ordering};
 
     /// ACPI PM timer frequency: 3.579545 MHz
     const PM_TIMER_FREQ: u64 = 3_579_545;
@@ -290,8 +282,13 @@ mod x86_calibration {
 
             if let Some(freq) = calibrate_tsc_with_pm_timer() {
                 let cycles_per_us = freq / 1_000_000;
-                COUNTER_FREQ_HZ.store(freq, Ordering::Relaxed);
-                COUNTER_CYCLES_PER_US.store(cycles_per_us, Ordering::Relaxed);
+                // SAFETY: single-threaded init; raw pointer avoids re-entrancy
+                // issues with the state lock.
+                unsafe {
+                    let t = &mut (*crate::state::drivers_mut_ptr()).timing;
+                    t.counter_freq_hz = freq;
+                    t.counter_cycles_per_us = cycles_per_us;
+                }
 
                 log::info!(
                     "TSC calibrated: {} MHz ({} cycles/us)",
@@ -312,8 +309,6 @@ mod x86_calibration {
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64_timer {
-    use super::*;
-
     /// Initialize aarch64 timing from the Generic Timer frequency register
     pub fn init(_acpi_rsdp: Option<u64>) {
         let freq = crate::arch::aarch64::read_counter_freq();
@@ -321,14 +316,24 @@ mod aarch64_timer {
         if freq == 0 {
             log::warn!("ARM Generic Timer frequency is 0, using 62.5 MHz fallback");
             let fallback = 62_500_000u64;
-            COUNTER_FREQ_HZ.store(fallback, Ordering::Relaxed);
-            COUNTER_CYCLES_PER_US.store(fallback / 1_000_000, Ordering::Relaxed);
+            // SAFETY: single-threaded init; raw pointer avoids re-entrancy
+            // issues with the state lock.
+            unsafe {
+                let t = &mut (*crate::state::drivers_mut_ptr()).timing;
+                t.counter_freq_hz = fallback;
+                t.counter_cycles_per_us = fallback / 1_000_000;
+            }
             return;
         }
 
         let cycles_per_us = freq / 1_000_000;
-        COUNTER_FREQ_HZ.store(freq, Ordering::Relaxed);
-        COUNTER_CYCLES_PER_US.store(cycles_per_us.max(1), Ordering::Relaxed);
+        // SAFETY: single-threaded init; raw pointer avoids re-entrancy
+        // issues with the state lock.
+        unsafe {
+            let t = &mut (*crate::state::drivers_mut_ptr()).timing;
+            t.counter_freq_hz = freq;
+            t.counter_cycles_per_us = cycles_per_us.max(1);
+        }
 
         log::info!(
             "ARM Generic Timer: {} MHz ({} cycles/us)",
@@ -357,7 +362,7 @@ pub fn init(acpi_rsdp: Option<u64>) {
 /// Spin-wait for approximately `us` microseconds
 #[inline]
 pub fn delay_us(us: u64) {
-    let cycles = us * COUNTER_CYCLES_PER_US.load(Ordering::Relaxed);
+    let cycles = us * crate::state::drivers().timing.counter_cycles_per_us;
     let start = read_counter();
     while read_counter().wrapping_sub(start) < cycles {
         core::hint::spin_loop();
@@ -393,7 +398,7 @@ impl Timeout {
     /// Create a timeout that expires after `us` microseconds
     #[inline]
     pub fn from_us(us: u64) -> Self {
-        let cycles = us * COUNTER_CYCLES_PER_US.load(Ordering::Relaxed);
+        let cycles = us * crate::state::drivers().timing.counter_cycles_per_us;
         Self {
             deadline: read_counter().wrapping_add(cycles),
         }


### PR DESCRIPTION
Reorganize DriverState into logical sub-structs (PciState, SerialState,
TimingState, PlatformInfo) and migrate 16 scattered static variables
into the centralized FirmwareState, eliminating unnecessary Mutex locks
and unsound static mut declarations.

Statics removed:
- COUNTER_FREQ_HZ, COUNTER_CYCLES_PER_US (time.rs) -> timing
- BOOT_COUNTER (logger.rs) -> timing
- CBMEM_CONSOLE_ADDR (cbmem_console.rs) -> platform
- RDRAND_AVAILABLE (x86_64/rng.rs) -> rng_available
- RNG_AVAILABLE, RNG_METHOD (aarch64/rng.rs) -> rng_available + AtomicU8
- SETUP_MODE, SECURE_BOOT_ENABLED (auth/mod.rs) -> efi
- CURRENT_MODE (console_control.rs) -> console.screen_mode
- CONSOLE_MODE (console.rs) -> console.output_mode
- SERIAL_MODE (serial_io.rs) -> serial.io_mode
- ANY_SERIAL (serial.rs) -> serial.driver
- PCI_ACCESS (pci/mod.rs) -> pci.access
- STORAGE_REGISTRY (storage.rs) -> storage_registry
- FB_INFO, FB_CURSOR (fb_log.rs) -> existing console.logger_*

Functions called from log macros (serial, fb_log) use raw pointer
access via drivers_mut_ptr()/console_mut_ptr() to avoid re-entrancy
with the with_mut() debug guard.

Signed-off-by: Arthur Heymans <arthur@aheymans.xyz>
Co-authored-by: Claude <noreply@anthropic.com>