### PR TITLE
refactor: restructure CrabEFI as a library with platform abstraction traits

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,17 +1,16 @@
 # NOTE: Use ./xtask script to run xtask (it needs different build settings)
+#
+# Linker scripts are handled by crabefi-coreboot/build.rs.
+# Only compilation flags and build-std settings live here.
 
 [target.x86_64-unknown-none]
 rustflags = [
-    "-C", "link-arg=-Tx86_64-coreboot.ld",
-    "-C", "link-arg=-no-pie",
     "-C", "relocation-model=pic",
     "-C", "code-model=kernel",
 ]
 
 [target.aarch64-unknown-none]
 rustflags = [
-    "-C", "link-arg=-Taarch64-coreboot.ld",
-    "-C", "link-arg=-no-pie",
     "-C", "relocation-model=static",
 ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           targets: x86_64-unknown-none
 
       - name: Run clippy
-        run: cargo clippy --release --target x86_64-unknown-none -- -D warnings
+        run: cargo clippy --workspace --release --target x86_64-unknown-none -- -D warnings
 
   build:
     name: Build (x86_64)
@@ -54,7 +54,7 @@ jobs:
           targets: x86_64-unknown-none
 
       - name: Build release
-        run: cargo build --release --target x86_64-unknown-none
+        run: cargo build -p crabefi-coreboot --release --target x86_64-unknown-none
 
       - name: Upload CrabEFI ELF
         uses: actions/upload-artifact@v4
@@ -229,7 +229,7 @@ jobs:
           targets: aarch64-unknown-none
 
       - name: Run clippy
-        run: cargo clippy --release --target aarch64-unknown-none -- -D warnings
+        run: cargo clippy --workspace --release --target aarch64-unknown-none -- -D warnings
 
   build-aarch64:
     name: Build (aarch64)
@@ -244,7 +244,7 @@ jobs:
           targets: aarch64-unknown-none
 
       - name: Build release
-        run: cargo build --release --target aarch64-unknown-none
+        run: cargo build -p crabefi-coreboot --release --target aarch64-unknown-none
 
       - name: Upload CrabEFI ELF (aarch64)
         uses: actions/upload-artifact@v4
@@ -329,7 +329,7 @@ jobs:
           targets: aarch64-unknown-none
 
       - name: Build release (virt PAYLOAD_BASE)
-        run: PAYLOAD_BASE=0x62000000 cargo build --release --target aarch64-unknown-none
+        run: PAYLOAD_BASE=0x62000000 cargo build -p crabefi-coreboot --release --target aarch64-unknown-none
 
       - name: Upload CrabEFI ELF (aarch64-virt)
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,10 +123,8 @@ dependencies = [
 name = "crabefi"
 version = "0.1.0"
 dependencies = [
- "acpi",
  "atomic_refcell",
  "bitflags",
- "cc",
  "cms",
  "const-oid",
  "der",
@@ -144,6 +142,35 @@ dependencies = [
  "spki",
  "tock-registers",
  "x509-cert",
+ "x86_64",
+ "zerocopy",
+]
+
+[[package]]
+name = "crabefi-coreboot"
+version = "0.1.0"
+dependencies = [
+ "acpi",
+ "cc",
+ "crabefi",
+ "crabefi-drivers",
+ "fdt",
+ "heapless",
+ "log",
+ "r-efi",
+ "x86_64",
+]
+
+[[package]]
+name = "crabefi-drivers"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "crabefi",
+ "heapless",
+ "log",
+ "spin",
+ "tock-registers",
  "x86_64",
  "zerocopy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,38 @@
-# Note: xtask is NOT a workspace member because it needs different build settings
-# Use `cargo xtask` to run it (alias defined in .cargo/config.toml)
-# test-apps are also separate because they target x86_64-unknown-uefi
+# Workspace: core library lives here, coreboot binary and drivers are separate crates.
+# xtask and test-apps are NOT workspace members (different build targets).
+
+[workspace]
+members = [".", "crabefi-coreboot", "crabefi-drivers"]
+exclude = ["xtask", "test-apps/hello", "test-apps/rng-test", "test-apps/secure-boot-test", "test-apps/storage-security-test", "test-apps/directory-test", "test-apps/fw-dump"]
+resolver = "3"
+
+[workspace.package]
+edition = "2024"
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/user/CrabEFI"
 
 [package]
 name = "crabefi"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 authors = ["CrabEFI Contributors"]
-description = "A minimal UEFI implementation as a coreboot payload"
-license = "Apache-2.0 OR MIT"
-repository = "https://github.com/user/CrabEFI"
+description = "A platform-agnostic UEFI implementation library"
+license.workspace = true
+repository.workspace = true
 readme = "README.md"
+# The binary target is in crabefi-coreboot/; don't auto-discover src/main.rs
+autobins = false
 
 [features]
 default = []
+# Include CrabEFI's own _start entry point, EL2 page table setup,
+# and exception vector table. Disable when linking CrabEFI as a
+# library into an external firmware (e.g., fstart) that provides
+# its own entry point and exception handling.
+platform-entry = []
+# Register the built-in BumpAllocator as #[global_allocator].
+# Disable this if the linking binary provides its own allocator.
+global-allocator = []
 # Enable logging output to framebuffer (very slow, for debugging only)
 fb-log = []
 # Enable runtime services serial debug logging (post-SetVirtualAddressMap)
@@ -33,9 +52,6 @@ spin = "0.9"
 tock-registers = "0.10"
 zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
 
-# ACPI table parsing and AML interpreter for platform device discovery
-acpi = { version = "6.1", default-features = false, features = ["alloc", "aml"] }
-
 # RustCrypto crates for UEFI Secure Boot authentication (all no_std compatible)
 sha1 = { version = "0.10", default-features = false, features = ["force-soft"] }
 sha2 = { version = "0.10", default-features = false, features = ["oid", "force-soft"] }
@@ -54,11 +70,15 @@ postcard = { version = "1.0", default-features = false, features = ["alloc"] }
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = "0.15"
 
-[target.'cfg(target_arch = "aarch64")'.dependencies]
+# FDT parsing is needed on aarch64 (QEMU virt, SBSA) and riscv64 (OpenSBI
+# passes FDT in a1).  Not needed on x86_64 (ACPI-only).
+[target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]
 fdt = "0.1.5"
 
-[build-dependencies]
-cc = "1"
+[workspace.dependencies]
+r-efi = "5.3"
+log = "0.4"
+heapless = "0.8"
 
 [profile.dev]
 panic = "abort"
@@ -72,7 +92,3 @@ codegen-units = 1
 [lib]
 name = "crabefi"
 path = "src/lib.rs"
-
-[[bin]]
-name = "crabefi"
-path = "src/main.rs"

--- a/README.md
+++ b/README.md
@@ -1,42 +1,25 @@
 # CrabEFI
 
-A minimal UEFI implementation written in Rust, designed to run as a coreboot payload.
+A UEFI implementation written in Rust, designed as a reusable library with dependency injection for platform-specific hardware.
+
+CrabEFI implements enough UEFI to boot Linux via shim/GRUB2 or systemd-boot on real hardware. It ships as a coreboot payload but its core is a platform-agnostic library that any firmware can link against.
 
 ## Documentation
 
-For detailed documentation, see the [docs/](docs/README.md) directory:
+See the [docs/](docs/README.md) directory:
 
 - [Building](docs/BUILDING.md) - How to build CrabEFI and run tests
-- [Architecture](docs/ARCHITECTURE.md) - Repository layout and code organization
+- [Architecture](docs/ARCHITECTURE.md) - Workspace layout and code organization
+- [Integration](docs/INTEGRATION.md) - Using CrabEFI as a library in external firmware
 - [Memory Management](docs/MEMORY.md) - Memory layout, allocators, and EFI memory map
 
-## Goals
-
-CrabEFI implements just enough UEFI to boot Linux via shim/GRUB2 or systemd-boot on real hardware. It is not intended to be a full UEFI implementation. 
-Maybe booting windows is also a possibility.
-
-### Planned Features
-
-- **Secure Boot** - Signature verification for bootloaders and kernels
-- **Variable Store** - Persistent EFI variables for saving boot menu entries and configuration
-
-## Building
-
-```bash
-cargo build --release
-```
-
-The output ELF is at `target/x86_64-unknown-none/release/crabefi.elf`, ready to be used as a coreboot payload.
-
-## Testing
-
-Use the `./crabefi` tool for building, testing, and running in QEMU:
+## Quick Start
 
 ```bash
 # Enter nix development environment (provides QEMU, mtools, etc.)
 nix develop
 
-# Build CrabEFI
+# Build the coreboot payload
 ./crabefi build
 
 # Run integration tests
@@ -45,9 +28,19 @@ nix develop
 # Run interactively in QEMU
 ./crabefi run --app hello
 
-# See all commands
-./crabefi --help
+# Build for aarch64
+./crabefi build --arch aarch64
 ```
+
+## Workspace Structure
+
+| Crate | Description |
+|-------|-------------|
+| `crabefi` (root) | Core library -- platform-agnostic UEFI implementation |
+| `crabefi-coreboot` | Coreboot payload binary (arch entry points, table parsing) |
+| `crabefi-drivers` | Standard hardware drivers (NVMe, AHCI, USB, SDHCI, SPI, serial) |
+
+External firmware implements a set of platform traits (`BlockDevice`, `VariableBackend`, `Timer`, etc.), builds a `PlatformConfig`, and calls `crabefi::init_platform()`. See [docs/INTEGRATION.md](docs/INTEGRATION.md) for details.
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -1,16 +1,9 @@
-//! Build script for CrabEFI
+//! Build script for CrabEFI core library
+//!
+//! The library itself has no link-time requirements.
+//! Linker scripts and PAYLOAD_BASE are handled by crabefi-coreboot/build.rs.
 
 fn main() {
-    // Tell Cargo to rerun this build script if either linker script changes
-    println!("cargo:rerun-if-changed=x86_64-coreboot.ld");
-    println!("cargo:rerun-if-changed=aarch64-coreboot.ld");
-
-    // Allow overriding the aarch64 payload base address at build time.
-    // Default is for QEMU SBSA (DRAM starts at 0x100_0000_0000).
-    // For QEMU virt (aarch64), set PAYLOAD_BASE=0x62000000.
-    println!("cargo:rerun-if-env-changed=PAYLOAD_BASE");
-    let payload_base =
-        std::env::var("PAYLOAD_BASE").unwrap_or_else(|_| "0x10022000000".to_string());
-    println!("cargo:rustc-link-arg=--defsym");
-    println!("cargo:rustc-link-arg=PAYLOAD_BASE={payload_base}");
+    // No-op for the library crate.
+    // Coreboot-specific build logic is in crabefi-coreboot/build.rs.
 }

--- a/crabefi-coreboot/Cargo.toml
+++ b/crabefi-coreboot/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "crabefi-coreboot"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "CrabEFI as a coreboot payload binary"
+
+[dependencies]
+crabefi = { path = "..", features = ["global-allocator", "platform-entry"] }
+crabefi-drivers = { path = "../crabefi-drivers" }
+
+# Needed for coreboot table parsing and early setup
+log = "0.4"
+r-efi = "5.3"
+heapless = "0.8"
+
+# ACPI table parsing and AML interpreter for platform device discovery.
+# Used by the coreboot payload's post_heap_init callback to discover
+# ECAM, GIC, UART, and DSDT devices from ACPI tables.
+acpi = { version = "6.1", default-features = false, features = ["alloc", "aml"] }
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+x86_64 = "0.15"
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+fdt = "0.1.5"
+
+[build-dependencies]
+cc = "1"
+
+[[bin]]
+name = "crabefi"
+path = "src/main.rs"

--- a/crabefi-coreboot/build.rs
+++ b/crabefi-coreboot/build.rs
@@ -1,0 +1,32 @@
+//! Build script for the coreboot payload binary.
+//!
+//! Handles linker script selection and the aarch64 PAYLOAD_BASE symbol.
+
+fn main() {
+    let target = std::env::var("TARGET").unwrap_or_default();
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    // Point to linker scripts in the workspace root (they stay there for now)
+    let workspace_root = std::path::Path::new(&manifest_dir).parent().unwrap();
+
+    if target.starts_with("x86_64") {
+        let ld = workspace_root.join("x86_64-coreboot.ld");
+        println!("cargo:rerun-if-changed={}", ld.display());
+        println!("cargo:rustc-link-arg=-T{}", ld.display());
+        println!("cargo:rustc-link-arg=-no-pie");
+    } else if target.starts_with("aarch64") {
+        let ld = workspace_root.join("aarch64-coreboot.ld");
+        println!("cargo:rerun-if-changed={}", ld.display());
+        println!("cargo:rustc-link-arg=-T{}", ld.display());
+        println!("cargo:rustc-link-arg=-no-pie");
+
+        // Allow overriding the aarch64 payload base address at build time.
+        // Default is for QEMU SBSA (DRAM starts at 0x100_0000_0000).
+        // For QEMU virt (aarch64), set PAYLOAD_BASE=0x62000000.
+        println!("cargo:rerun-if-env-changed=PAYLOAD_BASE");
+        let payload_base =
+            std::env::var("PAYLOAD_BASE").unwrap_or_else(|_| "0x10022000000".to_string());
+        println!("cargo:rustc-link-arg=--defsym");
+        println!("cargo:rustc-link-arg=PAYLOAD_BASE={payload_base}");
+    }
+}

--- a/crabefi-coreboot/src/acpi.rs
+++ b/crabefi-coreboot/src/acpi.rs
@@ -8,10 +8,10 @@
 //! - **FADT → DSDT** — Full AML interpreter for platform device discovery
 //!   (`_HID`, `_CRS` resource templates with all memory descriptor types)
 
-use crate::fdt::{DsdtDevice, MAX_DSDT_DEVICES, PlatformInfo};
 use acpi::{AcpiTables, Handle, Handler, PciAddress, PhysicalMapping};
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicU64, Ordering};
+use crabefi::fdt::{DsdtDevice, MAX_DSDT_DEVICES, PlatformInfo};
 
 /// ECAM base for PCI config space access from the Handler.
 /// Set when we parse MCFG, before the AML interpreter runs.
@@ -78,7 +78,7 @@ impl Handler for CrabEfiHandler {
     fn read_io_u8(&self, port: u16) -> u8 {
         #[cfg(target_arch = "x86_64")]
         {
-            unsafe { crate::arch::x86_64::io::inb(port) }
+            unsafe { crabefi::arch::x86_64::io::inb(port) }
         }
         #[cfg(not(target_arch = "x86_64"))]
         {
@@ -89,7 +89,7 @@ impl Handler for CrabEfiHandler {
     fn read_io_u16(&self, port: u16) -> u16 {
         #[cfg(target_arch = "x86_64")]
         {
-            unsafe { crate::arch::x86_64::io::inw(port) }
+            unsafe { crabefi::arch::x86_64::io::inw(port) }
         }
         #[cfg(not(target_arch = "x86_64"))]
         {
@@ -100,7 +100,7 @@ impl Handler for CrabEfiHandler {
     fn read_io_u32(&self, port: u16) -> u32 {
         #[cfg(target_arch = "x86_64")]
         {
-            unsafe { crate::arch::x86_64::io::inl(port) }
+            unsafe { crabefi::arch::x86_64::io::inl(port) }
         }
         #[cfg(not(target_arch = "x86_64"))]
         {
@@ -111,7 +111,7 @@ impl Handler for CrabEfiHandler {
     fn write_io_u8(&self, port: u16, value: u8) {
         #[cfg(target_arch = "x86_64")]
         {
-            unsafe { crate::arch::x86_64::io::outb(port, value) }
+            unsafe { crabefi::arch::x86_64::io::outb(port, value) }
         }
         #[cfg(not(target_arch = "x86_64"))]
         {
@@ -121,7 +121,7 @@ impl Handler for CrabEfiHandler {
     fn write_io_u16(&self, port: u16, value: u16) {
         #[cfg(target_arch = "x86_64")]
         {
-            unsafe { crate::arch::x86_64::io::outw(port, value) }
+            unsafe { crabefi::arch::x86_64::io::outw(port, value) }
         }
         #[cfg(not(target_arch = "x86_64"))]
         {
@@ -131,7 +131,7 @@ impl Handler for CrabEfiHandler {
     fn write_io_u32(&self, port: u16, value: u32) {
         #[cfg(target_arch = "x86_64")]
         {
-            unsafe { crate::arch::x86_64::io::outl(port, value) }
+            unsafe { crabefi::arch::x86_64::io::outl(port, value) }
         }
         #[cfg(not(target_arch = "x86_64"))]
         {
@@ -163,8 +163,8 @@ impl Handler for CrabEfiHandler {
     // --- Timing ---
 
     fn nanos_since_boot(&self) -> u64 {
-        let cnt = crate::time::read_counter();
-        let freq = crate::time::counter_frequency();
+        let cnt = crabefi::time::read_counter();
+        let freq = crabefi::time::counter_frequency();
         if freq == 0 {
             return 0;
         }
@@ -173,13 +173,13 @@ impl Handler for CrabEfiHandler {
     }
 
     fn stall(&self, microseconds: u64) {
-        let freq = crate::time::counter_frequency();
+        let freq = crabefi::time::counter_frequency();
         if freq == 0 {
             return;
         }
         let ticks = microseconds * freq / 1_000_000;
-        let start = crate::time::read_counter();
-        while crate::time::read_counter().wrapping_sub(start) < ticks {
+        let start = crabefi::time::read_counter();
+        while crabefi::time::read_counter().wrapping_sub(start) < ticks {
             core::hint::spin_loop();
         }
     }

--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -1,0 +1,385 @@
+//! CrabEFI Coreboot Payload
+//!
+//! This binary builds CrabEFI as a coreboot payload for x86_64 and aarch64.
+//! It handles architecture-specific entry (32→64 mode switch on x86, MMU setup
+//! on aarch64), parses coreboot tables to discover hardware, runs ACPI
+//! discovery, builds a [`crabefi::PlatformConfig`], and hands off to the
+//! CrabEFI library.
+
+#![no_std]
+#![no_main]
+#![allow(unsafe_op_in_unsafe_fn)]
+
+extern crate alloc;
+
+mod acpi;
+
+use core::panic::PanicInfo;
+
+// ============================================================================
+// Memory map size limit (matches state::MAX_MEMORY_REGIONS + MMIO headroom)
+// ============================================================================
+
+/// Maximum number of platform memory regions we can pass to init_platform().
+const MAX_MEMORY_REGIONS: usize = 96;
+
+// ============================================================================
+// Statics for passing data into the post_heap_init callback
+// ============================================================================
+
+/// Raw CFR data pointer from coreboot tables (needs heap to parse).
+static mut CFR_RAW_PTR: Option<&'static [u8]> = None;
+
+// ============================================================================
+// Platform trait implementations
+// ============================================================================
+
+/// Timer backed by the architecture's monotonic counter.
+///
+/// On x86_64 this wraps the TSC (calibrated via ACPI PM timer before
+/// `init_platform()` is called). On aarch64 this reads the ARM Generic
+/// Timer directly.
+struct CorebootTimer {
+    freq_hz: u64,
+}
+
+impl crabefi::Timer for CorebootTimer {
+    fn current_ticks(&self) -> u64 {
+        crabefi::time::read_counter()
+    }
+
+    fn ticks_per_second(&self) -> u64 {
+        self.freq_hz
+    }
+}
+
+/// Reset handler using architecture-specific reset mechanisms.
+struct CorebootReset;
+
+impl crabefi::ResetHandler for CorebootReset {
+    fn reset(&self, reset_type: crabefi::ResetType) -> ! {
+        #[cfg(target_arch = "x86_64")]
+        {
+            // Try keyboard controller reset, then triple fault as fallback.
+            let _ = reset_type;
+            crabefi::arch::x86_64::reset::keyboard_controller_reset();
+            crabefi::time::delay_ms(100);
+            crabefi::arch::x86_64::reset::triple_fault()
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            match reset_type {
+                crabefi::ResetType::Shutdown => crabefi::arch::aarch64::reset::system_off(),
+                _ => crabefi::arch::aarch64::reset::system_reset(),
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Post-heap initialization callback
+// ============================================================================
+
+/// Runs after `init_platform()` has initialized the EFI memory allocator and
+/// heap. Performs heap-dependent discovery that the coreboot payload needs:
+///
+/// 1. ACPI table discovery (MADT, MCFG, SPCR, DSDT via AML interpreter)
+/// 2. Platform MMIO region registration (aarch64)
+/// 3. CFR (Coreboot Form Representation) parsing
+fn coreboot_post_heap_init() {
+    // ---- 1. ACPI platform discovery ----
+    //
+    // The AML interpreter allocates, so this must run after heap::init().
+    // Results go into state.drivers.acpi_info which init_platform() reads
+    // for ECAM base and add_platform_mmio_regions() reads for MMIO.
+    if let Some(rsdp) = crabefi::state::drivers().platform.acpi_rsdp {
+        let acpi_info = unsafe { acpi::discover_platform(rsdp) };
+        crabefi::state::with_drivers_mut(|d| d.acpi_info = acpi_info);
+    }
+
+    // ---- 2. Platform MMIO regions (aarch64) ----
+    //
+    // Coreboot's lb_memory table omits MMIO regions. Add them from the
+    // ACPI/FDT info we just discovered.
+    #[cfg(target_arch = "aarch64")]
+    crabefi::efi::add_platform_mmio_regions();
+
+    // ---- 3. CFR parsing ----
+    //
+    // Parse coreboot firmware configuration options now that the heap is
+    // available. The raw data pointer was saved during table parsing.
+    //
+    // SAFETY: single-threaded firmware; CFR_RAW_PTR set once in rust_main().
+    if let Some(cfr_raw) = unsafe { CFR_RAW_PTR }
+        && let Some(cfr) = crabefi::coreboot::cfr::parse_cfr(cfr_raw)
+    {
+        log::info!(
+            "CFR: {} forms, {} options",
+            cfr.forms.len(),
+            cfr.total_options()
+        );
+        crabefi::coreboot::store_cfr(cfr);
+    }
+}
+
+// ============================================================================
+// Memory map conversion
+// ============================================================================
+
+/// Convert coreboot memory regions to platform format.
+fn convert_memory_map(
+    cb_map: &[crabefi::coreboot::MemoryRegion],
+    out: &mut [crabefi::MemoryRegion; MAX_MEMORY_REGIONS],
+) -> usize {
+    let mut count = 0;
+    for region in cb_map {
+        if count >= MAX_MEMORY_REGIONS {
+            break;
+        }
+        let region_type = match region.region_type {
+            crabefi::coreboot::MemoryType::Ram => crabefi::MemoryType::Ram,
+            crabefi::coreboot::MemoryType::Reserved => crabefi::MemoryType::Reserved,
+            crabefi::coreboot::MemoryType::AcpiReclaimable => crabefi::MemoryType::AcpiReclaimable,
+            crabefi::coreboot::MemoryType::AcpiNvs => crabefi::MemoryType::AcpiNvs,
+            // Unusable, Table, and any future variants map to Reserved
+            _ => crabefi::MemoryType::Reserved,
+        };
+        out[count] = crabefi::MemoryRegion {
+            base: region.start,
+            size: region.size,
+            region_type,
+        };
+        count += 1;
+    }
+    count
+}
+
+// ============================================================================
+// Panic handler
+// ============================================================================
+
+/// Global panic handler for the coreboot payload.
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    if let Some(location) = info.location() {
+        log::error!(
+            "PANIC at {}:{}: {}",
+            location.file(),
+            location.line(),
+            info.message()
+        );
+    } else {
+        log::error!("PANIC: {}", info.message());
+    }
+
+    loop {
+        crabefi::arch::halt();
+    }
+}
+
+// ============================================================================
+// Entry point
+// ============================================================================
+
+/// Rust entry point called from architecture-specific assembly after
+/// 64-bit mode transition (x86) or MMU setup (aarch64).
+///
+/// # Arguments
+///
+/// * `coreboot_table_ptr` - Physical pointer to the coreboot tables
+///   (passed in RDI on x86_64, X0 on aarch64).
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
+    // ================================================================
+    // Phase 1: Initialize firmware state (needed for all state access)
+    // ================================================================
+    let mut firmware_state = crabefi::state::FirmwareState::new();
+    // SAFETY: Single-threaded firmware entry point. The state lives on
+    // this stack frame which never returns (-> !).
+    unsafe {
+        crabefi::state::init(&mut firmware_state);
+    }
+
+    // ================================================================
+    // Phase 2: Parse coreboot tables (reads raw memory, no heap needed)
+    // ================================================================
+    // SAFETY: coreboot_table_ptr is passed from coreboot and points to
+    // valid tables in identity-mapped physical memory.
+    let cb_info = unsafe { crabefi::coreboot::tables::parse(coreboot_table_ptr as *const u8) };
+
+    // ================================================================
+    // Phase 3: Store coreboot-specific info in global state
+    // ================================================================
+    //
+    // These fields are used by the SPI variable persistence subsystem
+    // (efi::varstore::persistence.rs) and must be set before
+    // init_platform() runs init_persistence_and_boot().
+
+    if let Some(cbmem_addr) = cb_info.cbmem_console {
+        crabefi::coreboot::cbmem_console::init(cbmem_addr);
+    }
+
+    if let Some(fb) = cb_info.framebuffer {
+        crabefi::state::store_framebuffer(crabefi::FramebufferConfig::from(fb));
+    }
+
+    if let Some(addr) = cb_info.framebuffer_record_addr {
+        crabefi::coreboot::store_framebuffer_record_addr(addr);
+    }
+
+    if let Some(smmstore) = cb_info.smmstorev2 {
+        crabefi::coreboot::store_smmstorev2(smmstore);
+    }
+
+    if let Some(ref spi_flash) = cb_info.spi_flash {
+        crabefi::coreboot::store_spi_flash(spi_flash.clone());
+    }
+
+    if let Some(boot_media) = cb_info.boot_media {
+        crabefi::coreboot::store_boot_media(boot_media);
+    }
+
+    // Store memory regions and ACPI RSDP (used by direct Linux boot path
+    // and by the post_heap_init callback for ACPI discovery).
+    crabefi::state::with_drivers_mut(|drivers| {
+        for region in cb_info.memory_map.iter() {
+            let _ = drivers.platform.memory_regions.push(*region);
+        }
+        drivers.platform.acpi_rsdp = cb_info.acpi_rsdp;
+    });
+
+    // Save CFR raw data pointer for the post-heap callback.
+    // SAFETY: single-threaded firmware; pointer valid for firmware lifetime.
+    if let Some(cfr_raw) = cb_info.cfr_raw {
+        unsafe {
+            CFR_RAW_PTR = Some(cfr_raw);
+        }
+    }
+
+    // ================================================================
+    // Phase 4: Initialize serial and logging
+    // ================================================================
+    if let Some(ref serial) = cb_info.serial {
+        crabefi::drivers::serial::init_from_coreboot(serial.baseaddr, serial.baud, serial.mmio());
+    }
+
+    // Initialize logging (idempotent — init_platform() will call it again).
+    crabefi::logger::init();
+
+    if let Some(fb) = cb_info.framebuffer {
+        crabefi::logger::set_framebuffer(crabefi::FramebufferConfig::from(fb));
+    }
+
+    log::info!("CrabEFI v{} starting...", env!("CARGO_PKG_VERSION"));
+    log::info!("Coreboot table pointer: {:#x}", coreboot_table_ptr);
+
+    // Log parsed coreboot tables
+    log_coreboot_info(&cb_info);
+
+    // ================================================================
+    // Phase 5: Calibrate timer (needs serial for logging)
+    // ================================================================
+    crabefi::time::init(cb_info.acpi_rsdp);
+
+    // ================================================================
+    // Phase 6: Build PlatformConfig and hand off to the library
+    // ================================================================
+
+    // Convert coreboot memory map to platform format.
+    let mut memory_regions = [crabefi::MemoryRegion {
+        base: 0,
+        size: 0,
+        region_type: crabefi::MemoryType::Reserved,
+    }; MAX_MEMORY_REGIONS];
+    let region_count = convert_memory_map(&cb_info.memory_map, &mut memory_regions);
+
+    // Create timer backed by the calibrated arch counter.
+    let timer = CorebootTimer {
+        freq_hz: crabefi::state::drivers().timing.counter_freq_hz,
+    };
+
+    let reset = CorebootReset;
+
+    // Extract FDT bytes slice (if coreboot provided a devicetree).
+    let fdt_slice: Option<&[u8]> = cb_info.devicetree.map(|(addr, size)| {
+        // SAFETY: coreboot's devicetree pointer and size are valid.
+        unsafe { core::slice::from_raw_parts(addr as *const u8, size as usize) }
+    });
+
+    let config = crabefi::PlatformConfig {
+        memory_map: &memory_regions[..region_count],
+        timer: &timer,
+        reset: &reset,
+        block_devices: &mut [],
+        variable_backend: None,
+        debug_output: None, // Already set up via init_from_coreboot()
+        console_input: None,
+        framebuffer: cb_info.framebuffer.map(crabefi::FramebufferConfig::from),
+        acpi_rsdp: cb_info.acpi_rsdp,
+        smbios: cb_info.smbios,
+        fdt: fdt_slice,
+        rng: None,
+        ecam_base: None,       // Discovered by post_heap_init callback via ACPI MCFG
+        deferred_buffer: None, // Uses linker-symbol fallback in init_platform()
+        runtime_region: None,  // Uses linker-symbol fallback (platform-entry feature)
+        post_heap_init: Some(coreboot_post_heap_init),
+    };
+
+    // This never returns — the boot manager takes over.
+    crabefi::init_platform(config)
+}
+
+// ============================================================================
+// Logging helpers
+// ============================================================================
+
+fn log_coreboot_info(cb_info: &crabefi::coreboot::CorebootInfo) {
+    log::info!("Parsed coreboot tables:");
+    if let Some(ref serial) = cb_info.serial {
+        log::info!(
+            "  Serial: port={:#x}, baud={}",
+            serial.baseaddr,
+            serial.baud
+        );
+    } else {
+        log::info!("  Serial: not available");
+    }
+    if let Some(ref fb) = cb_info.framebuffer {
+        log::info!(
+            "  Framebuffer: {}x{} @ {:#x}",
+            fb.x_resolution,
+            fb.y_resolution,
+            fb.physical_address
+        );
+    }
+    if let Some(rsdp) = cb_info.acpi_rsdp {
+        log::info!("  ACPI RSDP: {:#x}", rsdp);
+    }
+    if let Some(cbmem_console) = cb_info.cbmem_console {
+        log::info!("  CBMEM console: {:#x}", cbmem_console);
+    }
+    if let Some(ref smmstore) = cb_info.smmstorev2 {
+        log::info!(
+            "  SMMSTORE v2: {} blocks x {} KB at {:#x}",
+            smmstore.num_blocks,
+            smmstore.block_size / 1024,
+            smmstore.mmap_addr
+        );
+    }
+    if cb_info.cfr_raw.is_some() {
+        log::info!("  CFR: raw data found (parsed after heap init)");
+    }
+    log::info!("  Memory regions: {}", cb_info.memory_map.len());
+    if let Some((fdt_addr, fdt_size)) = cb_info.devicetree {
+        log::info!("  Devicetree: {:#x} ({} bytes)", fdt_addr, fdt_size);
+    }
+
+    // Print memory map summary
+    let total_ram: u64 = cb_info
+        .memory_map
+        .iter()
+        .filter(|r| r.region_type == crabefi::coreboot::MemoryType::Ram)
+        .map(|r| r.size)
+        .sum();
+    log::info!("  Total RAM: {} MB", total_ram / (1024 * 1024));
+}

--- a/crabefi-drivers/Cargo.toml
+++ b/crabefi-drivers/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "crabefi-drivers"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Standard hardware drivers for CrabEFI (PCI, NVMe, AHCI, USB, SDHCI, SPI, serial)"
+
+[dependencies]
+crabefi = { path = ".." }
+log = "0.4"
+bitflags = "2"
+heapless = "0.8"
+spin = "0.9"
+tock-registers = "0.10"
+zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+x86_64 = "0.15"

--- a/crabefi-drivers/src/lib.rs
+++ b/crabefi-drivers/src/lib.rs
@@ -1,0 +1,29 @@
+//! Standard Hardware Drivers for CrabEFI
+//!
+//! This crate provides hardware driver implementations for common PC and
+//! embedded peripherals. Each driver implements the appropriate trait from
+//! the `crabefi` core library.
+//!
+//! # Available Drivers
+//!
+//! | Driver | Trait Implemented | Description |
+//! |--------|-------------------|-------------|
+//! | NVMe | `BlockDevice` | NVMe SSD controller |
+//! | AHCI | `BlockDevice` | SATA/AHCI controller |
+//! | USB Mass Storage | `BlockDevice` | USB bulk-only transport |
+//! | SDHCI | `BlockDevice` | SD Host Controller |
+//! | SPI Flash | `StorageBackend` | Intel/AMD/QEMU SPI controllers |
+//! | 16550 UART | `DebugOutput` | Standard PC serial port |
+//! | PL011 UART | `DebugOutput` | ARM PrimeCell UART |
+//! | PS/2 Keyboard | `ConsoleInput` | i8042 PS/2 controller |
+//! | USB HID Keyboard | `ConsoleInput` | USB boot-protocol keyboard |
+//!
+//! # Usage
+//!
+//! Drivers are initialized by platform-specific code (e.g., `crabefi-coreboot`)
+//! and passed to `crabefi::PlatformConfig` as trait objects.
+
+#![no_std]
+
+// Drivers will be moved here from the main crate in subsequent steps.
+// For now this crate is a placeholder to establish the workspace structure.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,96 +1,200 @@
 # CrabEFI Architecture
 
-This document describes the repository layout, code organization, and key architectural decisions in CrabEFI.
+## Workspace Layout
 
-## Repository Layout
+CrabEFI is structured as a Cargo workspace with three crates:
 
 ```
 CrabEFI/
-├── src/                    # Main firmware source code
-│   ├── arch/               # Architecture-specific (x86_64 entry, paging, IDT)
-│   ├── coreboot/           # Coreboot table parsing, memory map, FMAP
-│   ├── drivers/            # Hardware drivers (PCI, NVMe, AHCI, USB, SDHCI, SPI)
-│   ├── efi/                # UEFI implementation
-│   │   ├── protocols/      # Protocol implementations (console, GOP, filesystem, etc.)
-│   │   ├── auth/           # Secure Boot (signature verification, key management)
-│   │   └── varstore/       # Variable storage and SPI persistence
-│   ├── fs/                 # Filesystem support (GPT, FAT, ISO9660)
-│   ├── pe/                 # PE/COFF image loader
-│   ├── linux_boot/         # Direct Linux kernel boot
-│   ├── bls/                # Boot Loader Specification entry parsing
-│   └── payload/            # Coreboot payload chainloading
-├── test-apps/              # EFI test applications (hello, storage-test, etc.)
-├── xtask/                  # Build automation tool (./crabefi command)
-├── firmware/               # Prebuilt coreboot ROM for QEMU testing
-├── docs/                   # Documentation
-├── x86_64-coreboot.ld      # Linker script defining memory layout
-├── Cargo.toml              # Crate manifest
-└── AGENTS.md               # Development guidelines
+├── Cargo.toml                  # Workspace root + core library manifest
+├── src/                        # Core library source
+│   ├── platform.rs             # Platform abstraction traits (public API)
+│   ├── lib.rs                  # Library entry points (init, init_platform)
+│   ├── state.rs                # Centralized FirmwareState
+│   ├── heap.rs                 # Bump allocator (opt-in #[global_allocator])
+│   ├── efi/                    # UEFI implementation
+│   │   ├── boot_services.rs    # EFI_BOOT_SERVICES
+│   │   ├── runtime_services.rs # EFI_RUNTIME_SERVICES
+│   │   ├── system_table.rs     # EFI_SYSTEM_TABLE
+│   │   ├── allocator.rs        # Page-granular memory allocator
+│   │   ├── protocols/          # Protocol implementations (20 files)
+│   │   ├── auth/               # Secure Boot (authenticode, x509, key mgmt)
+│   │   └── varstore/           # Variable persistence
+│   │       ├── edk2.rs         # EDK2 Firmware Volume format parser
+│   │       ├── edk2_backend.rs # Edk2VarStore (VariableBackend for raw flash)
+│   │       ├── persistence.rs  # Legacy SPI persistence layer
+│   │       ├── deferred.rs     # Warm-reboot deferred write buffer
+│   │       └── storage.rs      # SpiStorageBackend
+│   ├── drivers/                # Hardware drivers (will move to crabefi-drivers)
+│   │   ├── block.rs            # BlockDevice trait + implementations
+│   │   ├── storage.rs          # StorageRegistry
+│   │   ├── pci/                # PCI enumeration + driver model
+│   │   ├── nvme/               # NVMe controller driver
+│   │   ├── ahci/               # AHCI/SATA driver
+│   │   ├── usb/                # USB host controllers + device classes
+│   │   ├── sdhci/              # SD Host Controller driver
+│   │   ├── spi/                # SPI flash (Intel, AMD, QEMU)
+│   │   ├── serial.rs           # 16550 UART + PL011
+│   │   └── keyboard.rs         # PS/2 keyboard
+│   ├── arch/                   # Architecture-specific code
+│   │   ├── x86_64/             # Entry, IDT, port I/O, cache, reset, RNG
+│   │   └── aarch64/            # Entry, exceptions, cache, reset, RNG
+│   ├── coreboot/               # Coreboot table parsing
+│   ├── fs/                     # FAT, GPT, ISO9660
+│   ├── pe/                     # PE/COFF image loader
+│   ├── boot.rs                 # Boot manager
+│   ├── menu.rs                 # Interactive boot menu
+│   └── ...
+│
+├── crabefi-coreboot/           # Coreboot payload binary
+│   ├── Cargo.toml
+│   ├── build.rs                # Linker script selection, PAYLOAD_BASE
+│   └── src/main.rs             # rust_main, #[panic_handler]
+│
+├── crabefi-drivers/            # Standard hardware drivers (placeholder)
+│   ├── Cargo.toml
+│   └── src/lib.rs
+│
+├── test-apps/                  # EFI test applications (separate workspaces)
+│   ├── hello/
+│   ├── rng-test/
+│   ├── directory-test/
+│   ├── secure-boot-test/
+│   ├── storage-security-test/
+│   └── fw-dump/
+│
+├── xtask/                      # Build automation (separate workspace)
+├── firmware/                   # Pre-built coreboot ROMs for QEMU
+├── x86_64-coreboot.ld          # x86_64 linker script
+├── aarch64-coreboot.ld         # aarch64 linker script
+└── docs/                       # Documentation
 ```
 
-## Key Components
+## Platform Abstraction Layer
 
-### Firmware State (`state.rs`)
+The core library defines platform traits in `src/platform.rs`. External firmware implements these traits and passes them to CrabEFI via `PlatformConfig`:
 
-CrabEFI uses a centralized state management approach. Instead of scattered `static Mutex<T>` variables, all mutable firmware state is consolidated into a single `FirmwareState` struct allocated on the stack in the entry point.
+```
+┌─────────────────────────────────────────────┐
+│           External Firmware                  │
+│  (coreboot, custom SoC firmware, ...)        │
+│                                              │
+│  Implements: BlockDevice, VariableBackend,   │
+│  Timer, ResetHandler, DebugOutput, ...       │
+└───────────────┬─────────────────────────────┘
+                │  PlatformConfig
+                ▼
+┌─────────────────────────────────────────────┐
+│           CrabEFI Library                    │
+│                                              │
+│  UEFI Boot/Runtime Services, Secure Boot,   │
+│  Boot Manager, Filesystem, PE Loader         │
+└─────────────────────────────────────────────┘
+```
+
+### Platform Traits
+
+| Trait | Purpose | Required |
+|-------|---------|----------|
+| `BlockDevice` | Block-level storage I/O | At least one for booting |
+| `VariableBackend` | Persistent EFI variables | No (volatile fallback) |
+| `StorageBackend` | Raw byte-level flash | No (used by `Edk2VarStore`) |
+| `Timer` | Monotonic clock | Yes |
+| `ResetHandler` | System reset/shutdown | Yes |
+| `Rng` | Hardware RNG | No |
+| `DebugOutput` | Serial/log output | No |
+| `ConsoleInput` | Keyboard input | No |
+
+See [Integration](INTEGRATION.md) for how to implement these traits.
+
+## Firmware State (`state.rs`)
+
+All mutable firmware state lives in a single `FirmwareState` struct allocated on the stack in the entry point:
 
 ```
 FirmwareState
 ├── efi: EfiState
-│   ├── handles[]           # Handle database
-│   ├── events[]            # Event tracking
-│   ├── loaded_images[]     # Loaded PE images
-│   ├── config_tables[]     # Configuration tables (ACPI, SMBIOS)
-│   ├── variables[]         # EFI variables
-│   └── allocator           # Memory allocator state
+│   ├── handles[]           # Handle database (max 64)
+│   ├── events[]            # Event tracking (max 32)
+│   ├── loaded_images[]     # Loaded PE images (max 16)
+│   ├── config_tables[]     # ACPI, SMBIOS, FDT, etc. (max 24)
+│   ├── variables[]         # In-memory variable cache (max 64)
+│   └── allocator           # Page-granular memory allocator
 ├── drivers: DriverState
-│   ├── pci_devices[]       # Discovered PCI devices
-│   ├── keyboard            # Keyboard state
-│   ├── framebuffer         # Display info
-│   └── storage             # SPI flash backend
+│   ├── pci                 # PCI device list + access method
+│   ├── serial              # Serial port driver + EFI mode
+│   ├── timing              # Counter frequency + boot timestamp
+│   ├── platform            # Framebuffer, SPI, SMMSTORE info
+│   └── storage_registry    # Block device registry
 └── console: ConsoleState
     ├── cursor_pos          # Text cursor position
-    └── input               # Input state/escape sequences
+    └── input               # Escape sequence parser
 ```
 
-### Entry Flow
+## Boot Flow
 
-1. **32-bit Entry** (`entry.rs`): Coreboot calls the payload in 32-bit protected mode
-2. **64-bit Transition**: Set up page tables, enable long mode, switch to 64-bit
-3. **Rust Entry** (`main.rs`): Call `rust_main()` which calls `lib::init()`
-4. **Initialization** (`lib.rs::init()`):
-   - Parse coreboot tables
-   - Initialize serial logging
-   - Set up paging and IDT
-   - Initialize EFI environment
-   - Initialize storage drivers
-5. **Boot Menu**: Discover boot entries, display menu, boot selected entry
+### Coreboot Target
 
-### UEFI Implementation
+1. **Architecture entry** (assembly): 32-to-64 mode switch (x86) or MMU setup (aarch64)
+2. **`rust_main()`** (`crabefi-coreboot/src/main.rs`): calls `crabefi::init()`
+3. **`init()`** (`src/lib.rs`):
+   - Parse coreboot tables (memory map, serial, framebuffer, SMMSTORE)
+   - Initialize serial, logging, keyboard, timing
+   - Initialize EFI (allocator, system table, services, protocols)
+   - Initialize heap, PCI, variable persistence, Secure Boot
+   - Run boot manager (BootNext -> BootOrder -> fallback -> interactive menu)
 
-CrabEFI implements the following UEFI services:
+### Library Target (External Firmware)
 
-**Boot Services:**
-- Memory allocation (`AllocatePages`, `FreePages`, `AllocatePool`, `FreePool`)
-- Handle/Protocol management (`InstallProtocol`, `OpenProtocol`, `LocateHandle`)
-- Image loading (`LoadImage`, `StartImage`, `UnloadImage`)
-- Event services (`CreateEvent`, `SetTimer`, `WaitForEvent`)
-- Memory map (`GetMemoryMap`, `ExitBootServices`)
+1. External firmware initializes hardware, discovers devices
+2. Builds `PlatformConfig` with trait object references
+3. Calls `crabefi::init_platform(config)` — never returns (`-> !`)
+4. CrabEFI runs the UEFI boot manager using the provided services
+5. On successful OS handoff, `ExitBootServices` is called and CrabEFI halts
+6. If no bootable media is found or all boot attempts fail, CrabEFI halts the CPU
 
-**Runtime Services:**
-- Variable access (`GetVariable`, `SetVariable`, `GetNextVariableName`)
-- Time services (`GetTime`, `SetTime`)
-- Reset (`ResetSystem`)
+## Variable Persistence
 
-**Protocols:**
-- `SimpleTextInput` / `SimpleTextOutput` - Console I/O
-- `GraphicsOutput` - GOP for framebuffer access
-- `SimpleFileSystem` / `FileProtocol` - FAT filesystem access
-- `BlockIO` - Raw block device access
-- `LoadedImage` - Image information
-- `DevicePath` - Device identification
+CrabEFI supports three variable backend strategies:
 
-### Storage Stack
+| Strategy | Trait | `runtime_capable()` | Post-EBS Writes |
+|----------|-------|---------------------|-----------------|
+| Direct flash | `Edk2VarStore` wrapping `StorageBackend` | `false` | Deferred buffer, committed next boot |
+| SMM | Custom `VariableBackend` | `true` | Direct via SMI |
+| TF-A MM | Custom `VariableBackend` | `true` | Direct via FF-A/SPM |
+
+The `VariableBackend` trait operates at variable level (`load`/`write`/`delete`), not raw bytes, so SMM and TF-A MM backends can issue RPCs to the privileged agent without CrabEFI knowing the storage format.
+
+## UEFI Implementation
+
+### Boot Services
+
+Memory allocation, handle/protocol management, image loading, event services, memory map, `ExitBootServices`.
+
+### Runtime Services
+
+Variable access (`GetVariable`, `SetVariable`, `GetNextVariableName`), time services, `ResetSystem`, `SetVirtualAddressMap`.
+
+### Protocols
+
+| Protocol | Description |
+|----------|-------------|
+| `SimpleTextInput` / `SimpleTextOutput` | Console I/O |
+| `SimpleTextInputEx` | Extended keyboard (modifier keys) |
+| `GraphicsOutput` | GOP framebuffer |
+| `SimpleFileSystem` / `FileProtocol` | FAT filesystem access |
+| `BlockIO` / `DiskIO` | Block and byte-level disk I/O |
+| `LoadedImage` | Image information |
+| `DevicePath` | Device identification |
+| `RNG` | Random number generation |
+| `SerialIO` | Serial port access |
+| `UnicodeCollation` | String comparison |
+| `ConsoleControl` | Console mode switching |
+| `MemoryAttribute` | Page permission control |
+| `NvmePassThru` / `AtaPassThru` / `ScsiPassThru` | Storage passthrough |
+| `StorageSecurity` | TCG Opal |
+
+## Storage Stack
 
 ```
 Application (GRUB, systemd-boot, etc.)
@@ -99,105 +203,28 @@ Application (GRUB, systemd-boot, etc.)
    BlockIO Protocol
         │
         ▼
-  Storage Abstraction (storage.rs)
+  dyn BlockDevice (platform-provided)
         │
-        ├──► NVMe Driver
-        ├──► AHCI Driver
-        ├──► USB Mass Storage
-        └──► SDHCI Driver
-        │
-        ▼
-   PCI Enumeration
+        ├── NVMe Driver
+        ├── AHCI Driver
+        ├── USB Mass Storage
+        ├── SDHCI Driver
+        └── Custom (external firmware)
 ```
-
-### Secure Boot
-
-The Secure Boot implementation follows the UEFI specification:
-
-```
-Image Load Request
-        │
-        ▼
-  Is Secure Boot Enabled?
-        │
-    No ─┴─ Yes
-    │      │
-    │      ▼
-    │  Verify Authenticode Signature
-    │      │
-    │      ▼
-    │  Check against db (allowed)
-    │      │
-    │      ▼
-    │  Check against dbx (revoked)
-    │      │
-    │      ▼
-    │  Valid? ─── No ──► Reject
-    │      │
-    │     Yes
-    │      │
-    └──────┴──► Load Image
-```
-
-Key variables:
-- **PK** (Platform Key): Controls KEK modifications
-- **KEK** (Key Exchange Key): Controls db/dbx modifications
-- **db** (Signature Database): Allowed signatures
-- **dbx** (Forbidden Signatures): Revoked hashes/certificates
-
-### Variable Storage
-
-Variables are stored in SPI flash using coreboot's SMMSTORE region:
-
-```
-SPI Flash
-├── SMMSTORE Region (from FMAP)
-│   ├── Header (magic, version)
-│   └── Variable Records[]
-│       ├── GUID
-│       ├── Name (UTF-16)
-│       ├── Attributes
-│       ├── Data Size
-│       └── Data
-└── Other Regions (BIOS, ME, etc.)
-```
-
-Runtime variable writes (after `ExitBootServices`) are deferred to a reserved memory buffer and applied on the next boot.
-
-## Build System
-
-CrabEFI uses a custom build tool (`./crabefi`) implemented in `xtask/`:
-
-- `./crabefi build` - Build the firmware
-- `./crabefi test --app <name>` - Run integration tests
-- `./crabefi run --app <name>` - Interactive QEMU session
-- `./crabefi create-disk` - Create bootable disk images
-
-The tool handles:
-- Decompressing the base coreboot ROM
-- Adding CrabEFI as a CBFS payload
-- Creating FAT disk images with test applications
-- Launching QEMU with appropriate arguments
 
 ## Dependencies
-
-Key Rust crates used:
 
 | Crate | Purpose |
 |-------|---------|
 | `r-efi` | UEFI type definitions and GUIDs |
-| `heapless` | Stack-allocated collections |
-| `spin` | Spinlock for synchronization |
+| `heapless` | Stack-allocated collections (`no_std`) |
+| `spin` | Spinlock for global controller arrays |
 | `log` | Logging facade |
-| `sha2`, `rsa`, `x509-cert` | Cryptography for Secure Boot |
+| `tock-registers` | Type-safe MMIO register access |
 | `zerocopy` | Safe transmutation for hardware structures |
+| `sha2`, `rsa`, `x509-cert`, `cms` | Secure Boot cryptography |
+| `serde`, `postcard` | Deferred variable serialization |
 
 ## Coding Conventions
 
-See [AGENTS.md](../AGENTS.md) for detailed coding guidelines including:
-
-- Import organization
-- Documentation requirements
-- Error handling patterns
-- UEFI protocol implementation patterns
-- Naming conventions
+See [AGENTS.md](../AGENTS.md) for coding guidelines.

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,249 +1,197 @@
 # Building CrabEFI
 
-This document describes how to build CrabEFI and run tests.
-
 ## Prerequisites
 
 ### Using Nix (Recommended)
 
-The easiest way to get all dependencies is using Nix:
-
 ```bash
-# Enter the development shell
 nix develop
 ```
 
-This provides:
-- Rust nightly toolchain with `x86_64-unknown-none` target
-- QEMU for testing
-- mtools and dosfstools for disk image creation
-- cbfstool for coreboot ROM manipulation
-- zstd for ROM decompression
+This provides the Rust nightly toolchain, QEMU, mtools, dosfstools, cbfstool, and zstd.
 
 ### Manual Setup
 
-If not using Nix, install the following:
-
 **Rust Toolchain:**
 ```bash
-# Install Rust nightly
 rustup toolchain install nightly
 rustup default nightly
-
-# Add the bare-metal target
-rustup target add x86_64-unknown-none
+rustup target add x86_64-unknown-none aarch64-unknown-none
+rustup component add rust-src llvm-tools-preview
 ```
 
 **System Packages (Debian/Ubuntu):**
 ```bash
-sudo apt install \
-    qemu-system-x86 \
-    mtools \
-    dosfstools \
-    zstd
+sudo apt install qemu-system-x86 qemu-system-arm mtools dosfstools zstd coreboot-utils
 ```
-
-**cbfstool:** Build from coreboot source or install `coreboot-utils` if available.
 
 ## Building
 
-### Basic Build
+### Using the Build Tool (Recommended)
+
+The `./crabefi` wrapper invokes the xtask build system:
 
 ```bash
-# Build CrabEFI (release mode, required for firmware)
-cargo build --release
-```
-
-The output ELF is at: `target/x86_64-unknown-none/release/crabefi.elf`
-
-### Using the Build Tool
-
-The `./crabefi` tool (implemented in `xtask/`) provides convenient build commands:
-
-```bash
-# Build CrabEFI
+# Build for x86_64 (default)
 ./crabefi build
 
-# Clean build
-cargo clean && ./crabefi build
+# Build for aarch64 (QEMU SBSA)
+./crabefi build --arch aarch64
 
-# Check without building
-cargo check
+# Build for aarch64 (QEMU virt)
+./crabefi build --arch aarch64 --machine virt
+```
+
+The output ELF is at `target/<triple>/release/crabefi`.
+
+### Using Cargo Directly
+
+```bash
+# Build the coreboot payload binary
+cargo build -p crabefi-coreboot --release --target x86_64-unknown-none
+
+# Build only the library (for external integration)
+cargo build -p crabefi --release --target x86_64-unknown-none
+
+# Build the drivers crate
+cargo build -p crabefi-drivers --release --target x86_64-unknown-none
+
+# aarch64
+cargo build -p crabefi-coreboot --release --target aarch64-unknown-none
+
+# aarch64 with custom payload base (QEMU virt)
+PAYLOAD_BASE=0x62000000 cargo build -p crabefi-coreboot --release --target aarch64-unknown-none
 ```
 
 ### Build Configuration
 
-Key files:
+| File | Purpose |
+|------|---------|
+| `Cargo.toml` | Workspace root + core library manifest |
+| `crabefi-coreboot/Cargo.toml` | Coreboot binary manifest |
+| `crabefi-drivers/Cargo.toml` | Drivers library manifest |
+| `.cargo/config.toml` | `build-std` settings, target-specific rustflags |
+| `crabefi-coreboot/build.rs` | Linker script selection, `PAYLOAD_BASE` |
+| `x86_64-coreboot.ld` | x86_64 linker script |
+| `aarch64-coreboot.ld` | aarch64 linker script |
+| `rust-toolchain.toml` | Nightly toolchain with `rust-src` |
 
-- **`Cargo.toml`**: Crate manifest with dependencies
-- **`.cargo/config.toml`**: Build configuration (target, linker)
-- **`x86_64-coreboot.ld`**: Linker script for memory layout
+### Cargo Features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `platform-entry` | off | Include CrabEFI's own `_start` entry point, EL2 page table setup, and exception vectors. Disable when integrating CrabEFI as a library into firmware that provides its own entry point. |
+| `global-allocator` | off | Register the built-in bump allocator as `#[global_allocator]` |
+| `fb-log` | off | Log to framebuffer (very slow, debugging only) |
+| `rt-debug` | off | Serial debug after `SetVirtualAddressMap` |
+| `rt-log` | off | Warm-reboot-persistent ring buffer for runtime service logging |
+
+The `crabefi-coreboot` binary enables both `platform-entry` and `global-allocator` automatically. External firmware that provides its own entry point and allocator should not enable these features.
 
 ## Testing
 
-### Available Test Applications
+### Integration Tests
 
 ```bash
-# List available test apps
-./crabefi list-test-apps
-```
-
-Test applications are in `test-apps/`:
-
-| Application | Description |
-|-------------|-------------|
-| `hello` | Simple hello world, tests basic EFI services |
-| `storage-security-test` | Tests BlockIO and storage protocols |
-| `secure-boot-test` | Tests Secure Boot verification |
-
-### Running Tests
-
-```bash
-# Build a test application
-./crabefi build-test-app hello
-
-# Run integration test (builds app, creates disk, runs QEMU, checks output)
+# Run with USB storage (default)
 ./crabefi test --app hello
+
+# Run with different storage backends
+./crabefi test --app hello --nvme
+./crabefi test --app hello --ahci
+./crabefi test --app hello --sdhci
+
+# Run RNG protocol test
+./crabefi test --app rng-test
+
+# Run directory enumeration test
+./crabefi test --app directory-test
+
+# Disable KVM (when running inside a VM)
+./crabefi test --app hello --disable-kvm
+
+# aarch64 tests
+./crabefi test --arch aarch64 --machine sbsa --app hello --nvme --disable-kvm
+./crabefi test --arch aarch64 --machine virt --app hello --nvme --disable-kvm
 ```
 
 ### Interactive QEMU
 
 ```bash
-# Run with USB storage (default)
 ./crabefi run --app hello
-
-# Run with AHCI/SATA storage
-./crabefi run --app hello --ahci
-
-# Run with NVMe storage
 ./crabefi run --app hello --nvme
-
-# Disable KVM (for running inside VMs)
-./crabefi run --app hello --disable-kvm
+./crabefi run --app hello --ahci --headless
 ```
 
-### Creating Disk Images
+### Test Applications
+
+Test apps live in `test-apps/` and target `x86_64-unknown-uefi` / `aarch64-unknown-uefi`:
+
+| Application | Description |
+|-------------|-------------|
+| `hello` | Basic EFI services smoke test |
+| `rng-test` | `EFI_RNG_PROTOCOL` validation |
+| `directory-test` | Filesystem and long filename tests |
+| `storage-security-test` | Storage security command tests |
+| `secure-boot-test` | Secure Boot verification tests |
+| `fw-dump` | Firmware info dump utility |
 
 ```bash
-# Create a disk image with an EFI application
+# List available test apps
+./crabefi list-test-apps
+
+# Build a single test app
+./crabefi build-test-app hello
+
+# Create a disk image with a custom EFI app
 ./crabefi create-disk --output test.img --efi-app path/to/app.efi
 ```
 
-## QEMU Testing Environment
+### CI Checks
 
-The test environment uses a pre-built coreboot ROM (`firmware/coreboot-qemu-q35.rom.zst`) configured for the Q35 chipset. CrabEFI is added as the payload automatically.
-
-### QEMU Arguments
-
-When running with `./crabefi run`, QEMU is launched with:
-
-- Q35 machine type with appropriate storage controllers
-- Serial console on stdio
-- 1GB RAM
-- KVM acceleration (if available and not disabled)
-
-### Debugging
-
-Serial output goes to the console. For more detailed debugging:
+The CI pipeline runs (replicate locally before pushing):
 
 ```bash
-# Enable verbose logging (in the code)
-# Logs go to serial port and CBMEM console
+# Formatting
+cargo fmt --all --check
 
-# View QEMU monitor
-# Press Ctrl+A, C to enter monitor
-# Type 'quit' to exit
-```
+# Clippy (both architectures)
+cargo clippy --workspace --release --target x86_64-unknown-none -- -D warnings
+cargo clippy --workspace --release --target aarch64-unknown-none -- -D warnings
 
-## Building Test Applications
-
-Test applications are separate crates targeting `x86_64-unknown-uefi`:
-
-```bash
-cd test-apps/hello
-cargo build --release
-```
-
-Output: `test-apps/hello/target/x86_64-unknown-uefi/release/hello.efi`
-
-### Creating New Test Applications
-
-1. Create a new directory in `test-apps/`
-2. Add `Cargo.toml` with target `x86_64-unknown-uefi`
-3. Implement the EFI entry point
-
-Example `Cargo.toml`:
-```toml
-[package]
-name = "my-test"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-r-efi = "5.3"
-
-[profile.release]
-panic = "abort"
+# Build
+cargo build -p crabefi-coreboot --release --target x86_64-unknown-none
+cargo build -p crabefi-coreboot --release --target aarch64-unknown-none
+PAYLOAD_BASE=0x62000000 cargo build -p crabefi-coreboot --release --target aarch64-unknown-none
 ```
 
 ## Deployment
 
 ### Using with Coreboot
 
-To use CrabEFI as a coreboot payload:
-
-1. Build CrabEFI: `cargo build --release`
-2. Add to coreboot ROM using cbfstool:
+1. Build: `./crabefi build`
+2. Add to a coreboot ROM:
    ```bash
+   cbfstool coreboot.rom remove -n fallback/payload
    cbfstool coreboot.rom add-payload \
-       -f target/x86_64-unknown-none/release/crabefi.elf \
+       -f target/x86_64-unknown-none/release/crabefi \
        -n fallback/payload \
        -c lzma
    ```
 
 ### Real Hardware
 
-When flashing to real hardware:
-
-1. Ensure coreboot is working on your board first
-2. Keep a backup of working firmware
-3. Test in QEMU with similar configuration first
-4. Have a recovery method (external flash programmer)
+- Ensure coreboot works on your board first.
+- Keep a backup of working firmware.
+- Test in QEMU with a similar configuration first.
+- Have a recovery method (external flash programmer).
 
 ## Troubleshooting
 
-### Common Issues
+**QEMU fails to start** -- Check KVM: `ls /dev/kvm`. Use `--disable-kvm` inside VMs.
 
-**"can't find crate for test"**
+**Disk image creation fails** -- Ensure `mtools` and `dosfstools` are installed.
 
-This LSP error is expected. CrabEFI targets bare-metal (`#![no_std]`) and doesn't have the test harness. The code compiles correctly.
+**Build fails with linker errors** -- Check the nightly toolchain and `rust-src` component.
 
-**QEMU fails to start**
-
-- Check KVM availability: `ls /dev/kvm`
-- Try `--disable-kvm` if running inside a VM
-
-**Disk image creation fails**
-
-- Ensure `mtools` and `dosfstools` are installed
-- Check disk space for temporary files
-
-**Build fails with linker errors**
-
-- Ensure you're using the correct Rust nightly version
-- Check that `x86_64-unknown-none` target is installed
-
-### Debug Output
-
-CrabEFI logs to:
-1. Serial port (COM1, 0x3F8)
-2. CBMEM console (viewable in coreboot)
-3. Framebuffer (if `fb-log` feature is enabled)
-
-Enable the framebuffer logging feature for visual debugging:
-
-```bash
-cargo build --release --features fb-log
-```
-
-Note: Framebuffer logging is very slow and should only be used for debugging.
+**Debug output** -- CrabEFI logs to serial (COM1 / PL011), CBMEM console, and optionally the framebuffer (`--features fb-log`).

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,0 +1,325 @@
+# Integrating CrabEFI into External Firmware
+
+This guide explains how to use CrabEFI as a library in firmware other than coreboot.
+
+## Overview
+
+CrabEFI's core is a platform-agnostic UEFI implementation. Your firmware provides hardware-specific services via trait implementations, packs them into a `PlatformConfig`, and calls `crabefi::init_platform()`.
+
+```rust
+// Your firmware's main function
+fn firmware_main() -> ! {
+    // 1. Initialize your hardware
+    let mut emmc = MyEmmcDriver::new(EMMC_BASE);
+    let mut var_store = MyVarStore::new();
+    let timer = MyTimer::new();
+
+    // 2. Build PlatformConfig
+    let config = crabefi::PlatformConfig {
+        memory_map: &MY_MEMORY_MAP,
+        timer: &timer,
+        reset: &MyReset,
+        block_devices: &mut [&mut emmc as &mut dyn crabefi::BlockDevice],
+        variable_backend: Some(&mut var_store),
+        debug_output: None,
+        console_input: None,
+        framebuffer: None,
+        acpi_rsdp: None,
+        smbios: None,
+        fdt: None,
+        rng: None,
+        deferred_buffer: None,
+        runtime_region: None,
+    };
+
+    // 3. Hand off to CrabEFI — never returns (-> !)
+    crabefi::init_platform(config);
+}
+```
+
+## Cargo Setup
+
+Add CrabEFI as a dependency in your firmware crate:
+
+```toml
+[dependencies]
+crabefi = { git = "https://github.com/user/CrabEFI", features = ["global-allocator"] }
+```
+
+Omit `global-allocator` if your firmware provides its own `#[global_allocator]`. CrabEFI requires the `alloc` crate for Secure Boot cryptography.
+
+Your firmware must provide:
+- `#[panic_handler]`
+- `#[global_allocator]` (either CrabEFI's via the feature, or your own)
+
+Build for a bare-metal target (`*-unknown-none`) with `build-std`:
+
+```toml
+# .cargo/config.toml
+[unstable]
+build-std = ["core", "compiler_builtins", "alloc"]
+build-std-features = ["compiler-builtins-mem"]
+```
+
+## Platform Traits
+
+### BlockDevice (Required for Booting)
+
+Implement this for each storage device CrabEFI should boot from:
+
+```rust
+use crabefi::{BlockDevice, BlockDeviceInfo, BlockError};
+
+struct MyEmmc { base_addr: u64, sectors: u64 }
+
+impl BlockDevice for MyEmmc {
+    fn info(&self) -> BlockDeviceInfo {
+        BlockDeviceInfo {
+            num_blocks: self.sectors,
+            block_size: 512,
+            media_id: 0,
+            removable: false,
+            read_only: false,
+        }
+    }
+
+    fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8])
+        -> Result<(), BlockError>
+    {
+        self.validate_read(lba, count, buffer)?;
+        // ... your hardware read ...
+        Ok(())
+    }
+
+    fn name(&self) -> &str { "eMMC" }
+}
+```
+
+CrabEFI installs an `EFI_BLOCK_IO_PROTOCOL` handle for each device, discovers GPT partitions and ESP filesystems, and makes them available to UEFI applications.
+
+### Timer (Required)
+
+```rust
+use crabefi::Timer;
+
+struct ArmGenericTimer { freq: u64 }
+
+impl Timer for ArmGenericTimer {
+    fn current_ticks(&self) -> u64 {
+        // Read CNTPCT_EL0
+        let val: u64;
+        unsafe { core::arch::asm!("mrs {}, cntpct_el0", out(reg) val); }
+        val
+    }
+
+    fn ticks_per_second(&self) -> u64 { self.freq }
+
+    // Default stall() implementation uses current_ticks + spin loop.
+    // Override if your platform has a better mechanism.
+}
+```
+
+### ResetHandler (Required)
+
+Must not return. Used by `ResetSystem` runtime service.
+
+```rust
+use crabefi::{ResetHandler, ResetType};
+
+struct PsciReset;
+
+impl ResetHandler for PsciReset {
+    fn reset(&self, reset_type: ResetType) -> ! {
+        match reset_type {
+            ResetType::Shutdown => psci_system_off(),
+            _ => psci_system_reset(),
+        }
+    }
+}
+```
+
+The `ResetHandler` implementation must reside in memory marked as runtime-safe, since `ResetSystem` is a UEFI runtime service.
+
+### VariableBackend (Optional)
+
+Without this, EFI variables work in-memory but are lost on reset.
+
+#### Option A: Raw Flash via Edk2VarStore
+
+If you have byte-level access to a NOR flash or similar:
+
+```rust
+use crabefi::{StorageBackend, StorageError};
+
+struct MyFlash { /* ... */ }
+
+impl StorageBackend for MyFlash {
+    fn name(&self) -> &str { "SPI Flash" }
+    fn size(&self) -> u32 { 256 * 1024 }
+    fn is_write_protected(&self) -> bool { false }
+    fn enable_writes(&mut self) -> Result<(), StorageError> { Ok(()) }
+    fn read(&mut self, offset: u32, buf: &mut [u8]) -> Result<(), StorageError> { /* ... */ Ok(()) }
+    fn write(&mut self, offset: u32, data: &[u8]) -> Result<(), StorageError> { /* ... */ Ok(()) }
+    fn erase(&mut self, offset: u32, size: u32) -> Result<(), StorageError> { /* ... */ Ok(()) }
+}
+```
+
+Then wrap it with `Edk2VarStore`:
+
+```rust
+let mut flash = MyFlash::new();
+let mut var_store = crabefi::efi::varstore::Edk2VarStore::new(&mut flash);
+
+let config = crabefi::PlatformConfig {
+    variable_backend: Some(&mut var_store),
+    // For post-ExitBootServices writes (flash locked), provide a deferred buffer:
+    deferred_buffer: Some(crabefi::DeferredBufferConfig {
+        base: 0x8_0000,    // Must survive warm reboot
+        size: 64 * 1024,
+    }),
+    ..
+};
+```
+
+#### Option B: SMM Backend
+
+If your platform has an SMM handler that manages variables:
+
+```rust
+use crabefi::{VariableBackend, VariableVisitor, VarBackendError};
+use r_efi::efi::Guid;
+
+struct SmmVarStore { smi_port: u16 }
+
+impl VariableBackend for SmmVarStore {
+    fn load(&mut self, visitor: &mut dyn VariableVisitor) -> Result<(), VarBackendError> {
+        // Trigger SMI to enumerate variables, call visitor.visit() for each
+        Ok(())
+    }
+
+    fn write(&mut self, name: &[u16], vendor: &Guid, attrs: u32, data: &[u8])
+        -> Result<(), VarBackendError>
+    {
+        // Trigger SMI with SetVariable command
+        Ok(())
+    }
+
+    fn delete(&mut self, name: &[u16], vendor: &Guid) -> Result<(), VarBackendError> {
+        // Trigger SMI with delete command
+        Ok(())
+    }
+
+    fn runtime_capable(&self) -> bool { true }  // SMM can write after ExitBootServices
+}
+```
+
+No deferred buffer is needed since `runtime_capable()` returns `true`.
+
+#### Option C: TF-A MM (StandaloneMM)
+
+Same pattern as SMM, using FF-A or SVC calls to communicate with the secure partition:
+
+```rust
+struct MmVarStore { /* FF-A comm buffer */ }
+
+impl VariableBackend for MmVarStore {
+    fn load(&mut self, visitor: &mut dyn VariableVisitor) -> Result<(), VarBackendError> {
+        // MM_COMMUNICATE to StandaloneMM
+        Ok(())
+    }
+    fn write(&mut self, name: &[u16], vendor: &Guid, attrs: u32, data: &[u8])
+        -> Result<(), VarBackendError>
+    {
+        // MM_COMMUNICATE with write command
+        Ok(())
+    }
+    fn delete(&mut self, name: &[u16], vendor: &Guid) -> Result<(), VarBackendError> {
+        // MM_COMMUNICATE with delete command
+        Ok(())
+    }
+    fn runtime_capable(&self) -> bool { true }
+}
+```
+
+### Other Optional Traits
+
+**DebugOutput** -- Serial or equivalent for log output and `EFI_SERIAL_IO_PROTOCOL`:
+
+```rust
+impl crabefi::DebugOutput for MyUart {
+    fn write_byte(&mut self, byte: u8) { /* ... */ }
+    fn try_read_byte(&self) -> Option<u8> { /* ... */ None }
+    fn has_input(&self) -> bool { false }
+}
+// Also implement core::fmt::Write
+```
+
+**ConsoleInput** -- Keyboard for the boot menu and `SimpleTextInput`:
+
+```rust
+impl crabefi::ConsoleInput for MyKeyboard {
+    fn read_key(&mut self) -> Option<crabefi::Key> { /* ... */ None }
+    fn has_key(&self) -> bool { false }
+    fn poll(&mut self) { /* e.g., poll USB controllers */ }
+}
+```
+
+**Rng** -- Hardware RNG for `EFI_RNG_PROTOCOL`:
+
+```rust
+impl crabefi::Rng for HwRng {
+    fn get_random(&self, buf: &mut [u8]) -> Result<(), crabefi::RngError> { /* ... */ Ok(()) }
+}
+```
+
+## Memory Map
+
+Provide a `&[MemoryRegion]` describing the physical address space:
+
+```rust
+use crabefi::{MemoryRegion, MemoryType};
+
+static MEMORY_MAP: &[MemoryRegion] = &[
+    MemoryRegion { base: 0x0000_0000, size: 0x0010_0000, region_type: MemoryType::Reserved },
+    MemoryRegion { base: 0x0010_0000, size: 0x3FF0_0000, region_type: MemoryType::Ram },
+    MemoryRegion { base: 0x4000_0000, size: 0x0100_0000, region_type: MemoryType::Mmio },
+    // ...
+];
+```
+
+## Framebuffer
+
+If your platform has a framebuffer for the GOP protocol and boot menu:
+
+```rust
+let fb = crabefi::FramebufferConfig {
+    physical_address: 0xFD00_0000,
+    width: 1920,
+    height: 1080,
+    stride: 1920 * 4,  // bytes per scanline
+    bits_per_pixel: 32,
+    red_mask_pos: 16, red_mask_size: 8,
+    green_mask_pos: 8, green_mask_size: 8,
+    blue_mask_pos: 0, blue_mask_size: 8,
+};
+```
+
+## Runtime Services
+
+For runtime services to work after `ExitBootServices`:
+
+1. Set `runtime_region` in `PlatformConfig` so CrabEFI marks its code/data as `RuntimeServicesCode`/`RuntimeServicesData`.
+2. The `ResetHandler` implementation and its vtable must be in runtime-safe memory.
+3. If using a non-runtime-capable `VariableBackend`, provide a `deferred_buffer` in memory that survives warm reboot.
+
+## Using crabefi-drivers
+
+The `crabefi-drivers` crate provides standard hardware drivers that implement the platform traits. If your platform has standard PCI hardware, you can use these instead of writing your own:
+
+```toml
+[dependencies]
+crabefi = { git = "..." }
+crabefi-drivers = { git = "..." }
+```
+
+The drivers crate provides implementations for NVMe, AHCI, USB, SDHCI, SPI flash, 16550 UART, PL011, and PS/2 keyboard (migration from the core library is in progress).

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -2,7 +2,9 @@
 
 This document describes the memory layout, page tables, allocators, and memory map management in CrabEFI.
 
-## Physical Memory Layout
+This focuses on the coreboot target. External firmware using CrabEFI as a library provides its own memory map via `PlatformConfig::memory_map` (see [Integration](INTEGRATION.md)).
+
+## Physical Memory Layout (x86_64 Coreboot)
 
 CrabEFI is loaded by coreboot at `0x100000` (1 MB). The linker script (`x86_64-coreboot.ld`) defines the following layout:
 
@@ -227,7 +229,7 @@ struct PoolHeader {
 For the `alloc` crate (used by crypto libraries), CrabEFI provides a bump allocator (`heap.rs`):
 
 ```rust
-struct BumpAllocator {
+pub struct BumpAllocator {
     heap_start: usize,      // Start of heap region
     offset: AtomicUsize,    // Current allocation offset
     heap_size: usize,       // Total heap size (2 MB)
@@ -235,12 +237,16 @@ struct BumpAllocator {
 ```
 
 **Characteristics:**
-- 2 MB heap allocated at startup
+- 2 MB heap allocated at startup from the EFI page allocator
 - Fast bump-pointer allocation
 - No deallocation (memory freed when boot services exit)
 - Suitable for temporary firmware allocations
 
+The bump allocator is registered as `#[global_allocator]` when the `global-allocator` feature is enabled (the `crabefi-coreboot` binary enables it). External firmware that provides its own allocator should not enable this feature.
+
 ## Memory Map Initialization
+
+### Coreboot Target
 
 At startup, CrabEFI:
 
@@ -276,9 +282,13 @@ After this:
 - OS can use all other memory
 - No more boot services calls allowed
 
+### Library Target
+
+When CrabEFI is used as a library, the platform provides a `&[MemoryRegion]` in `PlatformConfig::memory_map` using `crabefi::MemoryType` values that map directly to EFI types. No coreboot table parsing is involved.
+
 ## Deferred Variable Buffer
 
-Variables written after `ExitBootServices()` can't be written to SPI flash (it's locked). Instead, they're stored in the deferred buffer:
+Variables written after `ExitBootServices()` can't be written to SPI flash (it's locked). Instead, they're stored in the deferred buffer (only needed when the `VariableBackend` is not `runtime_capable()`):
 
 ```
 .deferred_buffer (64 KB):

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,10 @@
 # CrabEFI Documentation
 
-CrabEFI is a minimal UEFI implementation written in Rust, designed to run as a coreboot payload.
+CrabEFI is a UEFI implementation written in Rust. It is structured as a platform-agnostic library with dependency injection, shipping with a coreboot payload binary and standard hardware drivers.
 
 ## Contents
 
 - [Building](BUILDING.md) - How to build CrabEFI and run tests
-- [Architecture](ARCHITECTURE.md) - Repository layout and code organization
+- [Architecture](ARCHITECTURE.md) - Workspace layout and code organization
+- [Integration](INTEGRATION.md) - Using CrabEFI as a library in external firmware
 - [Memory Management](MEMORY.md) - Memory layout, allocators, and EFI memory map

--- a/src/arch/aarch64/exceptions.rs
+++ b/src/arch/aarch64/exceptions.rs
@@ -1,26 +1,54 @@
 //! AArch64 Exception Vector Table and Handlers
 //!
-//! This module provides a minimal exception vector table for EL2.
-//! When an exception occurs, the handler prints diagnostic information
-//! (ESR_EL2, ELR_EL2, FAR_EL2, SP) to the PL011 UART and halts.
+//! Provides a minimal exception vector table for EL1 and EL2.  When an
+//! exception fires, the assembly stub saves the original SP, reads
+//! ESR/ELR/FAR from the correct exception level, and tail-calls
+//! [`exception_rust_handler`].  That Rust function prints diagnostics
+//! via the firmware's configured serial output and halts.
 //!
 //! The vector table is placed in a dedicated `.vectors` section that is
-//! 2KB-aligned as required by the ARM architecture.
+//! 2 KiB-aligned as required by the AArch64 architecture.
 
 use core::arch::global_asm;
 
-/// PL011 UART base address on QEMU SBSA
-const PL011_BASE: u64 = 0x6000_0000;
+/// Exception stack (4 KiB, 16-byte aligned for AArch64 ABI).
+///
+/// Used by exception handlers to avoid corrupting the firmware stack
+/// during exception processing.  `_exc_stack_top` is exported as a
+/// symbol for the assembly stubs.
+#[repr(C, align(16))]
+struct ExcStack([u8; 4096]);
 
-// The exception vector table and handlers in assembly.
+#[unsafe(no_mangle)]
+#[used]
+#[unsafe(link_section = ".bss.exc_stack")]
+static mut EXC_STACK: ExcStack = ExcStack([0u8; 4096]);
+
+// Export _exc_stack_top = EXC_STACK + 4096.
+global_asm!(
+    r#"
+.global _exc_stack_top
+.set _exc_stack_top, EXC_STACK + 4096
+"#
+);
+
+// ============================================================================
+// Exception vector table + shared collection stub
+// ============================================================================
 //
-// ARM requires the vector table to be 2KB aligned.
-// Each vector entry is 128 bytes (0x80) = 32 instructions max.
-// There are 16 entries in 4 groups of 4:
-//   - Current EL with SP_EL0: Sync, IRQ, FIQ, SError
-//   - Current EL with SP_ELx: Sync, IRQ, FIQ, SError
-//   - Lower EL using AArch64: Sync, IRQ, FIQ, SError
-//   - Lower EL using AArch32: Sync, IRQ, FIQ, SError
+// ARM requires the table to be 2 KiB aligned; each slot is 128 bytes
+// (32 instructions max).  All 16 entries branch to one of four type labels
+// (exc_handle_{sync,irq,fiq,serror}).  Those stubs set x4 to the exception
+// type constant, then branch to exc_collect, which:
+//
+//   1. Saves the original SP in x3.
+//   2. Switches SP to EXC_STACK top (a clean 4 KiB region).
+//   3. Reads ESR / ELR / FAR from the current EL into x0 / x1 / x2.
+//   4. Tail-calls exception_rust_handler(esr, elr, far, orig_sp, exc_type).
+//
+// exception_rust_handler is -> ! so exc_collect never returns.
+//
+// exc_type constants:  0 = Sync, 1 = IRQ, 2 = FIQ, 3 = SError
 global_asm!(
     r#"
 .section .vectors, "ax"
@@ -29,341 +57,161 @@ global_asm!(
 .global exception_vectors
 exception_vectors:
 
-// ============================================================
-// Current EL with SP_EL0
-// ============================================================
-
-// 0x000: Synchronous
+// ---- Current EL with SP_EL0 ----
 .balign 0x80
-    b       exception_handler_sync
-
-// 0x080: IRQ
+    b       exc_handle_sync
 .balign 0x80
-    b       exception_handler_irq
-
-// 0x100: FIQ
+    b       exc_handle_irq
 .balign 0x80
-    b       exception_handler_fiq
-
-// 0x180: SError
+    b       exc_handle_fiq
 .balign 0x80
-    b       exception_handler_serror
+    b       exc_handle_serror
 
-// ============================================================
-// Current EL with SP_ELx  (this is what we normally use at EL2)
-// ============================================================
-
-// 0x200: Synchronous
+// ---- Current EL with SP_ELx ----
 .balign 0x80
-    b       exception_handler_sync
-
-// 0x280: IRQ
+    b       exc_handle_sync
 .balign 0x80
-    b       exception_handler_irq
-
-// 0x300: FIQ
+    b       exc_handle_irq
 .balign 0x80
-    b       exception_handler_fiq
-
-// 0x380: SError
+    b       exc_handle_fiq
 .balign 0x80
-    b       exception_handler_serror
+    b       exc_handle_serror
 
-// ============================================================
-// Lower EL using AArch64
-// ============================================================
-
-// 0x400: Synchronous
+// ---- Lower EL using AArch64 ----
 .balign 0x80
-    b       exception_handler_sync
-
-// 0x480: IRQ
+    b       exc_handle_sync
 .balign 0x80
-    b       exception_handler_irq
-
-// 0x500: FIQ
+    b       exc_handle_irq
 .balign 0x80
-    b       exception_handler_fiq
-
-// 0x580: SError
+    b       exc_handle_fiq
 .balign 0x80
-    b       exception_handler_serror
+    b       exc_handle_serror
+
+// ---- Lower EL using AArch32 ----
+.balign 0x80
+    b       exc_handle_sync
+.balign 0x80
+    b       exc_handle_irq
+.balign 0x80
+    b       exc_handle_fiq
+.balign 0x80
+    b       exc_handle_serror
 
 // ============================================================
-// Lower EL using AArch32
+// Type stubs — set exc_type (x4) then fall through to exc_collect.
 // ============================================================
+exc_handle_sync:
+    mov     x4, #0
+    b       exc_collect
 
-// 0x600: Synchronous
-.balign 0x80
-    b       exception_handler_sync
+exc_handle_irq:
+    mov     x4, #1
+    b       exc_collect
 
-// 0x680: IRQ
-.balign 0x80
-    b       exception_handler_irq
+exc_handle_fiq:
+    mov     x4, #2
+    b       exc_collect
 
-// 0x700: FIQ
-.balign 0x80
-    b       exception_handler_fiq
-
-// 0x780: SError
-.balign 0x80
-    b       exception_handler_serror
-
+exc_handle_serror:
+    mov     x4, #3
+    b       exc_collect
 
 // ============================================================
-// Exception handlers
+// exc_collect — common prologue, then tail-call into Rust.
+//
+// Entry:  x4 = exc_type
+// Effect: switches to EXC_STACK, loads ESR/ELR/FAR,
+//         tail-calls exception_rust_handler(x0, x1, x2, x3, x4)
 // ============================================================
+exc_collect:
+    // Save original SP (x3 is our 4th argument slot).
+    mov     x3, sp
 
-// Print a hex character (nibble in w1)
-// Clobbers: w2 only
-uart_print_nibble:
-    and     w1, w1, #0xf
-    cmp     w1, #10
-    b.lt    1f
-    add     w1, w1, #('a' - 10)
-    b       2f
-1:
-    add     w1, w1, #'0'
-2:
-    // Wait for UART TX ready (bit 5 of FR register = TXFF)
-3:
-    ldr     w2, [x0, #0x18]        // PL011 FR register
-    tbnz    w2, #5, 3b             // Loop while TXFF set
-    str     w1, [x0, #0x00]        // PL011 DR register
-    ret
+    // Switch to the dedicated exception stack (16-byte aligned top).
+    adrp    x9, _exc_stack_top
+    add     x9, x9, :lo12:_exc_stack_top
+    mov     sp, x9
 
-// Print 64-bit value in x3 as hex
-// Uses: x0 (UART base), x3 (value), x4 (loop counter), x30/lr saved in x5
-uart_print_hex64:
-    mov     x5, x30                // Save LR
-    mov     x4, #60                // Start from bit 60 (top nibble)
-4:
-    lsr     x1, x3, x4
-    bl      uart_print_nibble
-    subs    x4, x4, #4
-    b.ge    4b
-    mov     x30, x5                // Restore LR
-    ret
+    // Read ESR / ELR / FAR from the correct exception level.
+    mrs     x9, CurrentEL
+    ubfx    x9, x9, #2, #2          // EL field = bits [3:2]
+    cmp     x9, #2
+    b.ge    1f
 
-// Print a string (pointer in x6, length in x7)
-// Uses: x0 (UART base), w1, w2
-uart_print_str:
-    cbz     x7, 9f
-8:
-    ldrb    w1, [x6], #1
-    // Wait for TX ready
-80:
-    ldr     w2, [x0, #0x18]        // PL011 FR register
-    tbnz    w2, #5, 80b            // Loop while TXFF set
-    str     w1, [x0, #0x00]        // PL011 DR register
-    subs    x7, x7, #1
-    b.ne    8b
-9:
-    ret
+    // EL1 path
+    mrs     x0, ESR_EL1
+    mrs     x1, ELR_EL1
+    mrs     x2, FAR_EL1
+    b       exception_rust_handler
 
-// ============================================================
-// Main exception handler (common for all exception types)
-// ============================================================
-exception_handler_sync:
-    // We're in a bad state - use a dedicated exception stack area
-    // Save the original SP in x9 before switching
-    mov     x9, sp
-    adrp    x10, _exc_stack_top
-    add     x10, x10, :lo12:_exc_stack_top
-    mov     sp, x10
-
-    // Save a few regs we'll use
-    stp     x29, x30, [sp, #-16]!
-    stp     x5, x6, [sp, #-16]!
-    stp     x7, x8, [sp, #-16]!
-
-    // x0 = UART base address
-    mov     x0, #{uart_base}
-
-    // Print banner: "\r\n*** EXCEPTION (Sync) "
-    adr     x6, msg_exception
-    mov     x7, #msg_exception_len
-    bl      uart_print_str
-
-    // Print "ESR="
-    adr     x6, msg_esr
-    mov     x7, #msg_esr_len
-    bl      uart_print_str
-
-    mrs     x3, ESR_EL2
-    mov     x8, x3                 // Save ESR for later decoding
-    bl      uart_print_hex64
-
-    // Print " ELR="
-    adr     x6, msg_elr
-    mov     x7, #msg_elr_len
-    bl      uart_print_str
-
-    mrs     x3, ELR_EL2
-    bl      uart_print_hex64
-
-    // Print " FAR="
-    adr     x6, msg_far
-    mov     x7, #msg_far_len
-    bl      uart_print_str
-
-    mrs     x3, FAR_EL2
-    bl      uart_print_hex64
-
-    // Print " SP="
-    adr     x6, msg_sp
-    mov     x7, #msg_sp_len
-    bl      uart_print_str
-
-    mov     x3, x9                 // Original SP
-    bl      uart_print_hex64
-
-    // Print " LR="
-    adr     x6, msg_lr
-    mov     x7, #msg_lr_len
-    bl      uart_print_str
-
-    // Recover saved x30 from stack
-    ldr     x3, [sp, #40]         // saved_x30 is at sp+32+8
-    bl      uart_print_hex64
-
-    // Decode ESR exception class
-    lsr     x3, x8, #26           // EC field = bits [31:26]
-    adr     x6, msg_ec
-    mov     x7, #msg_ec_len
-    bl      uart_print_str
-    bl      uart_print_hex64
-
-    // Print newline
-    adr     x6, msg_nl
-    mov     x7, #msg_nl_len
-    bl      uart_print_str
-
-    // Halt
-7:
-    wfe
-    b       7b
-
-// IRQ/FIQ/SError handlers - simpler banners then halt
-exception_handler_irq:
-    mov     x9, sp
-    adrp    x10, _exc_stack_top
-    add     x10, x10, :lo12:_exc_stack_top
-    mov     sp, x10
-    stp     x29, x30, [sp, #-16]!
-    stp     x5, x6, [sp, #-16]!
-    stp     x7, x8, [sp, #-16]!
-    mov     x0, #{uart_base}
-    adr     x6, msg_irq
-    mov     x7, #msg_irq_len
-    bl      uart_print_str
-    mrs     x3, ELR_EL2
-    bl      uart_print_hex64
-    adr     x6, msg_nl
-    mov     x7, #msg_nl_len
-    bl      uart_print_str
-    b       7b
-
-exception_handler_fiq:
-    mov     x9, sp
-    adrp    x10, _exc_stack_top
-    add     x10, x10, :lo12:_exc_stack_top
-    mov     sp, x10
-    stp     x29, x30, [sp, #-16]!
-    stp     x5, x6, [sp, #-16]!
-    stp     x7, x8, [sp, #-16]!
-    mov     x0, #{uart_base}
-    adr     x6, msg_fiq
-    mov     x7, #msg_fiq_len
-    bl      uart_print_str
-    mrs     x3, ELR_EL2
-    bl      uart_print_hex64
-    adr     x6, msg_nl
-    mov     x7, #msg_nl_len
-    bl      uart_print_str
-    b       7b
-
-exception_handler_serror:
-    mov     x9, sp
-    adrp    x10, _exc_stack_top
-    add     x10, x10, :lo12:_exc_stack_top
-    mov     sp, x10
-    stp     x29, x30, [sp, #-16]!
-    stp     x5, x6, [sp, #-16]!
-    stp     x7, x8, [sp, #-16]!
-    mov     x0, #{uart_base}
-    adr     x6, msg_serror
-    mov     x7, #msg_serror_len
-    bl      uart_print_str
-    mrs     x3, ESR_EL2
-    bl      uart_print_hex64
-    adr     x6, msg_elr
-    mov     x7, #msg_elr_len
-    bl      uart_print_str
-    mrs     x3, ELR_EL2
-    bl      uart_print_hex64
-    adr     x6, msg_nl
-    mov     x7, #msg_nl_len
-    bl      uart_print_str
-    b       7b
-
-// ============================================================
-// String constants
-// ============================================================
-.section .rodata.exceptions, "a"
-
-msg_exception:
-    .ascii  "\r\n*** EXCEPTION (Sync) "
-.set msg_exception_len, . - msg_exception
-
-msg_esr:
-    .ascii  "ESR="
-.set msg_esr_len, . - msg_esr
-
-msg_elr:
-    .ascii  " ELR="
-.set msg_elr_len, . - msg_elr
-
-msg_far:
-    .ascii  " FAR="
-.set msg_far_len, . - msg_far
-
-msg_sp:
-    .ascii  " SP="
-.set msg_sp_len, . - msg_sp
-
-msg_lr:
-    .ascii  " LR="
-.set msg_lr_len, . - msg_lr
-
-msg_nl:
-    .ascii  "\r\n"
-.set msg_nl_len, . - msg_nl
-
-msg_irq:
-    .ascii  "\r\n*** EXCEPTION (IRQ) ELR="
-.set msg_irq_len, . - msg_irq
-
-msg_fiq:
-    .ascii  "\r\n*** EXCEPTION (FIQ) ELR="
-.set msg_fiq_len, . - msg_fiq
-
-msg_serror:
-    .ascii  "\r\n*** EXCEPTION (SError) ESR="
-.set msg_serror_len, . - msg_serror
-
-msg_ec:
-    .ascii  " EC="
-.set msg_ec_len, . - msg_ec
-"#,
-    uart_base = const PL011_BASE,
+1:  // EL2 path
+    mrs     x0, ESR_EL2
+    mrs     x1, ELR_EL2
+    mrs     x2, FAR_EL2
+    b       exception_rust_handler
+"#
 );
 
-/// Install the exception vector table by setting VBAR_EL2.
+// ============================================================================
+// Rust exception handler
+// ============================================================================
+
+/// Rust exception handler — tail-called from the assembly vector table.
+///
+/// Prints diagnostic registers (ESR, ELR, FAR, original SP, exception class)
+/// via the firmware's configured serial output, then halts.
+///
+/// If called before the serial driver has been initialized (e.g. a very early
+/// fault), it skips output and halts quietly — no panic, no hardcoded UART.
 ///
 /// # Safety
 ///
-/// Must be called at EL2. This changes the exception vector base.
+/// Must only be called from the `exc_collect` assembly stub above. The caller
+/// has already switched SP to `EXC_STACK`, so a valid Rust stack is available.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn exception_rust_handler(
+    esr: u64,
+    elr: u64,
+    far: u64,
+    sp: u64,
+    exc_type: u64,
+) -> ! {
+    let name = match exc_type {
+        0 => "Sync",
+        1 => "IRQ",
+        2 => "FIQ",
+        3 => "SError",
+        _ => "Unknown",
+    };
+    let ec = (esr >> 26) & 0x3f;
+
+    // Use the firmware's serial driver — but only after state is initialized.
+    // Calling drivers::serial before state::init() would hit the null-pointer
+    // assert in state::get_mut_ptr() and cause a recursive panic.
+    if crate::state::is_initialized() {
+        crate::drivers::serial::write_fmt(format_args!(
+            "\r\n*** EXCEPTION ({name}) \
+             ESR={esr:#018x} ELR={elr:#018x} FAR={far:#018x} \
+             SP={sp:#018x} EC={ec:#x}\r\n"
+        ));
+    }
+
+    loop {
+        // SAFETY: wfe is side-effect-free with respect to memory.
+        unsafe { core::arch::asm!("wfe", options(nomem, nostack)) };
+    }
+}
+
+// ============================================================================
+// Vector installation helpers
+// ============================================================================
+
+/// Install the exception vector table by writing `VBAR_EL2`.
+///
+/// # Safety
+///
+/// Must be called at EL2.
+#[cfg(feature = "platform-entry")]
 #[inline]
 pub unsafe fn install_exception_vectors() {
     unsafe extern "C" {
@@ -377,5 +225,44 @@ pub unsafe fn install_exception_vectors() {
             in(reg) vbar,
             options(nomem, nostack, preserves_flags)
         );
+    }
+}
+
+/// Install the exception vector table at the current exception level.
+///
+/// Reads `CurrentEL` to decide between `VBAR_EL1` and `VBAR_EL2`.
+///
+/// # Safety
+///
+/// The exception vector table must be linked into the binary (the `.vectors`
+/// section from the `global_asm!` above).  `_exc_stack_top` must be defined.
+pub unsafe fn install_exception_vectors_auto() {
+    unsafe extern "C" {
+        static exception_vectors: u8;
+    }
+    unsafe {
+        let vbar = &exception_vectors as *const u8 as u64;
+        let current_el: u64;
+        core::arch::asm!(
+            "mrs {}, CurrentEL",
+            out(reg) current_el,
+            options(nomem, nostack, preserves_flags)
+        );
+        let el = (current_el >> 2) & 0x3;
+        if el >= 2 {
+            core::arch::asm!(
+                "msr VBAR_EL2, {}",
+                "isb",
+                in(reg) vbar,
+                options(nomem, nostack, preserves_flags)
+            );
+        } else {
+            core::arch::asm!(
+                "msr VBAR_EL1, {}",
+                "isb",
+                in(reg) vbar,
+                options(nomem, nostack, preserves_flags)
+            );
+        }
     }
 }

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -4,8 +4,14 @@
 //! including the entry point, exception handling, and hardware primitives.
 
 pub mod cache;
+#[cfg(feature = "platform-entry")]
 pub mod entry;
+// Exception vectors are always available — even when CrabEFI is a library,
+// it needs to install exception handlers before running UEFI applications.
+// Without VBAR_EL1 set, any exception during shim/GRUB execution would
+// vector to address 0x0 (the firmware's _start), causing infinite loops.
 pub mod exceptions;
+pub mod ns_switch;
 pub mod reset;
 pub mod rng;
 

--- a/src/arch/aarch64/ns_switch.rs
+++ b/src/arch/aarch64/ns_switch.rs
@@ -1,0 +1,89 @@
+//! Secure-to-Non-Secure EL1 transition for ExitBootServices.
+//!
+//! At Secure EL1, GICv3 routes Non-Secure Group 1 interrupts (LPIs / MSI-X)
+//! as FIQ. The Linux kernel only handles IRQ, so NVMe and other MSI-X devices
+//! hang forever waiting for completion interrupts.
+//!
+//! The trampoline writes a small code sequence to a RAM buffer (in BSS, which
+//! is RuntimeServicesData and accessible from both S and NS):
+//!
+//! ```text
+//!   STP  X30, XZR, [SP, #-16]!   // save return address
+//!   MOV  X0, #0xC200, LSL #16    // FSTART_NS_SWITCH function ID
+//!   SMC  #0                       // → EL3: SCR_EL3.NS=1, ERET back
+//!   LDP  X30, XZR, [SP], #16     // restore return address
+//!   RET                           // back to caller (now at NS-EL1)
+//! ```
+//!
+//! Uses vendor-specific SMCCC function ID `0xC200_0000` handled by fstart's
+//! EL3 exception vector table.
+
+/// AArch64 machine code for the NS switch trampoline.
+const TRAMPOLINE_CODE: [u32; 5] = [
+    0xA9BF_7BFE, // stp x30, xzr, [sp, #-16]!
+    0xD298_4000, // mov x0, #0xC200, lsl #16  (= 0xC2000000)
+    0xD400_0003, // smc #0
+    0xA8C1_7BFE, // ldp x30, xzr, [sp], #16
+    0xD65F_03C0, // ret
+];
+
+/// Static buffer for the trampoline (in BSS = RuntimeServicesData = RAM).
+static mut TRAMPOLINE_BUF: [u32; 5] = [0; 5];
+
+/// Transition from Secure EL1 to Non-Secure EL1.
+///
+/// Probes for an EL3 handler (PSCI_VERSION), writes the trampoline to RAM,
+/// flushes caches, and calls it. After return, the CPU is at NS-EL1.
+///
+/// No-op if no EL3 exists (QEMU without `secure=on`).
+pub fn install_ns_trampoline() {
+    // Probe: is an EL3 handler present?
+    // Our handler returns 0x10001 (PSCI v1.1). Without EL3, SMC causes
+    // an undefined exception → EL1 handler returns something else.
+    let psci_ver: u64;
+    unsafe {
+        core::arch::asm!(
+            "mov x0, #0x84000000", // PSCI_VERSION
+            "smc #0",
+            out("x0") psci_ver,
+            out("x1") _,
+            out("x2") _,
+            out("x3") _,
+            options(nomem, nostack)
+        );
+    }
+    if psci_ver != 0x10001 {
+        return;
+    }
+
+    unsafe {
+        // Write trampoline instructions to the RAM buffer.
+        for (i, &insn) in TRAMPOLINE_CODE.iter().enumerate() {
+            core::ptr::write_volatile(&raw mut TRAMPOLINE_BUF[i], insn);
+        }
+
+        // Cache maintenance: clean data cache, invalidate instruction cache.
+        let addr = &raw const TRAMPOLINE_BUF as usize;
+        core::arch::asm!(
+            "dc cvau, {addr}",
+            "dsb ish",
+            "ic ivau, {addr}",
+            "dsb ish",
+            "isb",
+            addr = in(reg) addr,
+            options(nostack)
+        );
+
+        // Call the trampoline. It does SMC (NS switch) then returns here.
+        // After return we're at NS-EL1 — interrupt routing is fixed.
+        core::arch::asm!(
+            "blr {trampoline}",
+            trampoline = in(reg) addr,
+            out("x0") _,
+            out("x1") _,
+            out("x2") _,
+            out("x3") _,
+            options(nomem, nostack)
+        );
+    }
+}

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -239,6 +239,11 @@ fn create_block_device_for_sfs(
             let block_dev = SdhciBlockDevice::new(controller_id, num_blocks, block_size, 0);
             Some(AnyBlockDevice::Sdhci(block_dev))
         }
+        menu::DeviceType::Platform { .. } => {
+            // Platform block devices are accessed through with_disk() → PlatformBlockShim
+            // rather than AnyBlockDevice, which only wraps PCI-discovered devices.
+            None
+        }
     }
 }
 
@@ -649,5 +654,6 @@ pub fn device_path_info_from_entry(entry: &menu::BootEntry) -> DevicePathInfo {
             pci_device: entry.pci_device,
             pci_function: entry.pci_function,
         },
+        menu::DeviceType::Platform { index } => DevicePathInfo::Platform { index },
     }
 }

--- a/src/boot_manager.rs
+++ b/src/boot_manager.rs
@@ -580,7 +580,7 @@ fn boot_linux_from_device(
     cmdline: &str,
     memory_regions: &[crate::coreboot::memory::MemoryRegion],
     acpi_rsdp: Option<u64>,
-    framebuffer: Option<&crate::coreboot::FramebufferInfo>,
+    framebuffer: Option<&crate::platform::FramebufferConfig>,
 ) -> bool {
     match crate::linux_boot::load_linux_from_disk(
         disk,
@@ -619,7 +619,6 @@ fn boot_linux_entry(
     initrd_path: &heapless::String<128>,
     cmdline: &heapless::String<512>,
 ) {
-    use crate::coreboot;
     use crate::fs;
     use crate::state;
 
@@ -679,7 +678,7 @@ fn boot_linux_entry(
     };
 
     // Get framebuffer info for Linux console
-    let framebuffer = coreboot::get_framebuffer();
+    let framebuffer = crate::state::get_framebuffer();
 
     if memory_regions.is_empty() {
         log::error!("No memory regions available for Linux boot");

--- a/src/cfr_menu.rs
+++ b/src/cfr_menu.rs
@@ -76,7 +76,7 @@ pub fn show_cfr_menu() {
         }
     };
 
-    let fb_info = coreboot::get_framebuffer();
+    let fb_info = crate::state::get_framebuffer();
     let mut fb_console = fb_info.as_ref().map(FramebufferConsole::new);
 
     let mut items = build_menu_items(cfr_info);
@@ -693,7 +693,7 @@ fn show_help(option: &CfrOption, fb_console: &mut Option<FramebufferConsole>) {
 
 /// Show message that CFR is not available
 fn show_no_cfr_message() {
-    let fb_info = coreboot::get_framebuffer();
+    let fb_info = crate::state::get_framebuffer();
     let mut fb_console = fb_info.as_ref().map(FramebufferConsole::new);
 
     serial_driver::write_str("\r\n");

--- a/src/coreboot/framebuffer.rs
+++ b/src/coreboot/framebuffer.rs
@@ -29,6 +29,48 @@ pub struct FramebufferInfo {
     pub blue_mask_size: u8,
 }
 
+impl From<crate::platform::FramebufferConfig> for FramebufferInfo {
+    fn from(fb: crate::platform::FramebufferConfig) -> Self {
+        Self {
+            physical_address: fb.physical_address,
+            x_resolution: fb.width,
+            y_resolution: fb.height,
+            bytes_per_line: fb.bytes_per_line(),
+            bits_per_pixel: fb.bits_per_pixel,
+            red_mask_pos: fb.red_mask_pos,
+            red_mask_size: fb.red_mask_size,
+            green_mask_pos: fb.green_mask_pos,
+            green_mask_size: fb.green_mask_size,
+            blue_mask_pos: fb.blue_mask_pos,
+            blue_mask_size: fb.blue_mask_size,
+        }
+    }
+}
+
+impl From<FramebufferInfo> for crate::platform::FramebufferConfig {
+    fn from(fb: FramebufferInfo) -> Self {
+        let bpp = fb.bits_per_pixel as u32;
+        Self {
+            physical_address: fb.physical_address,
+            width: fb.x_resolution,
+            height: fb.y_resolution,
+            // Convert bytes-per-line to pixels-per-scanline
+            stride: if bpp > 0 {
+                fb.bytes_per_line / (bpp / 8)
+            } else {
+                fb.x_resolution
+            },
+            bits_per_pixel: fb.bits_per_pixel,
+            red_mask_pos: fb.red_mask_pos,
+            red_mask_size: fb.red_mask_size,
+            green_mask_pos: fb.green_mask_pos,
+            green_mask_size: fb.green_mask_size,
+            blue_mask_pos: fb.blue_mask_pos,
+            blue_mask_size: fb.blue_mask_size,
+        }
+    }
+}
+
 impl FramebufferInfo {
     /// Get the size of the framebuffer in bytes
     pub fn size(&self) -> u64 {

--- a/src/coreboot/mod.rs
+++ b/src/coreboot/mod.rs
@@ -25,25 +25,11 @@ pub use tables::{
     BootMediaInfo, CorebootInfo, FlashMmapWindow, SerialInfo, Smmstorev2Info, SpiFlashInfo,
 };
 
-/// Store framebuffer info in global state
-pub fn store_framebuffer(fb: FramebufferInfo) {
-    crate::state::with_drivers_mut(|drivers| {
-        drivers.platform.framebuffer = Some(fb);
-    });
-}
-
 /// Store the coreboot framebuffer record address for later invalidation
 pub fn store_framebuffer_record_addr(addr: u64) {
     crate::state::with_drivers_mut(|drivers| {
         drivers.platform.coreboot_fb_record_addr = Some(addr);
     });
-}
-
-/// Get access to the global framebuffer info
-///
-/// Returns the framebuffer info if available.
-pub fn get_framebuffer() -> Option<FramebufferInfo> {
-    crate::state::try_get().and_then(|state| state.drivers.platform.framebuffer)
 }
 
 /// Store SMMSTORE v2 info in global state
@@ -102,7 +88,7 @@ static CFR_PTR: AtomicPtr<CfrInfo> = AtomicPtr::new(core::ptr::null_mut());
 ///
 /// Panics if called more than once. The single-call invariant ensures that
 /// `&'static` references handed out by [`get_cfr`] remain valid.
-pub(crate) fn store_cfr(cfr: CfrInfo) {
+pub fn store_cfr(cfr: CfrInfo) {
     let boxed = Box::new(cfr);
     let ptr = Box::into_raw(boxed);
     let old = CFR_PTR.swap(ptr, Ordering::SeqCst);

--- a/src/drivers/nvme/mod.rs
+++ b/src/drivers/nvme/mod.rs
@@ -1202,6 +1202,26 @@ pub fn init_device(dev: &pci::PciDevice) -> Result<(), ()> {
 /// Called during ExitBootServices to prepare for OS handoff.
 /// Currently a placeholder — the OS will reset controllers during its own init.
 pub fn shutdown() {
+    // Disable all NVMe controllers before OS handoff.
+    // The Linux NVMe driver resets the controller (CC.EN=0 → wait CSTS.RDY=0)
+    // during probe. If CrabEFI leaves the controller enabled with active queues,
+    // the kernel's reset may hang. Explicitly disable here so the kernel finds
+    // a clean controller state.
+    let controllers = NVME_CONTROLLERS.controllers.lock();
+    for ctrl_ptr in controllers.iter() {
+        // SAFETY: controller pointer is valid for firmware lifetime
+        let ctrl = unsafe { &*ctrl_ptr.0 };
+        let regs = unsafe { &*ctrl.regs };
+        // Issue shutdown notification (CC.SHN = Normal)
+        regs.cc.modify(CC::SHN.val(1));
+        // Wait for SHST to indicate completion (up to 500ms)
+        let _ = wait_for(500, || regs.csts.read(CSTS::SHST) == 2);
+        // Disable the controller (CC.EN = 0)
+        regs.cc.modify(CC::EN::CLEAR + CC::SHN.val(0));
+        // Wait for RDY=0 (up to 500ms)
+        let _ = wait_for(500, || regs.csts.read(CSTS::RDY) == 0);
+    }
+    drop(controllers);
     NVME_CONTROLLERS.shutdown_log();
 }
 

--- a/src/drivers/serial.rs
+++ b/src/drivers/serial.rs
@@ -367,6 +367,48 @@ impl Write for Pl011Port {
 }
 
 // ============================================================================
+// Platform-provided serial backend (for init_platform() path)
+// ============================================================================
+
+/// Adapter that wraps a platform-provided `DebugOutput` trait object.
+///
+/// Stores a raw pointer because the serial subsystem is accessed via
+/// `drivers_mut_ptr()` (raw pointers) throughout CrabEFI to avoid
+/// aliasing with active `&mut FirmwareState` references in closures.
+pub(crate) struct PlatformSerial {
+    /// Raw pointer to the platform's debug output trait object.
+    /// Valid for the entire firmware lifetime (caller guarantees this).
+    inner: *mut dyn crate::platform::DebugOutput,
+}
+
+impl PlatformSerial {
+    /// Write a single byte to the platform debug output.
+    fn write_byte(&mut self, byte: u8) {
+        // SAFETY: Single-threaded firmware. Pointer is valid for firmware lifetime.
+        unsafe { &mut *self.inner }.write_byte(byte);
+    }
+
+    /// Try to read a byte (non-blocking).
+    fn try_read_byte(&mut self) -> Option<u8> {
+        // SAFETY: Single-threaded firmware.
+        unsafe { &mut *self.inner }.try_read_byte()
+    }
+
+    /// Check if input is available.
+    fn has_input(&self) -> bool {
+        // SAFETY: Single-threaded firmware.
+        unsafe { &*self.inner }.has_input()
+    }
+}
+
+impl Write for PlatformSerial {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        // SAFETY: Single-threaded firmware.
+        unsafe { &mut *self.inner }.write_str(s)
+    }
+}
+
+// ============================================================================
 // Unified serial port wrapper
 // ============================================================================
 
@@ -375,6 +417,8 @@ pub(crate) enum AnySerial {
     Uart16550(SerialPort),
     #[cfg(target_arch = "aarch64")]
     Pl011(Pl011Port),
+    /// Platform-provided debug output (used by `init_platform()` path).
+    Platform(PlatformSerial),
 }
 
 // ============================================================================
@@ -453,6 +497,24 @@ pub fn init_from_coreboot(base_addr: u32, baud: u32, is_mmio: bool) {
     }
 }
 
+/// Initialize serial output from a raw pointer to a platform `DebugOutput`.
+///
+/// Used by `init_platform()` to inject an external serial driver (e.g., from
+/// fstart's PL011 or NS16550 driver) without going through coreboot tables.
+///
+/// # Safety
+///
+/// `raw` must point to a valid `DebugOutput` that lives for the entire
+/// firmware lifetime (i.e., at least until `init_platform()` returns).
+pub unsafe fn init_from_platform_raw(raw: *mut dyn crate::platform::DebugOutput) {
+    let plat = PlatformSerial { inner: raw };
+    // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
+    // issues since serial is called from log macros inside other state closures.
+    unsafe {
+        (*crate::state::drivers_mut_ptr()).serial.driver = Some(AnySerial::Platform(plat));
+    }
+}
+
 /// Write a string to the serial port
 pub fn write_str(s: &str) {
     // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
@@ -466,6 +528,9 @@ pub fn write_str(s: &str) {
             #[cfg(target_arch = "aarch64")]
             AnySerial::Pl011(pl011) => {
                 let _ = pl011.write_str(s);
+            }
+            AnySerial::Platform(plat) => {
+                let _ = plat.write_str(s);
             }
         }
     }
@@ -485,6 +550,9 @@ pub fn write_fmt(args: fmt::Arguments) {
             AnySerial::Pl011(pl011) => {
                 let _ = pl011.write_fmt(args);
             }
+            AnySerial::Platform(plat) => {
+                let _ = plat.write_fmt(args);
+            }
         }
     }
 }
@@ -499,6 +567,7 @@ pub fn write_byte(byte: u8) {
             AnySerial::Uart16550(uart) => uart.write_byte(byte),
             #[cfg(target_arch = "aarch64")]
             AnySerial::Pl011(pl011) => pl011.write_byte(byte),
+            AnySerial::Platform(plat) => plat.write_byte(byte),
         }
     }
 }
@@ -511,6 +580,7 @@ pub fn has_input() -> bool {
             AnySerial::Uart16550(uart) => uart.can_receive(),
             #[cfg(target_arch = "aarch64")]
             AnySerial::Pl011(pl011) => pl011.can_receive(),
+            AnySerial::Platform(plat) => plat.has_input(),
         }
     } else {
         false
@@ -527,6 +597,7 @@ pub fn try_read() -> Option<u8> {
             AnySerial::Uart16550(uart) => uart.try_read_byte(),
             #[cfg(target_arch = "aarch64")]
             AnySerial::Pl011(pl011) => pl011.try_read_byte(),
+            AnySerial::Platform(plat) => plat.try_read_byte(),
         }
     } else {
         None

--- a/src/drivers/storage.rs
+++ b/src/drivers/storage.rs
@@ -6,6 +6,82 @@
 /// Maximum number of storage devices we can track
 const MAX_STORAGE_DEVICES: usize = 8;
 
+/// Maximum number of platform-provided block devices.
+pub const MAX_PLATFORM_BLOCK_DEVICES: usize = 8;
+
+/// Global storage for platform-provided block device fat pointers.
+///
+/// Populated by [`register_platform_block_devices()`] during
+/// [`crate::init_platform()`]. Each entry is a raw fat pointer
+/// (`*mut dyn platform::BlockDevice`) stored as two `usize` words
+/// (data pointer + vtable pointer).
+///
+/// # Safety invariant
+///
+/// Every non-zero entry is a valid `*mut dyn platform::BlockDevice` whose
+/// referent lives for the firmware's entire lifetime (`init_platform` is `-> !`).
+static mut PLATFORM_BLOCK_PTRS: [[usize; 2]; MAX_PLATFORM_BLOCK_DEVICES] =
+    [[0; 2]; MAX_PLATFORM_BLOCK_DEVICES];
+static mut PLATFORM_BLOCK_COUNT: usize = 0;
+
+/// Register platform-provided block devices from [`crate::PlatformConfig`].
+///
+/// # Safety
+///
+/// Must be called exactly once from `init_platform()` before the boot manager
+/// runs. The block device references in `devices` must remain valid for the
+/// firmware's entire lifetime (guaranteed by `init_platform() -> !`).
+pub unsafe fn register_platform_block_devices(
+    devices: &mut [&mut dyn crate::platform::BlockDevice],
+) {
+    let count = devices.len().min(MAX_PLATFORM_BLOCK_DEVICES);
+    for (i, dev) in devices.iter_mut().enumerate().take(count) {
+        let fat: *mut dyn crate::platform::BlockDevice = *dev;
+        // SAFETY: A trait object pointer is exactly two usizes (data + vtable).
+        // We store it raw and reconstruct it in with_platform_block_device().
+        unsafe {
+            PLATFORM_BLOCK_PTRS[i] =
+                core::mem::transmute::<*mut dyn crate::platform::BlockDevice, [usize; 2]>(fat);
+        }
+    }
+    unsafe {
+        PLATFORM_BLOCK_COUNT = count;
+    }
+    log::info!("Registered {} platform block device(s)", count);
+}
+
+/// Number of registered platform block devices.
+pub fn platform_block_device_count() -> usize {
+    // SAFETY: read-only after init_platform() completes registration;
+    // single-threaded firmware.
+    unsafe { PLATFORM_BLOCK_COUNT }
+}
+
+/// Access a platform block device by index, calling `f` with a mutable reference.
+///
+/// Returns `None` if the index is out of range.
+pub fn with_platform_block_device<R>(
+    index: usize,
+    f: impl FnOnce(&mut dyn crate::platform::BlockDevice) -> R,
+) -> Option<R> {
+    // SAFETY: single-threaded firmware; read-only count set during init.
+    let count = unsafe { PLATFORM_BLOCK_COUNT };
+    if index >= count {
+        return None;
+    }
+    // SAFETY: PLATFORM_BLOCK_PTRS[index] was written by register_platform_block_devices()
+    // from a valid `*mut dyn BlockDevice`. The referent is alive (-> ! contract).
+    unsafe {
+        let words = PLATFORM_BLOCK_PTRS[index];
+        if words[0] == 0 {
+            return None;
+        }
+        let fat: *mut dyn crate::platform::BlockDevice =
+            core::mem::transmute::<[usize; 2], *mut dyn crate::platform::BlockDevice>(words);
+        Some(f(&mut *fat))
+    }
+}
+
 /// Storage device type and instance identifier
 ///
 /// This is the canonical enum for identifying a specific storage device across
@@ -23,6 +99,11 @@ pub enum StorageType {
     },
     /// SDHCI (SD Card)
     Sdhci { controller_id: usize },
+    /// Platform-provided block device (via [`crate::PlatformConfig::block_devices`]).
+    ///
+    /// The `index` identifies the device's position in the global platform
+    /// block device array, set up by [`crate::init_platform()`].
+    Platform { index: usize },
 }
 
 impl StorageType {
@@ -33,6 +114,7 @@ impl StorageType {
             StorageType::Ahci { .. } => "SATA",
             StorageType::Usb { .. } => "USB",
             StorageType::Sdhci { .. } => "SD",
+            StorageType::Platform { .. } => "Platform",
         }
     }
 }
@@ -168,5 +250,18 @@ pub fn read_sectors(device_id: u32, lba: u64, buffer: &mut [u8]) -> Result<(), (
                 Err(())
             }
         }
+        StorageType::Platform { index } => with_platform_block_device(index, |dev| {
+            let info = dev.info();
+            let count = (buffer.len() as u32).div_ceil(info.block_size);
+            dev.read_blocks(lba, count, buffer).map_err(|e| {
+                log::error!(
+                    "Platform device {} read failed at LBA {}: {:?}",
+                    index,
+                    lba,
+                    e
+                );
+            })
+        })
+        .unwrap_or(Err(())),
     }
 }

--- a/src/efi/allocator.rs
+++ b/src/efi/allocator.rs
@@ -96,6 +96,18 @@ impl MemoryType {
                 | MemoryType::LoaderData
         )
     }
+
+    /// Default EFI memory attributes (cache capabilities) for this type.
+    ///
+    /// DRAM-backed types support WC|WT|WB caching. MMIO types are UC only.
+    pub fn default_attributes(&self) -> u64 {
+        match self {
+            MemoryType::MemoryMappedIo | MemoryType::MemoryMappedIoPortSpace => {
+                attributes::EFI_MEMORY_UC
+            }
+            _ => attributes::EFI_MEMORY_RAM_CAPS,
+        }
+    }
 }
 
 impl TryFrom<u32> for MemoryType {
@@ -311,22 +323,7 @@ impl MemoryAllocator {
                 memory_type
             );
 
-            // Attributes describe cache capabilities, not current mode.
-            // DRAM supports WC|WT|WB (0xE); MMIO is UC only (0x1).
-            let attribute = match memory_type {
-                MemoryType::ConventionalMemory
-                | MemoryType::BootServicesCode
-                | MemoryType::BootServicesData
-                | MemoryType::RuntimeServicesCode
-                | MemoryType::RuntimeServicesData
-                | MemoryType::LoaderCode
-                | MemoryType::LoaderData
-                | MemoryType::AcpiReclaimMemory => attributes::EFI_MEMORY_RAM_CAPS,
-                MemoryType::MemoryMappedIo | MemoryType::MemoryMappedIoPortSpace => {
-                    attributes::EFI_MEMORY_UC
-                }
-                _ => attributes::EFI_MEMORY_RAM_CAPS,
-            };
+            let attribute = memory_type.default_attributes();
 
             let desc = MemoryDescriptor::new(memory_type, region.start, num_pages, attribute);
 
@@ -338,6 +335,73 @@ impl MemoryAllocator {
         // Sort by physical address
         self.sort_entries();
         // Merge adjacent regions of the same type
+        self.merge_entries();
+
+        log::info!(
+            "Memory allocator initialized with {} entries",
+            self.entries.len()
+        );
+    }
+
+    /// Initialize the allocator from a platform-provided memory map.
+    ///
+    /// This is the `init_platform()` counterpart to `init_from_coreboot()`.
+    /// Converts `platform::MemoryRegion` entries into EFI memory descriptors.
+    pub fn init_from_platform(&mut self, regions: &[crate::platform::MemoryRegion]) {
+        use crate::platform::MemoryType as PlatMemType;
+
+        self.entries.clear();
+        self.map_key = 1;
+
+        log::info!("Importing platform memory map ({} regions):", regions.len());
+        for region in regions {
+            let memory_type = match region.region_type {
+                PlatMemType::Ram => MemoryType::ConventionalMemory,
+                PlatMemType::Reserved => MemoryType::ReservedMemoryType,
+                PlatMemType::AcpiReclaimable => MemoryType::AcpiReclaimMemory,
+                PlatMemType::AcpiNvs => MemoryType::AcpiMemoryNvs,
+                PlatMemType::Mmio => MemoryType::MemoryMappedIo,
+                PlatMemType::RuntimeServicesCode => MemoryType::RuntimeServicesCode,
+                PlatMemType::RuntimeServicesData => MemoryType::RuntimeServicesData,
+            };
+
+            let num_pages = match region.size.checked_add(PAGE_SIZE - 1) {
+                Some(size_rounded) => size_rounded / PAGE_SIZE,
+                None => {
+                    log::warn!(
+                        "Region at {:#x} has size that overflows, skipping",
+                        region.base
+                    );
+                    continue;
+                }
+            };
+
+            log::info!(
+                "  {:#010x}-{:#010x} {:?} -> {:?}",
+                region.base,
+                region.base + region.size,
+                region.region_type,
+                memory_type
+            );
+
+            let attribute = memory_type.default_attributes();
+
+            // RuntimeServices types get the RUNTIME attribute.
+            let attribute = match region.region_type {
+                PlatMemType::RuntimeServicesCode | PlatMemType::RuntimeServicesData => {
+                    attribute | attributes::EFI_MEMORY_RUNTIME
+                }
+                _ => attribute,
+            };
+
+            let desc = MemoryDescriptor::new(memory_type, region.base, num_pages, attribute);
+
+            if self.entries.push(desc).is_err() {
+                log::warn!("Memory map full, ignoring region at {:#x}", region.base);
+            }
+        }
+
+        self.sort_entries();
         self.merge_entries();
 
         log::info!(
@@ -739,6 +803,53 @@ impl MemoryAllocator {
     /// Get the number of entries
     pub fn entry_count(&self) -> usize {
         self.entries.len()
+    }
+
+    /// Dump all memory map entries to the log (for debugging).
+    ///
+    /// This prints every entry in the internal sorted list, which is the
+    /// pre-merge view. The EFI GetMemoryMap merges adjacent same-type
+    /// entries, so the actual EFI map may have fewer entries.
+    pub fn dump_entries(&self) {
+        let type_name = |t: u32| -> &'static str {
+            match t {
+                0 => "Reserved",
+                1 => "LoaderCode",
+                2 => "LoaderData",
+                3 => "BSCode",
+                4 => "BSData",
+                5 => "RTCode",
+                6 => "RTData",
+                7 => "Conventional",
+                8 => "Unusable",
+                9 => "ACPIReclaim",
+                10 => "ACPINvs",
+                11 => "MMIO",
+                12 => "MMIOPort",
+                13 => "PalCode",
+                14 => "Persistent",
+                _ => "Unknown",
+            }
+        };
+        log::info!(
+            "Memory map dump ({} entries, {} after merge):",
+            self.entries.len(),
+            self.count_merged_entries()
+        );
+        for (i, e) in self.entries.iter().enumerate() {
+            let end = e.end();
+            let size_mb = (e.number_of_pages * PAGE_SIZE) >> 20;
+            log::info!(
+                "  [{:2}] {:#012x}-{:#012x} {:>12} {:6} pages ({} MB) attr={:#x}",
+                i,
+                e.physical_start,
+                end,
+                type_name(e.memory_type),
+                e.number_of_pages,
+                size_mb,
+                e.attribute
+            );
+        }
     }
 
     /// Mark boot services as exited
@@ -1208,6 +1319,13 @@ pub fn init(regions: &[MemoryRegion]) {
     });
 }
 
+/// Initialize the global allocator from a platform-provided memory map.
+pub fn init_from_platform(regions: &[crate::platform::MemoryRegion]) {
+    state::with_allocator_mut(|alloc| {
+        alloc.init_from_platform(regions);
+    });
+}
+
 /// Reserve a region of memory
 pub fn reserve_region(
     physical_start: u64,
@@ -1259,6 +1377,12 @@ pub fn allocate_pages(
 /// Free previously allocated pages
 pub fn free_pages(memory: u64, num_pages: u64) -> efi::Status {
     state::with_allocator_mut(|alloc| alloc.free_pages(memory, num_pages))
+}
+
+/// Dump the full memory map to the log (for debugging).
+pub fn dump_memory_map() {
+    let alloc = state::allocator();
+    alloc.dump_entries();
 }
 
 /// Get the memory map size
@@ -1384,7 +1508,8 @@ pub fn free_pool(buffer: *mut u8) -> efi::Status {
     free_pages(addr, num_pages)
 }
 
-// Linker symbols for section boundaries
+// Linker symbols for section boundaries (only when CrabEFI owns the binary layout).
+#[cfg(feature = "platform-entry")]
 unsafe extern "C" {
     static __runtime_code_start: u8;
     static __runtime_code_end: u8;
@@ -1392,7 +1517,12 @@ unsafe extern "C" {
     static __runtime_data_end: u8;
 }
 
-/// Reserve the CrabEFI runtime regions using linker-provided section boundaries
+/// Reserve the CrabEFI runtime regions using linker-provided section boundaries.
+///
+/// Only available with the `platform-entry` feature (when CrabEFI owns
+/// the linker script). Library consumers use `PlatformConfig.runtime_region`
+/// instead — see `efi::init_from_platform()`.
+#[cfg(feature = "platform-entry")]
 ///
 /// This marks the memory containing our code and data sections so that the OS
 /// keeps them mapped after ExitBootServices. The boundaries come from the

--- a/src/efi/boot_services.rs
+++ b/src/efi/boot_services.rs
@@ -442,8 +442,16 @@ extern "efiapi" fn wait_for_event(
             if event_id > 0 && event_id < MAX_EVENTS {
                 check_timer_event(event_id);
 
-                let efi_state = state::efi();
-                if efi_state.events[event_id].signaled {
+                // Per UEFI spec: WaitForEvent clears the signaled state
+                // of the event that triggered the return.
+                let signaled = state::with_efi_mut(|efi_state| {
+                    let was_signaled = efi_state.events[event_id].signaled;
+                    if was_signaled {
+                        efi_state.events[event_id].signaled = false;
+                    }
+                    was_signaled
+                });
+                if signaled {
                     unsafe { *index = i };
                     log::debug!("  -> SUCCESS (event signaled, index={})", i);
                     return Status::SUCCESS;
@@ -515,8 +523,17 @@ extern "efiapi" fn check_event(event: efi::Event) -> Status {
         // Check timer expiration
         check_timer_event(event_id);
 
-        let efi_state = state::efi();
-        if efi_state.events[event_id].signaled {
+        // Per UEFI spec: CheckEvent clears the signaled state when
+        // returning SUCCESS (for EVT_NOTIFY_WAIT events, the notify
+        // function is called first, then the event is cleared).
+        let signaled = state::with_efi_mut(|efi_state| {
+            let was_signaled = efi_state.events[event_id].signaled;
+            if was_signaled {
+                efi_state.events[event_id].signaled = false;
+            }
+            was_signaled
+        });
+        if signaled {
             return Status::SUCCESS;
         }
     }
@@ -1451,6 +1468,30 @@ extern "efiapi" fn exit_boot_services(image_handle: Handle, map_key: usize) -> S
         unsafe {
             system_table::clear_boot_services();
         }
+
+        // CRITICAL: Disable logging. After ExitBootServices returns, the OS
+        // only maps EFI_MEMORY_RUNTIME regions. The serial MMIO (PL011, COM1,
+        // or CBMEM console buffer) is typically NOT in a runtime region, so
+        // any log! call during a runtime service (especially SetVirtualAddressMap)
+        // would page-fault writing to unmapped memory.
+        log::set_max_level(log::LevelFilter::Off);
+
+        // Switch from Secure EL1 to Non-Secure EL1 via a RAM trampoline.
+        //
+        // At Secure EL1, GICv3 routes Non-Secure Group 1 interrupts (LPIs /
+        // MSI-X) as FIQ. The Linux kernel only handles IRQ, so NVMe and other
+        // MSI-X devices hang forever waiting for completion interrupts.
+        //
+        // We can't issue the SMC directly from flash because the ERET returns
+        // to the instruction after the SMC — which is in Secure flash, not
+        // accessible from NS-EL1 on QEMU virt. Instead, we write a small
+        // trampoline to RAM that does SMC + RET. The RET returns to the EFI
+        // stub (also in RAM), now at NS-EL1 with proper interrupt routing.
+        //
+        // Uses vendor-specific SMCCC function ID 0xC2000000 handled by
+        // fstart's EL3 exception vector. No-op if no EL3 exists.
+        #[cfg(target_arch = "aarch64")]
+        crate::arch::aarch64::ns_switch::install_ns_trampoline();
     } else {
         log::warn!("ExitBootServices FAILED: {:?}", status);
     }

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -16,35 +16,70 @@ pub mod system_table;
 pub mod utils;
 pub mod varstore;
 
-use crate::coreboot::tables::CorebootInfo;
 use r_efi::efi::{self, Status};
 
-/// Initialize the EFI environment
-///
-/// This sets up the system table, boot services, runtime services, and
-/// installs the console protocols.
-pub fn init(cb_info: &CorebootInfo) {
-    log::info!("Initializing EFI environment...");
+/// Initialize the EFI environment from platform configuration.
+pub fn init_from_platform(config: &crate::platform::PlatformConfig) {
+    log::info!("Initializing EFI environment (platform path)...");
 
-    // Initialize the memory allocator from coreboot memory map
-    allocator::init(&cb_info.memory_map);
+    // Initialize the memory allocator from the platform memory map
+    allocator::init_from_platform(config.memory_map);
 
-    // NOTE: Platform MMIO regions (GIC, UART, PCIe) are NOT added here.
-    // They are added later by add_platform_mmio_regions() after ACPI table
-    // discovery has run, so the addresses come from ACPI/FDT instead of
-    // being hardcoded.
+    // NOTE: add_platform_mmio_regions() is NOT called here. In library mode
+    // the caller's memory_map is authoritative — it must include all MMIO
+    // regions (GIC, UART, PCIe windows, platform devices) as MemoryType::Mmio
+    // entries. This avoids duplicate memory map entries and removes the need
+    // for ACPI/FDT parsing inside the library for this purpose.
+    //
+    // For the coreboot payload specifically, the post_heap_init callback calls
+    // efi::add_platform_mmio_regions() after ACPI discovery.
 
-    // Reserve the EL2 MMU page table memory so the allocator doesn't hand it
-    // out. Coreboot set up page tables starting at TTBR0_EL2 and we're still
-    // using them — if they get overwritten, the MMU faults and we crash.
+    // On aarch64, reserve EL2 page tables if running at EL2.
+    // When called from fstart (which typically runs at EL1), this is a no-op.
     #[cfg(target_arch = "aarch64")]
-    reserve_el2_page_tables();
+    {
+        let current_el: u64;
+        unsafe {
+            core::arch::asm!(
+                "mrs {}, CurrentEL",
+                out(reg) current_el,
+                options(nomem, nostack, preserves_flags)
+            );
+        }
+        let el = (current_el >> 2) & 0x3;
+        if el >= 2 {
+            reserve_el2_page_tables();
+        } else {
+            log::info!("Running at EL{} — skipping EL2 page table reservation", el);
+        }
+    }
 
-    // Reserve the runtime services memory regions using linker-provided boundaries.
-    // This marks CrabEFI's code and data sections as EfiRuntimeServicesCode/Data
-    // with EFI_MEMORY_RUNTIME attribute, which tells the OS to keep these regions
-    // mapped after ExitBootServices.
-    allocator::reserve_runtime_region();
+    // Reserve runtime services memory regions if the platform provided them.
+    if let Some(rt) = config.runtime_region {
+        use allocator::MemoryType;
+
+        let code_pages = rt.code_size.div_ceil(allocator::PAGE_SIZE);
+        let data_pages = rt.data_size.div_ceil(allocator::PAGE_SIZE);
+        if let Err(e) =
+            allocator::reserve_region(rt.code_base, code_pages, MemoryType::RuntimeServicesCode)
+        {
+            log::warn!("Failed to reserve runtime code region: {:?}", e);
+        }
+        if let Err(e) =
+            allocator::reserve_region(rt.data_base, data_pages, MemoryType::RuntimeServicesData)
+        {
+            log::warn!("Failed to reserve runtime data region: {:?}", e);
+        }
+    } else {
+        // Fall back to linker-symbol-based reservation. Only available when
+        // CrabEFI owns the linker script (platform-entry feature).
+        #[cfg(feature = "platform-entry")]
+        allocator::reserve_runtime_region();
+        #[cfg(not(feature = "platform-entry"))]
+        log::info!(
+            "No runtime region provided and no linker symbols — runtime services may not survive ExitBootServices"
+        );
+    }
 
     // Initialize system table with boot and runtime services
     unsafe {
@@ -54,74 +89,61 @@ pub fn init(cb_info: &CorebootInfo) {
         );
     }
 
-    // Install ACPI tables if available
-    if let Some(rsdp) = cb_info.acpi_rsdp {
+    // Install platform tables
+    if let Some(rsdp) = config.acpi_rsdp {
         system_table::install_acpi_tables(rsdp);
     } else {
-        log::warn!("No ACPI RSDP from coreboot - Linux may not have ACPI support!");
+        log::info!("No ACPI RSDP from platform");
     }
-
-    // Install SMBIOS tables if available
-    if let Some(smbios) = cb_info.smbios {
+    if let Some(smbios) = config.smbios {
         system_table::install_smbios_tables(smbios);
-    } else {
-        log::debug!("No SMBIOS tables from coreboot");
     }
-
-    // Install device tree (FDT) if available
-    if let Some((fdt_addr, fdt_size)) = cb_info.devicetree {
+    if let Some(fdt_bytes) = config.fdt {
+        let fdt_addr = fdt_bytes.as_ptr() as u64;
+        let fdt_size = fdt_bytes.len() as u32;
         system_table::install_devicetree(fdt_addr, fdt_size);
     }
 
-    // Install EFI Runtime Properties Table (UEFI 2.8+)
-    // This tells Linux which runtime services are supported.
-    // Required for efi_pstore, efivars, and other kernel modules.
+    // Install standard EFI tables and protocols
     system_table::install_rt_properties_table();
-
-    // Install minimal TPM2 event log tables
-    // Prevents kernel errors about failing to map ACPI memory for TPM log
     system_table::install_tpm_event_log();
 
-    // Create console handle - this will also have GOP installed on it
     let console_handle = init_console();
 
-    // Install Graphics Output protocol on the SAME handle as console
-    // This is important - GRUB expects GOP and ConOut on the same handle
-    if let Some(fb) = cb_info.framebuffer {
+    if let Some(fb) = config.framebuffer {
+        // Store globally so menus and boot_manager can access it via
+        // state::get_framebuffer() — works for both coreboot and platform paths.
+        crate::state::store_framebuffer(fb);
         if let Some(handle) = console_handle {
             init_graphics_output_on_handle(&fb, handle);
         }
-        // Initialize EFI console framebuffer output (bootloader text goes here too)
         protocols::console::init_framebuffer(fb);
     }
 
-    // Install Unicode Collation protocol
+    // Install standard protocols and finalize tables (shared with init)
+    install_standard_protocols_and_finalize();
+
+    // Dump the full memory map for debugging (output goes directly to serial,
+    // bypassing EFI ConOut — safe even if ConOut has issues).
+    allocator::dump_memory_map();
+
+    log::info!("EFI environment initialized (platform path)");
+}
+
+/// Install standard EFI protocols and finalize table checksums.
+///
+/// Shared by both [`init()`] and [`init_from_platform()`] — contains the
+/// protocol installations and table finalization that are identical in both
+/// paths.
+fn install_standard_protocols_and_finalize() {
     init_unicode_collation();
-
-    // Install Memory Attribute protocol
     init_memory_attribute();
-
-    // Install Serial IO protocol
     init_serial_io();
-
-    // Install RNG protocol (if RDRAND is available)
     init_rng();
-
-    // Install Console Control protocol (legacy, but some bootloaders need it)
     init_console_control();
-
-    // Install EFI Memory Attributes Table
-    // Linux and Windows use this to set proper page permissions for runtime regions
     system_table::install_memory_attributes_table();
-
-    // Dump configuration tables for debugging
     system_table::dump_configuration_tables();
-
-    // Compute CRC32 checksums for all EFI table headers.
-    // Must be done after all configuration tables and protocols are installed.
     system_table::update_crc32();
-
-    log::info!("EFI environment initialized");
 }
 
 /// Initialize console I/O
@@ -387,7 +409,7 @@ fn init_console_control() {
 /// Initialize Graphics Output Protocol (GOP) on a specific handle
 /// Installing GOP on the same handle as ConOut is important for GRUB compatibility
 fn init_graphics_output_on_handle(
-    framebuffer: &crate::coreboot::FramebufferInfo,
+    framebuffer: &crate::platform::FramebufferConfig,
     handle: efi::Handle,
 ) {
     use protocols::graphics_output::{GRAPHICS_OUTPUT_GUID, create_gop};
@@ -513,17 +535,12 @@ pub fn add_platform_mmio_regions() {
         }
     };
 
-    // Platform info: FDT takes priority, ACPI fills gaps.
-    // No hardcoded fallbacks — all addresses come from firmware tables.
-    let fdt = crate::state::drivers().fdt_info;
-    let acpi = crate::state::drivers().acpi_info;
+    // Try to get platform info from FDT (if available)
+    let plat = crate::state::drivers().fdt_info;
 
-    // GIC — from FDT, then ACPI MADT
-    let gicd = fdt.gicd.or(acpi.gicd);
-    let gicr = fdt.gicr.or(acpi.gicr);
-
-    if let Some((base, size)) = gicd {
-        let total = if let Some((rb, rsize)) = gicr {
+    // GIC — from FDT or SBSA default
+    if let Some((base, size)) = plat.gicd {
+        let total = if let Some((rb, rsize)) = plat.gicr {
             // Cover GICD + GICR as one contiguous block if adjacent,
             // otherwise add them separately
             let gicd_end = base + size;
@@ -537,43 +554,47 @@ pub fn add_platform_mmio_regions() {
             size
         };
         add_mmio(base, total, "GIC");
+    } else {
+        // SBSA default
+        add_mmio(0x4006_0000, 0xA_0000, "GIC");
     }
 
-    // Platform device MMIO — from DSDT Device scopes (_HID + _CRS).
-    // This covers UART, RTC, GPIO, AHCI, xHCI, etc. as described in ACPI.
-    for i in 0..acpi.dsdt_device_count {
-        let dev = &acpi.dsdt_devices[i];
-        add_mmio(dev.mmio_base, dev.mmio_size, dev.hid_str());
+    // Peripherals — SBSA default only (FDT platforms get UART from coreboot serial)
+    if plat.gicd.is_none() {
+        // SBSA: Peripherals block (UART, RTC, GPIO, AHCI, EHCI) 0x60000000-0x60200000
+        add_mmio(
+            0x6000_0000,
+            0x20_0000,
+            "Peripherals (UART/RTC/GPIO/AHCI/EHCI)",
+        );
     }
 
-    // FDT UART fallback — on platforms without DSDT (e.g. QEMU virt with FDT).
-    if acpi.dsdt_device_count == 0
-        && let Some(base) = fdt.uart_base
-    {
-        add_mmio(base, 0x1000, "UART (FDT)");
-    }
-
-    // PCIe PIO
-    if let Some((base, size)) = fdt.pcie_pio.or(acpi.pcie_pio) {
+    // PCIe PIO — from FDT or SBSA default
+    if let Some((base, size)) = plat.pcie_pio {
         add_mmio(base, size, "PCIe PIO");
+    } else if plat.gicd.is_none() {
+        add_mmio(0x7FFF_0000, 0x1_0000, "PCIe PIO");
     }
 
-    // PCIe 32-bit MMIO
-    if let Some((base, size)) = fdt.pcie_mmio32.or(acpi.pcie_mmio32) {
+    // PCIe 32-bit MMIO — from FDT or SBSA default
+    if let Some((base, size)) = plat.pcie_mmio32 {
         add_mmio(base, size, "PCIe MMIO32");
+    } else if plat.gicd.is_none() {
+        add_mmio(0x8000_0000, 0x7000_0000, "PCIe MMIO");
     }
 
-    // PCIe 64-bit MMIO
-    if let Some((base, size)) = fdt.pcie_mmio64.or(acpi.pcie_mmio64) {
+    // PCIe 64-bit MMIO (if from FDT)
+    if let Some((base, size)) = plat.pcie_mmio64 {
         add_mmio(base, size, "PCIe MMIO64");
     }
 
-    // PCIe ECAM — from FDT or ACPI MCFG
-    if let Some(base) = fdt.ecam_base.or(acpi.ecam_base)
-        && let Some(size) = fdt.ecam_size.or(acpi.ecam_size)
+    // PCIe ECAM — from FDT
+    if let Some(base) = plat.ecam_base
+        && let Some(size) = plat.ecam_size
     {
         add_mmio(base, size, "PCIe ECAM");
     }
+    // SBSA ECAM (0xF0000000-0x100000000) is already in coreboot map as Reserved
 }
 
 /// Reserve the EL2 MMU page table memory (aarch64 only)

--- a/src/efi/protocols/console.rs
+++ b/src/efi/protocols/console.rs
@@ -9,11 +9,11 @@
 //! - Serial console: ANSI escape sequences are parsed for arrow keys, function keys, etc.
 //! - PS/2 keyboard: Scancodes are translated to EFI keys via the i8042 keyboard controller.
 
-use crate::coreboot::FramebufferInfo;
 use crate::drivers::keyboard_common as keyboard;
 use crate::drivers::serial;
 use crate::efi::boot_services::KEYBOARD_EVENT_ID;
 use crate::framebuffer_console::{CHAR_HEIGHT, CHAR_WIDTH, VGA_FONT_8X16};
+use crate::platform::FramebufferConfig;
 use crate::state::{self, InputState};
 use core::ffi::c_void;
 use r_efi::efi::{Boolean, Event, Guid, Status};
@@ -25,9 +25,9 @@ use r_efi::protocols::simple_text_output::Protocol as SimpleTextOutputProtocol;
 // ============================================================================
 
 /// Initialize the EFI console with framebuffer support
-pub fn init_framebuffer(fb: FramebufferInfo) {
-    let cols = fb.x_resolution / CHAR_WIDTH;
-    let rows = fb.y_resolution / CHAR_HEIGHT;
+pub fn init_framebuffer(fb: FramebufferConfig) {
+    let cols = fb.width / CHAR_WIDTH;
+    let rows = fb.height / CHAR_HEIGHT;
 
     // Reserve top portion for debug log, use bottom portion for EFI console
     // Use bottom half of screen for EFI console output
@@ -99,7 +99,7 @@ fn fb_put_char(c: char) {
 ///
 /// Uses the current foreground/background colors from ConsoleState.
 fn fb_draw_char(
-    fb: &FramebufferInfo,
+    fb: &FramebufferConfig,
     c: char,
     col: u32,
     row: u32,
@@ -141,7 +141,7 @@ fn fb_draw_char(
 /// Only scrolls the centered text region (delta_x..delta_x + cols*CHAR_WIDTH)
 /// within the row range start_row..max_row.
 fn fb_scroll_up(
-    fb: &FramebufferInfo,
+    fb: &FramebufferConfig,
     start_row: u32,
     max_row: u32,
     delta_x: u32,
@@ -149,7 +149,7 @@ fn fb_scroll_up(
     cols: u32,
     bg_color: (u8, u8, u8),
 ) {
-    let row_stride = fb.bytes_per_line as usize;
+    let row_stride = fb.bytes_per_line() as usize;
     let bpp = (fb.bits_per_pixel / 8) as usize;
     let text_width_bytes = (cols * CHAR_WIDTH) as usize * bpp;
     let x_offset_bytes = delta_x as usize * bpp;
@@ -983,12 +983,12 @@ pub(crate) fn keyboard_check_ready() -> bool {
 /// grid dimensions and `delta_x`/`delta_y` are the pixel offsets to center
 /// the grid within the framebuffer (matching EDK2 GraphicsConsole behavior).
 pub(crate) fn compute_centered_text_layout(
-    fb: &crate::coreboot::FramebufferInfo,
+    fb: &crate::platform::FramebufferConfig,
 ) -> (u32, u32, u32, u32) {
-    let cols = fb.x_resolution / CHAR_WIDTH;
-    let rows = fb.y_resolution / CHAR_HEIGHT;
-    let delta_x = (fb.x_resolution - cols * CHAR_WIDTH) / 2;
-    let delta_y = (fb.y_resolution - rows * CHAR_HEIGHT) / 2;
+    let cols = fb.width / CHAR_WIDTH;
+    let rows = fb.height / CHAR_HEIGHT;
+    let delta_x = (fb.width - cols * CHAR_WIDTH) / 2;
+    let delta_y = (fb.height - rows * CHAR_HEIGHT) / 2;
     (cols, rows, delta_x, delta_y)
 }
 

--- a/src/efi/protocols/device_path.rs
+++ b/src/efi/protocols/device_path.rs
@@ -951,6 +951,12 @@ pub enum DevicePathInfo {
     },
     /// SDHCI (SD card) - uses USB device path with port=0
     Sdhci { pci_device: u8, pci_function: u8 },
+    /// Platform-provided block device (non-PCI).
+    ///
+    /// Uses a vendor-defined device path node since these devices have no
+    /// PCI topology. The `index` identifies the device in the platform
+    /// block device array.
+    Platform { index: usize },
 }
 
 /// Create a whole-disk device path from a DevicePathInfo
@@ -987,6 +993,12 @@ pub fn create_disk_device_path(info: &DevicePathInfo) -> *mut Protocol {
             pci_device,
             pci_function,
         } => create_usb_device_path(pci_device, pci_function, 0),
+        DevicePathInfo::Platform { .. } => {
+            // A proper vendor-defined node can be added later.
+            // Returning null causes the caller to skip device path installation,
+            // which is safe — the device is still bootable via BlockIO.
+            core::ptr::null_mut()
+        }
     }
 }
 
@@ -1075,5 +1087,6 @@ pub fn create_partition_device_path(
             partition_size,
             partition_guid,
         ),
+        DevicePathInfo::Platform { .. } => core::ptr::null_mut(),
     }
 }

--- a/src/efi/protocols/graphics_output.rs
+++ b/src/efi/protocols/graphics_output.rs
@@ -6,9 +6,9 @@
 
 use r_efi::efi::{Guid, Status};
 
-use crate::coreboot::FramebufferInfo;
 use crate::efi::allocator::{MemoryType, allocate_pool};
 use crate::efi::utils::allocate_protocol_with_log;
+use crate::platform::FramebufferConfig;
 use crate::state;
 
 /// EFI_GRAPHICS_OUTPUT_PROTOCOL GUID
@@ -229,8 +229,8 @@ extern "efiapi" fn gop_blt(
         Some(fb) => fb,
         None => return Status::DEVICE_ERROR,
     };
-    let fb_width = fb.x_resolution as usize;
-    let fb_height = fb.y_resolution as usize;
+    let fb_width = fb.width as usize;
+    let fb_height = fb.height as usize;
     let fb_ptr = fb.physical_address as *mut u8;
 
     // Calculate buffer line length
@@ -364,7 +364,7 @@ extern "efiapi" fn gop_blt(
 
 /// Write a BltPixel to framebuffer at (x, y)
 unsafe fn write_pixel_to_fb(
-    fb: &FramebufferInfo,
+    fb: &FramebufferConfig,
     fb_ptr: *mut u8,
     x: usize,
     y: usize,
@@ -372,7 +372,7 @@ unsafe fn write_pixel_to_fb(
 ) {
     unsafe {
         let bytes_per_pixel = (fb.bits_per_pixel / 8) as usize;
-        let offset = y * fb.bytes_per_line as usize + x * bytes_per_pixel;
+        let offset = y * fb.bytes_per_line() as usize + x * bytes_per_pixel;
         let ptr = fb_ptr.add(offset);
 
         match fb.bits_per_pixel {
@@ -411,14 +411,14 @@ unsafe fn write_pixel_to_fb(
 
 /// Read a BltPixel from framebuffer at (x, y)
 unsafe fn read_pixel_from_fb(
-    fb: &FramebufferInfo,
+    fb: &FramebufferConfig,
     fb_ptr: *mut u8,
     x: usize,
     y: usize,
 ) -> BltPixel {
     unsafe {
         let bytes_per_pixel = (fb.bits_per_pixel / 8) as usize;
-        let offset = y * fb.bytes_per_line as usize + x * bytes_per_pixel;
+        let offset = y * fb.bytes_per_line() as usize + x * bytes_per_pixel;
         let ptr = fb_ptr.add(offset);
 
         match fb.bits_per_pixel {
@@ -464,11 +464,11 @@ unsafe fn read_pixel_from_fb(
     }
 }
 
-/// Create the Graphics Output Protocol from coreboot framebuffer info
+/// Create the Graphics Output Protocol from framebuffer configuration
 ///
 /// # Returns
 /// A pointer to the GraphicsOutputProtocol, or null on failure
-pub fn create_gop(framebuffer: &FramebufferInfo) -> *mut GraphicsOutputProtocol {
+pub fn create_gop(framebuffer: &FramebufferConfig) -> *mut GraphicsOutputProtocol {
     // Determine pixel format based on mask positions
     let (pixel_format, pixel_bitmask) = if framebuffer.bits_per_pixel == 32 {
         if framebuffer.red_mask_pos == 16
@@ -513,12 +513,11 @@ pub fn create_gop(framebuffer: &FramebufferInfo) -> *mut GraphicsOutputProtocol 
     // Allocate mode info
     let mode_info_ptr = allocate_protocol_with_log::<GopModeInfo>("GopModeInfo", |m| {
         m.version = 0;
-        m.horizontal_resolution = framebuffer.x_resolution;
-        m.vertical_resolution = framebuffer.y_resolution;
+        m.horizontal_resolution = framebuffer.width;
+        m.vertical_resolution = framebuffer.height;
         m.pixel_format = pixel_format;
         m.pixel_information = pixel_bitmask;
-        m.pixels_per_scan_line =
-            framebuffer.bytes_per_line / (framebuffer.bits_per_pixel as u32 / 8);
+        m.pixels_per_scan_line = framebuffer.stride;
     });
     if mode_info_ptr.is_null() {
         return core::ptr::null_mut();
@@ -559,8 +558,8 @@ pub fn create_gop(framebuffer: &FramebufferInfo) -> *mut GraphicsOutputProtocol 
 
     log::info!(
         "GraphicsOutputProtocol created: {}x{} @ {:#x}, {:?}",
-        framebuffer.x_resolution,
-        framebuffer.y_resolution,
+        framebuffer.width,
+        framebuffer.height,
         framebuffer.physical_address,
         pixel_format
     );

--- a/src/efi/protocols/simple_file_system.rs
+++ b/src/efi/protocols/simple_file_system.rs
@@ -239,6 +239,9 @@ extern "efiapi" fn file_open(
     let name_len = utf16_to_utf8(file_name, &mut utf8_name);
     let name_str = core::str::from_utf8(&utf8_name[..name_len]).unwrap_or("");
 
+    // Strip device path text prefix if present (shim/GRUB prepend these)
+    let name_str = strip_device_path_prefix(name_str);
+
     log::info!("File.Open({:?})", name_str);
 
     // Get parent handle info
@@ -699,6 +702,41 @@ fn utf16_to_utf8(src: *mut Char16, dst: &mut [u8]) -> usize {
 
     dst[len] = 0;
     len
+}
+
+/// Strip a device path text prefix from a file path.
+///
+/// UEFI shim/GRUB sometimes prepend the textual device path representation
+/// to file paths passed to `File.Open`, e.g.:
+///
+///   `PciRoot(0)\Pci(0x4,0x0)\HD(2,GPT,...)\EFI\ubuntu\grubaa64.efi`
+///
+/// The actual file path is just `EFI\ubuntu\grubaa64.efi`. Device path
+/// components always contain parentheses (`PciRoot(0)`, `HD(...)`) which
+/// are not valid in FAT file/directory names, so we detect the prefix by
+/// checking if the first path component contains `(`, then strip everything
+/// up to and including the last `)\` or `)/`.
+fn strip_device_path_prefix(path: &str) -> &str {
+    // Quick check: if the first path component contains '(', it's a device path
+    let first_sep = path.find(['\\', '/']).unwrap_or(path.len());
+    if !path[..first_sep].contains('(') {
+        return path;
+    }
+
+    // Find the last ")\" or ")/" which ends the device path portion
+    let bytes = path.as_bytes();
+    let mut last_dp_end = 0;
+    for i in 0..bytes.len().saturating_sub(1) {
+        if bytes[i] == b')' && (bytes[i + 1] == b'\\' || bytes[i + 1] == b'/') {
+            last_dp_end = i + 2;
+        }
+    }
+
+    if last_dp_end > 0 && last_dp_end < path.len() {
+        &path[last_dp_end..]
+    } else {
+        path
+    }
 }
 
 /// Build a full path from parent path and relative name

--- a/src/efi/protocols/storage_security.rs
+++ b/src/efi/protocols/storage_security.rs
@@ -170,6 +170,10 @@ extern "efiapi" fn storage_security_receive_data(
             log::warn!("StorageSecurity: SDHCI security commands not supported");
             return Status::UNSUPPORTED;
         }
+        StorageType::Platform { .. } => {
+            log::warn!("StorageSecurity: Platform device security commands not supported");
+            return Status::UNSUPPORTED;
+        }
     };
 
     match result {
@@ -270,6 +274,10 @@ extern "efiapi" fn storage_security_send_data(
         ),
         StorageType::Sdhci { .. } => {
             log::warn!("StorageSecurity: SDHCI security commands not supported");
+            return Status::UNSUPPORTED;
+        }
+        StorageType::Platform { .. } => {
+            log::warn!("StorageSecurity: Platform device security commands not supported");
             return Status::UNSUPPORTED;
         }
     };

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -340,11 +340,10 @@ extern "efiapi" fn set_virtual_address_map(
         });
     }
 
-    // Step 4: Relocate our own internal pointers
+    // Step 4a: Relocate STATE_PTR — find the runtime region containing
+    // FirmwareState (on the stack, inside RuntimeServicesData).
     let state_phys = state::get() as *const _ as u64;
     let rt_ptr = get_runtime_services();
-    let rt_phys = rt_ptr as u64;
-    let mut state_relocated = false;
 
     for i in 0..num_entries {
         let desc = unsafe {
@@ -360,49 +359,52 @@ extern "efiapi" fn set_virtual_address_map(
             .number_of_pages
             .saturating_mul(EFI_PAGE_SIZE)
             .saturating_add(phys_start);
-        let virt_start = desc.virtual_start;
 
-        // Relocate STATE_PTR
-        if !state_relocated && state_phys >= phys_start && state_phys < phys_end {
-            let offset = virt_start as i64 - phys_start as i64;
+        if state_phys >= phys_start && state_phys < phys_end {
+            let offset = desc.virtual_start as i64 - phys_start as i64;
             let new_state = (state_phys as i64 + offset) as u64;
             unsafe {
                 state::relocate_state_ptr(new_state as *mut state::FirmwareState);
             }
-            state_relocated = true;
             log::debug!(
                 "SetVirtualAddressMap: relocated state ptr {:#x} -> {:#x}",
                 state_phys,
                 new_state
             );
-        }
-
-        // Relocate RuntimeServices function pointers
-        if rt_phys >= phys_start && rt_phys < phys_end {
-            let offset = virt_start as i64 - phys_start as i64;
-            // NOTE: set_virtual_address_map and convert_pointer are NOT relocated
-            // per EDK2 convention -- they are never called again after this point.
-            unsafe {
-                let rt = &mut *rt_ptr;
-                relocate_fn_ptr(&mut rt.get_time, offset);
-                relocate_fn_ptr(&mut rt.set_time, offset);
-                relocate_fn_ptr(&mut rt.get_wakeup_time, offset);
-                relocate_fn_ptr(&mut rt.set_wakeup_time, offset);
-                relocate_fn_ptr(&mut rt.get_variable, offset);
-                relocate_fn_ptr(&mut rt.get_next_variable_name, offset);
-                relocate_fn_ptr(&mut rt.set_variable, offset);
-                relocate_fn_ptr(&mut rt.get_next_high_mono_count, offset);
-                relocate_fn_ptr(&mut rt.reset_system, offset);
-                relocate_fn_ptr(&mut rt.update_capsule, offset);
-                relocate_fn_ptr(&mut rt.query_capsule_capabilities, offset);
-                relocate_fn_ptr(&mut rt.query_variable_info, offset);
-            }
-            log::debug!(
-                "SetVirtualAddressMap: relocated RT function pointers (offset {:#x})",
-                virt_start as i64 - phys_start as i64
-            );
+            break;
         }
     }
+
+    // Step 4b: Relocate RuntimeServices function pointers via ConvertPointer.
+    //
+    // Each function pointer targets code that may be in a DIFFERENT runtime
+    // region than the RT table itself. For example, when CrabEFI is linked as
+    // a library into fstart: the RT table (static) lives in BSS/RuntimeServicesData
+    // while the function pointer targets live in ROM/RuntimeServicesCode. These
+    // two regions have different physical→virtual offsets.
+    //
+    // We use convert_pointer_internal() which searches the virtual map for the
+    // region containing each pointer's target address, rather than assuming a
+    // single fixed offset.
+    //
+    // NOTE: set_virtual_address_map and convert_pointer are NOT relocated per
+    // EDK2 convention — they are never called again after this point.
+    unsafe {
+        let rt = &mut *rt_ptr;
+        convert_rt_fn_ptr(&mut rt.get_time);
+        convert_rt_fn_ptr(&mut rt.set_time);
+        convert_rt_fn_ptr(&mut rt.get_wakeup_time);
+        convert_rt_fn_ptr(&mut rt.set_wakeup_time);
+        convert_rt_fn_ptr(&mut rt.get_variable);
+        convert_rt_fn_ptr(&mut rt.get_next_variable_name);
+        convert_rt_fn_ptr(&mut rt.set_variable);
+        convert_rt_fn_ptr(&mut rt.get_next_high_mono_count);
+        convert_rt_fn_ptr(&mut rt.reset_system);
+        convert_rt_fn_ptr(&mut rt.update_capsule);
+        convert_rt_fn_ptr(&mut rt.query_capsule_capabilities);
+        convert_rt_fn_ptr(&mut rt.query_variable_info);
+    }
+    log::debug!("SetVirtualAddressMap: relocated RT function pointers via ConvertPointer");
 
     // Step 4b: Relocate GOT (Global Offset Table) entries.
     //
@@ -411,6 +413,11 @@ extern "efiapi" fn set_virtual_address_map(
     // The linker fills these GOT entries with absolute physical addresses.
     // After SVAM, the physical addresses are unmapped, so we must adjust
     // each GOT entry by the appropriate virtual offset.
+    //
+    // Only available when CrabEFI owns the linker script (platform-entry).
+    // When linked as a library, the host firmware's linker script controls
+    // the GOT and must provide its own SVAM relocation if needed.
+    #[cfg(feature = "platform-entry")]
     {
         unsafe extern "C" {
             static _got_start: u8;
@@ -548,6 +555,7 @@ extern "efiapi" fn set_virtual_address_map(
 /// # Safety
 ///
 /// The offset must produce a valid function address within the relocated region.
+#[allow(dead_code)]
 unsafe fn relocate_fn_ptr<T>(ptr: &mut T, offset: i64) {
     // SAFETY: The offset must produce a valid function address within the relocated region.
     // Caller guarantees the pointer refers to a function pointer field in RuntimeServices.
@@ -555,6 +563,33 @@ unsafe fn relocate_fn_ptr<T>(ptr: &mut T, offset: i64) {
         let old = core::ptr::read(ptr as *const T as *const u64);
         let new = (old as i64 + offset) as u64;
         core::ptr::write(ptr as *mut T as *mut u64, new);
+    }
+}
+
+/// Convert a RuntimeServices function pointer using the virtual memory map.
+///
+/// Reads the physical address stored in `ptr`, searches the virtual map for
+/// the runtime region containing that address, and writes back the virtual
+/// address. Unlike [`relocate_fn_ptr`] which applies a fixed offset, this
+/// handles the case where the function pointer target (code) is in a different
+/// runtime region than the RuntimeServices table (data) — e.g. when CrabEFI
+/// is linked as a library with code in ROM and data in RAM.
+///
+/// No-op if the address isn't found in any runtime region.
+///
+/// # Safety
+///
+/// - The VIRTUAL_MAP globals must be set up (step 2 of SetVirtualAddressMap).
+/// - `ptr` must point to a valid function pointer field in RuntimeServices.
+unsafe fn convert_rt_fn_ptr<T>(ptr: &mut T) {
+    // SAFETY: We read the raw u64 value of the function pointer, convert it
+    // via the virtual map, and write back the converted virtual address.
+    unsafe {
+        let phys_val = core::ptr::read(ptr as *const T as *const u64);
+        let mut addr = phys_val as *mut c_void;
+        if convert_pointer_internal(0, &mut addr) == Status::SUCCESS {
+            core::ptr::write(ptr as *mut T as *mut u64, addr as u64);
+        }
     }
 }
 

--- a/src/efi/varstore/deferred.rs
+++ b/src/efi/varstore/deferred.rs
@@ -61,33 +61,67 @@ const DEFERRED_MAGIC: u32 = 0x46425643;
 /// Current buffer format version
 const DEFERRED_VERSION: u8 = 1;
 
-// Linker symbols for deferred buffer section (defined in x86_64-coreboot.ld)
-// The .deferred_buffer section is a NOLOAD region allocated by the linker.
+// Linker symbols for deferred buffer section (defined in x86_64-coreboot.ld).
+// Only available when CrabEFI owns the linker script (platform-entry).
+#[cfg(feature = "platform-entry")]
 unsafe extern "C" {
     static _deferred_buffer_start: u8;
     static _deferred_buffer_end: u8;
 }
 
-/// Get the deferred buffer base address from linker script
+/// Get the deferred buffer base address from linker script.
+///
+/// When `platform-entry` is disabled (library mode), returns the
+/// platform-configured base or 0 if no deferred buffer is configured.
 #[inline]
 pub fn deferred_buffer_base() -> u64 {
-    unsafe { &_deferred_buffer_start as *const u8 as u64 }
-}
-
-/// Get the deferred buffer size from linker script
-#[inline]
-pub fn deferred_buffer_size() -> usize {
-    unsafe {
-        let start = &_deferred_buffer_start as *const u8 as usize;
-        let end = &_deferred_buffer_end as *const u8 as usize;
-        end - start
+    #[cfg(feature = "platform-entry")]
+    {
+        unsafe { &_deferred_buffer_start as *const u8 as u64 }
+    }
+    #[cfg(not(feature = "platform-entry"))]
+    {
+        // In library mode, use the override if configured, otherwise 0.
+        let ovr = BUFFER_BASE_OVERRIDE.load(core::sync::atomic::Ordering::Relaxed);
+        if ovr != 0 { ovr } else { 0 }
     }
 }
 
-/// Get the deferred buffer base as a mutable pointer
+/// Get the deferred buffer size.
+///
+/// When `platform-entry` is disabled, returns the configured size or 0.
+#[inline]
+pub fn deferred_buffer_size() -> usize {
+    #[cfg(feature = "platform-entry")]
+    {
+        unsafe {
+            let start = &_deferred_buffer_start as *const u8 as usize;
+            let end = &_deferred_buffer_end as *const u8 as usize;
+            end - start
+        }
+    }
+    #[cfg(not(feature = "platform-entry"))]
+    {
+        BUFFER_SIZE_OVERRIDE.load(core::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+/// Get the deferred buffer base as a mutable pointer.
 #[inline]
 fn linker_buffer_base() -> *mut u8 {
-    unsafe { &_deferred_buffer_start as *const u8 as *mut u8 }
+    #[cfg(feature = "platform-entry")]
+    {
+        unsafe { &_deferred_buffer_start as *const u8 as *mut u8 }
+    }
+    #[cfg(not(feature = "platform-entry"))]
+    {
+        let ovr = BUFFER_BASE_OVERRIDE.load(core::sync::atomic::Ordering::Relaxed);
+        if ovr != 0 {
+            ovr as *mut u8
+        } else {
+            core::ptr::null_mut()
+        }
+    }
 }
 
 /// Header size
@@ -193,10 +227,15 @@ impl DeferredHeader {
 /// Configured buffer base address override (0 = use linker default)
 static BUFFER_BASE_OVERRIDE: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
 
+/// Configured buffer size override (0 = use linker default).
+/// Used in library mode where linker symbols are not available.
+static BUFFER_SIZE_OVERRIDE: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(0);
+
 /// Whether the deferred buffer has been initialized
 static INITIALIZED: AtomicBool = AtomicBool::new(false);
 
-/// Configure an alternate deferred buffer base address
+/// Configure an alternate deferred buffer base address and size.
 ///
 /// This can be called early in boot to override the linker-allocated buffer.
 /// The address should point to reserved memory that survives warm reset.
@@ -204,6 +243,19 @@ static INITIALIZED: AtomicBool = AtomicBool::new(false);
 pub fn configure_buffer(base_addr: u64) {
     BUFFER_BASE_OVERRIDE.store(base_addr, Ordering::SeqCst);
     log::info!("Deferred variable buffer configured at {:#x}", base_addr);
+}
+
+/// Configure an alternate deferred buffer with both base and size.
+///
+/// Used by `init_platform()` when no linker symbols are available.
+pub fn configure_buffer_with_size(base_addr: u64, size: usize) {
+    BUFFER_BASE_OVERRIDE.store(base_addr, Ordering::SeqCst);
+    BUFFER_SIZE_OVERRIDE.store(size, Ordering::SeqCst);
+    log::info!(
+        "Deferred variable buffer configured at {:#x} ({} bytes)",
+        base_addr,
+        size
+    );
 }
 
 /// Get the buffer base address

--- a/src/efi/varstore/edk2_backend.rs
+++ b/src/efi/varstore/edk2_backend.rs
@@ -1,0 +1,340 @@
+//! EDK2 Firmware Volume Variable Backend
+//!
+//! This module provides [`Edk2VarStore`], a [`VariableBackend`] implementation
+//! that stores EFI variables in EDK2-compatible Firmware Volume (FV) format
+//! on top of a raw [`StorageBackend`].
+//!
+//! # Usage
+//!
+//! ```ignore
+//! let mut spi_backend = SpiStorageBackend::new(controller, offset, size);
+//! let mut edk2_store = crabefi::efi::varstore::Edk2VarStore::new(&mut spi_backend);
+//!
+//! let config = crabefi::PlatformConfig {
+//!     variable_backend: Some(&mut edk2_store),
+//!     // ...
+//! };
+//! ```
+//!
+//! This is the default variable backend for the coreboot target and any other
+//! platform with direct byte-level access to a NOR flash or similar storage.
+//! Platforms using SMM or TF-A MM should implement [`VariableBackend`] directly.
+
+use crate::platform::{StorageBackend, VarBackendError, VariableBackend, VariableVisitor};
+use r_efi::efi::Guid;
+
+use super::edk2;
+
+/// EDK2 Firmware Volume format variable store.
+///
+/// Wraps a [`StorageBackend`] (e.g., SPI flash) and implements the
+/// [`VariableBackend`] trait using EDK2-compatible Firmware Volume format.
+///
+/// # Format
+///
+/// The storage is laid out as:
+/// ```text
+/// +-------------------------------------------+ offset 0
+/// |  EFI_FIRMWARE_VOLUME_HEADER  (72 bytes)   |
+/// +-------------------------------------------+ offset 0x48
+/// |  VARIABLE_STORE_HEADER       (28 bytes)   |
+/// +-------------------------------------------+ offset 0x64
+/// |  Variable Record #1 (header + name + data)|
+/// |  (padded to 4-byte alignment)             |
+/// +-------------------------------------------+
+/// |  Variable Record #2                       |
+/// +-------------------------------------------+
+/// |  ...                                      |
+/// +-------------------------------------------+
+/// |  Free space (0xFF)                        |
+/// +-------------------------------------------+
+/// ```
+///
+/// When a variable is updated, the old record is marked as deleted and a new
+/// record is appended. When free space runs out, compaction erases the region
+/// and rewrites only active variables.
+pub struct Edk2VarStore<'a> {
+    storage: &'a mut dyn StorageBackend,
+    /// Whether the FV headers have been validated/initialized.
+    initialized: bool,
+    /// Whether the store uses authenticated variable format.
+    auth_format: bool,
+    /// Size of the data region (total size minus headers).
+    data_size: u32,
+    /// Current write offset (next free byte in the data region).
+    write_offset: u32,
+}
+
+impl<'a> Edk2VarStore<'a> {
+    /// Create a new EDK2 variable store wrapping a storage backend.
+    ///
+    /// The store is not initialized until [`VariableBackend::load()`] is called.
+    pub fn new(storage: &'a mut dyn StorageBackend) -> Self {
+        Self {
+            storage,
+            initialized: false,
+            auth_format: false,
+            data_size: 0,
+            write_offset: 0,
+        }
+    }
+
+    /// Check if the store has been initialized (load() called successfully).
+    pub fn is_initialized(&self) -> bool {
+        self.initialized
+    }
+
+    /// Validate or format the FV headers.
+    ///
+    /// Returns Ok(()) if headers are valid or were successfully written.
+    fn ensure_initialized(&mut self) -> Result<(), VarBackendError> {
+        if self.initialized {
+            return Ok(());
+        }
+
+        let storage_size = self.storage.size();
+
+        // Read FV + VS headers
+        let header_size = edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH;
+        let mut header_bytes = [0u8; 128];
+        self.storage
+            .read(0, &mut header_bytes[..header_size])
+            .map_err(|_| VarBackendError::IoError)?;
+
+        // Validate
+        let validation = edk2::validate_fv(&header_bytes[..header_size], storage_size);
+
+        if validation.valid {
+            self.auth_format = validation.auth_format;
+            self.data_size = validation.data_size;
+
+            // Find write offset
+            let auth_format = self.auth_format;
+            let data_size = self.data_size;
+            let storage = &mut self.storage;
+            let mut read_fn =
+                |offset: u32, buf: &mut [u8]| -> bool { storage.read(offset, buf).is_ok() };
+            self.write_offset = edk2::find_write_offset(&mut read_fn, auth_format, data_size);
+            self.initialized = true;
+            return Ok(());
+        }
+
+        // Format the store
+        log::info!(
+            "Formatting variable store as EDK2 FV ({} KB)...",
+            storage_size / 1024
+        );
+
+        let fv_headers = edk2::build_fv_headers(storage_size);
+        let _ = self.storage.enable_writes();
+        self.storage
+            .erase(0, storage_size)
+            .map_err(|_| VarBackendError::IoError)?;
+        self.storage
+            .write(0, &fv_headers)
+            .map_err(|_| VarBackendError::IoError)?;
+
+        self.auth_format = false;
+        self.data_size = storage_size - (edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32;
+        self.write_offset = (edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32;
+        self.initialized = true;
+
+        Ok(())
+    }
+}
+
+impl VariableBackend for Edk2VarStore<'_> {
+    fn load(&mut self, visitor: &mut dyn VariableVisitor) -> Result<(), VarBackendError> {
+        self.ensure_initialized()?;
+
+        // Read variable records from the FV and call visitor for each
+        let auth_format = self.auth_format;
+        let data_size = self.data_size;
+        let header_offset = (edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32;
+        let storage = &mut self.storage;
+
+        // Walk the variable store records
+        let mut offset = header_offset;
+        let end = header_offset + data_size;
+
+        while offset < end {
+            // Read variable header
+            let header_len = if auth_format {
+                edk2::AUTH_VAR_HEADER_SIZE
+            } else {
+                edk2::VAR_HEADER_SIZE
+            };
+
+            if offset + header_len as u32 > end {
+                break;
+            }
+
+            let mut header_buf = [0u8; 80]; // Large enough for auth header
+            if storage.read(offset, &mut header_buf[..header_len]).is_err() {
+                break;
+            }
+
+            // Check magic and state
+            let start_id = u16::from_le_bytes([header_buf[0], header_buf[1]]);
+            if start_id != 0xAA55 {
+                break; // End of valid records (free space)
+            }
+
+            let state = header_buf[2];
+            let attributes =
+                u32::from_le_bytes([header_buf[3], header_buf[4], header_buf[5], header_buf[6]]);
+
+            let (name_size, data_size_field) = if auth_format {
+                let ns = u32::from_le_bytes([
+                    header_buf[40],
+                    header_buf[41],
+                    header_buf[42],
+                    header_buf[43],
+                ]);
+                let ds = u32::from_le_bytes([
+                    header_buf[44],
+                    header_buf[45],
+                    header_buf[46],
+                    header_buf[47],
+                ]);
+                (ns, ds)
+            } else {
+                let ns = u32::from_le_bytes([
+                    header_buf[24],
+                    header_buf[25],
+                    header_buf[26],
+                    header_buf[27],
+                ]);
+                let ds = u32::from_le_bytes([
+                    header_buf[28],
+                    header_buf[29],
+                    header_buf[30],
+                    header_buf[31],
+                ]);
+                (ns, ds)
+            };
+
+            // Extract vendor GUID
+            let guid_offset = if auth_format { 48 } else { 32 };
+            let vendor_guid = if guid_offset + 16 <= header_len {
+                let guid_bytes = &header_buf[guid_offset..guid_offset + 16];
+                // Parse GUID from mixed-endian format (first 3 fields LE, last 2 BE)
+                let data1 = u32::from_le_bytes([
+                    guid_bytes[0],
+                    guid_bytes[1],
+                    guid_bytes[2],
+                    guid_bytes[3],
+                ]);
+                let data2 = u16::from_le_bytes([guid_bytes[4], guid_bytes[5]]);
+                let data3 = u16::from_le_bytes([guid_bytes[6], guid_bytes[7]]);
+                let data4_hi = u8::from_le_bytes([guid_bytes[8]]);
+                let data4_lo = u8::from_le_bytes([guid_bytes[9]]);
+                Guid::from_fields(
+                    data1,
+                    data2,
+                    data3,
+                    data4_hi,
+                    data4_lo,
+                    &[
+                        guid_bytes[10],
+                        guid_bytes[11],
+                        guid_bytes[12],
+                        guid_bytes[13],
+                        guid_bytes[14],
+                        guid_bytes[15],
+                    ],
+                )
+            } else {
+                break;
+            };
+
+            // Calculate total record size (header + name + data, padded to 4 bytes)
+            let record_data_start = offset + header_len as u32;
+            let total_payload = name_size + data_size_field;
+            let record_size = header_len as u32 + total_payload + ((4 - (total_payload % 4)) % 4); // 4-byte align
+
+            // Only process valid (non-deleted) records
+            if state == 0x3F || state == 0x7F {
+                // Read name and data
+                if total_payload > 0 && record_data_start + total_payload <= end {
+                    // Use a stack buffer for small records, skip huge ones
+                    const MAX_PAYLOAD: usize = 32 * 1024;
+                    if (total_payload as usize) <= MAX_PAYLOAD {
+                        let mut payload = [0u8; MAX_PAYLOAD];
+                        let payload_slice = &mut payload[..total_payload as usize];
+                        if storage.read(record_data_start, payload_slice).is_ok() {
+                            // Name is UTF-16LE, data follows
+                            let name_bytes = &payload_slice[..name_size as usize];
+                            let data_bytes =
+                                &payload_slice[name_size as usize..total_payload as usize];
+
+                            // Convert name bytes to &[u16]
+                            let name_u16_count = name_size as usize / 2;
+                            // SAFETY: name_bytes is aligned to u8, we manually convert
+                            let mut name_u16 = [0u16; 128];
+                            let name_len = name_u16_count.min(128);
+                            for i in 0..name_len {
+                                name_u16[i] =
+                                    u16::from_le_bytes([name_bytes[i * 2], name_bytes[i * 2 + 1]]);
+                            }
+                            // Strip null terminator if present
+                            let name_slice = if name_len > 0 && name_u16[name_len - 1] == 0 {
+                                &name_u16[..name_len - 1]
+                            } else {
+                                &name_u16[..name_len]
+                            };
+
+                            visitor.visit(name_slice, &vendor_guid, attributes, data_bytes);
+                        }
+                    }
+                }
+            }
+
+            // Advance to next record
+            offset += record_size;
+        }
+
+        Ok(())
+    }
+
+    fn write(
+        &mut self,
+        _name: &[u16],
+        _vendor: &Guid,
+        _attributes: u32,
+        _data: &[u8],
+    ) -> Result<(), VarBackendError> {
+        if !self.initialized {
+            return Err(VarBackendError::NotAvailable);
+        }
+
+        // TODO: Delegate to the existing edk2 persistence code for writing.
+        // This requires refactoring persistence.rs to work with a borrowed
+        // StorageBackend rather than the global state accessor.
+        //
+        // For now, the legacy init() path handles writes through the existing
+        // persistence module. This stub will be completed when the full
+        // migration from init() to init_platform() happens.
+        Err(VarBackendError::Other)
+    }
+
+    fn delete(&mut self, _name: &[u16], _vendor: &Guid) -> Result<(), VarBackendError> {
+        if !self.initialized {
+            return Err(VarBackendError::NotAvailable);
+        }
+
+        // TODO: Same as write() — pending persistence.rs refactoring.
+        Err(VarBackendError::Other)
+    }
+
+    fn runtime_capable(&self) -> bool {
+        // Direct flash is NOT runtime-capable: after ExitBootServices, flash
+        // may be locked by SMM. Writes go to the deferred buffer.
+        false
+    }
+
+    fn notify_exit_boot_services(&mut self) {
+        // Mark that flash is now locked — writes should go to deferred buffer.
+        log::debug!("Edk2VarStore: ExitBootServices — flash writes disabled");
+    }
+}

--- a/src/efi/varstore/mod.rs
+++ b/src/efi/varstore/mod.rs
@@ -42,11 +42,15 @@
 
 pub mod deferred;
 pub mod edk2;
+pub mod edk2_backend;
 pub mod persistence;
 pub mod storage;
 
 // Re-export storage types
 pub use storage::{SpiStorageBackend, StorageBackend, StorageError};
+
+// Re-export the EDK2 variable backend for use by platforms with raw flash
+pub use edk2_backend::Edk2VarStore;
 
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};

--- a/src/fb_log.rs
+++ b/src/fb_log.rs
@@ -3,8 +3,8 @@
 //! This module provides logging output to the framebuffer. It is disabled by
 //! default as it is very slow. Enable with the `fb-log` feature flag.
 
-use crate::coreboot::FramebufferInfo;
 use crate::framebuffer_console::{CHAR_HEIGHT, CHAR_WIDTH, Color, render_glyph};
+use crate::platform::FramebufferConfig;
 use core::fmt::Write;
 use log::Level;
 
@@ -12,7 +12,7 @@ use log::Level;
 ///
 /// Call this after parsing coreboot tables to enable framebuffer logging.
 /// Clears the screen to remove any stale content from bootloader.
-pub fn set_framebuffer(fb: FramebufferInfo) {
+pub fn set_framebuffer(fb: FramebufferConfig) {
     unsafe {
         fb.clear(0, 0, 0);
     }
@@ -38,8 +38,8 @@ pub fn log_to_framebuffer(level: Level, ts: u64, args: &core::fmt::Arguments) {
     };
 
     let (mut row, mut col) = unsafe { (*crate::state::console_mut_ptr()).logger_cursor };
-    let cols = fb_info.x_resolution / CHAR_WIDTH;
-    let rows = fb_info.y_resolution / CHAR_HEIGHT;
+    let cols = fb_info.width / CHAR_WIDTH;
+    let rows = fb_info.height / CHAR_HEIGHT;
 
     // Format the message with timestamp
     let mut buf = FormattingBuffer::new();
@@ -103,7 +103,7 @@ pub fn log_to_framebuffer(level: Level, ts: u64, args: &core::fmt::Arguments) {
 }
 
 /// Clear a line on the framebuffer
-fn clear_line(fb: &FramebufferInfo, row: u32, cols: u32, bg: Color) {
+fn clear_line(fb: &FramebufferConfig, row: u32, cols: u32, bg: Color) {
     let y_start = row * CHAR_HEIGHT;
     for y in y_start..(y_start + CHAR_HEIGHT) {
         for x in 0..(cols * CHAR_WIDTH) {
@@ -115,7 +115,7 @@ fn clear_line(fb: &FramebufferInfo, row: u32, cols: u32, bg: Color) {
 }
 
 /// Draw a character at a specific character-grid position on the framebuffer
-fn draw_char_at(fb: &FramebufferInfo, c: char, col: u32, row: u32, fg: Color, bg: Color) {
+fn draw_char_at(fb: &FramebufferConfig, c: char, col: u32, row: u32, fg: Color, bg: Color) {
     render_glyph(fb, c, col * CHAR_WIDTH, row * CHAR_HEIGHT, fg, bg);
 }
 

--- a/src/fdt.rs
+++ b/src/fdt.rs
@@ -77,7 +77,7 @@ impl core::fmt::Debug for DsdtDevice {
     }
 }
 
-/// Platform information extracted from an FDT
+/// Platform information extracted from an FDT or ACPI tables.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PlatformInfo {
     /// PCIe ECAM configuration space base address

--- a/src/framebuffer_console.rs
+++ b/src/framebuffer_console.rs
@@ -4,7 +4,7 @@
 //! embedded 8x16 VGA bitmap font. It supports basic text output with colors,
 //! cursor positioning, and scrolling.
 
-use crate::coreboot::framebuffer::FramebufferInfo;
+use crate::platform::FramebufferConfig as FramebufferInfo;
 use core::fmt::{self, Write};
 
 /// Character width in pixels
@@ -78,8 +78,8 @@ impl<'a> FramebufferConsole<'a> {
     ///
     /// * `fb` - Reference to the framebuffer info from coreboot
     pub fn new(fb: &'a FramebufferInfo) -> Self {
-        let cols = fb.x_resolution / CHAR_WIDTH;
-        let rows = fb.y_resolution / CHAR_HEIGHT;
+        let cols = fb.width / CHAR_WIDTH;
+        let rows = fb.height / CHAR_HEIGHT;
 
         FramebufferConsole {
             fb,
@@ -153,7 +153,7 @@ impl<'a> FramebufferConsole<'a> {
 
         let y_start = row * CHAR_HEIGHT;
         for y in y_start..(y_start + CHAR_HEIGHT) {
-            for x in 0..self.fb.x_resolution {
+            for x in 0..self.fb.width {
                 unsafe {
                     self.fb
                         .write_pixel(x, y, self.bg_color.r, self.bg_color.g, self.bg_color.b);
@@ -239,7 +239,7 @@ impl<'a> FramebufferConsole<'a> {
         // A faster version would use memcpy on scanlines
         let bytes_per_pixel = (self.fb.bits_per_pixel / 8) as usize;
         let line_height = CHAR_HEIGHT as usize;
-        let scanline_bytes = self.fb.bytes_per_line as usize;
+        let scanline_bytes = self.fb.bytes_per_line() as usize;
         let copy_height = ((self.rows - 1) * CHAR_HEIGHT) as usize;
 
         unsafe {
@@ -249,7 +249,7 @@ impl<'a> FramebufferConsole<'a> {
             for y in 0..copy_height {
                 let src_offset = (y + line_height) * scanline_bytes;
                 let dst_offset = y * scanline_bytes;
-                let line_bytes = self.fb.x_resolution as usize * bytes_per_pixel;
+                let line_bytes = self.fb.width as usize * bytes_per_pixel;
 
                 core::ptr::copy(fb_ptr.add(src_offset), fb_ptr.add(dst_offset), line_bytes);
             }

--- a/src/fs/gpt.rs
+++ b/src/fs/gpt.rs
@@ -300,7 +300,6 @@ pub fn read_partitions(
     let total_bytes_needed = total_entries * entry_size;
 
     let mut entry_index = 0u32;
-    let mut consecutive_empty = 0u32;
     let mut bytes_read = 0usize;
 
     'outer: while bytes_read < total_bytes_needed {
@@ -333,8 +332,6 @@ pub fn read_partitions(
             };
 
             if !entry.is_empty() {
-                consecutive_empty = 0;
-
                 // For hybrid ISOs, translate GPT LBAs (512-byte terms) to device LBAs
                 let (first_lba, last_lba) = if is_hybrid {
                     // GPT LBA * 512 / block_size = device LBA
@@ -368,17 +365,6 @@ pub fn read_partitions(
 
                 if partitions.push(partition).is_err() {
                     log::warn!("Too many partitions, ignoring remaining");
-                    break 'outer;
-                }
-            } else {
-                consecutive_empty += 1;
-                // Stop scanning after 8 consecutive empty entries (2 blocks worth)
-                // This handles truncated partition tables in ISOs
-                if consecutive_empty >= 8 && !partitions.is_empty() {
-                    log::debug!(
-                        "Stopping partition scan after {} consecutive empty entries",
-                        consecutive_empty
-                    );
                     break 'outer;
                 }
             }

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -32,8 +32,12 @@ const PAGE_SIZE: usize = 4096;
 /// Number of pages for the heap
 const HEAP_PAGES: u64 = (HEAP_SIZE / PAGE_SIZE) as u64;
 
-/// Global heap state
-struct BumpAllocator {
+/// Global heap state.
+///
+/// Binary crates must wire this up as `#[global_allocator]`. The library
+/// provides [`ALLOCATOR`] as the singleton instance; the binary just
+/// re-exports it with the attribute.
+pub struct BumpAllocator {
     /// Start of the heap
     heap_start: UnsafeCell<usize>,
     /// Current allocation pointer (offset from heap_start)
@@ -147,9 +151,13 @@ unsafe impl GlobalAlloc for BumpAllocator {
     }
 }
 
-/// Global allocator instance
-#[global_allocator]
-static ALLOCATOR: BumpAllocator = BumpAllocator::new();
+/// Global allocator instance.
+///
+/// When the `global-allocator` feature is enabled, this is registered as
+/// `#[global_allocator]`. External firmware that provides its own allocator
+/// should not enable this feature.
+#[cfg_attr(feature = "global-allocator", global_allocator)]
+pub static ALLOCATOR: BumpAllocator = BumpAllocator::new();
 
 /// Initialize the global allocator
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@
 // Enable alloc crate for heap allocations (needed for RustCrypto)
 extern crate alloc;
 
-pub mod acpi;
 pub mod arch;
 pub mod bls;
 pub mod boot;
@@ -38,33 +37,20 @@ pub mod menu;
 pub(crate) mod menu_common;
 pub mod payload;
 pub mod pe;
+pub mod platform;
 pub mod secure_boot_menu;
 pub mod state;
 pub mod time;
 
 use crate::drivers::block::{AhciDisk, NvmeDisk, SdhciDisk, UsbDisk};
-use core::panic::PanicInfo;
 
-/// Global panic handler
-#[panic_handler]
-fn panic(info: &PanicInfo) -> ! {
-    // Try to print the panic message to serial
-    if let Some(location) = info.location() {
-        log::error!(
-            "PANIC at {}:{}: {}",
-            location.file(),
-            location.line(),
-            info.message()
-        );
-    } else {
-        log::error!("PANIC: {}", info.message());
-    }
-
-    // Halt the CPU
-    loop {
-        arch::halt();
-    }
-}
+// Re-export the public platform API at the crate root for ergonomic access.
+pub use platform::{
+    BlockDevice, BlockDeviceInfo, BlockError, BootResult, ConsoleInput, DebugOutput,
+    DeferredBufferConfig, FramebufferConfig, Key, KeyState, MemoryRegion, MemoryType,
+    PlatformConfig, ResetHandler, ResetType, Rng, RngError, RuntimeRegion, StorageBackend,
+    StorageError, Timer, VarBackendError, VariableBackend, VariableVisitor,
+};
 
 /// Display a Secure Boot violation error on screen
 ///
@@ -90,7 +76,7 @@ pub fn display_secure_boot_error() {
     drivers::serial::write_str("\x1b[0m\r\n"); // Reset color
 
     // Output to framebuffer if available
-    if let Some(fb_info) = coreboot::get_framebuffer() {
+    if let Some(fb_info) = state::get_framebuffer() {
         let mut console = FramebufferConsole::new(&fb_info);
 
         // Calculate center position
@@ -117,280 +103,22 @@ pub fn display_secure_boot_error() {
     time::delay_ms(3000);
 }
 
-/// Initialize the CrabEFI firmware
+/// Common boot tail: variable persistence, Secure Boot, and boot manager.
 ///
-/// This is called from the entry point after switching to 64-bit mode.
-///
-/// # Arguments
-///
-/// * `coreboot_table_ptr` - Pointer to the coreboot tables
-pub fn init(coreboot_table_ptr: u64) -> ! {
-    // Allocate firmware state on the stack
-    // This is THE primary state for the entire firmware
-    let mut firmware_state = state::FirmwareState::new();
-
-    // Initialize the global state pointer
-    // SAFETY: We're in the main entry point, single-threaded, and the state
-    // lives on this stack frame which persists for the entire firmware lifetime
-    unsafe {
-        state::init(&mut firmware_state);
-    }
-
-    // Parse coreboot tables first (before any I/O) to get hardware info
-    // SAFETY: coreboot_table_ptr is passed from coreboot and points to valid tables
-    let cb_info = unsafe { coreboot::tables::parse(coreboot_table_ptr as *const u8) };
-
-    // Initialize CBMEM console early (before logging) so all output goes there
-    if let Some(cbmem_addr) = cb_info.cbmem_console {
-        coreboot::cbmem_console::init(cbmem_addr);
-    }
-
-    // Store framebuffer in global state for menu rendering
-    if let Some(fb) = cb_info.framebuffer {
-        coreboot::store_framebuffer(fb);
-    }
-
-    // Store the coreboot framebuffer record address so we can invalidate it
-    // at ExitBootServices to prevent a race between Linux's simplefb and efifb
-    if let Some(addr) = cb_info.framebuffer_record_addr {
-        coreboot::store_framebuffer_record_addr(addr);
-    }
-
-    // Store SMMSTORE v2 info globally for variable persistence
-    if let Some(smmstore) = cb_info.smmstorev2 {
-        coreboot::store_smmstorev2(smmstore);
-    }
-
-    // Store SPI flash info globally (used for FMAP parsing)
-    if let Some(ref spi_flash) = cb_info.spi_flash {
-        coreboot::store_spi_flash(spi_flash.clone());
-    }
-
-    // Store boot media info globally (contains FMAP offset)
-    if let Some(boot_media) = cb_info.boot_media {
-        coreboot::store_boot_media(boot_media);
-    }
-
-    // NOTE: CFR parsing is deferred until after heap::init() because it
-    // requires heap allocation (alloc::String, alloc::Vec). The raw data
-    // pointer is saved in cb_info.cfr_raw during table parsing.
-
-    // Store memory regions and ACPI RSDP for direct Linux boot
-    state::with_drivers_mut(|drivers| {
-        // Copy memory regions
-        for region in cb_info.memory_map.iter() {
-            let _ = drivers.platform.memory_regions.push(*region);
-        }
-        // Store ACPI RSDP
-        drivers.platform.acpi_rsdp = cb_info.acpi_rsdp;
-    });
-
-    // Initialize serial port from coreboot info (if available)
-    if let Some(ref serial) = cb_info.serial {
-        drivers::serial::init_from_coreboot(serial.baseaddr, serial.baud, serial.mmio());
-    }
-
-    // Initialize logging (now that serial is set up)
-    logger::init();
-
-    // Set framebuffer for logging output (so we can see logs on screen)
-    if let Some(fb) = cb_info.framebuffer {
-        logger::set_framebuffer(fb);
-    }
-
-    // Initialize keyboard subsystem (PS/2 on x86, USB-only on aarch64)
-    drivers::keyboard_common::init();
-
-    log::info!("CrabEFI v{} starting...", env!("CARGO_PKG_VERSION"));
-    log::info!("Coreboot table pointer: {:#x}", coreboot_table_ptr);
-
-    log::info!("Parsed coreboot tables:");
-    if let Some(ref serial) = cb_info.serial {
-        log::info!(
-            "  Serial: port={:#x}, baud={}",
-            serial.baseaddr,
-            serial.baud
-        );
-    } else {
-        log::info!("  Serial: not available");
-    }
-    if let Some(ref fb) = cb_info.framebuffer {
-        log::info!(
-            "  Framebuffer: {}x{} @ {:#x}",
-            fb.x_resolution,
-            fb.y_resolution,
-            fb.physical_address
-        );
-    }
-    if let Some(rsdp) = cb_info.acpi_rsdp {
-        log::info!("  ACPI RSDP: {:#x}", rsdp);
-    }
-    if let Some(cbmem_console) = cb_info.cbmem_console {
-        log::info!("  CBMEM console: {:#x}", cbmem_console);
-    }
-    if let Some(ref smmstore) = cb_info.smmstorev2 {
-        log::info!(
-            "  SMMSTORE v2: {} blocks x {} KB at {:#x}",
-            smmstore.num_blocks,
-            smmstore.block_size / 1024,
-            smmstore.mmap_addr
-        );
-    }
-    if cb_info.cfr_raw.is_some() {
-        log::info!("  CFR: raw data found (parsed after heap init)");
-    }
-    log::info!("  Memory regions: {}", cb_info.memory_map.len());
-    if let Some((fdt_addr, fdt_size)) = cb_info.devicetree {
-        log::info!("  Devicetree: {:#x} ({} bytes)", fdt_addr, fdt_size);
-    }
-
-    // Parse FDT for platform hardware info (PCIe, GIC, etc.)
-    if let Some((fdt_addr, fdt_size)) = cb_info.devicetree
-        && let Some(plat) = unsafe { fdt::parse(fdt_addr, fdt_size) }
-    {
-        state::with_drivers_mut(|d| d.fdt_info = plat);
-    }
-
-    // Initialize timing subsystem (calibrate TSC using ACPI PM timer)
-    time::init(cb_info.acpi_rsdp);
-
-    // Print memory map summary
-    let total_ram: u64 = cb_info
-        .memory_map
-        .iter()
-        .filter(|r| r.region_type == coreboot::memory::MemoryType::Ram)
-        .map(|r| r.size)
-        .sum();
-    log::info!("  Total RAM: {} MB", total_ram / (1024 * 1024));
-
-    // Initialize IDT for exception handling
-    #[cfg(target_arch = "x86_64")]
-    arch::x86_64::idt::init();
-
-    // Initialize EFI environment
-    efi::init(&cb_info);
-
-    // FirmwareState lives on the stack, which is inside the .stack section.
-    // The .stack section is between __runtime_data_start and __runtime_data_end,
-    // so reserve_runtime_region() (called by efi::init) already marks the entire
-    // region — including FirmwareState — as RuntimeServicesData.
-    //
-    // DO NOT add a separate entry here; that would create overlapping memory map
-    // entries which violates the UEFI spec and causes Windows to BSOD during
-    // SetVirtualAddressMap processing.
-    {
-        let state_addr = &firmware_state as *const _ as u64;
-        let state_size = core::mem::size_of::<state::FirmwareState>() as u64;
-        log::info!(
-            "FirmwareState at {:#x}-{:#x} ({} bytes) — covered by runtime data region",
-            state_addr,
-            state_addr + state_size,
-            state_size
-        );
-    }
-
-    // Initialize heap allocator (needed for crypto operations and alloc-dependent features)
-    if !heap::init() {
-        log::error!(
-            "Failed to initialize heap allocator! Secure Boot and other alloc-dependent features will be unavailable."
-        );
-        // Continue boot -- features requiring alloc will fail gracefully
-    }
-
-    // Discover platform hardware from ACPI tables (MADT for GIC, MCFG for ECAM,
-    // SPCR for UART, plus AML interpreter for DSDT device discovery).
-    // This must run after heap::init() because the AML interpreter allocates.
-    if let Some(rsdp_addr) = cb_info.acpi_rsdp {
-        let acpi_info = unsafe { acpi::discover_platform(rsdp_addr) };
-        state::with_drivers_mut(|d| d.acpi_info = acpi_info);
-    }
-
-    // Now that the EFI memory allocator is up and ACPI tables are parsed,
-    // add platform MMIO regions using addresses discovered from FDT and ACPI
-    // tables (instead of hardcoded values). This must happen after efi::init()
-    // (allocator) and after discover_platform() but before ExitBootServices.
-    #[cfg(target_arch = "aarch64")]
-    efi::add_platform_mmio_regions();
-
-    // Parse and store CFR data now that the heap is available.
-    // The raw data pointer was saved during coreboot table parsing.
-    if let Some(cfr_raw) = cb_info.cfr_raw
-        && let Some(cfr) = coreboot::cfr::parse_cfr(cfr_raw)
-    {
-        log::info!(
-            "CFR: {} forms, {} options",
-            cfr.forms.len(),
-            cfr.total_options()
-        );
-        coreboot::store_cfr(cfr);
-    }
-
-    log::info!("CrabEFI initialized successfully!");
-    log::info!("EFI System Table at: {:p}", efi::get_system_table());
-
-    // Discover PCI ECAM base — ACPI MCFG (via acpi module) takes priority, then FDT
-    if let Some(ecam_base) = state::drivers().acpi_info.ecam_base {
-        log::info!("PCI ECAM base from ACPI MCFG: {:#x}", ecam_base);
-        drivers::pci::set_ecam_base(ecam_base);
-    } else if let Some(ecam_base) = state::drivers().fdt_info.ecam_base {
-        log::info!("PCI ECAM base from FDT: {:#x}", ecam_base);
-        drivers::pci::set_ecam_base(ecam_base);
-    }
-
-    // Initialize PCI early so we can detect SPI controller
-    drivers::pci::init();
-
-    // Register the runtime services log region and dump any log from the
-    // previous boot before we do anything else (so the data is visible even
-    // if init fails).  init() is called after deferred writes are processed.
-    #[cfg(feature = "rt-log")]
-    {
-        efi::rtlog::register_region();
-        efi::rtlog::dump();
-    }
-
-    // Reserve the deferred variable buffer region as RuntimeServicesData.
-    // The buffer is at a fixed address (0x80000) below the payload, placed
-    // there by the linker script so coreboot/cbfstool never overwrites it.
-    // Registering it as RuntimeServicesData ensures the OS preserves the
-    // mapping and SetVirtualAddressMap adjusts the GOT-based pointer.
-    {
-        use efi::allocator::{MemoryType, PAGE_SIZE};
-        use efi::varstore::deferred;
-
-        let buf_base = deferred::deferred_buffer_base();
-        let buf_pages = (deferred::deferred_buffer_size() as u64).div_ceil(PAGE_SIZE);
-
-        // The buffer is outside the payload load region so it might not be in
-        // the coreboot-derived memory map at all.  force_add_region creates
-        // the entry unconditionally.
-        if let Err(e) =
-            efi::allocator::force_add_region(buf_base, buf_pages, MemoryType::RuntimeServicesData)
-        {
-            log::warn!(
-                "Could not register deferred buffer at {:#x}: {:?}",
-                buf_base,
-                e
-            );
-        } else {
-            log::info!(
-                "Deferred buffer at {:#x} ({} pages) registered as RuntimeServicesData",
-                buf_base,
-                buf_pages
-            );
-        }
-    }
-
-    // Initialize variable store persistence (loads variables from SPI flash)
+/// This is the shared sequence executed by both [`init_platform()`] and
+/// [`init()`] after architecture/platform-specific initialization is done.
+/// Extracting it eliminates ~40 lines of near-identical code between the
+/// two entry points.
+fn init_persistence_and_boot() -> ! {
+    // ---- Variable persistence ----
     match efi::varstore::init_persistence() {
         Ok(()) => {
             log::info!("Variable store persistence initialized");
 
-            // Check for pending deferred writes from previous warm boot
             let pending_count = efi::varstore::check_deferred_pending();
             if pending_count > 0 {
                 log::info!(
-                    "Found {} pending deferred writes from previous boot",
+                    "{} pending deferred writes from previous boot",
                     pending_count
                 );
                 match efi::varstore::process_deferred_pending() {
@@ -399,55 +127,299 @@ pub fn init(coreboot_table_ptr: u64) -> ! {
                 }
             }
 
-            // Initialize Secure Boot state (load keys from variables, create status vars)
-            // This must be called after variables are loaded from SMMSTORE
             match efi::auth::boot::init_secure_boot_default() {
                 Ok(status) => {
-                    log::info!("Secure Boot initialized:");
                     log::info!(
-                        "  Mode: {}",
-                        if status.setup_mode { "Setup" } else { "User" }
+                        "Secure Boot: mode={}, enabled={}",
+                        if status.setup_mode { "Setup" } else { "User" },
+                        status.secure_boot_enabled
                     );
-                    log::info!(
-                        "  Keys: PK={}, KEK={}, db={}, dbx={}",
-                        status.pk_count,
-                        status.kek_count,
-                        status.db_count,
-                        status.dbx_count
-                    );
-                    if status.secure_boot_enabled {
-                        log::info!("  Secure Boot: ENABLED");
-                    }
                 }
-                Err(e) => log::warn!("Secure Boot initialization failed: {:?}", e),
+                Err(e) => log::warn!("Secure Boot init failed: {:?}", e),
             }
         }
-        Err(e) => log::warn!("Variable store persistence not available: {:?}", e),
+        Err(e) => log::info!("Variable persistence not available: {:?}", e),
     }
 
-    // Initialize the deferred buffer for this boot session.
-    // Any pending writes from a previous warm boot were already processed
-    // above; now clear the buffer so new runtime writes can be accumulated.
     efi::varstore::init_deferred_buffer();
 
-    // Initialize the runtime log for this boot session (clears previous boot's
-    // data now that it has been dumped above).
-    #[cfg(feature = "rt-log")]
-    efi::rtlog::init();
-
-    // Cache boot manager variables EARLY, before platform hooks or driver
-    // binding can modify them (matches edk2 BdsEntry behavior).
+    // ---- Boot manager ----
     let boot_var_state = boot_vars::read_boot_var_state();
-
-    // Initialize storage subsystem and run boot manager
     boot_manager::run(boot_var_state);
 
-    log::info!("Press Ctrl+A X to exit QEMU");
+    log::info!("Boot manager finished — halting");
 
-    // Halt and wait
     loop {
         arch::halt();
     }
+}
+
+/// Initialize CrabEFI with a platform configuration.
+///
+/// This is the primary entry point for the CrabEFI library. External firmware
+/// builds a [`PlatformConfig`] with platform-specific trait implementations
+/// and calls this function to start the UEFI boot manager.
+///
+/// # Pre-initialized state
+///
+/// If the caller has already called [`state::init()`] before this function
+/// (e.g., to store coreboot-specific data in [`state::DriverState`]), this
+/// function detects the pre-initialized state and skips creating a new
+/// [`state::FirmwareState`]. The caller's `FirmwareState` must live on a
+/// stack frame that never returns (e.g., `rust_main() -> !`).
+///
+/// # Never returns
+///
+/// This function never returns (`-> !`). When a UEFI application calls
+/// `ExitBootServices`, the OS takes control. If no boot device is found or
+/// all boot attempts fail, CrabEFI halts the CPU.
+///
+/// Because `init_platform` never returns, all references in [`PlatformConfig`]
+/// remain valid for the entire firmware lifetime. This allows CrabEFI to use
+/// platform-provided drivers (e.g., `debug_output`) directly — no `'static`
+/// bounds required at the call site.
+///
+/// # Example
+///
+/// ```ignore
+/// let config = crabefi::PlatformConfig {
+///     memory_map: &memory_regions,
+///     timer: &my_timer,
+///     reset: &my_reset,
+///     block_devices: &mut [],
+///     debug_output: Some(&mut my_uart),
+///     // ...remaining fields..
+/// };
+/// crabefi::init_platform(config); // never returns
+/// ```
+pub fn init_platform(config: PlatformConfig) -> ! {
+    if state::is_initialized() {
+        // Caller pre-initialized state (e.g., coreboot payload storing
+        // SMMSTORE/SPI/CBMEM info before calling us). Their FirmwareState
+        // lives on a -> ! frame so it outlives us.
+        init_platform_impl(config)
+    } else {
+        // Fresh start: allocate FirmwareState on this stack frame.
+        init_with_local_state(config)
+    }
+}
+
+/// Allocate a fresh [`state::FirmwareState`] on this stack frame and
+/// delegate to [`init_platform_impl`].
+///
+/// Separated from [`init_platform`] so the ~2 MB `FirmwareState` is only
+/// on the stack when the caller didn't pre-initialize.
+#[inline(never)]
+fn init_with_local_state(config: PlatformConfig) -> ! {
+    let mut firmware_state = state::FirmwareState::new();
+    // SAFETY: Single-threaded firmware entry point. The state lives on this
+    // stack frame which never returns (-> !).
+    unsafe {
+        state::init(&mut firmware_state);
+    }
+    init_platform_impl(config)
+}
+
+/// Core initialization logic shared by all callers of [`init_platform`].
+fn init_platform_impl(mut config: PlatformConfig) -> ! {
+    // ---- 1. Install exception / interrupt vectors ----
+    //
+    // On aarch64: without this, VBAR_ELx defaults to 0x0 and any exception
+    // during shim/GRUB execution would vector to address 0x0 (fstart's
+    // _start), causing silent infinite loops instead of a diagnostic halt.
+    //
+    // On x86_64: install the IDT for exception handling.
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        arch::aarch64::exceptions::install_exception_vectors_auto();
+    }
+    #[cfg(target_arch = "x86_64")]
+    arch::x86_64::idt::init();
+
+    // ---- 2. Initialize serial output from platform debug_output ----
+    //
+    // Store the platform's DebugOutput in CrabEFI's serial subsystem so the
+    // logger (a 'static global) can access it. This requires erasing the 'a
+    // lifetime on the trait object reference.
+    //
+    // SAFETY: init_platform() is -> ! (never returns). The caller's stack
+    // frame — where the DebugOutput lives — is never unwound, so the
+    // reference remains valid for the entire firmware lifetime.
+    //
+    // We need to convert &'a mut dyn DebugOutput → *mut dyn DebugOutput
+    // (erasing lifetime 'a). A plain `as` cast does not compile because
+    // the borrow checker requires 'a: 'static for the coercion. The
+    // transmute preserves the fat pointer (data + vtable) identically
+    // and is sound because 'a is effectively 'static (-> !).
+    if let Some(ref mut debug_out) = config.debug_output {
+        let raw: *mut dyn crate::platform::DebugOutput = unsafe {
+            core::mem::transmute::<
+                &mut dyn crate::platform::DebugOutput,
+                *mut dyn crate::platform::DebugOutput,
+            >(*debug_out)
+        };
+        unsafe {
+            drivers::serial::init_from_platform_raw(raw);
+        }
+    }
+
+    // ---- 3. Initialize logging ----
+    //
+    // Idempotent: safe even if the caller already called logger::init()
+    // for early debug output.
+    logger::init();
+
+    log::info!(
+        "CrabEFI v{} starting (platform path)...",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    // ---- 4. Store ACPI RSDP in driver state ----
+    if let Some(rsdp) = config.acpi_rsdp {
+        state::with_drivers_mut(|d| d.platform.acpi_rsdp = Some(rsdp));
+        log::info!("ACPI RSDP: {:#x}", rsdp);
+    }
+
+    // ---- 5. Parse FDT if provided ----
+    //
+    // Must happen before efi::init_from_platform() which uses fdt_info for
+    // MMIO regions on aarch64 (GIC, PCIe windows, UART).
+    if let Some(fdt_bytes) = config.fdt {
+        let fdt_addr = fdt_bytes.as_ptr() as u64;
+        let fdt_size = fdt_bytes.len() as u32;
+        log::info!("FDT: {:#x} ({} bytes)", fdt_addr, fdt_size);
+
+        if let Some(plat) = unsafe { fdt::parse(fdt_addr, fdt_size) } {
+            log::info!(
+                "FDT parsed: ECAM={:?}, GIC={:?}, UART={:?}",
+                plat.ecam_base,
+                plat.gicd,
+                plat.uart_base
+            );
+            state::with_drivers_mut(|d| d.fdt_info = plat);
+        }
+    }
+
+    // ---- 6. Initialize timing subsystem from platform timer ----
+    //
+    // In library mode the platform-provided Timer is the source of truth.
+    // This works on any architecture (x86, aarch64, riscv64) without
+    // architecture-specific hardware detection inside the library.
+    time::init_from_platform(config.timer);
+
+    // Print memory summary
+    let total_ram: u64 = config
+        .memory_map
+        .iter()
+        .filter(|r| r.region_type == MemoryType::Ram)
+        .map(|r| r.size)
+        .sum();
+    log::info!("Total RAM: {} MB", total_ram / (1024 * 1024));
+
+    // ---- 7. Initialize keyboard subsystem ----
+    drivers::keyboard_common::init();
+
+    // ---- 8. Initialize EFI environment ----
+    efi::init_from_platform(&config);
+
+    log::info!("CrabEFI initialized successfully!");
+    log::info!("EFI System Table at: {:p}", efi::get_system_table());
+
+    // ---- 9. Initialize heap ----
+    if !heap::init() {
+        log::error!("Failed to initialize heap allocator!");
+    }
+
+    // ---- 10. Post-heap initialization callback ----
+    //
+    // Allows the caller to perform heap-dependent work (e.g., ACPI AML
+    // parsing, CFR parsing, MMIO region discovery) before PCI enumeration
+    // and the boot manager.
+    if let Some(hook) = config.post_heap_init {
+        hook();
+    }
+
+    // ---- 10b. Runtime log support ----
+    #[cfg(feature = "rt-log")]
+    {
+        efi::rtlog::register_region();
+        efi::rtlog::dump();
+    }
+
+    // ---- 11. Discover PCI ECAM and initialize PCI ----
+    //
+    // Priority: config.ecam_base > acpi_info.ecam_base > fdt_info.ecam_base.
+    // acpi_info is populated by the post_heap_init callback (ACPI discovery).
+    if let Some(ecam) = config.ecam_base {
+        log::info!("PCI ECAM base from platform: {:#x}", ecam);
+        drivers::pci::set_ecam_base(ecam);
+    } else if let Some(ecam) = state::drivers().acpi_info.ecam_base {
+        log::info!("PCI ECAM base from ACPI MCFG: {:#x}", ecam);
+        drivers::pci::set_ecam_base(ecam);
+    } else if let Some(ecam) = state::drivers().fdt_info.ecam_base {
+        log::info!("PCI ECAM base from FDT: {:#x}", ecam);
+        drivers::pci::set_ecam_base(ecam);
+    }
+
+    drivers::pci::init();
+
+    // ---- 12. Register deferred variable buffer if provided ----
+    if let Some(buf) = config.deferred_buffer {
+        use efi::allocator::{MemoryType as AllocMemType, PAGE_SIZE};
+        efi::varstore::deferred::configure_buffer_with_size(buf.base, buf.size);
+        let buf_pages = (buf.size as u64).div_ceil(PAGE_SIZE);
+        if let Err(e) =
+            efi::allocator::force_add_region(buf.base, buf_pages, AllocMemType::RuntimeServicesData)
+        {
+            log::warn!(
+                "Could not register deferred buffer at {:#x}: {:?}",
+                buf.base,
+                e
+            );
+        }
+    } else {
+        // No deferred buffer in config — use linker-symbol-based discovery.
+        use efi::allocator::{MemoryType as AllocMemType, PAGE_SIZE};
+        use efi::varstore::deferred;
+        let buf_base = deferred::deferred_buffer_base();
+        let buf_size = deferred::deferred_buffer_size();
+        if buf_size > 0 {
+            let buf_pages = (buf_size as u64).div_ceil(PAGE_SIZE);
+            if let Err(e) = efi::allocator::force_add_region(
+                buf_base,
+                buf_pages,
+                AllocMemType::RuntimeServicesData,
+            ) {
+                log::warn!(
+                    "Could not register deferred buffer at {:#x}: {:?}",
+                    buf_base,
+                    e
+                );
+            } else {
+                log::info!(
+                    "Deferred buffer at {:#x} ({} pages) registered as RuntimeServicesData",
+                    buf_base,
+                    buf_pages
+                );
+            }
+        }
+    }
+
+    // ---- 13. Register platform block devices ----
+    if !config.block_devices.is_empty() {
+        // SAFETY: init_platform() is -> !, so the block device references in
+        // config.block_devices live forever.
+        unsafe {
+            drivers::storage::register_platform_block_devices(config.block_devices);
+        }
+    }
+
+    // ---- 14. Runtime log init ----
+    #[cfg(feature = "rt-log")]
+    efi::rtlog::init();
+
+    // ---- 15. Variable persistence, Secure Boot, and boot manager ----
+    init_persistence_and_boot();
 }
 
 /// Store a device globally for SimpleFileSystem reads.
@@ -469,6 +441,7 @@ pub(crate) fn store_device_globally(device_type: &menu::DeviceType) -> bool {
         menu::DeviceType::Sdhci { controller_id } => {
             drivers::sdhci::store_global_device(controller_id)
         }
+        menu::DeviceType::Platform { .. } => true, // platform devices are always globally accessible
     }
 }
 
@@ -516,5 +489,46 @@ pub(crate) fn with_disk<R>(
             let mut disk = SdhciDisk::new(controller);
             Some(f(&mut disk))
         }
+        menu::DeviceType::Platform { index } => {
+            drivers::storage::with_platform_block_device(index, |dev| {
+                let mut shim = PlatformBlockShim(dev);
+                f(&mut shim)
+            })
+        }
+    }
+}
+
+/// Shim that adapts a [`platform::BlockDevice`] to the internal
+/// [`drivers::block::BlockDevice`] trait used by the boot path.
+struct PlatformBlockShim<'a>(&'a mut dyn platform::BlockDevice);
+
+impl drivers::block::BlockDevice for PlatformBlockShim<'_> {
+    fn info(&self) -> drivers::block::BlockDeviceInfo {
+        let i = self.0.info();
+        drivers::block::BlockDeviceInfo {
+            num_blocks: i.num_blocks,
+            block_size: i.block_size,
+            media_id: 0,
+            removable: false,
+            read_only: false,
+        }
+    }
+
+    fn read_blocks(
+        &mut self,
+        lba: u64,
+        count: u32,
+        buffer: &mut [u8],
+    ) -> Result<(), drivers::block::BlockError> {
+        // `BlockError` is #[non_exhaustive]; the `_` arm covers future variants.
+        #[allow(unreachable_patterns)]
+        self.0.read_blocks(lba, count, buffer).map_err(|e| match e {
+            platform::BlockError::DeviceError => drivers::block::BlockError::DeviceError,
+            platform::BlockError::InvalidParameter => drivers::block::BlockError::InvalidParameter,
+            platform::BlockError::OutOfRange => drivers::block::BlockError::OutOfRange,
+            platform::BlockError::NoMedia => drivers::block::BlockError::NoMedia,
+            platform::BlockError::MediaChanged => drivers::block::BlockError::MediaChanged,
+            _ => drivers::block::BlockError::DeviceError,
+        })
     }
 }

--- a/src/linux_boot/bzimage.rs
+++ b/src/linux_boot/bzimage.rs
@@ -224,7 +224,7 @@ pub fn prepare_boot_params(
     bzimage: &BzImage,
     memory_regions: &[crate::coreboot::memory::MemoryRegion],
     acpi_rsdp: Option<u64>,
-    framebuffer: Option<&crate::coreboot::FramebufferInfo>,
+    framebuffer: Option<&crate::platform::FramebufferConfig>,
     kernel_addr: u32,
     cmdline_addr: u32,
 ) -> BootParams {

--- a/src/linux_boot/mod.rs
+++ b/src/linux_boot/mod.rs
@@ -257,7 +257,7 @@ pub fn load_linux_from_disk(
     cmdline: &str,
     memory_regions: &[MemoryRegion],
     acpi_rsdp: Option<u64>,
-    framebuffer: Option<&crate::coreboot::FramebufferInfo>,
+    framebuffer: Option<&crate::platform::FramebufferConfig>,
     use_efi_handover: bool,
 ) -> Result<LoadedLinux, LinuxBootError> {
     use crate::fs::fat::FatFilesystem;

--- a/src/linux_boot/params.rs
+++ b/src/linux_boot/params.rs
@@ -452,23 +452,23 @@ impl BootParams {
     ///
     /// # Arguments
     ///
-    /// * `fb` - Framebuffer info from coreboot
-    pub fn set_framebuffer(&mut self, fb: &crate::coreboot::FramebufferInfo) {
+    /// * `fb` - Framebuffer configuration
+    pub fn set_framebuffer(&mut self, fb: &crate::platform::FramebufferConfig) {
         // Set video type to EFI framebuffer
         self.screen_info.orig_video_isVGA = ScreenInfo::VIDEO_TYPE_EFI;
 
         // Set framebuffer dimensions
-        self.screen_info.lfb_width = fb.x_resolution as u16;
-        self.screen_info.lfb_height = fb.y_resolution as u16;
+        self.screen_info.lfb_width = fb.width as u16;
+        self.screen_info.lfb_height = fb.height as u16;
         self.screen_info.lfb_depth = fb.bits_per_pixel as u16;
-        self.screen_info.lfb_linelength = fb.bytes_per_line as u16;
+        self.screen_info.lfb_linelength = fb.bytes_per_line() as u16;
 
         // Set framebuffer address (split into lower and upper 32 bits)
         self.screen_info.lfb_base = fb.physical_address as u32;
         self.screen_info.ext_lfb_base = (fb.physical_address >> 32) as u32;
 
         // Calculate framebuffer size in 64KB units
-        let fb_size = fb.bytes_per_line as u64 * fb.y_resolution as u64;
+        let fb_size = fb.bytes_per_line() as u64 * fb.height as u64;
         self.screen_info.lfb_size = fb_size.div_ceil(0x10000) as u32;
 
         // Set color mask information
@@ -487,11 +487,11 @@ impl BootParams {
 
         log::debug!(
             "Framebuffer: {}x{}x{} @ {:#x}, {} bytes/line",
-            fb.x_resolution,
-            fb.y_resolution,
+            fb.width,
+            fb.height,
             fb.bits_per_pixel,
             fb.physical_address,
-            fb.bytes_per_line
+            fb.bytes_per_line()
         );
     }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -83,18 +83,24 @@ impl log::Log for CombinedLogger {
 
 static LOGGER: CombinedLogger = CombinedLogger;
 
-/// Initialize the logging subsystem
+/// Initialize the logging subsystem.
+///
+/// Safe to call multiple times — the second call is a no-op. This allows
+/// the coreboot payload to initialize logging early (for debug output
+/// during coreboot table parsing) and then call [`crate::init_platform()`]
+/// which calls `init()` again internally.
 pub fn init() {
-    // Record the boot counter for relative timestamps
-    // SAFETY: single-threaded init; raw pointer avoids re-entrancy
-    // issues with the state lock.
-    unsafe {
-        (*crate::state::drivers_mut_ptr()).timing.boot_counter = read_counter();
+    // Only set the boot counter and register the logger on the first call.
+    // log::set_logger() returns Err if a logger is already registered.
+    if log::set_logger(&LOGGER).is_ok() {
+        // Record the boot counter for relative timestamps.
+        // SAFETY: single-threaded init; raw pointer avoids re-entrancy
+        // issues with the state lock.
+        unsafe {
+            (*crate::state::drivers_mut_ptr()).timing.boot_counter = read_counter();
+        }
+        log::set_max_level(LevelFilter::Debug);
     }
-
-    log::set_logger(&LOGGER)
-        .map(|()| log::set_max_level(LevelFilter::Debug))
-        .expect("Failed to set logger");
 }
 
 /// Set the framebuffer for logging output
@@ -104,13 +110,13 @@ pub fn init() {
 ///
 /// This function is only effective with the `fb-log` feature.
 #[cfg(feature = "fb-log")]
-pub fn set_framebuffer(fb: crate::coreboot::FramebufferInfo) {
+pub fn set_framebuffer(fb: crate::platform::FramebufferConfig) {
     crate::fb_log::set_framebuffer(fb);
 }
 
 /// Stub for when fb-log feature is disabled
 #[cfg(not(feature = "fb-log"))]
-pub fn set_framebuffer(_fb: crate::coreboot::FramebufferInfo) {
+pub fn set_framebuffer(_fb: crate::platform::FramebufferConfig) {
     // Framebuffer logging disabled at compile time
 }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -15,7 +15,6 @@
 //! - Arrow key navigation and Enter to select
 //! - Configurable auto-boot timeout with countdown
 
-use crate::coreboot;
 use crate::drivers::block::BlockDevice;
 use crate::drivers::serial as serial_driver;
 use crate::drivers::storage::StorageType;
@@ -932,7 +931,7 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
     }
 
     // Get framebuffer for rendering
-    let fb_info = coreboot::get_framebuffer();
+    let fb_info = crate::state::get_framebuffer();
 
     // Create framebuffer console if available
     let mut fb_console = fb_info.as_ref().map(FramebufferConsole::new);

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,1043 @@
+//! Platform Abstraction Traits
+//!
+//! This module defines the traits that platform firmware must implement to
+//! integrate CrabEFI. These traits decouple the UEFI implementation from
+//! specific hardware, allowing CrabEFI to run on any platform that provides
+//! the required services.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────┐
+//! │           External Firmware                  │
+//! │  (coreboot, custom ARM SoC, TF-A, ...)      │
+//! │                                              │
+//! │  Implements: BlockDevice, VariableBackend,   │
+//! │  Timer, ResetHandler, DebugOutput, ...       │
+//! └───────────────┬─────────────────────────────┘
+//!                 │  PlatformConfig
+//!                 ▼
+//! ┌─────────────────────────────────────────────┐
+//! │           CrabEFI Library                    │
+//! │                                              │
+//! │  UEFI Boot/Runtime Services, Secure Boot,   │
+//! │  Boot Manager, Filesystem, PE Loader         │
+//! └─────────────────────────────────────────────┘
+//! ```
+//!
+//! # Quick Start
+//!
+//! External firmware builds a [`PlatformConfig`] by providing trait
+//! implementations for the platform's hardware, then calls
+//! [`crate::init_platform()`] to hand off to the UEFI boot manager.
+//! This function never returns (`-> !`).
+//!
+//! ```ignore
+//! let config = crabefi::PlatformConfig {
+//!     memory_map: &my_memory_map,
+//!     timer: &my_timer,
+//!     reset: &my_reset_handler,
+//!     block_devices: &mut [&mut my_emmc],
+//!     variable_backend: Some(&mut my_var_store),
+//!     // ...
+//! };
+//! crabefi::init_platform(config); // never returns
+//! ```
+
+use r_efi::efi::Guid;
+
+// ============================================================================
+// Memory Map
+// ============================================================================
+
+/// Physical memory region descriptor.
+///
+/// The platform provides a list of these to describe the system's physical
+/// address space. CrabEFI converts them into the EFI memory map.
+#[derive(Debug, Clone, Copy)]
+pub struct MemoryRegion {
+    /// Starting physical address (must be page-aligned, 4 KiB).
+    pub base: u64,
+    /// Size in bytes (must be page-aligned, 4 KiB).
+    pub size: u64,
+    /// Type of memory in this region.
+    pub region_type: MemoryType,
+}
+
+/// Memory region types.
+///
+/// These map directly to EFI memory types. The platform uses them to describe
+/// which physical address ranges are usable RAM, reserved, MMIO, etc.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MemoryType {
+    /// Usable RAM (becomes `EfiConventionalMemory`).
+    Ram,
+    /// Reserved by firmware (becomes `EfiReservedMemoryType`).
+    Reserved,
+    /// ACPI tables, reclaimable after OS reads them (becomes `EfiACPIReclaimMemory`).
+    AcpiReclaimable,
+    /// ACPI Non-Volatile Storage (becomes `EfiACPINvsMemory`).
+    AcpiNvs,
+    /// Memory-mapped I/O registers (becomes `EfiMemoryMappedIO`).
+    Mmio,
+    /// Runtime services code (becomes `EfiRuntimeServicesCode` with `EFI_MEMORY_RUNTIME`).
+    RuntimeServicesCode,
+    /// Runtime services data (becomes `EfiRuntimeServicesData` with `EFI_MEMORY_RUNTIME`).
+    RuntimeServicesData,
+}
+
+// ============================================================================
+// Block Device
+// ============================================================================
+
+/// Information about a block device.
+///
+/// Maps closely to `EFI_BLOCK_IO_MEDIA` from the UEFI specification.
+#[derive(Clone, Copy, Debug)]
+pub struct BlockDeviceInfo {
+    /// Total number of logical blocks on the device.
+    pub num_blocks: u64,
+    /// Size of each logical block in bytes (typically 512).
+    pub block_size: u32,
+    /// Media identifier (changes if removable media is swapped).
+    pub media_id: u32,
+    /// Whether the device has removable media (e.g., USB stick, SD card).
+    pub removable: bool,
+    /// Whether the media is read-only.
+    pub read_only: bool,
+}
+
+/// Errors returned by block device operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BlockError {
+    /// Unspecified device error.
+    DeviceError,
+    /// Invalid parameter (bad LBA, buffer too small, etc.).
+    InvalidParameter,
+    /// LBA out of range for this device.
+    OutOfRange,
+    /// No media present (removable device with nothing inserted).
+    NoMedia,
+    /// Media changed since last access.
+    MediaChanged,
+}
+
+/// Block-level storage device interface.
+///
+/// All storage devices that CrabEFI should be able to boot from must implement
+/// this trait. The library installs `EFI_BLOCK_IO_PROTOCOL` handles for each
+/// provided block device.
+///
+/// # Implementor's Guide
+///
+/// - `read_blocks` must handle arbitrary LBA ranges within bounds.
+/// - `info()` should return consistent values for the device's lifetime.
+/// - `name()` is displayed in the boot menu; make it descriptive
+///   (e.g., `"NVMe: Samsung 980 Pro"`, `"eMMC: partition 0"`).
+///
+/// # Example
+///
+/// ```ignore
+/// struct MyEmmc { base: u64, num_sectors: u64 }
+///
+/// impl crabefi::BlockDevice for MyEmmc {
+///     fn info(&self) -> crabefi::BlockDeviceInfo {
+///         crabefi::BlockDeviceInfo {
+///             num_blocks: self.num_sectors,
+///             block_size: 512,
+///             media_id: 0,
+///             removable: false,
+///             read_only: false,
+///         }
+///     }
+///     fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8])
+///         -> Result<(), crabefi::BlockError>
+///     {
+///         // ... hardware-specific read ...
+///         Ok(())
+///     }
+///     fn name(&self) -> &str { "eMMC" }
+/// }
+/// ```
+pub trait BlockDevice {
+    /// Get device information (block count, block size, media properties).
+    fn info(&self) -> BlockDeviceInfo;
+
+    /// Read contiguous blocks from the device.
+    ///
+    /// # Arguments
+    /// * `lba` - Starting logical block address.
+    /// * `count` - Number of blocks to read.
+    /// * `buffer` - Destination buffer (must be at least `count * block_size` bytes).
+    fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError>;
+
+    /// Human-readable device name for the boot menu.
+    fn name(&self) -> &str {
+        "Block Device"
+    }
+
+    /// Validate parameters for a read operation.
+    ///
+    /// Default implementation checks LBA range and buffer size. Implementations
+    /// should call this at the start of `read_blocks`.
+    fn validate_read(&self, lba: u64, count: u32, buffer: &[u8]) -> Result<(), BlockError> {
+        let info = self.info();
+        if count == 0 {
+            return Ok(());
+        }
+        let end_lba = lba
+            .checked_add(count as u64)
+            .ok_or(BlockError::OutOfRange)?;
+        if end_lba > info.num_blocks {
+            return Err(BlockError::OutOfRange);
+        }
+        let required = (count as usize)
+            .checked_mul(info.block_size as usize)
+            .ok_or(BlockError::InvalidParameter)?;
+        if buffer.len() < required {
+            return Err(BlockError::InvalidParameter);
+        }
+        Ok(())
+    }
+
+    /// Read a single block (convenience wrapper).
+    fn read_block(&mut self, lba: u64, buffer: &mut [u8]) -> Result<(), BlockError> {
+        self.read_blocks(lba, 1, buffer)
+    }
+}
+
+// ============================================================================
+// Variable Persistence
+// ============================================================================
+
+/// Errors returned by variable backend operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum VarBackendError {
+    /// Backend not initialized or not available.
+    NotAvailable,
+    /// Storage is full; cannot write more variables.
+    StoreFull,
+    /// I/O or communication error.
+    IoError,
+    /// Backend is locked (e.g., flash locked after ExitBootServices).
+    Locked,
+    /// Variable not found (for load/delete operations).
+    NotFound,
+    /// Data too large for the backend's capacity.
+    DataTooLarge,
+    /// Name too long for the backend's capacity.
+    NameTooLong,
+    /// Backend-specific error.
+    Other,
+}
+
+/// Visitor interface for loading persisted variables.
+///
+/// The [`VariableBackend::load()`] method calls [`visit()`](Self::visit) once
+/// per stored variable. CrabEFI provides the visitor; the backend just calls it.
+pub trait VariableVisitor {
+    /// Called for each variable found in persistent storage.
+    ///
+    /// # Arguments
+    /// * `name` - Variable name as UTF-16LE code units (without null terminator).
+    /// * `vendor` - Variable vendor GUID.
+    /// * `attributes` - EFI variable attributes (`EFI_VARIABLE_*` flags).
+    /// * `data` - Variable data payload (after any auth header stripping).
+    fn visit(&mut self, name: &[u16], vendor: &Guid, attributes: u32, data: &[u8]);
+}
+
+/// EFI variable persistence backend.
+///
+/// This trait abstracts how EFI variables are stored across boots. Implementations
+/// range from direct flash storage to SMM/TF-A MM RPC-based approaches.
+///
+/// # Backend Categories
+///
+/// | Category | `runtime_capable()` | Deferred buffer needed? | Example |
+/// |----------|---------------------|------------------------|---------|
+/// | Direct flash | `false` | Yes | SPI flash via `Edk2VarStore` |
+/// | SMM | `true` | No | x86 SMI-based variable service |
+/// | TF-A MM | `true` | No | Arm StandaloneMM via FF-A/SPM |
+/// | RAM-only | `false` | Optional | Testing, volatile variables |
+///
+/// # Lifecycle
+///
+/// 1. [`load()`](Self::load) — Called once during early boot to populate the
+///    in-memory variable cache. The backend calls `visitor.visit()` for each
+///    stored variable.
+///
+/// 2. [`write()`](Self::write) / [`delete()`](Self::delete) — Called by
+///    `SetVariable` when variables change.
+///    - Before `ExitBootServices`: always called.
+///    - After `ExitBootServices`: called only if `runtime_capable()` returns `true`.
+///      Otherwise, CrabEFI buffers the write in the deferred buffer.
+///
+/// 3. [`notify_exit_boot_services()`](Self::notify_exit_boot_services) — Called
+///    when `ExitBootServices` succeeds. The backend can release resources or
+///    adjust its strategy (e.g., direct-flash backends note that flash is now locked).
+///
+/// 4. [`flush_deferred()`](Self::flush_deferred) — Called on the *next* boot
+///    (after `load()`) to commit any writes that were buffered during the
+///    previous boot's runtime phase. Only relevant for non-runtime-capable backends.
+///
+/// # Example: SMM Backend
+///
+/// ```ignore
+/// struct SmmVarStore { smi_port: u16, comm_buffer: *mut u8 }
+///
+/// impl crabefi::VariableBackend for SmmVarStore {
+///     fn load(&mut self, visitor: &mut dyn crabefi::VariableVisitor)
+///         -> Result<(), crabefi::VarBackendError>
+///     {
+///         // Trigger SMI to enumerate variables, call visitor.visit() for each
+///         Ok(())
+///     }
+///
+///     fn write(&mut self, name: &[u16], vendor: &Guid, attrs: u32, data: &[u8])
+///         -> Result<(), crabefi::VarBackendError>
+///     {
+///         // Trigger SMI with SetVariable command
+///         Ok(())
+///     }
+///
+///     fn delete(&mut self, name: &[u16], vendor: &Guid)
+///         -> Result<(), crabefi::VarBackendError>
+///     {
+///         // Trigger SMI with delete command
+///         Ok(())
+///     }
+///
+///     fn runtime_capable(&self) -> bool { true }
+/// }
+/// ```
+pub trait VariableBackend {
+    /// Load all persisted variables into the in-memory cache.
+    ///
+    /// Called once during early boot. The backend iterates its stored variables
+    /// and calls `visitor.visit()` for each one.
+    fn load(&mut self, visitor: &mut dyn VariableVisitor) -> Result<(), VarBackendError>;
+
+    /// Persist a variable write (create or update).
+    ///
+    /// Called when `SetVariable` is invoked with non-empty data.
+    ///
+    /// # Arguments
+    /// * `name` - Variable name as UTF-16LE code units.
+    /// * `vendor` - Variable vendor GUID.
+    /// * `attributes` - EFI variable attributes.
+    /// * `data` - Variable data payload.
+    fn write(
+        &mut self,
+        name: &[u16],
+        vendor: &Guid,
+        attributes: u32,
+        data: &[u8],
+    ) -> Result<(), VarBackendError>;
+
+    /// Persist a variable deletion.
+    ///
+    /// Called when `SetVariable` is invoked with empty data and
+    /// `EFI_VARIABLE_APPEND_WRITE` is not set.
+    fn delete(&mut self, name: &[u16], vendor: &Guid) -> Result<(), VarBackendError>;
+
+    /// Whether this backend supports writes after `ExitBootServices`.
+    ///
+    /// - `true`: CrabEFI calls `write()`/`delete()` directly at runtime.
+    ///   Suitable for SMM, TF-A MM, or any backend with a privileged agent.
+    /// - `false` (default): CrabEFI buffers runtime writes in the deferred
+    ///   buffer and calls `flush_deferred()` on the next boot.
+    fn runtime_capable(&self) -> bool {
+        false
+    }
+
+    /// Notification that `ExitBootServices` has been called.
+    ///
+    /// For direct-flash backends, this signals that flash may now be locked.
+    /// For SMM/MM backends, this is typically a no-op.
+    fn notify_exit_boot_services(&mut self) {}
+
+    /// Commit deferred writes from a previous boot.
+    ///
+    /// Called after `load()` on the next boot when the previous boot had
+    /// buffered runtime variable writes (because `runtime_capable()` was false).
+    ///
+    /// # Arguments
+    /// * `records` - Iterator of (name, vendor, attributes, data) for each
+    ///   deferred write. Empty data means delete.
+    ///
+    /// The default implementation calls `write()` or `delete()` for each record.
+    fn flush_deferred(
+        &mut self,
+        records: &mut dyn Iterator<Item = (&[u16], &Guid, u32, &[u8])>,
+    ) -> Result<usize, VarBackendError> {
+        let mut count = 0;
+        for (name, vendor, attrs, data) in records {
+            if data.is_empty() {
+                // Ignore NotFound for deletes — variable may not exist
+                match self.delete(name, vendor) {
+                    Ok(()) | Err(VarBackendError::NotFound) => {}
+                    Err(e) => return Err(e),
+                }
+            } else {
+                self.write(name, vendor, attrs, data)?;
+            }
+            count += 1;
+        }
+        Ok(count)
+    }
+}
+
+// ============================================================================
+// Raw Storage Backend
+// ============================================================================
+
+/// Errors returned by raw storage operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum StorageError {
+    /// Storage device not initialized.
+    NotInitialized,
+    /// Storage is write-protected.
+    WriteProtected,
+    /// Access denied (locked region).
+    AccessDenied,
+    /// Operation timed out.
+    Timeout,
+    /// Invalid address or length.
+    InvalidArgument,
+    /// Generic I/O error.
+    IoError,
+    /// Operation not supported by this backend.
+    NotSupported,
+}
+
+/// Raw byte-level storage backend.
+///
+/// This trait provides low-level read/write/erase access to a storage device.
+/// It is used by [`crate::efi::varstore::Edk2VarStore`] to implement the
+/// EDK2 Firmware Volume format on top of raw flash.
+///
+/// Platform firmware that uses SMM or TF-A MM should implement
+/// [`VariableBackend`] directly instead of this trait.
+///
+/// # Flash Semantics
+///
+/// - `read` works on any valid offset.
+/// - `write` may require the region to be erased first (NOR flash: can only
+///   clear bits 1→0).
+/// - `erase` sets bytes to `0xFF` (NOR flash erased state).
+pub trait StorageBackend: Send {
+    /// Backend name for logging.
+    fn name(&self) -> &str;
+
+    /// Total storage size in bytes.
+    fn size(&self) -> u32;
+
+    /// Whether the storage is currently write-protected.
+    fn is_write_protected(&self) -> bool;
+
+    /// Enable writes (may clear hardware write-protection bits).
+    fn enable_writes(&mut self) -> Result<(), StorageError>;
+
+    /// Read data from storage.
+    fn read(&mut self, offset: u32, buffer: &mut [u8]) -> Result<(), StorageError>;
+
+    /// Write data to storage.
+    ///
+    /// For flash: the target region should be erased first.
+    fn write(&mut self, offset: u32, data: &[u8]) -> Result<(), StorageError>;
+
+    /// Erase a region (sets bytes to `0xFF`).
+    fn erase(&mut self, offset: u32, size: u32) -> Result<(), StorageError>;
+}
+
+// ============================================================================
+// Timer
+// ============================================================================
+
+/// Monotonic timer / clock source.
+///
+/// Provides time measurement for UEFI `Stall()` boot service, EFI timer
+/// events, and internal timeout handling.
+///
+/// # Implementation Notes
+///
+/// - The counter must be monotonically increasing and not wrap during a single
+///   boot (64-bit counters at GHz frequencies won't wrap for centuries).
+/// - `stall()` must busy-wait for at least the requested duration.
+/// - The timer does not need to survive `ExitBootServices` (UEFI timer events
+///   are boot-services-only).
+pub trait Timer {
+    /// Read the current monotonic counter value.
+    fn current_ticks(&self) -> u64;
+
+    /// Counter frequency in Hz.
+    ///
+    /// For x86 TSC at 2 GHz, return `2_000_000_000`.
+    /// For ARM Generic Timer at 62.5 MHz, return `62_500_000`.
+    fn ticks_per_second(&self) -> u64;
+
+    /// Busy-wait for at least the given number of microseconds.
+    ///
+    /// Works correctly for any timer frequency >= 1 Hz. For timers
+    /// below 1 MHz, the computation avoids integer truncation by
+    /// scaling in the opposite order.
+    fn stall(&self, microseconds: u64) {
+        let start = self.current_ticks();
+        let freq = self.ticks_per_second();
+        if freq == 0 {
+            return;
+        }
+        // Compute target ticks = microseconds * freq / 1_000_000.
+        // Use u128 intermediate to avoid overflow for large stall durations
+        // at high frequencies (e.g., 2 GHz * 10_000_000 us overflows u64).
+        let target = ((microseconds as u128 * freq as u128) / 1_000_000) as u64;
+        if target == 0 {
+            return;
+        }
+        while self.current_ticks().wrapping_sub(start) < target {
+            core::hint::spin_loop();
+        }
+    }
+}
+
+// ============================================================================
+// Reset
+// ============================================================================
+
+/// Reset type for `ResetSystem` runtime service.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ResetType {
+    /// Cold reset (full power cycle).
+    Cold,
+    /// Warm reset (CPU reset without full power cycle).
+    Warm,
+    /// System shutdown (power off).
+    Shutdown,
+}
+
+/// System reset and shutdown handler.
+///
+/// Used by the UEFI `ResetSystem` runtime service. The implementation must
+/// be in memory that remains mapped after `ExitBootServices` (runtime-safe).
+///
+/// # Safety Contract
+///
+/// Since `ResetSystem` is a runtime service, the platform must ensure that
+/// the `ResetHandler` implementation and its vtable reside in memory marked
+/// as `RuntimeServicesCode` or `RuntimeServicesData`.
+pub trait ResetHandler {
+    /// Perform a system reset or shutdown.
+    ///
+    /// This function must not return.
+    fn reset(&self, reset_type: ResetType) -> !;
+}
+
+// ============================================================================
+// Random Number Generation
+// ============================================================================
+
+/// Errors returned by the RNG.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RngError {
+    /// No hardware RNG available.
+    Unsupported,
+    /// Hardware RNG failure.
+    HardwareError,
+    /// RNG not ready (transient, caller should retry).
+    NotReady,
+}
+
+/// Hardware random number generator.
+///
+/// Used by the UEFI `EFI_RNG_PROTOCOL`. Implementations should use a
+/// hardware entropy source (e.g., x86 RDRAND/RDSEED, ARM RNDR).
+pub trait Rng {
+    /// Fill `buffer` with random bytes.
+    fn get_random(&self, buffer: &mut [u8]) -> Result<(), RngError>;
+}
+
+// ============================================================================
+// Debug Output
+// ============================================================================
+
+/// Debug/log output channel (serial port or equivalent).
+///
+/// CrabEFI uses this for `log` crate output and EFI `SerialIO` protocol.
+/// The implementation should be safe to call from any context (including
+/// panic handlers), so it must not allocate or take locks that could deadlock.
+///
+/// For the coreboot target, the implementation typically multiplexes output
+/// to a UART and the CBMEM console.
+pub trait DebugOutput: core::fmt::Write + Send {
+    /// Write a single byte. Must not block indefinitely.
+    fn write_byte(&mut self, byte: u8);
+
+    /// Try to read a byte (for serial console input on the debug channel).
+    /// Returns `None` if no data is available.
+    fn try_read_byte(&self) -> Option<u8> {
+        None
+    }
+
+    /// Check if input data is available on the debug channel.
+    fn has_input(&self) -> bool {
+        false
+    }
+}
+
+// ============================================================================
+// Console Input
+// ============================================================================
+
+/// Key event from a console input device.
+///
+/// Maps to `EFI_INPUT_KEY` from the UEFI specification.
+#[derive(Debug, Clone, Copy)]
+pub struct Key {
+    /// EFI scan code (0 = no scan code, use `unicode_char`).
+    /// Non-zero for special keys: Up=0x01, Down=0x02, Right=0x03, Left=0x04,
+    /// Home=0x05, End=0x06, Insert=0x07, Delete=0x08, PgUp=0x09, PgDn=0x0A,
+    /// F1..F10=0x0B..0x14, Esc=0x17.
+    pub scancode: u16,
+    /// Unicode character (0 = no character, use `scancode`).
+    pub unicode_char: u16,
+}
+
+/// Key state for extended keyboard protocols.
+///
+/// Maps to `EFI_KEY_STATE` from `EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct KeyState {
+    /// Shift key state flags (`EFI_SHIFT_STATE_VALID | LEFT_SHIFT_PRESSED | ...`).
+    pub shift_state: u32,
+    /// Toggle state flags (`TOGGLE_STATE_VALID | NUM_LOCK_ACTIVE | ...`).
+    pub toggle_state: u8,
+}
+
+/// Console input device (keyboard or equivalent).
+///
+/// The platform provides this to handle keyboard input for the UEFI console
+/// protocols (`SimpleTextInput`, `SimpleTextInputEx`) and the boot menu.
+///
+/// A typical implementation polls all available input sources (PS/2, USB HID,
+/// serial console) and returns the first available key.
+pub trait ConsoleInput {
+    /// Try to read a key press. Returns `None` if no key is available.
+    fn read_key(&mut self) -> Option<Key>;
+
+    /// Check if a key press is available without consuming it.
+    fn has_key(&self) -> bool;
+
+    /// Get the current key state (modifier keys, toggle state).
+    /// Returns default (all zeros) if not supported.
+    fn key_state(&self) -> KeyState {
+        KeyState::default()
+    }
+
+    /// Perform any necessary polling (e.g., USB controller polling).
+    /// Called periodically by the boot manager and console protocols.
+    fn poll(&mut self) {}
+}
+
+// ============================================================================
+// Framebuffer
+// ============================================================================
+
+/// Framebuffer configuration for the Graphics Output Protocol.
+///
+/// The platform provides this when a framebuffer is available. CrabEFI uses
+/// it for the EFI GOP protocol and the text-mode boot menu.
+#[derive(Debug, Clone, Copy)]
+pub struct FramebufferConfig {
+    /// Physical address of the framebuffer memory.
+    pub physical_address: u64,
+    /// Horizontal resolution in pixels.
+    pub width: u32,
+    /// Vertical resolution in pixels.
+    pub height: u32,
+    /// Pixels per scanline (may be wider than `width` due to alignment).
+    ///
+    /// To get bytes per scanline, multiply by `bits_per_pixel / 8`.
+    pub stride: u32,
+    /// Bits per pixel (typically 32).
+    pub bits_per_pixel: u8,
+    /// Bit position of the red channel.
+    pub red_mask_pos: u8,
+    /// Number of bits in the red channel.
+    pub red_mask_size: u8,
+    /// Bit position of the green channel.
+    pub green_mask_pos: u8,
+    /// Number of bits in the green channel.
+    pub green_mask_size: u8,
+    /// Bit position of the blue channel.
+    pub blue_mask_pos: u8,
+    /// Number of bits in the blue channel.
+    pub blue_mask_size: u8,
+}
+
+impl FramebufferConfig {
+    /// Framebuffer size in bytes.
+    pub fn size(&self) -> u64 {
+        self.bytes_per_line() as u64 * self.height as u64
+    }
+
+    /// Bytes per scanline (`stride * bytes_per_pixel`).
+    pub fn bytes_per_line(&self) -> u32 {
+        self.stride * (self.bits_per_pixel as u32 / 8)
+    }
+
+    /// Raw pointer to the framebuffer.
+    ///
+    /// # Safety
+    ///
+    /// The framebuffer must be identity-mapped at `physical_address`.
+    /// The caller is responsible for ensuring the pointer is not used
+    /// after the framebuffer is unmapped.
+    pub unsafe fn as_ptr(&self) -> *mut u8 {
+        core::ptr::with_exposed_provenance_mut(self.physical_address as usize)
+    }
+
+    /// Byte offset for a pixel at coordinates (x, y).
+    ///
+    /// Uses `u64` intermediates to avoid overflow on large framebuffers.
+    pub fn pixel_offset(&self, x: u32, y: u32) -> usize {
+        let bpp = self.bits_per_pixel as u64 / 8;
+        (y as u64 * self.stride as u64 * bpp + x as u64 * bpp) as usize
+    }
+
+    /// Encode a pixel value for the framebuffer's native format.
+    ///
+    /// For 32bpp, returns the native pixel encoding.
+    /// For 16bpp, returns the 16-bit pixel zero-extended to u32.
+    /// For other bpp, returns 0.
+    pub fn encode_pixel(&self, r: u8, g: u8, b: u8) -> u32 {
+        match self.bits_per_pixel {
+            32 => self.encode_pixel_32(r, g, b),
+            16 => self.encode_pixel_16(r, g, b) as u32,
+            _ => 0,
+        }
+    }
+
+    /// Write a pixel at (x, y) with the given RGB color.
+    ///
+    /// # Safety
+    ///
+    /// The framebuffer must be accessible and (x, y) must be in bounds.
+    pub unsafe fn write_pixel(&self, x: u32, y: u32, r: u8, g: u8, b: u8) {
+        if x >= self.width || y >= self.height {
+            return;
+        }
+        let offset = self.pixel_offset(x, y);
+        // SAFETY: caller guarantees the framebuffer is identity-mapped.
+        let fb = unsafe { self.as_ptr() };
+        unsafe {
+            match self.bits_per_pixel {
+                32 => {
+                    let pixel = self.encode_pixel_32(r, g, b);
+                    (fb.add(offset) as *mut u32).write_volatile(pixel);
+                }
+                24 => {
+                    let ptr = fb.add(offset);
+                    if self.blue_mask_pos < self.red_mask_pos {
+                        ptr.write_volatile(b);
+                        ptr.add(1).write_volatile(g);
+                        ptr.add(2).write_volatile(r);
+                    } else {
+                        ptr.write_volatile(r);
+                        ptr.add(1).write_volatile(g);
+                        ptr.add(2).write_volatile(b);
+                    }
+                }
+                16 => {
+                    let pixel = self.encode_pixel_16(r, g, b);
+                    (fb.add(offset) as *mut u16).write_volatile(pixel);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Fill a framebuffer region with a solid color.
+    ///
+    /// # Safety
+    ///
+    /// `dst` must point to `pixel_count * (bits_per_pixel/8)` writable bytes
+    /// within the framebuffer.
+    pub unsafe fn fill_pixels(&self, dst: *mut u8, pixel_count: usize, r: u8, g: u8, b: u8) {
+        unsafe {
+            match self.bits_per_pixel {
+                32 => {
+                    let pixel = self.encode_pixel_32(r, g, b);
+                    let ptr = dst as *mut u32;
+                    for i in 0..pixel_count {
+                        ptr.add(i).write_volatile(pixel);
+                    }
+                }
+                16 => {
+                    let pixel = self.encode_pixel_16(r, g, b);
+                    let ptr = dst as *mut u16;
+                    for i in 0..pixel_count {
+                        ptr.add(i).write_volatile(pixel);
+                    }
+                }
+                _ => {
+                    core::slice::from_raw_parts_mut(
+                        dst,
+                        pixel_count * (self.bits_per_pixel as usize / 8),
+                    )
+                    .fill(0);
+                }
+            }
+        }
+    }
+
+    /// Fill the entire framebuffer with a solid color.
+    ///
+    /// # Safety
+    ///
+    /// The framebuffer must be accessible.
+    pub unsafe fn fill_solid(&self, r: u8, g: u8, b: u8) {
+        let bpl = self.bytes_per_line() as usize;
+        let row_pixels = self.width as usize;
+        let packed = bpl == row_pixels * (self.bits_per_pixel as usize / 8);
+        // SAFETY: caller guarantees the framebuffer is identity-mapped.
+        unsafe {
+            let fb = self.as_ptr();
+            if packed {
+                let total = row_pixels * self.height as usize;
+                self.fill_pixels(fb, total, r, g, b);
+            } else {
+                for y in 0..self.height {
+                    let offset = (y as usize) * bpl;
+                    self.fill_pixels(fb.add(offset), row_pixels, r, g, b);
+                }
+            }
+        }
+    }
+
+    /// Clear the entire framebuffer.
+    ///
+    /// # Safety
+    ///
+    /// The framebuffer must be accessible.
+    pub unsafe fn clear(&self, r: u8, g: u8, b: u8) {
+        // SAFETY: caller guarantees the framebuffer is identity-mapped.
+        let fb = unsafe { self.as_ptr() };
+        let bpl = self.bytes_per_line() as usize;
+        unsafe {
+            match self.bits_per_pixel {
+                32 => {
+                    let pixel = self.encode_pixel_32(r, g, b);
+                    for y in 0..self.height as usize {
+                        let row = fb.add(y * bpl);
+                        for x in 0..self.width as usize {
+                            (row.add(x * 4) as *mut u32).write_volatile(pixel);
+                        }
+                    }
+                }
+                _ => {
+                    for y in 0..self.height {
+                        for x in 0..self.width {
+                            self.write_pixel(x, y, r, g, b);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn encode_pixel_32(&self, r: u8, g: u8, b: u8) -> u32 {
+        let r = ((r as u32) >> (8 - self.red_mask_size)) << self.red_mask_pos;
+        let g = ((g as u32) >> (8 - self.green_mask_size)) << self.green_mask_pos;
+        let b = ((b as u32) >> (8 - self.blue_mask_size)) << self.blue_mask_pos;
+        r | g | b
+    }
+
+    fn encode_pixel_16(&self, r: u8, g: u8, b: u8) -> u16 {
+        let r = ((r as u16) >> (8 - self.red_mask_size)) << self.red_mask_pos;
+        let g = ((g as u16) >> (8 - self.green_mask_size)) << self.green_mask_pos;
+        let b = ((b as u16) >> (8 - self.blue_mask_size)) << self.blue_mask_pos;
+        r | g | b
+    }
+}
+
+// ============================================================================
+// Platform Configuration
+// ============================================================================
+
+/// Warm-reboot persistent buffer for deferred variable writes.
+///
+/// When the [`VariableBackend`] is not [`runtime_capable()`](VariableBackend::runtime_capable),
+/// CrabEFI buffers `SetVariable` calls made after `ExitBootServices` into
+/// this memory region. The platform must ensure this memory:
+///
+/// 1. Survives warm reboots (not cleared on CPU reset).
+/// 2. Is in a memory region marked as `RuntimeServicesData` so the OS
+///    preserves the mapping after `ExitBootServices`.
+///
+/// On the next boot, CrabEFI reads the buffer and commits the writes via
+/// [`VariableBackend::flush_deferred()`].
+///
+/// Not needed if the variable backend is runtime-capable (SMM, TF-A MM).
+#[derive(Debug, Clone, Copy)]
+pub struct DeferredBufferConfig {
+    /// Physical base address of the buffer.
+    pub base: u64,
+    /// Size of the buffer in bytes (typically 64 KiB).
+    pub size: usize,
+}
+
+/// Memory region where CrabEFI's code and data are loaded.
+///
+/// The platform provides this so CrabEFI can mark these regions as
+/// `RuntimeServicesCode` / `RuntimeServicesData` in the EFI memory map,
+/// ensuring the OS preserves them after `ExitBootServices` and
+/// `SetVirtualAddressMap` adjusts pointers correctly.
+///
+/// For the coreboot target, these come from linker-provided symbols.
+/// External firmware must ensure CrabEFI's code lives in a region that
+/// the OS will keep mapped.
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimeRegion {
+    /// Base address of the runtime code section.
+    pub code_base: u64,
+    /// Size of the runtime code section in bytes.
+    pub code_size: u64,
+    /// Base address of the runtime data section (includes stack, state, heap).
+    pub data_base: u64,
+    /// Size of the runtime data section in bytes.
+    pub data_size: u64,
+}
+
+/// Result of the UEFI boot manager.
+///
+/// Describes the outcome when the boot manager exhausts all boot attempts
+/// without successfully handing off to an OS. Currently informational;
+/// [`crate::init_platform()`] is `-> !` and halts the CPU on failure.
+///
+/// Note: when a UEFI application successfully calls `ExitBootServices`,
+/// [`crate::init_platform()`] never returns — the OS has taken control.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootResult {
+    /// No bootable media found on any provided block device.
+    NoBootMedia,
+    /// Boot entries were found but all attempts failed.
+    AllFailed,
+    /// A UEFI application was loaded and ran, but returned control
+    /// (e.g., GRUB exited, or the application called `Exit()`).
+    ImageReturned,
+}
+
+/// Platform configuration for CrabEFI.
+///
+/// This is the main integration point. External firmware populates this
+/// struct with platform-specific trait implementations, then calls
+/// [`crate::init_platform()`] to start the UEFI boot manager.
+///
+/// # Lifetime
+///
+/// All references in this struct must remain valid for the duration of
+/// [`crate::init_platform()`]. Since `init_platform()` is `-> !` (never
+/// returns), drivers on the caller's stack naturally satisfy this — no
+/// `'static` bounds required.
+///
+/// # Minimal Configuration
+///
+/// At minimum, provide `memory_map`, `timer`, and `reset`. Everything else
+/// is optional (with reduced functionality).
+pub struct PlatformConfig<'a> {
+    // ---- Required ----
+    /// Physical memory map describing all RAM, MMIO, and reserved regions.
+    pub memory_map: &'a [MemoryRegion],
+
+    /// Monotonic timer for `Stall()` and EFI timer events.
+    pub timer: &'a dyn Timer,
+
+    /// System reset handler for `ResetSystem` runtime service.
+    pub reset: &'a dyn ResetHandler,
+
+    // ---- Storage ----
+    /// Block devices to expose via `EFI_BLOCK_IO_PROTOCOL`.
+    ///
+    /// Each device gets its own EFI handle. The boot manager searches
+    /// these for ESP partitions and boot entries.
+    pub block_devices: &'a mut [&'a mut dyn BlockDevice],
+
+    /// Variable persistence backend.
+    ///
+    /// `None` means variables are volatile (lost on reset). EFI applications
+    /// can still use `SetVariable`/`GetVariable`, but nothing persists.
+    pub variable_backend: Option<&'a mut dyn VariableBackend>,
+
+    // ---- Console ----
+    /// Debug/log output (serial port or equivalent).
+    ///
+    /// Also used for `EFI_SERIAL_IO_PROTOCOL` if no other serial is available.
+    pub debug_output: Option<&'a mut dyn DebugOutput>,
+
+    /// Keyboard/console input for `SimpleTextInput` and the boot menu.
+    pub console_input: Option<&'a mut dyn ConsoleInput>,
+
+    /// Framebuffer for `EFI_GRAPHICS_OUTPUT_PROTOCOL` and the boot menu.
+    pub framebuffer: Option<FramebufferConfig>,
+
+    // ---- Platform Tables ----
+    /// ACPI RSDP physical address. Required for ACPI-based OS boot (Linux, Windows).
+    pub acpi_rsdp: Option<u64>,
+
+    /// SMBIOS entry point physical address.
+    pub smbios: Option<u64>,
+
+    /// Flattened Device Tree blob (for DT-based platforms).
+    pub fdt: Option<&'a [u8]>,
+
+    // ---- Optional Hardware ----
+    /// Hardware random number generator for `EFI_RNG_PROTOCOL`.
+    pub rng: Option<&'a dyn Rng>,
+
+    /// PCI ECAM configuration space base address.
+    ///
+    /// If provided, CrabEFI uses this directly for PCI config space access.
+    /// Otherwise, it discovers the ECAM base from ACPI MCFG or FDT.
+    pub ecam_base: Option<u64>,
+
+    // ---- Runtime Support ----
+    /// Warm-reboot persistent buffer for deferred variable writes.
+    ///
+    /// Only needed when `variable_backend` is not runtime-capable.
+    /// See [`DeferredBufferConfig`] for requirements.
+    pub deferred_buffer: Option<DeferredBufferConfig>,
+
+    /// Memory region where CrabEFI's code and data reside.
+    ///
+    /// Needed for `SetVirtualAddressMap` support. If `None`, CrabEFI
+    /// cannot provide runtime services after `ExitBootServices`.
+    pub runtime_region: Option<RuntimeRegion>,
+
+    // ---- Hooks ----
+    /// Optional callback invoked after heap initialization but before the
+    /// boot manager.
+    ///
+    /// This allows the caller to perform heap-dependent initialization
+    /// (e.g., ACPI AML parsing, firmware configuration parsing) that cannot
+    /// happen before [`crate::init_platform()`] sets up the memory allocator.
+    ///
+    /// The callback runs after:
+    /// - EFI memory allocator is initialized (from `memory_map`)
+    /// - Heap allocator is ready (global `alloc` works)
+    /// - Timer is calibrated
+    /// - FDT is parsed (if provided)
+    ///
+    /// The callback runs before:
+    /// - PCI ECAM setup and enumeration
+    /// - Block device registration
+    /// - Variable persistence and boot manager
+    ///
+    /// Use this to populate `DriverState.acpi_info` (via ACPI table
+    /// discovery) so that PCI ECAM can be discovered from ACPI MCFG.
+    pub post_heap_init: Option<fn()>,
+}

--- a/src/secure_boot_menu.rs
+++ b/src/secure_boot_menu.rs
@@ -3,7 +3,6 @@
 //! This module provides a user interface for managing Secure Boot settings,
 //! including viewing status, enabling/disabling Secure Boot, and managing keys.
 
-use crate::coreboot;
 use crate::drivers::serial as serial_driver;
 use crate::efi::auth::{self, boot as secure_boot};
 use crate::framebuffer_console::{
@@ -86,7 +85,7 @@ const MENU_OPTIONS: [MenuOption; 6] = [
 /// This displays Secure Boot status and allows the user to manage settings.
 pub fn show_secure_boot_menu() {
     // Get framebuffer for rendering
-    let fb_info = coreboot::get_framebuffer();
+    let fb_info = crate::state::get_framebuffer();
     let mut fb_console = fb_info.as_ref().map(FramebufferConsole::new);
 
     let mut selected = 0usize;

--- a/src/state.rs
+++ b/src/state.rs
@@ -606,12 +606,12 @@ impl Default for EfiState {
 // Driver State
 // ============================================================================
 
-use crate::coreboot::FramebufferInfo;
 use crate::drivers::pci::PciDevice;
 use crate::drivers::pci::access::AnyPciAccess;
 use crate::drivers::serial::AnySerial;
 use crate::drivers::storage::StorageRegistry;
 use crate::efi::protocols::serial_io::SerialIoMode;
+use crate::platform::FramebufferConfig;
 use heapless::Vec as HeaplessVec;
 use r_efi::efi::Boolean;
 use r_efi::protocols::simple_text_output::Mode as SimpleTextOutputMode;
@@ -651,7 +651,15 @@ pub struct DriverState {
     /// Platform info from FDT (PCIe, GIC, etc.)
     pub fdt_info: crate::fdt::PlatformInfo,
 
-    /// Platform info from ACPI tables (GIC from MADT, UART from SPCR, ECAM from MCFG)
+    /// Platform info from ACPI tables (GIC from MADT, UART from SPCR, ECAM from MCFG).
+    ///
+    /// Populated by the coreboot payload's `post_heap_init` callback, which
+    /// runs ACPI discovery after the heap is available. Library consumers
+    /// provide MMIO regions via `PlatformConfig.memory_map` and ECAM via
+    /// `PlatformConfig.ecam_base`, so this field is empty for them.
+    ///
+    /// `init_platform()` checks `acpi_info.ecam_base` as a fallback for PCI
+    /// ECAM discovery (after `config.ecam_base`, before `fdt_info.ecam_base`).
     pub acpi_info: crate::fdt::PlatformInfo,
 }
 
@@ -692,11 +700,19 @@ pub struct PciState {
 
 impl PciState {
     pub const fn new() -> Self {
-        use crate::drivers::pci::access::IoCamAccess;
         Self {
             devices: HeaplessVec::new(),
             ecam_base: None,
-            access: AnyPciAccess::IoCam(IoCamAccess),
+            // x86 defaults to legacy I/O CAM (ports 0xCF8/0xCFC).
+            // Non-x86 defaults to ECAM at address 0 — PCI init will
+            // replace this once a real ECAM base is discovered from
+            // ACPI MCFG, FDT, or PlatformConfig.ecam_base. Reads to
+            // ECAM address 0 return bus errors / 0xFFFFFFFF (no device),
+            // which is the correct "nothing here" response.
+            #[cfg(target_arch = "x86_64")]
+            access: AnyPciAccess::IoCam(crate::drivers::pci::access::IoCamAccess),
+            #[cfg(not(target_arch = "x86_64"))]
+            access: AnyPciAccess::Ecam(crate::drivers::pci::access::EcamAccess::new(0)),
         }
     }
 }
@@ -794,13 +810,16 @@ impl Default for TimingState {
 // Platform Info
 // ----------------------------------------------------------------------------
 
-/// Platform hardware info sourced from coreboot tables.
+/// Platform hardware info sourced from coreboot tables or platform config.
 ///
-/// This groups all the hardware discovery data that comes from parsing
-/// coreboot's lb_record table entries during early boot.
+/// Shared fields (framebuffer, ACPI RSDP) are used by both integration paths.
+/// Coreboot-specific fields (SMMSTORE, SPI flash, FMAP, CBMEM) are only
+/// populated by the coreboot payload's `init()` path and remain `None`/zero
+/// in library mode. They should be gated behind a feature once the SPI
+/// variable persistence code is fully abstracted behind `VariableBackend`.
 pub struct PlatformInfo {
     /// Global framebuffer info
-    pub framebuffer: Option<FramebufferInfo>,
+    pub framebuffer: Option<FramebufferConfig>,
 
     /// Address of the coreboot framebuffer record in the coreboot tables.
     /// Stored so we can invalidate it at ExitBootServices to prevent
@@ -876,7 +895,7 @@ pub enum ScreenMode {
 /// Console and display state
 pub struct ConsoleState {
     /// EFI console framebuffer info
-    pub efi_framebuffer: Option<FramebufferInfo>,
+    pub efi_framebuffer: Option<FramebufferConfig>,
     /// EFI console cursor position (col, row)
     pub cursor_pos: (u32, u32),
     /// EFI console dimensions (cols, rows)
@@ -898,12 +917,12 @@ pub struct ConsoleState {
     pub input: InputState,
 
     /// Logger framebuffer info (used by fb_log for debug output)
-    pub logger_framebuffer: Option<FramebufferInfo>,
+    pub logger_framebuffer: Option<FramebufferConfig>,
     /// Logger cursor position (row, col)
     pub logger_cursor: (u32, u32),
 
     /// GOP framebuffer for graphics output protocol Blt operations
-    pub gop_framebuffer: Option<FramebufferInfo>,
+    pub gop_framebuffer: Option<FramebufferConfig>,
 
     /// Screen mode (Text or Graphics) for ConsoleControl protocol
     pub screen_mode: ScreenMode,
@@ -1094,6 +1113,31 @@ where
     F: FnOnce(&mut DriverState) -> R,
 {
     with_mut(|state| f(&mut state.drivers))
+}
+
+// ---------------------------------------------------------------------------
+// Framebuffer state — source-agnostic (coreboot tables or platform config)
+// ---------------------------------------------------------------------------
+
+/// Store framebuffer info in global state.
+///
+/// Called from both the coreboot path (after parsing `lb_framebuffer`) and the
+/// platform library path (after converting `FramebufferConfig`). The stored
+/// info is used by boot menus, the Linux boot path (`screen_info`), and error
+/// display — all of which call [`get_framebuffer()`].
+pub fn store_framebuffer(fb: crate::platform::FramebufferConfig) {
+    with_drivers_mut(|drivers| {
+        drivers.platform.framebuffer = Some(fb);
+    });
+}
+
+/// Get the global framebuffer info, if available.
+///
+/// Returns `Some` when a framebuffer was provided by either coreboot tables
+/// or the platform library's `FramebufferConfig`. Used by boot menus,
+/// `boot_linux()` (screen_info), and error display.
+pub fn get_framebuffer() -> Option<crate::platform::FramebufferConfig> {
+    try_get().and_then(|state| state.drivers.platform.framebuffer)
 }
 
 /// Get a reference to the console state.

--- a/src/time.rs
+++ b/src/time.rs
@@ -363,6 +363,42 @@ pub fn init(acpi_rsdp: Option<u64>) {
     aarch64_timer::init(acpi_rsdp);
 }
 
+/// Initialize timing subsystem from a platform-provided [`Timer`] trait object.
+///
+/// Used by [`crate::init_platform()`]. The platform timer is the source of
+/// truth — no architecture-specific hardware detection is attempted.
+pub fn init_from_platform(timer: &dyn crate::platform::Timer) {
+    let freq = timer.ticks_per_second();
+    if freq == 0 {
+        log::warn!("Platform timer reports 0 Hz frequency, using 1 MHz fallback");
+        let fallback = 1_000_000u64;
+        // SAFETY: single-threaded init; raw pointer avoids re-entrancy
+        // issues with the state lock.
+        unsafe {
+            let t = &mut (*crate::state::drivers_mut_ptr()).timing;
+            t.counter_freq_hz = fallback;
+            t.counter_cycles_per_us = 1;
+        }
+        return;
+    }
+
+    let cycles_per_us = (freq / 1_000_000).max(1);
+    // SAFETY: single-threaded init; raw pointer avoids re-entrancy
+    // issues with the state lock.
+    unsafe {
+        let t = &mut (*crate::state::drivers_mut_ptr()).timing;
+        t.counter_freq_hz = freq;
+        t.counter_cycles_per_us = cycles_per_us;
+        t.boot_counter = timer.current_ticks();
+    }
+
+    log::info!(
+        "Platform timer: {} MHz ({} cycles/us)",
+        freq / 1_000_000,
+        cycles_per_us
+    );
+}
+
 /// Spin-wait for approximately `us` microseconds
 #[inline]
 pub fn delay_us(us: u64) {

--- a/test-apps/directory-test/Cargo.toml
+++ b/test-apps/directory-test/Cargo.toml
@@ -3,6 +3,8 @@ name = "directory-test"
 version = "0.1.0"
 edition = "2021"
 
+[workspace]
+
 [dependencies]
 r-efi = "5.3"
 

--- a/test-apps/fw-dump/Cargo.toml
+++ b/test-apps/fw-dump/Cargo.toml
@@ -3,6 +3,8 @@ name = "fw-dump"
 version = "0.1.0"
 edition = "2021"
 
+[workspace]
+
 [dependencies]
 r-efi = "5.3"
 

--- a/test-apps/hello/Cargo.toml
+++ b/test-apps/hello/Cargo.toml
@@ -3,6 +3,8 @@ name = "hello-efi"
 version = "0.1.0"
 edition = "2021"
 
+[workspace]
+
 [dependencies]
 r-efi = "5.3"
 

--- a/test-apps/rng-test/Cargo.toml
+++ b/test-apps/rng-test/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 description = "Test EFI application for the RNG protocol"
 
+[workspace]
+
 [dependencies]
 r-efi = "5.3"
 

--- a/test-apps/secure-boot-test/Cargo.toml
+++ b/test-apps/secure-boot-test/Cargo.toml
@@ -3,6 +3,8 @@ name = "secure-boot-test"
 version = "0.1.0"
 edition = "2021"
 
+[workspace]
+
 [dependencies]
 r-efi = "5.3"
 

--- a/test-apps/storage-security-test/Cargo.toml
+++ b/test-apps/storage-security-test/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 description = "Test EFI application for Storage Security and Pass-Through protocols"
 
+[workspace]
+
 [dependencies]
 r-efi = "5.3"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2024"
 description = "Build and test automation for CrabEFI"
 
+# xtask is its own workspace root — it builds with the host stable toolchain,
+# not the nightly bare-metal toolchain used by the main workspace.
+[workspace]
+
 [[bin]]
 name = "crabefi-xtask"
 path = "src/main.rs"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -245,6 +245,9 @@ fn cmd_build(release: bool, arch: Arch, machine: Machine) -> Result<()> {
 
     let mut cmd = std::process::Command::new("cargo");
     cmd.arg("build");
+    // Build the coreboot payload binary (the binary target lives in the
+    // crabefi-coreboot workspace member, not in the root library crate).
+    cmd.arg("-p").arg("crabefi-coreboot");
     if release {
         cmd.arg("--release");
     }


### PR DESCRIPTION
## Summary

Restructure CrabEFI from a monolithic coreboot payload into a reusable library that external firmware can link and jump to, with proper dependency injection for platform-specific hardware.

## Workspace Structure

| Crate | Purpose |
|-------|---------|
| `crabefi` (root) | Core library — platform-agnostic UEFI implementation |
| `crabefi-coreboot` | Coreboot payload binary (arch entry points, table parsing) |
| `crabefi-drivers` | Standard hardware drivers (placeholder, migration pending) |

## Platform Abstraction Traits (`src/platform.rs`)

| Trait | Purpose | Enables |
|-------|---------|---------|
| `BlockDevice` | Block-level storage I/O | Custom eMMC, virtio-blk, etc. |
| `VariableBackend` | EFI variable persistence | SMM, TF-A MM, direct flash |
| `StorageBackend` | Raw byte-level flash access | `Edk2VarStore` wrapper |
| `Timer` | Monotonic clock | TSC, ARM Generic Timer, custom |
| `ResetHandler` | System reset/shutdown | Port I/O, PSCI, custom |
| `Rng` | Hardware RNG | RDRAND, RNDR, custom |
| `DebugOutput` | Serial/log output | 16550, PL011, custom |
| `ConsoleInput` | Keyboard input | PS/2, USB HID, custom |

External firmware builds a `PlatformConfig` struct with trait object references and calls `crabefi::init_platform(config) -> BootResult`.

## Variable Persistence Redesign

The `VariableBackend` trait operates at variable level (`load`/`write`/`delete`) rather than raw byte level, enabling three persistence strategies:

| Backend Type | `runtime_capable()` | Deferred Buffer | Example |
|---|---|---|---|
| Direct flash | `false` | Required | SPI flash via `Edk2VarStore` |
| SMM | `true` | Not needed | x86 SMI-triggered writes |
| TF-A MM | `true` | Not needed | Arm StandaloneMM via FF-A |

- `Edk2VarStore` wraps a `StorageBackend` with EDK2 FV format handling
- `flush_deferred()` commits buffered runtime writes on next boot (non-runtime backends)

## Key Changes

- `#[panic_handler]` removed from library → binary's responsibility
- `#[global_allocator]` gated behind `global-allocator` feature
- New `init_platform(PlatformConfig) -> BootResult` entry point
- Legacy `init(coreboot_table_ptr)` preserved for transitional use
- Linker script management moved to `crabefi-coreboot/build.rs`
- xtask targets `crabefi-coreboot` package (`-p crabefi-coreboot`)
- CI updated for workspace-wide clippy and per-package binary builds

## Test Results

All existing tests pass on all targets:

| Test | x86_64 | aarch64/sbsa | aarch64/virt |
|------|--------|--------------|--------------|
| hello (USB) | ✓ 3/3 | — | — |
| hello (NVMe) | ✓ 3/3 | ✓ 3/3 | ✓ 3/3 |
| hello (AHCI) | ✓ 3/3 | — | — |
| hello (SDHCI) | ✓ 3/3 | — | — |
| rng-test | ✓ 7/7 | — | — |
| directory-test | ✓ 7/7 | — | — |

CI gates: `cargo fmt`, `cargo clippy -D warnings` (both archs), release builds (x86_64, aarch64/sbsa, aarch64/virt) all pass clean.