### PR TITLE
Add graphical UI with mouse support (`ui` feature flag)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "fdt",
  "heapless",
  "log",
+ "noto-sans-mono-bitmap",
  "postcard",
  "r-efi",
  "rsa",
@@ -314,6 +315,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "noto-sans-mono-bitmap"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f102c477fd4ec864c149803bf606ecc23bc9329602ec0f99073a728abf454abc"
 
 [[package]]
 name = "num-bigint-dig"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ rt-debug = []
 # ExitBootServices into a warm-reboot-persistent ring buffer; requires
 # _rt_log_start/_rt_log_end linker symbols)
 rt-log = []
+# Enable graphical UI with mouse support (PS/2 and USB HID mouse drivers,
+# cursor rendering, SimplePointerProtocol, and rlvgl-based setup utility)
+ui = []
 
 [dependencies]
 r-efi = "5.3"
@@ -49,6 +52,9 @@ bitflags = "2"
 heapless = "0.8"
 atomic_refcell = "0.1"
 spin = "0.9"
+noto-sans-mono-bitmap = { version = "0.3", default-features = false, features = [
+    "regular", "size_16", "size_20", "size_24", "size_32", "unicode-basic-latin",
+] }
 tock-registers = "0.10"
 zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
 

--- a/src/boot_manager.rs
+++ b/src/boot_manager.rs
@@ -15,8 +15,6 @@ use crate::drivers;
 use crate::efi;
 use crate::menu;
 
-
-
 /// Initialize storage subsystem (PCI drivers, USB keyboards, etc.)
 ///
 /// This is called once before the boot manager starts trying boot options.

--- a/src/boot_manager.rs
+++ b/src/boot_manager.rs
@@ -15,6 +15,8 @@ use crate::drivers;
 use crate::efi;
 use crate::menu;
 
+
+
 /// Initialize storage subsystem (PCI drivers, USB keyboards, etc.)
 ///
 /// This is called once before the boot manager starts trying boot options.
@@ -30,6 +32,10 @@ fn init_storage_subsystem() {
 
     // Initialize USB keyboards (needs to happen after USB controllers are bound)
     drivers::usb::init_keyboards_public();
+
+    // Initialize USB mice (needs to happen after USB controllers are bound)
+    #[cfg(feature = "ui")]
+    drivers::usb::init_mice();
 
     // Initialize pass-through protocols for TCG Opal support
     efi::protocols::pass_thru_init::init();
@@ -148,6 +154,10 @@ pub(crate) fn run(boot_var_state: boot_vars::BootVarState) {
 
     if boot_menu.entry_count() == 0 {
         log::warn!("No bootable media found!");
+
+        #[cfg(feature = "ui")]
+        crate::ui::show_no_media_screen();
+
         return;
     }
 
@@ -155,6 +165,11 @@ pub(crate) fn run(boot_var_state: boot_vars::BootVarState) {
     boot_menu.set_timeout(timeout_seconds);
 
     log::debug!("Showing boot menu...");
+
+    // Use graphical UI when feature is enabled, text menu otherwise
+    #[cfg(feature = "ui")]
+    let selected = crate::ui::show_graphical_menu(&mut boot_menu);
+    #[cfg(not(feature = "ui"))]
     let selected = menu::show_menu(&mut boot_menu);
     log::info!("Menu returned: {:?}", selected);
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,0 +1,214 @@
+//! Mouse Cursor Sprite Rendering
+//!
+//! Renders a mouse cursor sprite on the framebuffer with save-under
+//! compositing: the framebuffer contents beneath the cursor are saved
+//! before drawing and restored when the cursor moves.
+//!
+//! The cursor is a 12x19 pixel arrow pointer, similar to the classic
+//! Windows/X11 cursor shape. It uses XOR-like compositing (black outline
+//! with white fill) so it is visible on any background.
+
+use crate::coreboot::FramebufferInfo;
+
+/// Cursor width in pixels
+pub const CURSOR_W: usize = 12;
+
+/// Cursor height in pixels
+pub const CURSOR_H: usize = 19;
+
+/// Cursor hot spot X offset (tip of the arrow)
+pub const HOTSPOT_X: i32 = 0;
+
+/// Cursor hot spot Y offset
+pub const HOTSPOT_Y: i32 = 0;
+
+/// Cursor sprite bitmap.
+///
+/// 0 = transparent, 1 = black (outline), 2 = white (fill)
+#[rustfmt::skip]
+static CURSOR_BITMAP: [[u8; CURSOR_W]; CURSOR_H] = [
+    [1,0,0,0,0,0,0,0,0,0,0,0],
+    [1,1,0,0,0,0,0,0,0,0,0,0],
+    [1,2,1,0,0,0,0,0,0,0,0,0],
+    [1,2,2,1,0,0,0,0,0,0,0,0],
+    [1,2,2,2,1,0,0,0,0,0,0,0],
+    [1,2,2,2,2,1,0,0,0,0,0,0],
+    [1,2,2,2,2,2,1,0,0,0,0,0],
+    [1,2,2,2,2,2,2,1,0,0,0,0],
+    [1,2,2,2,2,2,2,2,1,0,0,0],
+    [1,2,2,2,2,2,2,2,2,1,0,0],
+    [1,2,2,2,2,2,2,2,2,2,1,0],
+    [1,2,2,2,2,2,2,1,1,1,1,1],
+    [1,2,2,2,1,2,2,1,0,0,0,0],
+    [1,2,2,1,0,1,2,2,1,0,0,0],
+    [1,2,1,0,0,1,2,2,1,0,0,0],
+    [1,1,0,0,0,0,1,2,2,1,0,0],
+    [1,0,0,0,0,0,1,2,2,1,0,0],
+    [0,0,0,0,0,0,0,1,2,1,0,0],
+    [0,0,0,0,0,0,0,1,1,0,0,0],
+];
+
+/// Cursor rendering state
+pub struct CursorRenderer {
+    /// Whether cursor is currently drawn on screen
+    visible: bool,
+    /// Last drawn X position
+    last_x: i32,
+    /// Last drawn Y position
+    last_y: i32,
+    /// Save-under buffer (CURSOR_W * CURSOR_H pixels, stored as packed RGB)
+    save_buffer: [[u32; CURSOR_W]; CURSOR_H],
+    /// Which pixels were actually drawn (within screen bounds)
+    save_valid: [[bool; CURSOR_W]; CURSOR_H],
+}
+
+impl CursorRenderer {
+    /// Create a new cursor renderer.
+    pub const fn new() -> Self {
+        Self {
+            visible: false,
+            last_x: 0,
+            last_y: 0,
+            save_buffer: [[0; CURSOR_W]; CURSOR_H],
+            save_valid: [[false; CURSOR_W]; CURSOR_H],
+        }
+    }
+
+    /// Erase the cursor from the framebuffer by restoring saved pixels.
+    fn erase(&mut self, fb: &FramebufferInfo) {
+        if !self.visible {
+            return;
+        }
+
+        for row in 0..CURSOR_H {
+            for col in 0..CURSOR_W {
+                if self.save_valid[row][col] {
+                    let px = self.last_x + col as i32;
+                    let py = self.last_y + row as i32;
+                    let saved = self.save_buffer[row][col];
+                    let r = ((saved >> 16) & 0xFF) as u8;
+                    let g = ((saved >> 8) & 0xFF) as u8;
+                    let b = (saved & 0xFF) as u8;
+                    // SAFETY: x,y bounds are validated; framebuffer is memory-mapped
+                    unsafe { fb.write_pixel(px as u32, py as u32, r, g, b) };
+                }
+            }
+        }
+
+        self.visible = false;
+    }
+
+    /// Draw the cursor at the given position, saving the pixels underneath.
+    fn draw(&mut self, fb: &FramebufferInfo, x: i32, y: i32) {
+        // Reset save validity
+        for row in &mut self.save_valid {
+            row.fill(false);
+        }
+
+        for row in 0..CURSOR_H {
+            for col in 0..CURSOR_W {
+                let pixel = CURSOR_BITMAP[row][col];
+                if pixel == 0 {
+                    continue; // Transparent
+                }
+
+                let px = x + col as i32;
+                let py = y + row as i32;
+
+                // Bounds check
+                if px < 0 || py < 0 || px >= fb.x_resolution as i32 || py >= fb.y_resolution as i32
+                {
+                    continue;
+                }
+
+                // Save the pixel underneath
+                self.save_buffer[row][col] = read_pixel(fb, px as u32, py as u32);
+                self.save_valid[row][col] = true;
+
+                // Draw cursor pixel
+                let (r, g, b) = match pixel {
+                    1 => (0, 0, 0),       // Black outline
+                    2 => (255, 255, 255), // White fill
+                    _ => continue,
+                };
+                // SAFETY: x,y bounds are checked above; framebuffer is memory-mapped
+                unsafe { fb.write_pixel(px as u32, py as u32, r, g, b) };
+            }
+        }
+
+        self.last_x = x;
+        self.last_y = y;
+        self.visible = true;
+    }
+
+    /// Update the cursor position on the framebuffer.
+    ///
+    /// Erases the old cursor, then draws at the new position.
+    pub fn update(&mut self, fb: &FramebufferInfo, x: i32, y: i32) {
+        // Skip if position hasn't changed and cursor is already drawn
+        if self.visible && x == self.last_x && y == self.last_y {
+            return;
+        }
+
+        self.erase(fb);
+        self.draw(fb, x, y);
+    }
+
+    /// Hide the cursor (erase without redrawing).
+    pub fn hide(&mut self, fb: &FramebufferInfo) {
+        self.erase(fb);
+    }
+
+    /// Show the cursor at the current position.
+    pub fn show(&mut self, fb: &FramebufferInfo, x: i32, y: i32) {
+        if !self.visible {
+            self.draw(fb, x, y);
+        }
+    }
+
+    /// Check if the cursor is currently visible.
+    pub fn is_visible(&self) -> bool {
+        self.visible
+    }
+}
+
+/// Read a pixel from the framebuffer as packed RGB (0x00RRGGBB).
+///
+/// This reads raw bytes from the framebuffer and converts to a canonical
+/// format for save-under buffering.
+fn read_pixel(fb: &FramebufferInfo, x: u32, y: u32) -> u32 {
+    let offset = (y * fb.bytes_per_line + x * (fb.bits_per_pixel as u32 / 8)) as usize;
+    let base = fb.physical_address as *const u8;
+
+    // SAFETY: The framebuffer address and dimensions come from coreboot tables
+    // and have been validated. x,y are bounds-checked by the caller.
+    unsafe {
+        match fb.bits_per_pixel {
+            32 => {
+                let ptr = base.add(offset);
+                let b = *ptr;
+                let g = *ptr.add(1);
+                let r = *ptr.add(2);
+                ((r as u32) << 16) | ((g as u32) << 8) | b as u32
+            }
+            24 => {
+                let ptr = base.add(offset);
+                let b = *ptr;
+                let g = *ptr.add(1);
+                let r = *ptr.add(2);
+                ((r as u32) << 16) | ((g as u32) << 8) | b as u32
+            }
+            16 => {
+                let ptr = base.add(offset) as *const u16;
+                let pixel = *ptr;
+                // RGB565: RRRRRGGGGGGBBBBB
+                let r = ((pixel >> 11) & 0x1F) as u32;
+                let g = ((pixel >> 5) & 0x3F) as u32;
+                let b = (pixel & 0x1F) as u32;
+                // Expand to 8-bit
+                ((r << 19) | (r << 14)) | ((g << 10) | (g << 4)) | ((b << 3) | (b >> 2))
+            }
+            _ => 0,
+        }
+    }
+}

--- a/src/drivers/keyboard.rs
+++ b/src/drivers/keyboard.rs
@@ -66,7 +66,7 @@ register_bitfields![u8,
 ];
 
 /// PS/2 controller port addresses
-mod ports {
+pub(crate) mod ports {
     /// Data port address (read/write)
     pub const DATA: u16 = 0x60;
     /// Status register (read) / Command register (write) address
@@ -132,7 +132,7 @@ mod response {
 ///
 /// Note: tock-registers Field::mask is unshifted, so we define these
 /// pre-shifted constants for use with raw byte operations.
-mod masks {
+pub(crate) mod masks {
     // Status register bits
     pub const OUTPUT_FULL: u8 = 1 << 0;
     pub const AUX_DATA: u8 = 1 << 5;
@@ -140,6 +140,7 @@ mod masks {
     // Config byte bits
     pub const KB_INT: u8 = 1 << 0;
     pub const AUX_INT: u8 = 1 << 1;
+    pub const AUX_DISABLE: u8 = 1 << 5;
     pub const TRANSLATION: u8 = 1 << 6;
 }
 
@@ -367,11 +368,15 @@ pub fn init() {
 
     let mut config_byte = kb.ports.data.get();
 
-    // Enable translation (scancode set 2 -> set 1) and disable interrupts
-    // We poll the keyboard instead of using interrupts
+    // Enable translation (scancode set 2 -> set 1) and disable interrupts.
+    // We poll the keyboard instead of using interrupts.
+    // Clear AUX_DISABLE so the mouse AUX port clock remains enabled —
+    // without this, the PS/2 mouse can't communicate after keyboard init
+    // (critical on Lenovo H8 EC where ENABLE_AUX alone may not suffice).
     config_byte |= masks::TRANSLATION;
     config_byte &= !masks::KB_INT;
     config_byte &= !masks::AUX_INT;
+    config_byte &= !masks::AUX_DISABLE;
 
     if !kb.send_controller_cmd(cmd::WRITE_CONFIG) {
         log::warn!("Failed to write PS/2 controller config");
@@ -547,8 +552,12 @@ pub fn try_read_key() -> Option<(u16, u16)> {
     }
 
     if (status & masks::AUX_DATA) != 0 {
-        // Mouse data, discard it
-        let _ = kb.ports.data.get();
+        // Mouse data — forward to PS/2 mouse driver instead of discarding
+        let byte = kb.ports.data.get();
+        #[cfg(feature = "ui")]
+        crate::drivers::mouse::push_aux_byte(byte);
+        #[cfg(not(feature = "ui"))]
+        let _ = byte;
         return None;
     }
 

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -143,6 +143,10 @@ pub mod block;
 pub mod keyboard;
 pub mod keyboard_common;
 pub mod mmio;
+#[cfg(all(feature = "ui", target_arch = "x86_64"))]
+pub mod mouse;
+#[cfg(feature = "ui")]
+pub mod mouse_cursor;
 pub mod nvme;
 pub mod pci;
 pub mod sdhci;

--- a/src/drivers/mouse.rs
+++ b/src/drivers/mouse.rs
@@ -1,0 +1,690 @@
+//! PS/2 Mouse Driver (i8042 Controller AUX Port)
+//!
+//! Supports standard 3-button PS/2 mice **and** Synaptics touchpads in
+//! absolute mode with TrackPoint pass-through — the configuration found on
+//! ThinkPad T480 / T470s / X280 / X1C5 / X1C6 and similar models.
+//!
+//! # T480 / ThinkPad Architecture
+//!
+//! On these machines Linux uses SMBus for the Synaptics touchpad (richer
+//! protocol, multi-touch).  In our firmware there is no SMBus driver, so
+//! the Synaptics runs in basic PS/2 mode as the only device on the AUX
+//! port.  The TrackPoint sits behind the Synaptics **pass-through port**
+//! and is **invisible** in basic relative mode.
+//!
+//! To access the TrackPoint we must:
+//!  1. Detect the Synaptics (magic E8×4 + E9 identify query).
+//!  2. Read its capability register to confirm pass-through support.
+//!  3. Switch it to absolute mode (6-byte packets).
+//!  4. Recognise pass-through packets and extract the 3-byte TrackPoint
+//!     sub-packet (bytes 1, 4, 5 of the 6-byte frame).
+//!  5. Also convert the touchpad's absolute X/Y to relative motion so the
+//!     touchpad itself still works as a pointing device.
+//!
+//! # References
+//!
+//! - `linux/drivers/input/mouse/synaptics.c` — detection, capabilities,
+//!   absolute mode, pass-through packet signature
+//! - `linux/drivers/input/mouse/trackpoint.c` — TrackPoint protocol
+//! - `linux/drivers/input/mouse/psmouse-base.c` — probe ordering, resets
+//! - libpayload `payloads/libpayload/drivers/i8042/mouse.c`
+
+use spin::Mutex;
+use tock_registers::interfaces::{Readable, Writeable};
+
+use crate::arch::x86_64::port_regs::{PortAliased8, PortReadWrite8};
+use crate::drivers::keyboard::{masks, ports, Status};
+
+// ============================================================================
+// PS/2 Mouse Constants
+// ============================================================================
+
+mod mouse_cmd {
+    pub const SET_SAMPLE_RATE: u8 = 0xF3;
+    pub const GET_DEVICE_ID: u8 = 0xF2;
+    pub const STATUS_REQUEST: u8 = 0xE9; // also used for Synaptics queries
+    pub const SET_RESOLUTION: u8 = 0xE8; // also used for Synaptics sliced-cmd
+    pub const ENABLE: u8 = 0xF4;
+    pub const DISABLE: u8 = 0xF5;
+    pub const SET_DEFAULTS: u8 = 0xF6;
+    #[allow(dead_code)]
+    pub const RESET: u8 = 0xFF;
+}
+
+mod aux_cmd {
+    pub const ENABLE_AUX: u8 = 0xA8;
+    pub const TEST_AUX: u8 = 0xA9;
+    pub const WRITE_AUX: u8 = 0xD4;
+}
+
+/// Synaptics magic identification byte in the second byte of a GET_INFO
+/// response after 4× SET_RESOLUTION 0. (From synaptics.c `synaptics_detect`.)
+const SYN_ID_MAGIC: u8 = 0x47;
+
+/// Synaptics capability bit 5 — pass-through port present.
+const SYN_CAP_PASS_THROUGH_BIT: u8 = 1 << 5;
+
+/// Synaptics mode byte bits.
+///
+/// Linux (`synaptics_set_mode()`) builds this from hardware queries:
+///   - `SYN_BIT_ABSOLUTE_MODE` (bit 7) — absolute coordinate reporting
+///   - `SYN_BIT_DISABLE_GESTURE` (bit 2) — suppress internal gesture
+///     processing; without this the touchpad's firmware swallows raw
+///     touches and only emits processed gesture events (or nothing at
+///     all if no gesture is recognised), resulting in zero data on the
+///     wire.  Set for `SYN_ID_MAJOR >= 4` (ours is 8).
+///   - `SYN_BIT_W_MODE` (bit 0) — enable extended W field in NEWABS
+///     packets.  Set when `SYN_CAP_EXTENDED` (our caps have bit 7 set).
+const SYN_MODE_ABSOLUTE: u8 = 0x80;
+const SYN_MODE_DISABLE_GESTURE: u8 = 0x04;
+const SYN_MODE_W: u8 = 0x01;
+
+/// Synaptics commit rate for `SET_RATE` after a sliced-command mode byte.
+const SYN_MODE_COMMIT_RATE: u8 = 0x14; // 20 samples/sec
+
+/// Synaptics pass-through commit rate — used to forward a byte to the
+/// TrackPoint: sliced-command(byte) + SET_RATE(SYN_PT_COMMIT_RATE).
+const SYN_PT_COMMIT_RATE: u8 = 0xC8; // 200 — SYN_PS_CLIENT_CMD
+
+/// Minimum Z (pressure) to treat a Synaptics touch as intentional.
+const SYN_Z_THRESHOLD: i32 = 30;
+
+/// Divisor for converting Synaptics 12-bit absolute coordinates to relative
+/// pixel motion. Larger → slower cursor; tune to taste.
+const SYN_MOTION_SCALE: i32 = 8;
+
+// ============================================================================
+// Protocol
+// ============================================================================
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MouseProtocol {
+    /// Standard PS/2 mouse — 3-byte packets.
+    Standard,
+    /// Microsoft IntelliMouse — 4-byte packets (scroll wheel). Kept for
+    /// non-ThinkPad hardware but not actively negotiated; we fall back to
+    /// Standard to avoid multiplexing issues on EC-multiplexed ports.
+    #[allow(dead_code)]
+    IntelliMouse,
+    /// Synaptics touchpad in absolute mode — 6-byte packets.
+    /// Pass-through (TrackPoint) packets are embedded inside these.
+    SynapticsAbsolute,
+}
+
+impl MouseProtocol {
+    fn packet_size(self) -> usize {
+        match self {
+            MouseProtocol::Standard => 3,
+            MouseProtocol::IntelliMouse => 4,
+            MouseProtocol::SynapticsAbsolute => 6,
+        }
+    }
+}
+
+// ============================================================================
+// State
+// ============================================================================
+
+struct MouseState {
+    initialized: bool,
+    protocol: MouseProtocol,
+    /// Packet assembly buffer — large enough for 6-byte Synaptics packets.
+    packet_buf: [u8; 6],
+    packet_idx: usize,
+    rel_x: i32,
+    rel_y: i32,
+    rel_z: i32,
+    buttons: u32,
+    data_port: PortReadWrite8<()>,
+    status_port: PortAliased8<Status::Register, ()>,
+    // Synaptics absolute → relative state
+    /// Previous absolute X (Synaptics 12-bit, 0 = invalid / no finger).
+    syn_prev_x: i32,
+    /// Previous absolute Y (Synaptics 12-bit, 0 = invalid / no finger).
+    syn_prev_y: i32,
+    /// Previous Z (pressure, 0 = no contact).
+    syn_prev_z: i32,
+}
+
+static AUX_FIFO: Mutex<heapless::Deque<u8, 128>> = Mutex::new(heapless::Deque::new());
+
+impl MouseState {
+    const fn new() -> Self {
+        Self {
+            initialized: false,
+            protocol: MouseProtocol::Standard,
+            packet_buf: [0; 6],
+            packet_idx: 0,
+            rel_x: 0,
+            rel_y: 0,
+            rel_z: 0,
+            buttons: 0,
+            data_port: PortReadWrite8::new(ports::DATA),
+            status_port: PortAliased8::new(ports::STATUS_CMD),
+            syn_prev_x: 0,
+            syn_prev_y: 0,
+            syn_prev_z: 0,
+        }
+    }
+
+    // ── Port helpers ──────────────────────────────────────────────────────────
+
+    fn wait_input_ready(&self) -> bool {
+        for _ in 0..10000 {
+            if (self.status_port.get() & (1 << 1)) == 0 {
+                return true;
+            }
+            for _ in 0..50 {
+                core::hint::spin_loop();
+            }
+        }
+        false
+    }
+
+    fn wait_output_ready(&self) -> bool {
+        for _ in 0..10000 {
+            if (self.status_port.get() & masks::OUTPUT_FULL) != 0 {
+                return true;
+            }
+            for _ in 0..50 {
+                core::hint::spin_loop();
+            }
+        }
+        false
+    }
+
+    fn wait_aux_output(&self) -> bool {
+        for _ in 0..10000 {
+            let st = self.status_port.get();
+            if (st & masks::OUTPUT_FULL) != 0 && (st & masks::AUX_DATA) != 0 {
+                return true;
+            }
+            for _ in 0..50 {
+                core::hint::spin_loop();
+            }
+        }
+        false
+    }
+
+    fn send_controller_cmd(&self, cmd: u8) -> bool {
+        if !self.wait_input_ready() {
+            return false;
+        }
+        self.status_port.set(cmd);
+        self.wait_input_ready()
+    }
+
+    /// Send a single byte to the AUX device and wait for ACK (0xFA).
+    fn send_mouse_byte(&self, b: u8) -> bool {
+        if !self.send_controller_cmd(aux_cmd::WRITE_AUX) {
+            return false;
+        }
+        if !self.wait_input_ready() {
+            return false;
+        }
+        self.data_port.set(b);
+        if !self.wait_aux_output() {
+            return false;
+        }
+        self.data_port.get() == 0xFA
+    }
+
+    /// Send a two-byte command + argument to the AUX device, both with ACKs.
+    fn send_mouse_cmd_data(&self, cmd: u8, data: u8) -> bool {
+        self.send_mouse_byte(cmd) && self.send_mouse_byte(data)
+    }
+
+    fn read_aux_byte(&self) -> Option<u8> {
+        if self.wait_aux_output() {
+            Some(self.data_port.get())
+        } else {
+            None
+        }
+    }
+
+    /// Drain any pending bytes from the output buffer.
+    fn flush(&self) {
+        for _ in 0..128 {
+            if (self.status_port.get() & masks::OUTPUT_FULL) == 0 {
+                break;
+            }
+            let _ = self.data_port.get();
+            for _ in 0..10 {
+                core::hint::spin_loop();
+            }
+        }
+    }
+
+    fn has_aux_data(&self) -> bool {
+        let st = self.status_port.get();
+        (st & masks::OUTPUT_FULL) != 0 && (st & masks::AUX_DATA) != 0
+    }
+
+    // ── Synaptics helpers ─────────────────────────────────────────────────────
+
+    /// Encode `byte` as a Synaptics "sliced command": four consecutive
+    /// `SET_RESOLUTION` bytes carrying 2 bits each (MSB pair first).
+    ///
+    /// This is how the Synaptics driver communicates a mode or query byte
+    /// without ambiguity on the shared PS/2 bus.
+    ///
+    /// Reference: `ps2_sliced_command()` in Linux `drivers/input/serio/ps2.c`
+    fn synaptics_sliced_cmd(&self, byte: u8) -> bool {
+        for shift in [6u8, 4, 2, 0] {
+            let pair = (byte >> shift) & 3;
+            if !self.send_mouse_byte(mouse_cmd::SET_RESOLUTION) {
+                return false;
+            }
+            if !self.send_mouse_byte(pair) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Read N bytes from the AUX port (no ACK expected — raw data bytes).
+    fn read_aux_bytes<const N: usize>(&self) -> Option<[u8; N]> {
+        let mut out = [0u8; N];
+        for b in &mut out {
+            *b = self.read_aux_byte()?;
+        }
+        Some(out)
+    }
+
+    /// Detect a Synaptics touchpad and return (capabilities, has_passthrough).
+    ///
+    /// Detection sequence (from `synaptics_detect` in Linux `synaptics.c`):
+    ///   4× SET_RESOLUTION 0  +  STATUS_REQUEST → read 3 bytes.
+    ///   If byte[1] == 0x47 → Synaptics confirmed.
+    ///
+    /// Capability query (`SYN_QUE_CAPABILITIES = 0x02`):
+    ///   sliced_cmd(0x02)  +  STATUS_REQUEST → read 3 bytes.
+    ///   Byte[0] bit 5 = pass-through port present.
+    fn detect_synaptics(&self) -> Option<bool> {
+        // ── Identify ──────────────────────────────────────────────────────────
+        if !self.synaptics_sliced_cmd(0x00) {
+            return None;
+        }
+        if !self.send_mouse_byte(mouse_cmd::STATUS_REQUEST) {
+            return None;
+        }
+        let id = self.read_aux_bytes::<3>()?;
+        if id[1] != SYN_ID_MAGIC {
+            return None; // Not Synaptics
+        }
+        log::info!(
+            "Synaptics touchpad detected (id={:#x},{:#x},{:#x})",
+            id[0],
+            id[1],
+            id[2]
+        );
+
+        // ── Capabilities (query 0x02) ─────────────────────────────────────────
+        if !self.synaptics_sliced_cmd(0x02) {
+            return None;
+        }
+        if !self.send_mouse_byte(mouse_cmd::STATUS_REQUEST) {
+            return None;
+        }
+        let cap = self.read_aux_bytes::<3>()?;
+        let has_pt = (cap[0] & SYN_CAP_PASS_THROUGH_BIT) != 0;
+        log::info!(
+            "Synaptics caps={:#010b} ext={:#x} pass-through={}",
+            cap[0],
+            cap[1],
+            has_pt
+        );
+        Some(has_pt)
+    }
+
+    /// Switch the Synaptics touchpad to absolute mode.
+    ///
+    /// The full mode byte is sent as a sliced command followed by
+    /// `SET_RATE(SYN_MODE_COMMIT_RATE)`.
+    ///
+    /// Reference: `synaptics_mode_cmd()` / `synaptics_set_mode()` in
+    /// Linux `synaptics.c`.
+    fn synaptics_set_absolute_mode(&self) -> bool {
+        let mode = SYN_MODE_ABSOLUTE | SYN_MODE_DISABLE_GESTURE | SYN_MODE_W;
+        if !self.synaptics_sliced_cmd(mode) {
+            return false;
+        }
+        self.send_mouse_cmd_data(mouse_cmd::SET_SAMPLE_RATE, SYN_MODE_COMMIT_RATE)
+    }
+
+    /// Send a byte to the TrackPoint through the Synaptics pass-through port.
+    ///
+    /// Encoding (from `synaptics_pt_write()` in Linux `synaptics.c`):
+    ///   sliced_cmd(byte)  +  SET_RATE(0xC8)
+    ///
+    /// The Synaptics interprets `SET_RATE(0xC8)` as "forward the buffered
+    /// sliced byte to the pass-through device".
+    fn synaptics_pt_send(&self, byte: u8) -> bool {
+        if !self.synaptics_sliced_cmd(byte) {
+            return false;
+        }
+        self.send_mouse_cmd_data(mouse_cmd::SET_SAMPLE_RATE, SYN_PT_COMMIT_RATE)
+    }
+
+    /// Detect Synaptics + enable absolute mode + enable TrackPoint via PT.
+    ///
+    /// Returns `true` if Synaptics is present and absolute mode was enabled.
+    fn try_synaptics_init(&mut self) -> bool {
+        match self.detect_synaptics() {
+            None => return false,
+            Some(has_pt) => {
+                if !has_pt {
+                    log::info!("Synaptics has no pass-through port, staying in relative mode");
+                    return false;
+                }
+            }
+        }
+
+        // Switch to absolute mode
+        if !self.synaptics_set_absolute_mode() {
+            log::warn!("Failed to set Synaptics absolute mode");
+            return false;
+        }
+
+        self.protocol = MouseProtocol::SynapticsAbsolute;
+        self.packet_idx = 0;
+        self.flush();
+
+        log::info!("Synaptics absolute mode enabled");
+
+        // Start data reporting (ENABLE).
+        //
+        // The touchpad was DISABLE'd during identification above and will not
+        // send any packets until it receives ENABLE.  The non-Synaptics path
+        // below does the same for standard mice; we must do it here too.
+        if !self.send_mouse_byte(mouse_cmd::ENABLE) {
+            log::warn!("Failed to enable Synaptics data reporting");
+            return false;
+        }
+
+        // Enable TrackPoint data reporting through the pass-through port.
+        // We send ENABLE (0xF4) to the TrackPoint via the pass-through mechanism.
+        // The BIOS may have already done this; sending it again is harmless.
+        // We don't check the result because the ACK comes back as a pass-through
+        // packet which we haven't started reading yet.
+        let _ = self.synaptics_pt_send(mouse_cmd::ENABLE);
+
+        true
+    }
+
+    // ── Packet processing ──────────────────────────────────────────────────────
+
+    fn process_byte(&mut self, byte: u8) {
+        if self.packet_idx == 0 {
+            // Sync check depends on protocol.
+            // Standard PS/2: bit 3 of byte 0 is always 1.
+            // Synaptics absolute (new-abs): bit 7 = 1, bit 6 = 0.
+            //   Pass-through packets also satisfy this (0x84–0x87, 0xC4–0xC7, etc.)
+            //   because (byte & 0xC0) == 0x80.
+            let valid = match self.protocol {
+                MouseProtocol::SynapticsAbsolute => (byte & 0xC0) == 0x80,
+                _ => (byte & 0x08) != 0,
+            };
+            if !valid {
+                return;
+            }
+        }
+
+        self.packet_buf[self.packet_idx] = byte;
+        self.packet_idx += 1;
+
+        if self.packet_idx >= self.protocol.packet_size() {
+            self.decode_packet();
+            self.packet_idx = 0;
+        }
+    }
+
+    fn decode_packet(&mut self) {
+        match self.protocol {
+            MouseProtocol::Standard | MouseProtocol::IntelliMouse => {
+                self.decode_standard_packet();
+            }
+            MouseProtocol::SynapticsAbsolute => {
+                self.decode_synaptics_packet();
+            }
+        }
+    }
+
+    /// Decode a standard 3-byte PS/2 relative-motion packet.
+    fn decode_standard_packet(&mut self) {
+        let b0 = self.packet_buf[0];
+        let b1 = self.packet_buf[1];
+        let b2 = self.packet_buf[2];
+
+        let dx = b1 as i32 - (((b0 as i32) << 4) & 0x100);
+        self.rel_x += dx;
+
+        let dy = b2 as i32 - (((b0 as i32) << 3) & 0x100);
+        self.rel_y -= dy; // PS/2 Y-up → screen Y-down
+
+        self.buttons = (b0 & 0x07) as u32;
+    }
+
+    /// Decode a 6-byte Synaptics absolute-mode packet.
+    ///
+    /// Two packet types are handled:
+    ///
+    /// 1. **Pass-through** (TrackPoint data):
+    ///    `(buf[0] & 0xFC) == 0x84 && (buf[3] & 0xCC) == 0xC4`
+    ///    Data bytes: buf[1] = PS/2 byte0 (buttons+signs), buf[4] = ΔX, buf[5] = ΔY.
+    ///    Decoded as a standard 3-byte PS/2 relative packet.
+    ///
+    /// 2. **Synaptics touchpad** (absolute position):
+    ///    NEWABS format:
+    ///      X = ((buf[3]&0x10)<<8) | ((buf[1]&0x0f)<<8) | buf[4]
+    ///      Y = ((buf[3]&0x20)<<7) | ((buf[1]&0xf0)<<4) | buf[5]
+    ///      Z = buf[2]
+    ///    Converted to relative motion by differencing consecutive positions
+    ///    while Z > threshold.
+    ///
+    /// Reference: `synaptics_is_pt_packet()`, `synaptics_pass_pt_packet()`,
+    ///            `synaptics_parse_hw_state()` in Linux `synaptics.c`.
+    fn decode_synaptics_packet(&mut self) {
+        let buf = self.packet_buf;
+
+        // ── Pass-through check (TrackPoint data) ──────────────────────────────
+        // Signature from Linux `synaptics_is_pt_packet()`.
+        if (buf[0] & 0xFC) == 0x84 && (buf[3] & 0xCC) == 0xC4 {
+            // TrackPoint 3-byte PS/2 packet is at bytes 1, 4, 5.
+            // (byte 2 would carry the 4th byte if TrackPoint were in IntelliMouse
+            //  mode, but we keep TrackPoint in Standard 3-byte mode.)
+            let tp0 = buf[1]; // buttons (L/R/M) + X/Y overflow/sign bits
+            let tp1 = buf[4]; // X delta
+            let tp2 = buf[5]; // Y delta
+
+            let dx = tp1 as i32 - (((tp0 as i32) << 4) & 0x100);
+            self.rel_x += dx;
+
+            let dy = tp2 as i32 - (((tp0 as i32) << 3) & 0x100);
+            self.rel_y -= dy;
+
+            self.buttons = (tp0 & 0x07) as u32;
+            return;
+        }
+
+        // ── Synaptics absolute touchpad motion ────────────────────────────────
+        // New-abs format (all modern Synaptics devices).
+        // Reference: `synaptics_parse_hw_state()`, NEWABS branch in Linux.
+        let x =
+            (((buf[3] as u32 & 0x10) << 8) | ((buf[1] as u32 & 0x0f) << 8) | buf[4] as u32) as i32;
+        let y =
+            (((buf[3] as u32 & 0x20) << 7) | ((buf[1] as u32 & 0xf0) << 4) | buf[5] as u32) as i32;
+        let z = buf[2] as i32;
+
+        // Buttons (left = bit 0, right = bit 1 of byte 0)
+        self.buttons = (buf[0] & 0x03) as u32;
+
+        if z > SYN_Z_THRESHOLD && self.syn_prev_z > SYN_Z_THRESHOLD {
+            // Only count motion when there was continuous contact.
+            let dx = x - self.syn_prev_x;
+            let dy = y - self.syn_prev_y;
+            self.rel_x += dx / SYN_MOTION_SCALE;
+            self.rel_y -= dy / SYN_MOTION_SCALE; // Synaptics Y-up → screen Y-down
+        }
+
+        self.syn_prev_x = x;
+        self.syn_prev_y = y;
+        self.syn_prev_z = z;
+    }
+}
+
+// ============================================================================
+// Global state
+// ============================================================================
+
+static MOUSE: Mutex<MouseState> = Mutex::new(MouseState::new());
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/// Forward an AUX byte captured by the keyboard driver.
+pub fn push_aux_byte(byte: u8) {
+    let mut fifo = AUX_FIFO.lock();
+    let _ = fifo.push_back(byte);
+}
+
+/// Initialize the PS/2 mouse.
+///
+/// After basic PS/2 init, detects whether the AUX device is a Synaptics
+/// touchpad.  If so, switches it to absolute mode and enables TrackPoint
+/// pass-through — this is the path required on ThinkPad T480 / T470s /
+/// X280 and similar models.
+pub fn init() {
+    let mut mouse = MOUSE.lock();
+    if mouse.initialized {
+        return;
+    }
+
+    log::debug!("Initializing PS/2 mouse");
+
+    if mouse.status_port.get() == 0xFF {
+        log::debug!("No i8042 controller");
+        return;
+    }
+
+    // ── Ensure AUX clock is running ───────────────────────────────────────────
+    // keyboard::init() may have left AUX_DISABLE (bit 5) set in the
+    // controller config byte, preventing any AUX communication.
+    if mouse.send_controller_cmd(0x20) {
+        if mouse.wait_output_ready() {
+            let mut cfg = mouse.data_port.get();
+            if cfg & (1 << 5) != 0 {
+                cfg &= !(1 << 5);
+                if mouse.send_controller_cmd(0x60) {
+                    let _ = mouse.wait_input_ready();
+                    mouse.data_port.set(cfg);
+                }
+            }
+        }
+    }
+
+    mouse.flush();
+
+    // ── AUX port self-test ────────────────────────────────────────────────────
+    if !mouse.send_controller_cmd(aux_cmd::TEST_AUX) {
+        log::debug!("AUX port test failed");
+        return;
+    }
+    if !mouse.wait_output_ready() {
+        log::debug!("AUX port test timeout");
+        return;
+    }
+    let test = mouse.data_port.get();
+    if test != 0x00 {
+        log::debug!("AUX port test returned {:#x}", test);
+        return;
+    }
+
+    // Enable AUX port (0xA8); response may be absent on Lenovo H8 EC.
+    let _ = mouse.send_controller_cmd(aux_cmd::ENABLE_AUX);
+    mouse.flush();
+
+    // ── Basic PS/2 handshake (talks to the primary AUX device) ───────────────
+    if !mouse.send_mouse_byte(mouse_cmd::DISABLE) {
+        log::debug!("No AUX device responded to DISABLE");
+        return;
+    }
+    if !mouse.send_mouse_byte(mouse_cmd::GET_DEVICE_ID) {
+        log::debug!("GET_DEVICE_ID failed");
+        return;
+    }
+    let id = mouse.read_aux_byte();
+    if id != Some(0x00) {
+        log::debug!("Unexpected device ID: {:?}", id);
+        return;
+    }
+
+    // ── Try Synaptics absolute mode (required for ThinkPad TrackPoint) ────────
+    //
+    // If the AUX device is a Synaptics touchpad, switch it to absolute mode
+    // so that TrackPoint pass-through packets become available.  The basic
+    // DISABLE / GET_DEVICE_ID above always succeeds for Synaptics (it reports
+    // ID 0x00 in basic mode), so we attempt the Synaptics init unconditionally
+    // and fall back to Standard if it fails.
+    let synaptics_ok = mouse.try_synaptics_init();
+
+    if !synaptics_ok {
+        // Standard PS/2 mouse (or Synaptics without pass-through — use relative mode)
+        mouse.protocol = MouseProtocol::Standard;
+        mouse.send_mouse_byte(mouse_cmd::SET_DEFAULTS);
+        if !mouse.send_mouse_byte(mouse_cmd::ENABLE) {
+            log::warn!("Failed to enable mouse data reporting");
+            return;
+        }
+    }
+
+    mouse.initialized = true;
+    log::info!("PS/2 mouse initialized (protocol: {:?})", mouse.protocol);
+}
+
+/// Poll for new data from both the FIFO (filled by keyboard driver) and
+/// directly from the i8042 output buffer.
+pub fn poll() {
+    let mut mouse = MOUSE.lock();
+    if !mouse.initialized {
+        return;
+    }
+
+    // Drain the FIFO filled by keyboard::try_read_key()
+    {
+        let mut fifo = AUX_FIFO.lock();
+        while let Some(byte) = fifo.pop_front() {
+            mouse.process_byte(byte);
+        }
+    }
+
+    // Also poll the i8042 directly for any pending AUX bytes
+    for _ in 0..64 {
+        if !mouse.has_aux_data() {
+            break;
+        }
+        let byte = mouse.data_port.get();
+        mouse.process_byte(byte);
+    }
+}
+
+/// Get and reset accumulated relative motion.
+pub fn get_relative_motion() -> (i32, i32, i32) {
+    let mut mouse = MOUSE.lock();
+    let (dx, dy, dz) = (mouse.rel_x, mouse.rel_y, mouse.rel_z);
+    mouse.rel_x = 0;
+    mouse.rel_y = 0;
+    mouse.rel_z = 0;
+    (dx, dy, dz)
+}
+
+/// Get current button state bitmask (bit 0=left, 1=right, 2=middle).
+pub fn get_buttons() -> u32 {
+    MOUSE.lock().buttons
+}
+
+/// Returns `true` if the PS/2 mouse (or Synaptics+TrackPoint) is ready.
+pub fn is_available() -> bool {
+    MOUSE.lock().initialized
+}

--- a/src/drivers/mouse.rs
+++ b/src/drivers/mouse.rs
@@ -33,7 +33,7 @@ use spin::Mutex;
 use tock_registers::interfaces::{Readable, Writeable};
 
 use crate::arch::x86_64::port_regs::{PortAliased8, PortReadWrite8};
-use crate::drivers::keyboard::{masks, ports, Status};
+use crate::drivers::keyboard::{Status, masks, ports};
 
 // ============================================================================
 // PS/2 Mouse Constants

--- a/src/drivers/mouse_cursor.rs
+++ b/src/drivers/mouse_cursor.rs
@@ -1,0 +1,269 @@
+//! Unified Mouse Cursor Abstraction
+//!
+//! Aggregates mouse input from PS/2 and USB HID mouse drivers into a single
+//! cursor position with acceleration and speed control.
+//!
+//! This follows the same pattern as libpayload's `drivers/mouse_cursor.c`:
+//! relative deltas from all input sources are accumulated, optionally
+//! accelerated, and converted to an absolute cursor position.
+//!
+//! # Coordinate Model
+//!
+//! - Internal accumulators use 1/256 fixed-point for sub-pixel precision
+//! - Public API returns integer pixel coordinates
+//! - Absolute position is clamped to screen boundaries
+
+use spin::Mutex;
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/// Default acceleration threshold (in raw delta units).
+///
+/// If the distance of a single mouse poll exceeds this value,
+/// the speed multiplier is applied.
+const DEFAULT_ACCELERATION_THRESHOLD: u32 = 16;
+
+/// Default speed multiplier (in 1/256 fixed-point units).
+///
+/// ~2.6x acceleration when above threshold. Equivalent to 0x299
+/// from libpayload.
+const DEFAULT_SPEED: u32 = 0x299;
+
+/// Base multiplier for non-accelerated movement (1x in 1/256 fixed-point).
+const BASE_SPEED: u32 = 256;
+
+// ============================================================================
+// Cursor State
+// ============================================================================
+
+/// Mouse cursor state
+struct CursorState {
+    /// Whether the cursor system is initialized
+    initialized: bool,
+    /// Current absolute X position (pixels)
+    abs_x: i32,
+    /// Current absolute Y position (pixels)
+    abs_y: i32,
+    /// Screen width (pixels)
+    screen_w: u32,
+    /// Screen height (pixels)
+    screen_h: u32,
+    /// Acceleration threshold (raw delta units)
+    acceleration: u32,
+    /// Speed multiplier (1/256 fixed-point)
+    speed: u32,
+    /// Accumulated button state from all sources
+    buttons: u32,
+    /// Previous frame's button state (for edge detection)
+    prev_buttons: u32,
+    /// Pending click events (rising-edge: 0→1 transitions, consumed on read)
+    click_pending: u32,
+    /// Accumulated scroll delta
+    scroll: i32,
+}
+
+impl CursorState {
+    const fn new() -> Self {
+        Self {
+            initialized: false,
+            abs_x: 0,
+            abs_y: 0,
+            screen_w: 0,
+            screen_h: 0,
+            acceleration: DEFAULT_ACCELERATION_THRESHOLD,
+            speed: DEFAULT_SPEED,
+            buttons: 0,
+            prev_buttons: 0,
+            click_pending: 0,
+            scroll: 0,
+        }
+    }
+}
+
+static CURSOR: Mutex<CursorState> = Mutex::new(CursorState::new());
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/// Initialize the mouse cursor system.
+///
+/// # Arguments
+/// * `screen_width` - Display width in pixels
+/// * `screen_height` - Display height in pixels
+pub fn init(screen_width: u32, screen_height: u32) {
+    let mut cursor = CURSOR.lock();
+    cursor.screen_w = screen_width;
+    cursor.screen_h = screen_height;
+    // Start cursor at center of screen
+    cursor.abs_x = screen_width as i32 / 2;
+    cursor.abs_y = screen_height as i32 / 2;
+    cursor.initialized = true;
+
+    // Initialize PS/2 mouse (x86 only)
+    #[cfg(target_arch = "x86_64")]
+    super::mouse::init();
+
+    log::info!(
+        "Mouse cursor initialized ({}x{}, start at {}, {})",
+        screen_width,
+        screen_height,
+        cursor.abs_x,
+        cursor.abs_y
+    );
+}
+
+/// Poll all mouse input sources and update cursor position.
+///
+/// Should be called from the main event loop.
+pub fn poll() {
+    let mut cursor = CURSOR.lock();
+    if !cursor.initialized {
+        return;
+    }
+
+    let mut total_dx: i32 = 0;
+    let mut total_dy: i32 = 0;
+    let mut total_dz: i32 = 0;
+    let mut combined_buttons: u32 = 0;
+
+    // Poll PS/2 mouse
+    #[cfg(target_arch = "x86_64")]
+    {
+        // Must drop cursor lock before calling poll (which acquires MOUSE lock)
+        drop(cursor);
+        super::mouse::poll();
+        let (dx, dy, dz) = super::mouse::get_relative_motion();
+        combined_buttons |= super::mouse::get_buttons();
+        total_dx += dx;
+        total_dy += dy;
+        total_dz += dz;
+        cursor = CURSOR.lock();
+    }
+
+    // Poll USB mouse
+    {
+        let mouse_ctrl_idx = super::usb::hid_mouse::controller_idx();
+        if let Some(ctrl_idx) = mouse_ctrl_idx {
+            drop(cursor);
+            // Poll the USB controller that has the mouse
+            super::usb::poll_mice_on_controller(ctrl_idx);
+            let (udx, udy) = super::usb::hid_mouse::get_relative_motion();
+            combined_buttons |= super::usb::hid_mouse::get_buttons();
+            total_dx += udx;
+            total_dy += udy;
+            cursor = CURSOR.lock();
+        }
+    }
+
+    if total_dx == 0 && total_dy == 0 && total_dz == 0 && combined_buttons == cursor.buttons {
+        return;
+    }
+
+    // Apply acceleration (use i64 to avoid i32 overflow on large deltas)
+    let distance_sq =
+        (total_dx as i64 * total_dx as i64 + total_dy as i64 * total_dy as i64) as u32;
+    let threshold_sq = cursor.acceleration * cursor.acceleration;
+    let multiplier = if distance_sq > threshold_sq {
+        cursor.speed
+    } else {
+        BASE_SPEED
+    };
+
+    // Scale deltas by multiplier (1/256 fixed-point → integer pixels)
+    let scaled_dx = (total_dx * multiplier as i32) / BASE_SPEED as i32;
+    let scaled_dy = (total_dy * multiplier as i32) / BASE_SPEED as i32;
+
+    // Update absolute position with clamping
+    cursor.abs_x = (cursor.abs_x + scaled_dx).clamp(0, cursor.screen_w as i32 - 1);
+    cursor.abs_y = (cursor.abs_y + scaled_dy).clamp(0, cursor.screen_h as i32 - 1);
+
+    // Edge detection: record rising edges (0→1) as pending clicks
+    let rising = combined_buttons & !cursor.prev_buttons;
+    cursor.click_pending |= rising;
+    cursor.prev_buttons = combined_buttons;
+    cursor.buttons = combined_buttons;
+    cursor.scroll += total_dz;
+}
+
+/// Get the current absolute cursor position.
+///
+/// Returns `(x, y)` in pixel coordinates.
+pub fn position() -> (i32, i32) {
+    let cursor = CURSOR.lock();
+    (cursor.abs_x, cursor.abs_y)
+}
+
+/// Get and reset the accumulated scroll delta.
+pub fn get_scroll() -> i32 {
+    let mut cursor = CURSOR.lock();
+    let dz = cursor.scroll;
+    cursor.scroll = 0;
+    dz
+}
+
+/// Get the current button state.
+///
+/// Bit 0=left, 1=right, 2=middle, 3=btn4, 4=btn5.
+pub fn buttons() -> u32 {
+    CURSOR.lock().buttons
+}
+
+/// Check if the left mouse button is pressed (level-triggered).
+pub fn left_pressed() -> bool {
+    (buttons() & 1) != 0
+}
+
+/// Check if the left mouse button was just clicked (edge-triggered).
+///
+/// Returns `true` exactly once per press-down transition (0→1).
+/// The click is consumed on read — subsequent calls return `false`
+/// until the button is released and pressed again.
+pub fn left_clicked() -> bool {
+    let mut cursor = CURSOR.lock();
+    let clicked = (cursor.click_pending & 1) != 0;
+    cursor.click_pending &= !1; // consume the click
+    clicked
+}
+
+/// Check if the right mouse button is pressed.
+pub fn right_pressed() -> bool {
+    (buttons() & 2) != 0
+}
+
+/// Check if the cursor system is initialized.
+pub fn is_initialized() -> bool {
+    CURSOR.lock().initialized
+}
+
+/// Set cursor speed multiplier (1/256 fixed-point).
+///
+/// 256 = 1x (no acceleration), 512 = 2x, etc.
+pub fn set_speed(speed: u32) {
+    CURSOR.lock().speed = speed;
+}
+
+/// Get current speed multiplier.
+pub fn get_speed() -> u32 {
+    CURSOR.lock().speed
+}
+
+/// Set acceleration threshold.
+pub fn set_acceleration(threshold: u32) {
+    CURSOR.lock().acceleration = threshold;
+}
+
+/// Set cursor position directly (e.g., for touchscreen/absolute input).
+pub fn set_position(x: i32, y: i32) {
+    let mut cursor = CURSOR.lock();
+    cursor.abs_x = x.clamp(0, cursor.screen_w as i32 - 1);
+    cursor.abs_y = y.clamp(0, cursor.screen_h as i32 - 1);
+}
+
+/// Get screen dimensions.
+pub fn screen_size() -> (u32, u32) {
+    let cursor = CURSOR.lock();
+    (cursor.screen_w, cursor.screen_h)
+}

--- a/src/drivers/usb/controller.rs
+++ b/src/drivers/usb/controller.rs
@@ -585,6 +585,8 @@ pub enum UsbError {
     Nak,
     /// Device disconnected
     Disconnected,
+    /// Operation not supported by this controller
+    NotSupported,
 }
 
 /// USB device handle - identifies a device on a controller
@@ -643,6 +645,23 @@ pub trait UsbController {
         is_in: bool,
         data: &mut [u8],
     ) -> Result<usize, UsbError>;
+
+    /// Perform a single synchronous interrupt IN transfer.
+    ///
+    /// This is the correct way to poll HID devices (mice, keyboards) since
+    /// many devices do not implement the GET_REPORT class request and will
+    /// stall control transfers instead.
+    ///
+    /// The default implementation returns `NotSupported`.  Controllers that
+    /// have configured the interrupt endpoint should override this.
+    fn interrupt_transfer(
+        &mut self,
+        _device: u8,
+        _endpoint: u8,
+        _data: &mut [u8],
+    ) -> Result<usize, UsbError> {
+        Err(UsbError::NotSupported)
+    }
 
     /// Create an interrupt transfer queue
     ///
@@ -716,6 +735,22 @@ pub trait UsbController {
             .find_map(|d| d.as_ref().filter(|d| d.is_hid_keyboard).map(|d| d.address))
     }
 
+    /// Find a HID mouse device
+    ///
+    /// # Returns
+    /// Device address/slot ID if found
+    fn find_hid_mouse(&self) -> Option<u8> {
+        self.devices()
+            .iter()
+            .find_map(|d| d.as_ref().filter(|d| d.is_hid_mouse).map(|d| d.address))
+    }
+
+    /// Get mouse interrupt endpoint info for a device
+    fn get_mouse_interrupt_endpoint(&self, device: u8) -> Option<EndpointInfo> {
+        self.get_device(device)
+            .and_then(|d| d.mouse_interrupt_in)
+    }
+
     /// Get device info
     fn get_device_info(&self, device: u8) -> Option<DeviceInfo> {
         self.get_device(device).map(UsbDevice::device_info)
@@ -754,6 +789,8 @@ pub struct DeviceInfo {
     pub is_hid: bool,
     /// Is this a keyboard?
     pub is_keyboard: bool,
+    /// Is this a mouse?
+    pub is_mouse: bool,
     /// Is this a hub?
     pub is_hub: bool,
 }
@@ -785,6 +822,8 @@ pub struct UsbDevice {
     pub mass_storage_interface: u8,
     /// Is HID keyboard
     pub is_hid_keyboard: bool,
+    /// Is HID mouse (boot protocol)
+    pub is_hid_mouse: bool,
     /// Is USB hub
     pub is_hub: bool,
     /// Number of hub ports (if is_hub)
@@ -793,8 +832,10 @@ pub struct UsbDevice {
     pub bulk_in: Option<EndpointInfo>,
     /// Bulk OUT endpoint
     pub bulk_out: Option<EndpointInfo>,
-    /// Interrupt IN endpoint
+    /// Interrupt IN endpoint (keyboard)
     pub interrupt_in: Option<EndpointInfo>,
+    /// Mouse interrupt IN endpoint
+    pub mouse_interrupt_in: Option<EndpointInfo>,
     /// Control endpoint max packet size
     pub ep0_max_packet: u16,
     /// Data toggle for bulk IN
@@ -819,11 +860,13 @@ impl UsbDevice {
             is_mass_storage: false,
             mass_storage_interface: 0,
             is_hid_keyboard: false,
+            is_hid_mouse: false,
             is_hub: false,
             num_hub_ports: 0,
             bulk_in: None,
             bulk_out: None,
             interrupt_in: None,
+            mouse_interrupt_in: None,
             ep0_max_packet: speed.default_max_packet_size(),
             bulk_in_toggle: false,
             bulk_out_toggle: false,
@@ -850,8 +893,9 @@ impl UsbDevice {
             device_class: self.device_desc.device_class,
             is_mass_storage: self.is_mass_storage,
             mass_storage_interface: self.mass_storage_interface,
-            is_hid: self.is_hid_keyboard,
+            is_hid: self.is_hid_keyboard || self.is_hid_mouse,
             is_keyboard: self.is_hid_keyboard,
+            is_mouse: self.is_hid_mouse,
             is_hub: self.is_hub,
         }
     }
@@ -1107,6 +1151,13 @@ impl InterfaceInfo {
             && self.interface_protocol == 0x01 // Keyboard
     }
 
+    /// Check if this is a HID mouse interface (boot protocol mouse)
+    pub fn is_hid_mouse(&self) -> bool {
+        self.interface_class == class::HID
+            && self.interface_subclass == 0x01 // Boot interface
+            && self.interface_protocol == 0x02 // Mouse
+    }
+
     /// Find bulk IN endpoint
     pub fn find_bulk_in(&self) -> Option<&EndpointInfo> {
         self.endpoints[..self.num_endpoints]
@@ -1256,6 +1307,10 @@ where
             device.is_hid_keyboard = true;
             device.interrupt_in = iface.find_interrupt_in().cloned();
             log::info!("    HID Keyboard interface");
+        } else if iface.is_hid_mouse() {
+            device.is_hid_mouse = true;
+            device.mouse_interrupt_in = iface.find_interrupt_in().cloned();
+            log::info!("    HID Mouse interface");
         } else if iface.interface_class == class::HUB {
             device.is_hub = true;
             log::info!("    USB Hub interface");

--- a/src/drivers/usb/controller.rs
+++ b/src/drivers/usb/controller.rs
@@ -747,8 +747,7 @@ pub trait UsbController {
 
     /// Get mouse interrupt endpoint info for a device
     fn get_mouse_interrupt_endpoint(&self, device: u8) -> Option<EndpointInfo> {
-        self.get_device(device)
-            .and_then(|d| d.mouse_interrupt_in)
+        self.get_device(device).and_then(|d| d.mouse_interrupt_in)
     }
 
     /// Get device info

--- a/src/drivers/usb/hid_mouse.rs
+++ b/src/drivers/usb/hid_mouse.rs
@@ -95,10 +95,7 @@ impl UsbHidMouse {
     }
 
     /// Set boot protocol mode
-    fn set_boot_protocol<C: UsbController>(
-        &self,
-        controller: &mut C,
-    ) -> Result<(), UsbError> {
+    fn set_boot_protocol<C: UsbController>(&self, controller: &mut C) -> Result<(), UsbError> {
         controller.control_transfer(
             self.device_address,
             req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_INTERFACE,
@@ -111,11 +108,7 @@ impl UsbHidMouse {
     }
 
     /// Set idle rate
-    fn set_idle<C: UsbController>(
-        &self,
-        controller: &mut C,
-        rate_ms: u8,
-    ) -> Result<(), UsbError> {
+    fn set_idle<C: UsbController>(&self, controller: &mut C, rate_ms: u8) -> Result<(), UsbError> {
         let duration = rate_ms / 4;
         controller.control_transfer(
             self.device_address,
@@ -329,11 +322,7 @@ pub fn get_relative_motion() -> (i32, i32) {
 
 /// Get current button state.
 pub fn get_buttons() -> u32 {
-    USB_MOUSE
-        .lock()
-        .as_ref()
-        .map(|m| m.buttons)
-        .unwrap_or(0)
+    USB_MOUSE.lock().as_ref().map(|m| m.buttons).unwrap_or(0)
 }
 
 /// Check if USB mouse is available.

--- a/src/drivers/usb/hid_mouse.rs
+++ b/src/drivers/usb/hid_mouse.rs
@@ -1,0 +1,356 @@
+//! USB HID Mouse Driver
+//!
+//! This module implements USB HID mouse support using the boot protocol.
+//! Boot protocol mice send 3-byte reports: buttons, X delta, Y delta.
+//!
+//! # Polling Strategy
+//!
+//! Many USB mice do NOT implement the HID class GET_REPORT request (they
+//! stall the control pipe).  The only reliable way to read mouse data is
+//! via interrupt IN transfers on the device's interrupt endpoint.
+//!
+//! We use interrupt IN transfers exclusively.  If the xHCI controller does
+//! not have interrupt transfer support configured for the endpoint, we fall
+//! back to GET_REPORT but give up after a few stalls to avoid chewing
+//! through the command ring endlessly.
+//!
+//! # References
+//! - USB HID Specification 1.11, Appendix B.2 (Boot Interface — Mouse)
+//! - libpayload: `payloads/libpayload/drivers/usb/usbhid.c`
+
+use super::controller::{UsbController, UsbError, hid_request, req_type};
+use crate::time::Timeout;
+use spin::Mutex;
+
+// ============================================================================
+// HID Boot Protocol Mouse
+// ============================================================================
+
+/// Boot protocol mouse report (3+ bytes)
+///
+/// The boot protocol defines a fixed 3-byte report:
+/// - Byte 0: Button state (bit 0=left, 1=right, 2=middle)
+/// - Byte 1: X displacement (signed 8-bit)
+/// - Byte 2: Y displacement (signed 8-bit)
+#[repr(C)]
+#[derive(Clone, Copy, Default, Debug)]
+pub struct MouseReport {
+    /// Button state (bit 0=left, 1=right, 2=middle)
+    pub buttons: u8,
+    /// X displacement (signed)
+    pub x: i8,
+    /// Y displacement (signed)
+    pub y: i8,
+}
+
+// ============================================================================
+// USB HID Mouse State
+// ============================================================================
+
+/// USB HID mouse state
+pub struct UsbHidMouse {
+    /// Controller index
+    controller_idx: usize,
+    /// Device address
+    device_address: u8,
+    /// Interrupt endpoint number
+    endpoint: u8,
+    /// Max packet size
+    max_packet: u16,
+    /// Polling interval in ms
+    interval: u8,
+    /// Accumulated X relative motion
+    rel_x: i32,
+    /// Accumulated Y relative motion
+    rel_y: i32,
+    /// Current button state
+    buttons: u32,
+    /// Consecutive GET_REPORT stall count (if using fallback)
+    stall_count: u32,
+    /// Whether GET_REPORT has been disabled due to persistent stalls
+    get_report_disabled: bool,
+}
+
+impl UsbHidMouse {
+    /// Create a new USB HID mouse
+    fn new(
+        controller_idx: usize,
+        device_address: u8,
+        endpoint: u8,
+        max_packet: u16,
+        interval: u8,
+    ) -> Self {
+        Self {
+            controller_idx,
+            device_address,
+            endpoint,
+            max_packet,
+            interval,
+            rel_x: 0,
+            rel_y: 0,
+            buttons: 0,
+            stall_count: 0,
+            get_report_disabled: false,
+        }
+    }
+
+    /// Set boot protocol mode
+    fn set_boot_protocol<C: UsbController>(
+        &self,
+        controller: &mut C,
+    ) -> Result<(), UsbError> {
+        controller.control_transfer(
+            self.device_address,
+            req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_INTERFACE,
+            hid_request::SET_PROTOCOL,
+            0, // Boot protocol
+            0, // Interface 0
+            None,
+        )?;
+        Ok(())
+    }
+
+    /// Set idle rate
+    fn set_idle<C: UsbController>(
+        &self,
+        controller: &mut C,
+        rate_ms: u8,
+    ) -> Result<(), UsbError> {
+        let duration = rate_ms / 4;
+        controller.control_transfer(
+            self.device_address,
+            req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_INTERFACE,
+            hid_request::SET_IDLE,
+            (duration as u16) << 8,
+            0,
+            None,
+        )?;
+        Ok(())
+    }
+
+    /// Process a mouse report
+    fn process_report(&mut self, report: &MouseReport) {
+        self.rel_x += report.x as i32;
+        self.rel_y += report.y as i32;
+        self.buttons = (report.buttons & 0x07) as u32;
+    }
+
+    /// Get device address
+    pub fn device_address(&self) -> u8 {
+        self.device_address
+    }
+
+    /// Get controller index
+    pub fn controller_idx(&self) -> usize {
+        self.controller_idx
+    }
+
+    /// Get interrupt endpoint number
+    pub fn endpoint(&self) -> u8 {
+        self.endpoint
+    }
+}
+
+// ============================================================================
+// Global USB Mouse
+// ============================================================================
+
+/// Global USB mouse instance
+static USB_MOUSE: Mutex<Option<UsbHidMouse>> = Mutex::new(None);
+
+/// Minimum poll interval in milliseconds
+const MIN_POLL_INTERVAL_MS: u64 = 8;
+
+/// Number of consecutive GET_REPORT stalls before giving up.
+const MAX_CONSECUTIVE_STALLS: u32 = 3;
+
+/// Next poll timeout
+static NEXT_POLL_TIMEOUT: Mutex<Option<Timeout>> = Mutex::new(None);
+
+/// Initialize USB mouse from a controller.
+///
+/// Called during USB device enumeration when a HID mouse is detected.
+pub fn init_mouse<C: UsbController>(
+    controller: &mut C,
+    controller_idx: usize,
+) -> Result<(), UsbError> {
+    // Find HID mouse device
+    let device_addr = controller
+        .find_hid_mouse()
+        .ok_or(UsbError::DeviceNotFound)?;
+
+    // Get interrupt endpoint
+    let ep_info = controller
+        .get_mouse_interrupt_endpoint(device_addr)
+        .ok_or(UsbError::DeviceNotFound)?;
+
+    log::info!(
+        "USB HID mouse found: device {}, endpoint {}, max_pkt {}, interval {}ms",
+        device_addr,
+        ep_info.number,
+        ep_info.max_packet_size,
+        ep_info.interval
+    );
+
+    let mouse = UsbHidMouse::new(
+        controller_idx,
+        device_addr,
+        ep_info.number,
+        ep_info.max_packet_size,
+        ep_info.interval,
+    );
+
+    // Set boot protocol
+    if let Err(e) = mouse.set_boot_protocol(controller) {
+        log::warn!("Failed to set mouse boot protocol: {:?}", e);
+    }
+
+    // Set idle rate to 0 (infinite — only report on change)
+    // This is the correct setting for interrupt-driven polling.
+    if let Err(e) = mouse.set_idle(controller, 0) {
+        log::debug!("Failed to set mouse idle rate: {:?}", e);
+    }
+
+    *USB_MOUSE.lock() = Some(mouse);
+
+    log::info!("USB HID mouse initialized");
+    Ok(())
+}
+
+/// Poll USB mouse for new reports.
+///
+/// Tries interrupt IN transfer first (the correct HID approach).
+/// Falls back to GET_REPORT only if interrupt transfers are not available,
+/// and gives up after [`MAX_CONSECUTIVE_STALLS`] to avoid hammering the
+/// xHCI command ring.
+pub fn poll<C: UsbController>(controller: &mut C) {
+    // Rate limit polling
+    {
+        let mut timeout_guard = NEXT_POLL_TIMEOUT.lock();
+        if let Some(ref timeout) = *timeout_guard
+            && !timeout.is_expired()
+        {
+            return;
+        }
+        *timeout_guard = Some(Timeout::from_ms(MIN_POLL_INTERVAL_MS));
+    }
+
+    let mut mouse_guard = USB_MOUSE.lock();
+    let mouse = match mouse_guard.as_mut() {
+        Some(m) => m,
+        None => return,
+    };
+
+    // If GET_REPORT has been permanently disabled due to stalls, and we
+    // don't have interrupt transfer support yet, there's nothing to do.
+    if mouse.get_report_disabled {
+        return;
+    }
+
+    // Try interrupt IN transfer first — this is the proper way to poll a HID mouse.
+    let dev_addr = mouse.device_address();
+    let ep = mouse.endpoint();
+    let mut report_buf = [0u8; 8];
+    let result = controller.interrupt_transfer(dev_addr, ep, &mut report_buf);
+
+    match result {
+        Ok(bytes_read) if bytes_read >= 3 => {
+            mouse.stall_count = 0;
+            let report = MouseReport {
+                buttons: report_buf[0],
+                x: report_buf[1] as i8,
+                y: report_buf[2] as i8,
+            };
+            mouse.process_report(&report);
+            return;
+        }
+        Ok(_) => {
+            // Short read — might be NAK (no data). Not an error.
+            return;
+        }
+        Err(UsbError::NotSupported) => {
+            // Controller doesn't implement interrupt_transfer — fall through
+            // to GET_REPORT below.
+        }
+        Err(_) => {
+            // Transfer error or NAK — not fatal for interrupt endpoints.
+            return;
+        }
+    }
+
+    // ── Fallback: GET_REPORT via control transfer ──
+    let mut ctrl_buf = [0u8; 4];
+    let result = controller.control_transfer(
+        dev_addr,
+        req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_INTERFACE,
+        hid_request::GET_REPORT,
+        0x0100, // Report type = Input (1), Report ID = 0
+        0,      // Interface 0
+        Some(&mut ctrl_buf),
+    );
+
+    match result {
+        Ok(_) => {
+            mouse.stall_count = 0;
+            let report = MouseReport {
+                buttons: ctrl_buf[0],
+                x: ctrl_buf[1] as i8,
+                y: ctrl_buf[2] as i8,
+            };
+            mouse.process_report(&report);
+        }
+        Err(_) => {
+            mouse.stall_count += 1;
+            if mouse.stall_count >= MAX_CONSECUTIVE_STALLS {
+                log::warn!(
+                    "USB mouse: GET_REPORT stalled {} times, disabling \
+                     (device does not support HID class GET_REPORT)",
+                    mouse.stall_count
+                );
+                mouse.get_report_disabled = true;
+            }
+        }
+    }
+}
+
+/// Get accumulated relative motion and reset it.
+pub fn get_relative_motion() -> (i32, i32) {
+    let mut guard = USB_MOUSE.lock();
+    let mouse = match guard.as_mut() {
+        Some(m) => m,
+        None => return (0, 0),
+    };
+    let dx = mouse.rel_x;
+    let dy = mouse.rel_y;
+    mouse.rel_x = 0;
+    mouse.rel_y = 0;
+    (dx, dy)
+}
+
+/// Get current button state.
+pub fn get_buttons() -> u32 {
+    USB_MOUSE
+        .lock()
+        .as_ref()
+        .map(|m| m.buttons)
+        .unwrap_or(0)
+}
+
+/// Check if USB mouse is available.
+pub fn is_available() -> bool {
+    USB_MOUSE.lock().is_some()
+}
+
+/// Check if USB mouse has pending motion.
+pub fn has_motion() -> bool {
+    USB_MOUSE
+        .lock()
+        .as_ref()
+        .map(|m| m.rel_x != 0 || m.rel_y != 0)
+        .unwrap_or(false)
+}
+
+/// Get the controller index that has the mouse.
+pub fn controller_idx() -> Option<usize> {
+    USB_MOUSE.lock().as_ref().map(|m| m.controller_idx())
+}

--- a/src/drivers/usb/mod.rs
+++ b/src/drivers/usb/mod.rs
@@ -568,7 +568,9 @@ impl UsbController for XhciController {
             device_class: slot.device_desc.device_class,
             is_mass_storage: slot.is_mass_storage,
             mass_storage_interface: slot.mass_storage_interface,
-            is_hid: slot.is_hid_keyboard || slot.is_hid_mouse || slot.device_desc.device_class == 0x03,
+            is_hid: slot.is_hid_keyboard
+                || slot.is_hid_mouse
+                || slot.device_desc.device_class == 0x03,
             is_keyboard: slot.is_hid_keyboard,
             is_mouse: slot.is_hid_mouse,
             is_hub: slot.device_desc.device_class == 0x09,

--- a/src/drivers/usb/mod.rs
+++ b/src/drivers/usb/mod.rs
@@ -21,6 +21,8 @@ pub mod controller;
 pub mod ehci;
 pub mod ehci_regs;
 pub mod hid_keyboard;
+#[cfg(feature = "ui")]
+pub mod hid_mouse;
 pub mod mass_storage;
 pub mod ohci;
 pub mod ohci_regs;
@@ -280,6 +282,37 @@ fn init_keyboards() {
     }
 }
 
+/// Initialize USB mice from all controllers
+#[cfg(feature = "ui")]
+pub fn init_mice() {
+    let controllers = ALL_CONTROLLERS.lock();
+
+    for (idx, handle) in controllers.iter().enumerate() {
+        with_usb_controller!(handle, mut |controller| {
+            if let Err(e) = hid_mouse::init_mouse(controller, idx) {
+                log::debug!(
+                    "No HID mouse on {} controller {}: {:?}",
+                    controller.controller_type(),
+                    idx,
+                    e
+                );
+            }
+        });
+    }
+}
+
+/// Poll USB mouse on a specific controller
+#[cfg(feature = "ui")]
+pub fn poll_mice_on_controller(controller_idx: usize) {
+    let controllers = ALL_CONTROLLERS.lock();
+
+    if let Some(handle) = controllers.get(controller_idx) {
+        with_usb_controller!(handle, mut |controller| {
+            hid_mouse::poll(controller);
+        });
+    }
+}
+
 /// Clean up all USB controllers before ExitBootServices
 ///
 /// This must be called before handing off to the OS to ensure Linux's
@@ -454,6 +487,21 @@ impl UsbController for XhciController {
         })
     }
 
+    fn interrupt_transfer(
+        &mut self,
+        device: u8,
+        endpoint: u8,
+        data: &mut [u8],
+    ) -> Result<usize, self::controller::UsbError> {
+        let result = xhci::do_interrupt_transfer(self, device, endpoint, data);
+        result.map_err(|e| match e {
+            XhciError::Timeout => self::controller::UsbError::Nak,
+            XhciError::StallError => self::controller::UsbError::Stall,
+            XhciError::DeviceNotFound => self::controller::UsbError::DeviceNotFound,
+            _ => self::controller::UsbError::TransactionError,
+        })
+    }
+
     fn create_interrupt_queue(
         &mut self,
         _device: u8,
@@ -485,6 +533,30 @@ impl UsbController for XhciController {
         })
     }
 
+    fn find_hid_mouse(&self) -> Option<u8> {
+        (0..xhci::MAX_SLOTS as u8).find(|&slot_id| {
+            self.get_slot(slot_id)
+                .map(|slot| slot.is_hid_mouse)
+                .unwrap_or(false)
+        })
+    }
+
+    fn get_mouse_interrupt_endpoint(&self, device: u8) -> Option<self::controller::EndpointInfo> {
+        let slot = self.get_slot(device)?;
+        if !slot.is_hid_mouse || slot.mouse_interrupt_in_ep == 0 {
+            return None;
+        }
+
+        Some(self::controller::EndpointInfo {
+            number: slot.mouse_interrupt_in_ep,
+            direction: self::controller::Direction::In,
+            transfer_type: self::controller::EndpointType::Interrupt,
+            max_packet_size: slot.mouse_interrupt_max_packet,
+            interval: slot.mouse_interrupt_interval,
+            toggle: false,
+        })
+    }
+
     fn get_device_info(&self, device: u8) -> Option<self::controller::DeviceInfo> {
         let slot = self.get_slot(device)?;
         Some(self::controller::DeviceInfo {
@@ -496,8 +568,9 @@ impl UsbController for XhciController {
             device_class: slot.device_desc.device_class,
             is_mass_storage: slot.is_mass_storage,
             mass_storage_interface: slot.mass_storage_interface,
-            is_hid: slot.is_hid_keyboard || slot.device_desc.device_class == 0x03,
+            is_hid: slot.is_hid_keyboard || slot.is_hid_mouse || slot.device_desc.device_class == 0x03,
             is_keyboard: slot.is_hid_keyboard,
+            is_mouse: slot.is_hid_mouse,
             is_hub: slot.device_desc.device_class == 0x09,
         })
     }

--- a/src/drivers/usb/xhci.rs
+++ b/src/drivers/usb/xhci.rs
@@ -12,7 +12,8 @@ use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use zerocopy::FromBytes;
 
 use super::controller::{
-    ConfigurationInfo, DeviceDescriptor, desc_type, parse_configuration, req_type, request,
+    ConfigurationInfo, DeviceDescriptor, HUB_DESCRIPTOR_TYPE, desc_type, hub_feature,
+    hub_port_status, parse_configuration, req_type, request,
 };
 
 // Import typed register structs and bitfield modules
@@ -27,6 +28,7 @@ use super::xhci_regs::{
     PORTSC_CHANGE_MASK, PORTSC_RW_MASK, TRB_CC_BABBLE_DETECTED, TRB_CC_SHORT_PACKET,
     TRB_CC_STALL_ERROR, TRB_CC_SUCCESS, TRB_CC_USB_TRANSACTION_ERROR, TRB_TYPE_ADDRESS_DEVICE,
     TRB_TYPE_COMMAND_COMPLETION, TRB_TYPE_CONFIGURE_ENDPOINT, TRB_TYPE_DATA, TRB_TYPE_ENABLE_SLOT,
+    TRB_TYPE_EVALUATE_CONTEXT,
     TRB_TYPE_HOST_CONTROLLER, TRB_TYPE_LINK, TRB_TYPE_NORMAL, TRB_TYPE_PORT_STATUS_CHANGE,
     TRB_TYPE_RESET_ENDPOINT, TRB_TYPE_SET_TR_DEQUEUE, TRB_TYPE_SETUP, TRB_TYPE_STATUS,
     TRB_TYPE_TRANSFER_EVENT, trb_cc_name,
@@ -92,6 +94,30 @@ impl SlotContext {
 
     fn set_root_hub_port(&mut self, port: u8) {
         self.dw1 = (self.dw1 & !0x00FF0000) | ((port as u32) << 16);
+    }
+
+    fn set_route_string(&mut self, route: u32) {
+        self.dw0 = (self.dw0 & !0x000FFFFF) | (route & 0x000FFFFF);
+    }
+
+    fn set_hub(&mut self, is_hub: bool) {
+        if is_hub {
+            self.dw0 |= 1 << 26;
+        } else {
+            self.dw0 &= !(1 << 26);
+        }
+    }
+
+    fn set_num_ports(&mut self, n: u8) {
+        self.dw1 = (self.dw1 & !0xFF000000) | ((n as u32) << 24);
+    }
+
+    fn set_parent_hub_slot(&mut self, slot: u8) {
+        self.dw2 = (self.dw2 & !0x000000FF) | (slot as u32);
+    }
+
+    fn set_parent_port_num(&mut self, port: u8) {
+        self.dw2 = (self.dw2 & !0x0000FF00) | ((port as u32) << 8);
     }
 }
 
@@ -355,12 +381,28 @@ pub struct UsbSlot {
     pub bulk_max_packet: u16,
     /// Is this a HID keyboard device?
     pub is_hid_keyboard: bool,
-    /// Interrupt IN endpoint for HID
+    /// Is this a HID mouse device?
+    pub is_hid_mouse: bool,
+    /// Interrupt IN endpoint for HID keyboard
     pub interrupt_in_ep: u8,
+    /// Mouse interrupt IN endpoint
+    pub mouse_interrupt_in_ep: u8,
+    /// Max packet size for mouse interrupt endpoint
+    pub mouse_interrupt_max_packet: u16,
+    /// Polling interval for mouse interrupt endpoint (in ms)
+    pub mouse_interrupt_interval: u8,
     /// Max packet size for interrupt endpoint
     pub interrupt_max_packet: u16,
     /// Polling interval for interrupt endpoint (in ms)
     pub interrupt_interval: u8,
+    /// Is this a hub?
+    pub is_hub: bool,
+    /// Number of downstream ports (if hub)
+    pub hub_ports: u8,
+    /// Route string for this device (xHCI hub topology)
+    pub route_string: u32,
+    /// Root hub port this device chain starts from
+    pub root_port: u8,
 }
 
 /// xHCI MMIO region size (64KB should cover all controllers)
@@ -1290,9 +1332,17 @@ impl XhciController {
             bulk_out_ep: 0,
             bulk_max_packet: 0,
             is_hid_keyboard: false,
+            is_hid_mouse: false,
             interrupt_in_ep: 0,
+            mouse_interrupt_in_ep: 0,
+            mouse_interrupt_max_packet: 0,
+            mouse_interrupt_interval: 0,
             interrupt_max_packet: 0,
             interrupt_interval: 0,
+            is_hub: false,
+            hub_ports: 0,
+            route_string: 0,
+            root_port: port,
         });
 
         Ok(())
@@ -1448,6 +1498,406 @@ impl XhciController {
             0,
             None,
         )?;
+        Ok(())
+    }
+
+    /// Configure a hub device and enumerate its downstream ports.
+    ///
+    /// This mirrors the EHCI `enumerate_hub()` logic adapted for xHCI's
+    /// route-string-based addressing model.
+    fn configure_and_enumerate_hub(
+        &mut self,
+        hub_slot_id: u8,
+        root_port: u8,
+    ) -> Result<(), XhciError> {
+        // Get config descriptor to find hub interface and SET_CONFIGURATION
+        let config_info = self.get_config_descriptor(hub_slot_id)?;
+
+        // Verify this is actually a hub
+        let has_hub_iface = config_info.interfaces[..config_info.num_interfaces]
+            .iter()
+            .any(|i| i.interface_class == 0x09);
+        let is_hub_class = self
+            .slots
+            .get(hub_slot_id as usize)
+            .and_then(|s| s.as_ref())
+            .map(|s| s.device_desc.device_class == 0x09)
+            .unwrap_or(false);
+
+        if !is_hub_class && !has_hub_iface {
+            return Err(XhciError::DeviceNotFound);
+        }
+
+        // Set configuration (activates hub endpoints)
+        if config_info.configuration_value > 0 {
+            self.set_configuration(hub_slot_id, config_info.configuration_value)?;
+        }
+
+        // Get hub descriptor
+        let mut hub_desc_buf = [0u8; 12];
+        self.control_transfer(
+            hub_slot_id,
+            req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_DEVICE,
+            request::GET_DESCRIPTOR,
+            (HUB_DESCRIPTOR_TYPE as u16) << 8,
+            0,
+            Some(&mut hub_desc_buf),
+        )?;
+
+        let num_ports = hub_desc_buf[2];
+        let power_delay = (hub_desc_buf[5] as u64) * 2; // PwrOn2PwrGood in 2ms units
+
+        if num_ports == 0 || num_ports > 15 {
+            log::debug!("Hub has {} ports, skipping", num_ports);
+            return Ok(());
+        }
+
+        log::info!(
+            "xHCI: Hub slot {} has {} ports, power delay {}ms",
+            hub_slot_id,
+            num_ports,
+            power_delay
+        );
+
+        // Mark slot as hub and store route info
+        if let Some(slot) = self
+            .slots
+            .get_mut(hub_slot_id as usize)
+            .and_then(|s| s.as_mut())
+        {
+            slot.is_hub = true;
+            slot.hub_ports = num_ports;
+        }
+
+        // Update the hub's slot context via Evaluate Context so xHC knows
+        // this device is a hub (required for proper downstream routing).
+        self.evaluate_hub_context(hub_slot_id, num_ports)?;
+
+        // Power on all hub ports
+        for p in 1..=num_ports {
+            let _ = self.control_transfer(
+                hub_slot_id,
+                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                request::SET_FEATURE,
+                hub_feature::PORT_POWER,
+                p as u16,
+                None,
+            );
+        }
+
+        crate::time::delay_ms(power_delay.max(100));
+
+        // Check each port for connected devices
+        for p in 1..=num_ports {
+            let mut status_buf = [0u8; 4];
+            if self
+                .control_transfer(
+                    hub_slot_id,
+                    req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                    request::GET_STATUS,
+                    0,
+                    p as u16,
+                    Some(&mut status_buf),
+                )
+                .is_err()
+            {
+                continue;
+            }
+
+            let port_status = u16::from_le_bytes([status_buf[0], status_buf[1]]);
+            if (port_status & hub_port_status::CONNECTION) == 0 {
+                continue;
+            }
+
+            log::info!("xHCI: Device on hub slot {} port {}", hub_slot_id, p);
+
+            // Clear connection change
+            let _ = self.control_transfer(
+                hub_slot_id,
+                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                request::CLEAR_FEATURE,
+                hub_feature::C_PORT_CONNECTION,
+                p as u16,
+                None,
+            );
+
+            // Reset the port
+            let _ = self.control_transfer(
+                hub_slot_id,
+                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                request::SET_FEATURE,
+                hub_feature::PORT_RESET,
+                p as u16,
+                None,
+            );
+
+            crate::time::delay_ms(60);
+
+            // Poll for reset completion
+            let timeout = crate::time::Timeout::from_ms(500);
+            let mut speed = 0u8;
+            let mut reset_ok = false;
+            while !timeout.is_expired() {
+                let mut sb = [0u8; 4];
+                if self
+                    .control_transfer(
+                        hub_slot_id,
+                        req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                        request::GET_STATUS,
+                        0,
+                        p as u16,
+                        Some(&mut sb),
+                    )
+                    .is_err()
+                {
+                    break;
+                }
+                let ps = u16::from_le_bytes([sb[0], sb[1]]);
+                let pc = u16::from_le_bytes([sb[2], sb[3]]);
+
+                if pc & 0x10 != 0 {
+                    // C_PORT_RESET
+                    let _ = self.control_transfer(
+                        hub_slot_id,
+                        req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                        request::CLEAR_FEATURE,
+                        hub_feature::C_PORT_RESET,
+                        p as u16,
+                        None,
+                    );
+                    if ps & hub_port_status::ENABLE != 0 {
+                        speed = if ps & hub_port_status::HIGH_SPEED != 0 {
+                            3
+                        } else if ps & hub_port_status::LOW_SPEED != 0 {
+                            2
+                        } else {
+                            1
+                        };
+                        reset_ok = true;
+                    }
+                    break;
+                }
+                crate::time::delay_ms(10);
+            }
+
+            if !reset_ok {
+                log::debug!("Hub port {} reset failed", p);
+                continue;
+            }
+
+            crate::time::delay_ms(10);
+
+            // Build route string: parent's route | (port << (4 * tier))
+            let parent_route = self
+                .slots
+                .get(hub_slot_id as usize)
+                .and_then(|s| s.as_ref())
+                .map(|s| s.route_string)
+                .unwrap_or(0);
+            // Find which nibble is the first zero (that's our tier)
+            let mut route = parent_route;
+            for tier in 0..5u32 {
+                if (route >> (tier * 4)) & 0xF == 0 {
+                    route |= (p as u32 & 0xF) << (tier * 4);
+                    break;
+                }
+            }
+
+            // Enable slot and address the downstream device
+            if let Err(e) = self.attach_device_on_hub(
+                hub_slot_id,
+                p,
+                speed,
+                route,
+                root_port,
+            ) {
+                log::warn!("Failed to attach device on hub port {}: {:?}", p, e);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Issue an Evaluate Context command to inform the xHC that a device
+    /// is a hub (sets Hub flag and NumberOfPorts in the slot context).
+    fn evaluate_hub_context(
+        &mut self,
+        slot_id: u8,
+        num_ports: u8,
+    ) -> Result<(), XhciError> {
+        let slot = self
+            .slots
+            .get(slot_id as usize)
+            .and_then(|s| s.as_ref())
+            .ok_or(XhciError::DeviceNotFound)?;
+
+        let input_ctx = unsafe { &mut *slot.input_context };
+        input_ctx.control.add_flags = 0x1; // Evaluate slot context only
+        input_ctx.control.drop_flags = 0;
+        input_ctx.slot.set_hub(true);
+        input_ctx.slot.set_num_ports(num_ports);
+        // Context entries must cover at least slot + EP0
+        input_ctx.slot.set_context_entries(1);
+
+        let mut trb = Trb::default();
+        trb.param = slot.input_context as u64;
+        trb.set_type(TRB_TYPE_EVALUATE_CONTEXT);
+        trb.control |= (slot_id as u32) << 24;
+
+        self.cmd_ring.enqueue(&trb, false);
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+        self.ring_doorbell(0, 0);
+
+        self.wait_command_completion()?;
+        Ok(())
+    }
+
+    /// Attach a device that is behind a USB hub.
+    fn attach_device_on_hub(
+        &mut self,
+        hub_slot_id: u8,
+        hub_port: u8,
+        speed: u8,
+        route_string: u32,
+        root_port: u8,
+    ) -> Result<(), XhciError> {
+        let slot_id = self.enable_slot()?;
+
+        // Allocate device context
+        let device_context_mem = efi::allocate_pages(1).ok_or(XhciError::AllocationFailed)?;
+        device_context_mem.fill(0);
+        let device_context = device_context_mem.as_ptr() as u64;
+
+        // Allocate input context
+        let input_context_mem = efi::allocate_pages(1).ok_or(XhciError::AllocationFailed)?;
+        input_context_mem.fill(0);
+        let input_context = input_context_mem.as_ptr() as u64;
+
+        // Allocate transfer ring for control endpoint
+        let transfer_ring_mem = efi::allocate_pages(1).ok_or(XhciError::AllocationFailed)?;
+        let transfer_ring = transfer_ring_mem.as_ptr() as u64;
+
+        let input = unsafe { &mut *(input_context_mem.as_mut_ptr() as *mut InputContext) };
+        input.control.add_flags = 0x3; // Add slot + EP0
+
+        // Slot context with hub topology info
+        input.slot.set_context_entries(1);
+        input.slot.set_speed(speed);
+        input.slot.set_root_hub_port(root_port + 1);
+        input.slot.set_route_string(route_string);
+        input.slot.set_parent_hub_slot(hub_slot_id);
+        input.slot.set_parent_port_num(hub_port);
+
+        // Control endpoint
+        let max_packet = match speed {
+            1 => 8,
+            2 => 8,
+            3 => 64,
+            4 => 512,
+            _ => 8,
+        };
+
+        input.endpoints[0].set_ep_type(4);
+        input.endpoints[0].set_max_packet_size(max_packet);
+        input.endpoints[0].set_max_burst_size(0);
+        input.endpoints[0].set_cerr(3);
+        input.endpoints[0].set_tr_dequeue_ptr(transfer_ring, true);
+        input.endpoints[0].set_avg_trb_length(8);
+
+        let ring = TrbRing::new(transfer_ring, 256);
+
+        // DCBAA
+        let dcbaa_entry = unsafe { &mut *((self.dcbaa + (slot_id as u64 * 8)) as *mut u64) };
+        *dcbaa_entry = device_context;
+
+        // Address Device command
+        let mut trb = Trb::default();
+        trb.param = input_context;
+        trb.set_type(TRB_TYPE_ADDRESS_DEVICE);
+        trb.control |= (slot_id as u32) << 24;
+
+        self.cmd_ring.enqueue(&trb, false);
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+        self.ring_doorbell(0, 0);
+        self.wait_command_completion()?;
+        crate::time::delay_ms(2);
+
+        // Store slot info
+        let mut transfer_rings: [Option<TrbRing>; 31] = core::array::from_fn(|_| None);
+        transfer_rings[0] = Some(ring);
+
+        let slot_entry = self
+            .slots
+            .get_mut(slot_id as usize)
+            .ok_or(XhciError::NoFreeSlots)?;
+        *slot_entry = Some(UsbSlot {
+            slot_id,
+            device_context: device_context as *mut DeviceContext,
+            input_context: input_context as *mut InputContext,
+            transfer_rings,
+            device_desc: DeviceDescriptor::default(),
+            port: hub_port,
+            speed,
+            is_mass_storage: false,
+            mass_storage_interface: 0,
+            bulk_in_ep: 0,
+            bulk_out_ep: 0,
+            bulk_max_packet: 0,
+            is_hid_keyboard: false,
+            is_hid_mouse: false,
+            interrupt_in_ep: 0,
+            mouse_interrupt_in_ep: 0,
+            mouse_interrupt_max_packet: 0,
+            mouse_interrupt_interval: 0,
+            interrupt_max_packet: 0,
+            interrupt_interval: 0,
+            is_hub: false,
+            hub_ports: 0,
+            route_string,
+            root_port,
+        });
+
+        // Now enumerate the device (get descriptor, configure, etc.)
+        match self.get_device_descriptor(slot_id) {
+            Ok(desc) => {
+                let vid = desc.vendor_id;
+                let pid = desc.product_id;
+                let class = desc.device_class;
+                let num_configs = desc.num_configurations;
+                log::info!(
+                    "  Hub port device: VID={:04x} PID={:04x} Class={:02x}",
+                    vid, pid, class
+                );
+
+                if let Some(slot) = self
+                    .slots
+                    .get_mut(slot_id as usize)
+                    .and_then(|s| s.as_mut())
+                {
+                    slot.device_desc = desc;
+                }
+
+                // Configure as storage / keyboard / mouse
+                if class == 0x08 || (class == 0x00 && num_configs > 0) {
+                    let _ = self.configure_mass_storage(slot_id);
+                }
+                if class == 0x03 || (class == 0x00 && num_configs > 0) {
+                    let _ = self.configure_hid_keyboard(slot_id);
+                    let _ = self.configure_hid_mouse(slot_id);
+                }
+
+                // Nested hub support (one level deep to keep it simple)
+                if class == 0x09 {
+                    if let Err(e) = self.configure_and_enumerate_hub(slot_id, root_port) {
+                        log::debug!("Nested hub enum failed: {:?}", e);
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!("Failed to get descriptor for hub device: {:?}", e);
+            }
+        }
+
         Ok(())
     }
 
@@ -1668,6 +2118,20 @@ impl XhciController {
                             {
                                 log::debug!("Not a HID keyboard: {:?}", e);
                             }
+
+                            // Try to configure as HID mouse (class 0x03 or class 0x00)
+                            if (class == 0x03 || (class == 0x00 && num_configs > 0))
+                                && let Err(e) = self.configure_hid_mouse(slot_id)
+                            {
+                                log::debug!("Not a HID mouse: {:?}", e);
+                            }
+
+                            // If it's a hub, enumerate its downstream ports
+                            if class == 0x09 || (class == 0x00 && num_configs > 0) {
+                                if let Err(e) = self.configure_and_enumerate_hub(slot_id, port) {
+                                    log::debug!("Not a hub or hub enum failed: {:?}", e);
+                                }
+                            }
                         }
                         Err(e) => {
                             log::error!("Failed to get device descriptor: {:?}", e);
@@ -1840,6 +2304,184 @@ impl XhciController {
 
         log::info!("USB HID Keyboard configured on slot {}", slot_id);
         Ok(())
+    }
+
+    /// Configure a HID mouse device.
+    ///
+    /// Unlike the keyboard (which may get away with GET_REPORT on some
+    /// hardware), USB mice almost universally require interrupt IN transfers.
+    /// We configure the interrupt endpoint with a transfer ring here so that
+    /// `interrupt_transfer()` can queue Normal TRBs on it later.
+    fn configure_hid_mouse(&mut self, slot_id: u8) -> Result<(), XhciError> {
+        let config_info = self.get_config_descriptor(slot_id)?;
+
+        let mut interrupt_in = 0u8;
+        let mut interrupt_max_packet = 0u16;
+        let mut interrupt_interval = 0u8;
+        let mut found = false;
+
+        for iface in &config_info.interfaces[..config_info.num_interfaces] {
+            if iface.is_hid_mouse() {
+                log::info!(
+                    "  Found USB HID Mouse interface {}",
+                    iface.interface_number
+                );
+
+                if let Some(ep) = iface.find_interrupt_in() {
+                    interrupt_in = ep.number;
+                    interrupt_max_packet = ep.max_packet_size;
+                    interrupt_interval = ep.interval;
+                }
+                found = true;
+                break;
+            }
+        }
+
+        if !found || interrupt_in == 0 {
+            return Err(XhciError::DeviceNotFound);
+        }
+
+        // Set configuration (only if not already set by keyboard config)
+        let already_configured = self
+            .slots
+            .get(slot_id as usize)
+            .and_then(|s| s.as_ref())
+            .map(|s| s.is_hid_keyboard || s.is_mass_storage)
+            .unwrap_or(false);
+
+        if !already_configured {
+            self.set_configuration(slot_id, config_info.configuration_value)?;
+        }
+
+        // ── Configure the interrupt IN endpoint on the xHC ──
+        //
+        // Allocate a transfer ring and tell the controller about the endpoint
+        // via Configure Endpoint.  This is required for interrupt IN transfers
+        // (many mice stall GET_REPORT so we must use the interrupt pipe).
+        let in_dci = (interrupt_in as usize * 2) + 1; // Interrupt IN → odd DCI
+
+        let ring_mem = efi::allocate_pages(1).ok_or(XhciError::AllocationFailed)?;
+        let ring_addr = ring_mem.as_ptr() as u64;
+        let ring = TrbRing::new(ring_addr, 256);
+
+        {
+            let slot = self
+                .slots
+                .get_mut(slot_id as usize)
+                .and_then(|s| s.as_mut())
+                .ok_or(XhciError::DeviceNotFound)?;
+
+            slot.is_hid_mouse = true;
+            slot.mouse_interrupt_in_ep = interrupt_in;
+            slot.mouse_interrupt_max_packet = interrupt_max_packet;
+            slot.mouse_interrupt_interval = interrupt_interval;
+            slot.transfer_rings[in_dci - 1] = Some(ring);
+
+            // Set up input context for Configure Endpoint
+            let input = unsafe { &mut *slot.input_context };
+            let device = unsafe { &*slot.device_context };
+            input.slot = device.slot;
+            input.slot.set_context_entries(in_dci as u8);
+            input.control.add_flags = 1 | (1 << in_dci); // Slot + this endpoint
+
+            // Interrupt IN endpoint context (EP Type 7)
+            // Convert bInterval to xHCI interval exponent:
+            //   For LS/FS: period = 2^(Interval) * 125µs, bInterval is in ms
+            //   Use Interval such that 2^Interval ≈ bInterval * 8
+            //   For HS: bInterval already is exponent+1
+            let speed = slot.speed;
+            let xhci_interval = if speed >= 3 {
+                // High/Super speed: bInterval is already exponent form
+                interrupt_interval.max(1)
+            } else {
+                // Low/Full speed: bInterval in ms, convert to 125µs exponent
+                // 2^N * 125µs ≈ bInterval * 1000µs → N ≈ log2(bInterval*8)
+                let frames = (interrupt_interval as u32).max(1) * 8;
+                let mut n = 0u8;
+                let mut v = 1u32;
+                while v < frames && n < 15 {
+                    n += 1;
+                    v <<= 1;
+                }
+                n.max(3) // At least 1ms (2^3 * 125µs)
+            };
+
+            input.endpoints[in_dci - 1].set_ep_type(7); // Interrupt IN
+            input.endpoints[in_dci - 1].set_max_packet_size(interrupt_max_packet);
+            input.endpoints[in_dci - 1].set_max_burst_size(0);
+            input.endpoints[in_dci - 1].set_cerr(3);
+            input.endpoints[in_dci - 1].set_tr_dequeue_ptr(ring_addr, true);
+            input.endpoints[in_dci - 1].set_avg_trb_length(interrupt_max_packet);
+            // Interval field in dw0 bits 23:16
+            input.endpoints[in_dci - 1].dw0 =
+                (input.endpoints[in_dci - 1].dw0 & !0x00FF0000)
+                | ((xhci_interval as u32) << 16);
+        }
+
+        // Issue Configure Endpoint command
+        let input_ctx_ptr = self
+            .slots
+            .get(slot_id as usize)
+            .and_then(|s| s.as_ref())
+            .ok_or(XhciError::DeviceNotFound)?
+            .input_context as u64;
+
+        let mut trb = Trb::default();
+        trb.param = input_ctx_ptr;
+        trb.set_type(TRB_TYPE_CONFIGURE_ENDPOINT);
+        trb.control |= (slot_id as u32) << 24;
+
+        self.cmd_ring.enqueue(&trb, false);
+        fence(Ordering::SeqCst);
+        self.ring_doorbell(0, 0);
+        self.wait_command_completion()?;
+
+        log::info!(
+            "USB HID Mouse configured on slot {}, interrupt EP {} (DCI {})",
+            slot_id, interrupt_in, in_dci
+        );
+        Ok(())
+    }
+
+    /// Perform a single synchronous interrupt IN transfer.
+    ///
+    /// Queues one Normal TRB on the interrupt endpoint's transfer ring,
+    /// rings the doorbell, and waits for the completion event.  Reuses the
+    /// existing `wait_transfer_completion` path.
+    fn interrupt_transfer_impl(
+        &mut self,
+        slot_id: u8,
+        endpoint: u8,
+        data: &mut [u8],
+    ) -> Result<usize, XhciError> {
+        let in_dci = (endpoint as usize * 2) + 1;
+
+        let slot = self
+            .slots
+            .get_mut(slot_id as usize)
+            .and_then(|s| s.as_mut())
+            .ok_or(XhciError::DeviceNotFound)?;
+
+        let ring = slot.transfer_rings[in_dci - 1]
+            .as_mut()
+            .ok_or(XhciError::DeviceNotFound)?;
+
+        // Queue a Normal TRB for the interrupt IN transfer
+        let mut trb = Trb::default();
+        trb.param = data.as_ptr() as u64;
+        trb.status = (data.len() as u32) & 0x1FFFF; // Transfer Length
+        trb.set_type(TRB_TYPE_NORMAL);
+        trb.control |= 1 << 5; // IOC (Interrupt On Completion)
+        trb.control |= 1 << 2; // ISP (Interrupt on Short Packet)
+
+        ring.enqueue(&trb, false);
+        fence(Ordering::SeqCst);
+        self.ring_doorbell(slot_id, in_dci as u8);
+
+        // Reuse the existing transfer completion path (expects 1 TRB event).
+        let residual = self.wait_transfer_completion(slot_id, endpoint, 1)?;
+        let transferred = data.len().saturating_sub(residual as usize);
+        Ok(transferred)
     }
 
     /// Configure bulk endpoints
@@ -2169,4 +2811,14 @@ pub fn do_bulk_transfer(
     data: &mut [u8],
 ) -> Result<usize, XhciError> {
     controller.bulk_transfer(slot_id, endpoint, is_in, data)
+}
+
+/// Perform an interrupt IN transfer on an xHCI controller
+pub fn do_interrupt_transfer(
+    controller: &mut XhciController,
+    slot_id: u8,
+    endpoint: u8,
+    data: &mut [u8],
+) -> Result<usize, XhciError> {
+    controller.interrupt_transfer_impl(slot_id, endpoint, data)
 }

--- a/src/drivers/usb/xhci.rs
+++ b/src/drivers/usb/xhci.rs
@@ -28,10 +28,9 @@ use super::xhci_regs::{
     PORTSC_CHANGE_MASK, PORTSC_RW_MASK, TRB_CC_BABBLE_DETECTED, TRB_CC_SHORT_PACKET,
     TRB_CC_STALL_ERROR, TRB_CC_SUCCESS, TRB_CC_USB_TRANSACTION_ERROR, TRB_TYPE_ADDRESS_DEVICE,
     TRB_TYPE_COMMAND_COMPLETION, TRB_TYPE_CONFIGURE_ENDPOINT, TRB_TYPE_DATA, TRB_TYPE_ENABLE_SLOT,
-    TRB_TYPE_EVALUATE_CONTEXT,
-    TRB_TYPE_HOST_CONTROLLER, TRB_TYPE_LINK, TRB_TYPE_NORMAL, TRB_TYPE_PORT_STATUS_CHANGE,
-    TRB_TYPE_RESET_ENDPOINT, TRB_TYPE_SET_TR_DEQUEUE, TRB_TYPE_SETUP, TRB_TYPE_STATUS,
-    TRB_TYPE_TRANSFER_EVENT, trb_cc_name,
+    TRB_TYPE_EVALUATE_CONTEXT, TRB_TYPE_HOST_CONTROLLER, TRB_TYPE_LINK, TRB_TYPE_NORMAL,
+    TRB_TYPE_PORT_STATUS_CHANGE, TRB_TYPE_RESET_ENDPOINT, TRB_TYPE_SET_TR_DEQUEUE, TRB_TYPE_SETUP,
+    TRB_TYPE_STATUS, TRB_TYPE_TRANSFER_EVENT, trb_cc_name,
 };
 
 // NOTE: USB descriptor types (DeviceDescriptor, ConfigurationDescriptor, etc.)
@@ -1704,13 +1703,7 @@ impl XhciController {
             }
 
             // Enable slot and address the downstream device
-            if let Err(e) = self.attach_device_on_hub(
-                hub_slot_id,
-                p,
-                speed,
-                route,
-                root_port,
-            ) {
+            if let Err(e) = self.attach_device_on_hub(hub_slot_id, p, speed, route, root_port) {
                 log::warn!("Failed to attach device on hub port {}: {:?}", p, e);
             }
         }
@@ -1720,11 +1713,7 @@ impl XhciController {
 
     /// Issue an Evaluate Context command to inform the xHC that a device
     /// is a hub (sets Hub flag and NumberOfPorts in the slot context).
-    fn evaluate_hub_context(
-        &mut self,
-        slot_id: u8,
-        num_ports: u8,
-    ) -> Result<(), XhciError> {
+    fn evaluate_hub_context(&mut self, slot_id: u8, num_ports: u8) -> Result<(), XhciError> {
         let slot = self
             .slots
             .get(slot_id as usize)
@@ -1866,7 +1855,9 @@ impl XhciController {
                 let num_configs = desc.num_configurations;
                 log::info!(
                     "  Hub port device: VID={:04x} PID={:04x} Class={:02x}",
-                    vid, pid, class
+                    vid,
+                    pid,
+                    class
                 );
 
                 if let Some(slot) = self
@@ -1887,10 +1878,10 @@ impl XhciController {
                 }
 
                 // Nested hub support (one level deep to keep it simple)
-                if class == 0x09 {
-                    if let Err(e) = self.configure_and_enumerate_hub(slot_id, root_port) {
-                        log::debug!("Nested hub enum failed: {:?}", e);
-                    }
+                if class == 0x09
+                    && let Err(e) = self.configure_and_enumerate_hub(slot_id, root_port)
+                {
+                    log::debug!("Nested hub enum failed: {:?}", e);
                 }
             }
             Err(e) => {
@@ -2127,10 +2118,10 @@ impl XhciController {
                             }
 
                             // If it's a hub, enumerate its downstream ports
-                            if class == 0x09 || (class == 0x00 && num_configs > 0) {
-                                if let Err(e) = self.configure_and_enumerate_hub(slot_id, port) {
-                                    log::debug!("Not a hub or hub enum failed: {:?}", e);
-                                }
+                            if (class == 0x09 || (class == 0x00 && num_configs > 0))
+                                && let Err(e) = self.configure_and_enumerate_hub(slot_id, port)
+                            {
+                                log::debug!("Not a hub or hub enum failed: {:?}", e);
                             }
                         }
                         Err(e) => {
@@ -2322,10 +2313,7 @@ impl XhciController {
 
         for iface in &config_info.interfaces[..config_info.num_interfaces] {
             if iface.is_hid_mouse() {
-                log::info!(
-                    "  Found USB HID Mouse interface {}",
-                    iface.interface_number
-                );
+                log::info!("  Found USB HID Mouse interface {}", iface.interface_number);
 
                 if let Some(ep) = iface.find_interrupt_in() {
                     interrupt_in = ep.number;
@@ -2414,8 +2402,7 @@ impl XhciController {
             input.endpoints[in_dci - 1].set_avg_trb_length(interrupt_max_packet);
             // Interval field in dw0 bits 23:16
             input.endpoints[in_dci - 1].dw0 =
-                (input.endpoints[in_dci - 1].dw0 & !0x00FF0000)
-                | ((xhci_interval as u32) << 16);
+                (input.endpoints[in_dci - 1].dw0 & !0x00FF0000) | ((xhci_interval as u32) << 16);
         }
 
         // Issue Configure Endpoint command
@@ -2438,7 +2425,9 @@ impl XhciController {
 
         log::info!(
             "USB HID Mouse configured on slot {}, interrupt EP {} (DCI {})",
-            slot_id, interrupt_in, in_dci
+            slot_id,
+            interrupt_in,
+            in_dci
         );
         Ok(())
     }

--- a/src/efi/protocols/mod.rs
+++ b/src/efi/protocols/mod.rs
@@ -18,6 +18,8 @@ pub mod rng;
 pub mod scsi_pass_thru;
 pub mod serial_io;
 pub mod simple_file_system;
+#[cfg(feature = "ui")]
+pub mod simple_pointer;
 pub mod simple_text_input_ex;
 pub mod storage_security;
 pub mod unicode_collation;

--- a/src/efi/protocols/simple_pointer.rs
+++ b/src/efi/protocols/simple_pointer.rs
@@ -1,0 +1,197 @@
+//! UEFI Simple Pointer Protocol
+//!
+//! Implements EFI_SIMPLE_POINTER_PROTOCOL for mouse input.
+//! This protocol provides relative pointer movement and button state,
+//! compatible with the UEFI 2.x specification.
+//!
+//! # References
+//!
+//! - UEFI Specification 2.10, Section 12.5
+
+use crate::drivers::mouse_cursor;
+
+// ============================================================================
+// Protocol GUIDs and Types
+// ============================================================================
+
+/// EFI_SIMPLE_POINTER_PROTOCOL GUID
+/// {31878C87-0B75-11D5-9A4F-0090273FC14D}
+pub const SIMPLE_POINTER_PROTOCOL_GUID: r_efi::efi::Guid = r_efi::efi::Guid::from_fields(
+    0x31878C87,
+    0x0B75,
+    0x11D5,
+    0x9A,
+    0x4F,
+    &[0x00, 0x90, 0x27, 0x3F, 0xC1, 0x4D],
+);
+
+/// Resolution values for pointer movement.
+///
+/// These define the granularity of the pointer axes in counts per mm.
+/// A value of 1 means the values are raw device counts.
+const RESOLUTION_X: u64 = 1;
+const RESOLUTION_Y: u64 = 1;
+const RESOLUTION_Z: u64 = 1;
+
+// ============================================================================
+// Protocol Structures (matching UEFI spec layout)
+// ============================================================================
+
+/// EFI_SIMPLE_POINTER_STATE
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct SimplePointerState {
+    /// Relative X movement since last GetState call
+    pub relative_movement_x: i32,
+    /// Relative Y movement since last GetState call
+    pub relative_movement_y: i32,
+    /// Relative Z movement (scroll wheel)
+    pub relative_movement_z: i32,
+    /// Left button pressed
+    pub left_button: r_efi::efi::Boolean,
+    /// Right button pressed
+    pub right_button: r_efi::efi::Boolean,
+}
+
+/// EFI_SIMPLE_POINTER_MODE
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SimplePointerMode {
+    /// Resolution of X axis (counts per mm)
+    pub resolution_x: u64,
+    /// Resolution of Y axis (counts per mm)
+    pub resolution_y: u64,
+    /// Resolution of Z axis (counts per mm)
+    pub resolution_z: u64,
+    /// Whether left button is supported
+    pub left_button: r_efi::efi::Boolean,
+    /// Whether right button is supported
+    pub right_button: r_efi::efi::Boolean,
+}
+
+/// EFI_SIMPLE_POINTER_PROTOCOL
+#[repr(C)]
+pub struct SimplePointerProtocol {
+    /// Reset the pointer device
+    pub reset: unsafe extern "efiapi" fn(
+        this: *mut SimplePointerProtocol,
+        extended_verification: r_efi::efi::Boolean,
+    ) -> r_efi::efi::Status,
+    /// Get the current state of the pointer
+    pub get_state: unsafe extern "efiapi" fn(
+        this: *mut SimplePointerProtocol,
+        state: *mut SimplePointerState,
+    ) -> r_efi::efi::Status,
+    /// Event to wait for input
+    pub wait_for_input: r_efi::efi::Event,
+    /// Pointer to mode information
+    pub mode: *mut SimplePointerMode,
+}
+
+// SAFETY: SimplePointerProtocol contains function pointers and an event handle.
+// These are set once during init and remain valid for the firmware lifetime.
+// CrabEFI is single-threaded.
+unsafe impl Send for SimplePointerProtocol {}
+unsafe impl Sync for SimplePointerProtocol {}
+
+// ============================================================================
+// Protocol Implementation
+// ============================================================================
+
+/// Reset the pointer device
+unsafe extern "efiapi" fn pointer_reset(
+    _this: *mut SimplePointerProtocol,
+    _extended_verification: r_efi::efi::Boolean,
+) -> r_efi::efi::Status {
+    // Poll to drain any stale data
+    mouse_cursor::poll();
+    r_efi::efi::Status::SUCCESS
+}
+
+/// Get the current state of the pointer
+unsafe extern "efiapi" fn pointer_get_state(
+    _this: *mut SimplePointerProtocol,
+    state: *mut SimplePointerState,
+) -> r_efi::efi::Status {
+    if state.is_null() {
+        return r_efi::efi::Status::INVALID_PARAMETER;
+    }
+
+    // Poll for new data
+    mouse_cursor::poll();
+
+    let (x, y) = mouse_cursor::position();
+    let _ = (x, y); // absolute position not used for SimplePointer
+
+    // SimplePointer uses relative movement
+    // We need the raw deltas, not the absolute position
+    // Poll the underlying drivers directly for relative data
+
+    #[cfg(target_arch = "x86_64")]
+    let (ps2_dx, ps2_dy, ps2_dz) = crate::drivers::mouse::get_relative_motion();
+    #[cfg(not(target_arch = "x86_64"))]
+    let (ps2_dx, ps2_dy, ps2_dz) = (0i32, 0i32, 0i32);
+
+    let (usb_dx, usb_dy) = crate::drivers::usb::hid_mouse::get_relative_motion();
+
+    let dx = ps2_dx + usb_dx;
+    let dy = ps2_dy + usb_dy;
+    let dz = ps2_dz;
+
+    if dx == 0 && dy == 0 && dz == 0 {
+        return r_efi::efi::Status::NOT_READY;
+    }
+
+    let buttons = mouse_cursor::buttons();
+
+    unsafe {
+        (*state).relative_movement_x = dx;
+        (*state).relative_movement_y = dy;
+        (*state).relative_movement_z = dz;
+        (*state).left_button = if (buttons & 1) != 0 {
+            r_efi::efi::Boolean::TRUE
+        } else {
+            r_efi::efi::Boolean::FALSE
+        };
+        (*state).right_button = if (buttons & 2) != 0 {
+            r_efi::efi::Boolean::TRUE
+        } else {
+            r_efi::efi::Boolean::FALSE
+        };
+    }
+
+    r_efi::efi::Status::SUCCESS
+}
+
+// ============================================================================
+// Global Protocol Instance
+// ============================================================================
+
+/// Global pointer mode
+static mut POINTER_MODE: SimplePointerMode = SimplePointerMode {
+    resolution_x: RESOLUTION_X,
+    resolution_y: RESOLUTION_Y,
+    resolution_z: RESOLUTION_Z,
+    left_button: r_efi::efi::Boolean::TRUE,
+    right_button: r_efi::efi::Boolean::TRUE,
+};
+
+/// Global protocol instance
+static mut POINTER_PROTOCOL: SimplePointerProtocol = SimplePointerProtocol {
+    reset: pointer_reset,
+    get_state: pointer_get_state,
+    wait_for_input: core::ptr::null_mut(),
+    mode: core::ptr::addr_of_mut!(POINTER_MODE),
+};
+
+/// Get a pointer to the global SimplePointerProtocol instance.
+///
+/// The returned pointer is valid for the firmware lifetime.
+pub fn get_protocol() -> *mut SimplePointerProtocol {
+    core::ptr::addr_of_mut!(POINTER_PROTOCOL)
+}
+
+/// Get the protocol GUID.
+pub fn guid() -> r_efi::efi::Guid {
+    SIMPLE_POINTER_PROTOCOL_GUID
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,6 +322,14 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
     // ---- 8. Initialize EFI environment ----
     efi::init_from_platform(&config);
 
+    // Initialize mouse cursor system (ui feature only).
+    // Must come after efi::init_from_platform(), which stores the framebuffer
+    // in global state via state::store_framebuffer().
+    #[cfg(feature = "ui")]
+    if let Some(fb) = crate::state::get_framebuffer() {
+        drivers::mouse_cursor::init(fb.width, fb.height);
+    }
+
     log::info!("CrabEFI initialized successfully!");
     log::info!("EFI System Table at: {:p}", efi::get_system_table());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ mod boot_manager;
 pub mod boot_vars;
 pub mod cfr_menu;
 pub mod coreboot;
+#[cfg(feature = "ui")]
+pub mod cursor;
 pub mod drivers;
 pub mod efi;
 #[cfg(feature = "fb-log")]
@@ -41,6 +43,8 @@ pub mod platform;
 pub mod secure_boot_menu;
 pub mod state;
 pub mod time;
+#[cfg(feature = "ui")]
+pub mod ui;
 
 use crate::drivers::block::{AhciDisk, NvmeDisk, SdhciDisk, UsbDisk};
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -32,7 +32,7 @@ use heapless::{String, Vec};
 #[cfg(feature = "ui")]
 fn update_cursor(
     cursor_renderer: &mut crate::cursor::CursorRenderer,
-    fb_info: &Option<crate::coreboot::FramebufferInfo>,
+    fb_info: &Option<crate::coreboot::FramebufferInfo>, // FramebufferInfo is the rendering type
 ) {
     if let Some(fb) = fb_info {
         if crate::drivers::mouse_cursor::is_initialized() {
@@ -946,11 +946,16 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
         return None;
     }
 
-    // Get framebuffer for rendering
-    let fb_info = crate::state::get_framebuffer();
+    // Get framebuffer.  FramebufferConsole uses platform::FramebufferConfig
+    // directly; the ui cursor renderer uses coreboot::FramebufferInfo.
+    let fb_config = crate::state::get_framebuffer();
+    #[cfg(feature = "ui")]
+    let fb_info: Option<crate::coreboot::FramebufferInfo> = fb_config.map(Into::into);
+    #[cfg(not(feature = "ui"))]
+    let _ = (); // fb_info unused without ui
 
     // Create framebuffer console if available
-    let mut fb_console = fb_info.as_ref().map(FramebufferConsole::new);
+    let mut fb_console = fb_config.as_ref().map(FramebufferConsole::new);
 
     // Clear screen
     menu_common::clear_screen(&mut fb_console);

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -26,6 +26,22 @@ use crate::time::{Timeout, delay_ms};
 use core::fmt::Write;
 use heapless::{String, Vec};
 
+/// Update the mouse cursor on the framebuffer.
+///
+/// Call this in the menu event loop to render the cursor at its current position.
+#[cfg(feature = "ui")]
+fn update_cursor(
+    cursor_renderer: &mut crate::cursor::CursorRenderer,
+    fb_info: &Option<crate::coreboot::FramebufferInfo>,
+) {
+    if let Some(fb) = fb_info {
+        if crate::drivers::mouse_cursor::is_initialized() {
+            let (x, y) = crate::drivers::mouse_cursor::position();
+            cursor_renderer.update(fb, x, y);
+        }
+    }
+}
+
 /// Maximum number of boot entries
 /// Increased to accommodate BLS, GRUB, and payload entries
 const MAX_BOOT_ENTRIES: usize = 16;
@@ -253,11 +269,11 @@ impl BootEntry {
 /// Boot menu state
 pub struct BootMenu {
     /// Discovered boot entries
-    entries: Vec<BootEntry, MAX_BOOT_ENTRIES>,
+    pub(crate) entries: Vec<BootEntry, MAX_BOOT_ENTRIES>,
     /// Currently selected entry index
-    selected: usize,
+    pub(crate) selected: usize,
     /// Timeout in seconds (0 = no timeout)
-    timeout_seconds: u32,
+    pub(crate) timeout_seconds: u32,
 }
 
 impl Default for BootMenu {
@@ -949,7 +965,14 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
     // Show initial countdown
     draw_countdown(remaining_seconds, &mut fb_console);
 
+    // Initialize cursor renderer for mouse support
+    #[cfg(feature = "ui")]
+    let mut cursor_renderer = crate::cursor::CursorRenderer::new();
+
     loop {
+        // Update mouse cursor on framebuffer
+        #[cfg(feature = "ui")]
+        update_cursor(&mut cursor_renderer, &fb_info);
         // Check for timeout (first tick fires after 1 real second)
         if remaining_seconds > 0 && last_second_check.is_expired() {
             remaining_seconds -= 1;
@@ -1060,6 +1083,25 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
                         draw_menu(menu, &mut fb_console);
                     }
                 }
+                // Handle mouse clicks - select entry under cursor
+                #[cfg(feature = "ui")]
+                KeyPress::MouseClick { y, .. } => {
+                    // Map screen Y pixel to menu entry index
+                    // Menu entries start at row ~5 (after header + category)
+                    if let Some(idx) = row_to_entry_index(menu, y) {
+                        menu.selected = idx;
+                        draw_menu(menu, &mut fb_console);
+                    }
+                }
+                #[cfg(feature = "ui")]
+                KeyPress::MouseScroll(dz) => {
+                    if dz > 0 {
+                        menu.select_next();
+                    } else {
+                        menu.select_previous();
+                    }
+                    draw_menu(menu, &mut fb_console);
+                }
                 _ => {}
             }
         }
@@ -1067,6 +1109,34 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
         // Small delay to avoid busy-waiting
         delay_ms(10);
     }
+}
+
+/// Map a screen row to a menu entry index.
+///
+/// Returns `Some(index)` if the row corresponds to a boot entry,
+/// `None` if it's a header, separator, or out of range.
+#[cfg(feature = "ui")]
+fn row_to_entry_index(menu: &BootMenu, row: u32) -> Option<usize> {
+    // Menu layout: row 0-2 = header, row 3 = blank, row 4+ = entries with separators
+    let start_row = 4u32;
+    let mut current_row = start_row;
+    let mut current_category: Option<BootCategory> = None;
+
+    for (i, entry) in menu.entries.iter().enumerate() {
+        if current_category != Some(entry.category) {
+            if current_category.is_some() {
+                current_row += 1; // blank line
+            }
+            current_row += 1; // category separator
+            current_category = Some(entry.category);
+        }
+
+        if row == current_row {
+            return Some(i);
+        }
+        current_row += 1;
+    }
+    None
 }
 
 use crate::menu_common::{self, KeyPress, SerialWriter};
@@ -1427,6 +1497,9 @@ fn edit_cmdline(entry: &mut BootEntry, fb_console: &mut Option<FramebufferConsol
                 }
                 // Ignore Up/Down in editor
                 KeyPress::Up | KeyPress::Down => {}
+                // Mouse events are ignored in the command line editor
+                #[cfg(feature = "ui")]
+                KeyPress::MouseClick { .. } | KeyPress::MouseScroll(_) => {}
             }
         }
 

--- a/src/menu_common.rs
+++ b/src/menu_common.rs
@@ -19,6 +19,15 @@ pub enum KeyPress {
     Enter,
     Escape,
     Char(char),
+    /// Mouse click at pixel coordinates.
+    #[cfg(feature = "ui")]
+    MouseClick {
+        x: u32,
+        y: u32,
+    },
+    /// Mouse scroll (positive = down, negative = up)
+    #[cfg(feature = "ui")]
+    MouseScroll(i32),
 }
 
 /// Read a key from keyboard (PS/2, USB, or serial)
@@ -49,6 +58,25 @@ pub fn read_key() -> Option<KeyPress> {
             0 if unicode_char > 0 => Some(KeyPress::Char(unicode_char as u8 as char)),
             _ => None,
         };
+    }
+
+    // Check mouse state (if UI feature is enabled).
+    // Note: callers must call mouse_cursor::poll() before read_key() —
+    // we only inspect the current state here, we do NOT poll again.
+    #[cfg(feature = "ui")]
+    {
+        let scroll = crate::drivers::mouse_cursor::get_scroll();
+        if scroll != 0 {
+            return Some(KeyPress::MouseScroll(scroll));
+        }
+
+        if crate::drivers::mouse_cursor::left_clicked() {
+            let (px, py) = crate::drivers::mouse_cursor::position();
+            return Some(KeyPress::MouseClick {
+                x: px as u32,
+                y: py as u32,
+            });
+        }
     }
 
     // Try serial input

--- a/src/ui/firmware_settings.rs
+++ b/src/ui/firmware_settings.rs
@@ -1,0 +1,389 @@
+//! Graphical Firmware Settings (CFR) screen — Kinetic Command design.
+
+use super::{
+    canvas, clear, draw_footer, draw_header, draw_sidebar, poll_and_render_cursor, render, theme,
+    update_sidebar_hover, NavItem, ScreenNav,
+};
+use crate::coreboot::FramebufferInfo;
+use crate::cursor::CursorRenderer;
+use crate::menu_common::{self, KeyPress};
+use crate::time::delay_ms;
+use render::FontSize;
+
+pub fn show(fb: &FramebufferInfo) -> ScreenNav {
+    let cfr = match crate::coreboot::get_cfr() {
+        Some(c) => c,
+        None => return show_no_cfr(fb),
+    };
+
+    let mut cursor = CursorRenderer::new();
+    let mut selected: usize = 0;
+    let mut hovered: Option<usize> = None;
+    let mut sidebar_hov: Option<NavItem> = None;
+    let mut scroll: usize = 0;
+    let form_count = cfr.forms.len();
+
+    draw_settings(fb, cfr, selected, hovered, scroll);
+
+    loop {
+        poll_and_render_cursor(fb, &mut cursor);
+
+        update_sidebar_hover(fb, &mut sidebar_hov, NavItem::Firmware);
+
+        // ── Card hover ──
+        let new_hov = form_hit(fb, cfr, scroll);
+        if new_hov != hovered {
+            let old = hovered;
+            hovered = new_hov;
+            // Repaint only the changed cards
+            if let Some(i) = old {
+                paint_form_card(fb, cfr, i, selected, hovered, scroll);
+            }
+            if let Some(i) = new_hov {
+                paint_form_card(fb, cfr, i, selected, hovered, scroll);
+            }
+        }
+
+        if let Some(key) = menu_common::read_key() {
+            match key {
+                KeyPress::Up | KeyPress::Char('k') => {
+                    if selected > 0 {
+                        selected -= 1;
+                    }
+                    if selected < scroll {
+                        scroll = selected;
+                    }
+                    draw_settings(fb, cfr, selected, hovered, scroll);
+                }
+                KeyPress::Down | KeyPress::Char('j') => {
+                    if selected + 1 < form_count {
+                        selected += 1;
+                    }
+                    let mv = max_vis(fb);
+                    if selected >= scroll + mv {
+                        scroll = selected - mv + 1;
+                    }
+                    draw_settings(fb, cfr, selected, hovered, scroll);
+                }
+                KeyPress::Enter => {
+                    cursor.hide(fb);
+                    crate::cfr_menu::show_cfr_menu();
+                    draw_settings(fb, cfr, selected, hovered, scroll);
+                }
+                KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
+                    return ScreenNav::Back;
+                }
+                #[cfg(feature = "ui")]
+                KeyPress::MouseClick { .. } => {
+                    // Sidebar click
+                    if let Some(nav) = sidebar_hov {
+                        if nav != NavItem::Firmware {
+                            cursor.hide(fb);
+                            return ScreenNav::Nav(nav);
+                        }
+                    }
+                    // Card click
+                    if let Some(idx) = hovered {
+                        if idx == selected {
+                            cursor.hide(fb);
+                            crate::cfr_menu::show_cfr_menu();
+                        } else {
+                            selected = idx;
+                        }
+                        draw_settings(fb, cfr, selected, hovered, scroll);
+                    }
+                }
+                #[cfg(feature = "ui")]
+                KeyPress::MouseScroll(dz) => {
+                    if dz > 0 && selected + 1 < form_count {
+                        selected += 1;
+                        let mv = max_vis(fb);
+                        if selected >= scroll + mv {
+                            scroll = selected - mv + 1;
+                        }
+                    } else if dz < 0 && selected > 0 {
+                        selected -= 1;
+                        if selected < scroll {
+                            scroll = selected;
+                        }
+                    }
+                    draw_settings(fb, cfr, selected, hovered, scroll);
+                }
+                _ => {}
+            }
+        }
+        delay_ms(8);
+    }
+}
+
+fn max_vis(fb: &FramebufferInfo) -> usize {
+    let (_, _, _, ch) = canvas(fb);
+    let header_h =
+        render::font_height(FontSize::Small) + 4 + render::font_height(FontSize::Display) + 16;
+    let avail = ch.saturating_sub(header_h);
+    (avail / (FORM_CARD_H + theme::GAP)) as usize
+}
+
+const FORM_CARD_H: u32 = 48;
+
+fn form_card_base_y(fb: &FramebufferInfo) -> i32 {
+    let (_, cy, _, _) = canvas(fb);
+    let header_h =
+        render::font_height(FontSize::Small) + 4 + render::font_height(FontSize::Display) + 16;
+    cy + header_h as i32
+}
+
+/// Repaint a single form card (avoids full-screen redraw on hover changes).
+fn paint_form_card(
+    fb: &FramebufferInfo,
+    cfr: &crate::coreboot::CfrInfo,
+    idx: usize,
+    selected: usize,
+    hovered: Option<usize>,
+    scroll: usize,
+) {
+    let mv = max_vis(fb);
+    // Only repaint if the card is currently visible
+    if idx < scroll || idx >= scroll + mv || idx >= cfr.forms.len() {
+        return;
+    }
+    let vi = idx - scroll;
+    let (cx, _, cw, _) = canvas(fb);
+    let base_y = form_card_base_y(fb);
+    let y = base_y + (vi as i32 * (FORM_CARD_H as i32 + theme::GAP as i32));
+
+    let form = &cfr.forms[idx];
+    let is_sel = idx == selected;
+    let is_hov = hovered == Some(idx) && !is_sel;
+
+    let bg = if is_sel {
+        theme::SURFACE_HI
+    } else if is_hov {
+        theme::CONT_HIGH
+    } else {
+        theme::CONT_LOW
+    };
+    render::fill_rounded_rect(fb, cx, y, cw, FORM_CARD_H, theme::RADIUS, bg);
+
+    if is_sel {
+        render::fill_rect(
+            fb,
+            cx,
+            y + 2,
+            theme::ACCENT_BAR,
+            FORM_CARD_H - 4,
+            theme::PRIMARY,
+        );
+    }
+
+    let tx = cx
+        + theme::PAD as i32
+        + if is_sel {
+            theme::ACCENT_BAR as i32 + 4
+        } else {
+            0
+        };
+
+    render::draw_text(
+        fb,
+        tx,
+        y + 6,
+        &form.ui_name,
+        FontSize::Normal,
+        theme::TEXT,
+        Some(bg),
+    );
+
+    let opt_count = form.options.len();
+    let mut buf = [0u8; 16];
+    let cs = fmt_opts(opt_count as u32, &mut buf);
+    render::draw_text_right(
+        fb,
+        cx,
+        y + 6,
+        cw - theme::PAD,
+        cs,
+        FontSize::Small,
+        theme::OUTLINE,
+        Some(bg),
+    );
+
+    let desc = if opt_count == 1 { "1 setting" } else { cs };
+    render::draw_text(
+        fb,
+        tx,
+        y + 6 + render::font_height(FontSize::Normal) as i32 + 2,
+        desc,
+        FontSize::Small,
+        theme::TEXT_DIM,
+        Some(bg),
+    );
+
+    if is_sel {
+        render::draw_text(
+            fb,
+            cx + cw as i32 - 28,
+            y + (FORM_CARD_H as i32 - render::font_height(FontSize::Normal) as i32) / 2,
+            ">",
+            FontSize::Normal,
+            theme::PRIMARY,
+            Some(bg),
+        );
+    }
+}
+
+/// Hit-test form cards.
+fn form_hit(fb: &FramebufferInfo, cfr: &crate::coreboot::CfrInfo, scroll: usize) -> Option<usize> {
+    let (mx, my) = crate::drivers::mouse_cursor::position();
+    let (cx, _, cw, _) = canvas(fb);
+    let base_y = form_card_base_y(fb);
+    let mv = max_vis(fb);
+
+    for vi in 0..mv {
+        let idx = scroll + vi;
+        if idx >= cfr.forms.len() {
+            break;
+        }
+        let card_y = base_y + (vi as i32 * (FORM_CARD_H as i32 + theme::GAP as i32));
+        if mx >= cx && mx < cx + cw as i32 && my >= card_y && my < card_y + FORM_CARD_H as i32 {
+            return Some(idx);
+        }
+    }
+    None
+}
+
+fn draw_settings(
+    fb: &FramebufferInfo,
+    cfr: &crate::coreboot::CfrInfo,
+    selected: usize,
+    hovered: Option<usize>,
+    scroll: usize,
+) {
+    clear(fb);
+    draw_header(fb);
+    draw_sidebar(fb, NavItem::Firmware, None);
+    draw_footer(fb, "Up/Down Navigate   Enter Edit   Esc Back");
+
+    let (cx, cy, cw, _) = canvas(fb);
+    let mut y = cy;
+
+    // Section label
+    render::draw_text_spaced(
+        fb,
+        cx,
+        y,
+        "HARDWARE CONFIGURATION",
+        FontSize::Small,
+        2,
+        theme::PRIMARY.darken(80),
+        None,
+    );
+    y += render::font_height(FontSize::Small) as i32 + 4;
+    render::draw_text(
+        fb,
+        cx,
+        y,
+        "Firmware Settings",
+        FontSize::Display,
+        theme::TEXT,
+        None,
+    );
+    let _ = y; // y was used to lay out the header; cards use form_card_base_y()
+
+    let mv = max_vis(fb);
+    for vi in 0..mv {
+        let idx = scroll + vi;
+        if idx >= cfr.forms.len() {
+            break;
+        }
+        paint_form_card(fb, cfr, idx, selected, hovered, scroll);
+    }
+
+    // Scroll indicators
+    let header_h =
+        render::font_height(FontSize::Small) + 4 + render::font_height(FontSize::Display) + 16;
+    if scroll > 0 {
+        render::draw_text_centered(
+            fb,
+            cx,
+            cy + header_h as i32 - 18,
+            cw,
+            "^",
+            FontSize::Small,
+            theme::PRIMARY,
+            None,
+        );
+    }
+    if scroll + mv < cfr.forms.len() {
+        let ay = fb.y_resolution as i32 - theme::FOOTER_H as i32 - 20;
+        render::draw_text_centered(fb, cx, ay, cw, "v", FontSize::Small, theme::PRIMARY, None);
+    }
+}
+
+fn show_no_cfr(fb: &FramebufferInfo) -> ScreenNav {
+    let mut cursor = CursorRenderer::new();
+    let mut sidebar_hov: Option<NavItem> = None;
+
+    clear(fb);
+    draw_header(fb);
+    draw_sidebar(fb, NavItem::Firmware, None);
+
+    let (cx, cy, cw, ch) = canvas(fb);
+    let mid = cy + ch as i32 / 2 - 20;
+    render::draw_dot(fb, cx + cw as i32 / 2, mid - 12, 6, theme::ORANGE);
+    render::draw_text_centered(
+        fb,
+        cx,
+        mid + 6,
+        cw,
+        "No firmware configuration available",
+        FontSize::Normal,
+        theme::TEXT,
+        None,
+    );
+    render::draw_text_centered(
+        fb,
+        cx,
+        mid + 30,
+        cw,
+        "CFR tables not found in coreboot",
+        FontSize::Small,
+        theme::TEXT_DIM,
+        None,
+    );
+
+    draw_footer(fb, "Esc: Back");
+
+    loop {
+        poll_and_render_cursor(fb, &mut cursor);
+
+        update_sidebar_hover(fb, &mut sidebar_hov, NavItem::Firmware);
+
+        if let Some(key) = menu_common::read_key() {
+            match key {
+                KeyPress::Escape | KeyPress::Char('q') => return ScreenNav::Back,
+                #[cfg(feature = "ui")]
+                KeyPress::MouseClick { .. } => {
+                    if let Some(nav) = sidebar_hov {
+                        if nav != NavItem::Firmware {
+                            cursor.hide(fb);
+                            return ScreenNav::Nav(nav);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        delay_ms(8);
+    }
+}
+
+fn fmt_opts<'a>(n: u32, buf: &'a mut [u8; 16]) -> &'a str {
+    let mut p = 0;
+    p += super::fmt_u32(n, &mut buf[p..]);
+    for &b in b" opts" {
+        buf[p] = b;
+        p += 1;
+    }
+    core::str::from_utf8(&buf[..p]).unwrap_or("??")
+}

--- a/src/ui/firmware_settings.rs
+++ b/src/ui/firmware_settings.rs
@@ -1,8 +1,8 @@
 //! Graphical Firmware Settings (CFR) screen — Kinetic Command design.
 
 use super::{
-    canvas, clear, draw_footer, draw_header, draw_sidebar, poll_and_render_cursor, render, theme,
-    update_sidebar_hover, NavItem, ScreenNav,
+    NavItem, ScreenNav, canvas, clear, draw_footer, draw_header, draw_sidebar,
+    poll_and_render_cursor, render, theme, update_sidebar_hover,
 };
 use crate::coreboot::FramebufferInfo;
 use crate::cursor::CursorRenderer;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,0 +1,807 @@
+//! Kinetic Command graphical UI.
+//!
+//! Implements the "Ethereal Machine" design system from the reference mockups:
+//! left sidebar navigation, tonal surface hierarchy, electric-cyan accents,
+//! hero cards, and a divider-free layout.  Multi-size anti-aliased Noto Sans
+//! Mono font for modern typography hierarchy.
+
+pub mod firmware_settings;
+pub mod render;
+pub mod secure_boot;
+pub mod theme;
+
+use crate::coreboot::{self, FramebufferInfo};
+use crate::cursor::CursorRenderer;
+use crate::drivers::mouse_cursor;
+use crate::menu::{BootCategory, BootMenu};
+use crate::menu_common::{self, KeyPress};
+use crate::time::{delay_ms, Timeout};
+use render::{FontSize, Rgb};
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Navigation types
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Which nav item is active.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum NavItem {
+    Boot,
+    Security,
+    Firmware,
+}
+
+/// Navigation result from any sub-screen.
+pub enum ScreenNav {
+    /// Go back (Esc or "Back" action).
+    Back,
+    /// Navigate to a different screen.
+    Nav(NavItem),
+}
+
+/// Result from the boot selection screen.
+enum BootResult {
+    /// User selected a boot entry.
+    Selected(usize),
+    /// Navigate to a different screen.
+    Nav(NavItem),
+}
+
+const NAV_ITEMS: [(NavItem, &str); 3] = [
+    (NavItem::Boot, "BOOT"),
+    (NavItem::Security, "SECURITY"),
+    (NavItem::Firmware, "FIRMWARE"),
+];
+
+fn nav_item_index(item: NavItem) -> usize {
+    match item {
+        NavItem::Boot => 0,
+        NavItem::Security => 1,
+        NavItem::Firmware => 2,
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Shared chrome (sidebar, header, footer) — used by every screen
+// ═══════════════════════════════════════════════════════════════════════
+
+pub fn clear(fb: &FramebufferInfo) {
+    unsafe { fb.clear(theme::BG.r, theme::BG.g, theme::BG.b) };
+}
+
+/// Draw the top header bar (branding + version).
+pub fn draw_header(fb: &FramebufferInfo) {
+    let w = fb.x_resolution;
+    render::fill_gradient_v(
+        fb,
+        0,
+        0,
+        w,
+        theme::HEADER_H,
+        Rgb::new(0x14, 0x17, 0x1c),
+        theme::BG,
+    );
+
+    let brand_y = (theme::HEADER_H as i32 - render::font_height(FontSize::Heading) as i32) / 2;
+    render::draw_text(
+        fb,
+        14,
+        brand_y,
+        "CRABEFI",
+        FontSize::Heading,
+        theme::PRIMARY,
+        None,
+    );
+    let vx = 14 + render::text_width("CRABEFI", FontSize::Heading) as i32 + 12;
+    let vy = (theme::HEADER_H as i32 - render::font_height(FontSize::Small) as i32) / 2;
+    render::draw_text(fb, vx, vy, "v0.1.0", FontSize::Small, theme::OUTLINE, None);
+}
+
+/// Draw the left sidebar with navigation items.
+pub fn draw_sidebar(fb: &FramebufferInfo, active: NavItem, hovered: Option<NavItem>) {
+    let sw = theme::SIDEBAR_W;
+    let sy = theme::HEADER_H;
+    let sh = fb.y_resolution - theme::HEADER_H - theme::FOOTER_H;
+
+    render::fill_rect(fb, 0, sy as i32, sw, sh, theme::SIDE);
+
+    // Title with letter-spacing
+    let title_y = (sy + 14) as i32;
+    render::draw_text_spaced(
+        fb,
+        14,
+        title_y,
+        "MAIN MENU",
+        FontSize::Small,
+        2,
+        theme::TEXT,
+        Some(theme::SIDE),
+    );
+
+    // Nav items
+    for (i, (item, label)) in NAV_ITEMS.iter().enumerate() {
+        paint_sidebar_item(fb, i, *item, label, active, hovered == Some(*item));
+    }
+}
+
+fn paint_sidebar_item(
+    fb: &FramebufferInfo,
+    idx: usize,
+    item: NavItem,
+    label: &str,
+    active: NavItem,
+    is_hov: bool,
+) {
+    let y = sidebar_item_y(idx);
+    let is_active = item == active;
+
+    let bg = if is_active {
+        theme::CONTAINER
+    } else if is_hov {
+        theme::CONT_HIGH
+    } else {
+        theme::SIDE
+    };
+    let fg = if is_active {
+        theme::PRIMARY
+    } else if is_hov {
+        theme::TEXT
+    } else {
+        theme::TEXT_DIM
+    };
+
+    render::fill_rect(fb, 0, y, theme::SIDEBAR_W, theme::NAV_ITEM_H, bg);
+    let text_y =
+        y + ((theme::NAV_ITEM_H as i32 - render::font_height(FontSize::Normal) as i32) / 2);
+    render::draw_text(fb, 16, text_y, label, FontSize::Normal, fg, Some(bg));
+
+    // Active indicator — right-edge accent bar
+    if is_active {
+        render::fill_rect(
+            fb,
+            (theme::SIDEBAR_W - theme::ACCENT_BAR) as i32,
+            y,
+            theme::ACCENT_BAR,
+            theme::NAV_ITEM_H,
+            theme::PRIMARY,
+        );
+    }
+}
+
+/// Draw the bottom footer bar.
+pub fn draw_footer(fb: &FramebufferInfo, hint: &str) {
+    let w = fb.x_resolution;
+    let fy = fb.y_resolution - theme::FOOTER_H;
+    render::fill_rect(fb, 0, fy as i32, w, theme::FOOTER_H, theme::BG);
+    let text_y =
+        (fy as i32) + ((theme::FOOTER_H as i32 - render::font_height(FontSize::Small) as i32) / 2);
+    render::draw_text_centered(
+        fb,
+        0,
+        text_y,
+        w,
+        hint,
+        FontSize::Small,
+        theme::OUTLINE,
+        None,
+    );
+}
+
+pub fn poll_and_render_cursor(fb: &FramebufferInfo, cursor: &mut CursorRenderer) {
+    mouse_cursor::poll();
+    let (mx, my) = mouse_cursor::position();
+    cursor.update(fb, mx, my);
+}
+
+/// Main canvas origin (x, y) and size (w, h) — right of sidebar, below header, above footer.
+fn canvas(fb: &FramebufferInfo) -> (i32, i32, u32, u32) {
+    let x = theme::SIDEBAR_W as i32 + theme::PAD as i32;
+    let y = (theme::HEADER_H + theme::PAD) as i32;
+    let w = fb.x_resolution - theme::SIDEBAR_W - theme::PAD * 2;
+    let h = fb.y_resolution - theme::HEADER_H - theme::FOOTER_H - theme::PAD * 2;
+    (x, y, w, h)
+}
+
+/// Y coordinate of the i-th sidebar nav item (0-indexed).
+fn sidebar_item_y(i: usize) -> i32 {
+    (theme::HEADER_H + theme::NAV_TOP_PAD) as i32
+        + (i as i32 * (theme::NAV_ITEM_H + theme::NAV_ITEM_STRIDE) as i32)
+}
+
+/// Update sidebar hover state.  Repaints only the changed items.
+/// Returns `true` if the hover state changed.
+pub fn update_sidebar_hover(
+    fb: &FramebufferInfo,
+    sidebar_hov: &mut Option<NavItem>,
+    active: NavItem,
+) -> bool {
+    let new = sidebar_hit();
+    if new == *sidebar_hov {
+        return false;
+    }
+    let old = *sidebar_hov;
+    *sidebar_hov = new;
+    if let Some(o) = old {
+        let idx = nav_item_index(o);
+        paint_sidebar_item(fb, idx, o, NAV_ITEMS[idx].1, active, false);
+    }
+    if let Some(n) = new {
+        let idx = nav_item_index(n);
+        paint_sidebar_item(fb, idx, n, NAV_ITEMS[idx].1, active, true);
+    }
+    true
+}
+
+/// Hit-test sidebar: which nav item is the mouse over?
+fn sidebar_hit() -> Option<NavItem> {
+    let (mx, my) = mouse_cursor::position();
+    if mx < 0 || mx >= theme::SIDEBAR_W as i32 {
+        return None;
+    }
+    for (i, (item, _)) in NAV_ITEMS.iter().enumerate() {
+        let iy = sidebar_item_y(i);
+        if my >= iy && my < iy + theme::NAV_ITEM_H as i32 {
+            return Some(*item);
+        }
+    }
+    None
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Public entry points (state machine for screen navigation)
+// ═══════════════════════════════════════════════════════════════════════
+
+pub fn show_graphical_menu(menu: &mut BootMenu) -> Option<usize> {
+    let fb = coreboot::get_framebuffer()?;
+    let mut screen = NavItem::Boot;
+
+    loop {
+        match screen {
+            NavItem::Boot => match run_boot(&fb, menu) {
+                BootResult::Selected(idx) => return Some(idx),
+                BootResult::Nav(nav) => screen = nav,
+            },
+            NavItem::Security => match secure_boot::show(&fb) {
+                ScreenNav::Nav(nav) => screen = nav,
+                ScreenNav::Back => screen = NavItem::Boot,
+            },
+            NavItem::Firmware => match firmware_settings::show(&fb) {
+                ScreenNav::Nav(nav) => screen = nav,
+                ScreenNav::Back => screen = NavItem::Boot,
+            },
+        }
+    }
+}
+
+pub fn show_no_media_screen() {
+    let fb = match coreboot::get_framebuffer() {
+        Some(f) => f,
+        None => return,
+    };
+    let mut screen = NavItem::Boot;
+
+    loop {
+        match screen {
+            NavItem::Boot => match run_no_media(&fb) {
+                ScreenNav::Nav(nav) => screen = nav,
+                ScreenNav::Back => return,
+            },
+            NavItem::Security => match secure_boot::show(&fb) {
+                ScreenNav::Nav(nav) => screen = nav,
+                ScreenNav::Back => screen = NavItem::Boot,
+            },
+            NavItem::Firmware => match firmware_settings::show(&fb) {
+                ScreenNav::Nav(nav) => screen = nav,
+                ScreenNav::Back => screen = NavItem::Boot,
+            },
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Boot Selection screen
+// ═══════════════════════════════════════════════════════════════════════
+
+struct BState {
+    sel: usize,
+    hovered: Option<usize>,
+    sidebar_hov: Option<NavItem>,
+    countdown: u32,
+    init_timeout: u32,
+    tick: Timeout,
+    count: usize,
+}
+
+impl BState {
+    fn new(count: usize, sel: usize, timeout: u32) -> Self {
+        Self {
+            sel,
+            hovered: None,
+            sidebar_hov: None,
+            countdown: timeout,
+            init_timeout: timeout,
+            tick: Timeout::from_ms(1000),
+            count,
+        }
+    }
+    fn sel_next(&mut self) {
+        if self.count > 0 && self.sel < self.count - 1 {
+            self.sel += 1;
+        }
+    }
+    fn sel_prev(&mut self) {
+        if self.sel > 0 {
+            self.sel -= 1;
+        }
+    }
+}
+
+fn run_boot(fb: &FramebufferInfo, menu: &mut BootMenu) -> BootResult {
+    let mut cursor = CursorRenderer::new();
+    let mut st = BState::new(menu.entry_count(), menu.selected, menu.timeout_seconds);
+
+    paint_boot(fb, menu, &st);
+
+    loop {
+        poll_and_render_cursor(fb, &mut cursor);
+
+        update_sidebar_hover(fb, &mut st.sidebar_hov, NavItem::Boot);
+
+        // ── Card hover ──
+        let hov = boot_hit(fb, menu);
+        if hov != st.hovered {
+            let prev = st.hovered;
+            st.hovered = hov;
+            if let Some(i) = prev {
+                paint_boot_card(fb, menu, &st, i);
+            }
+            if let Some(i) = hov {
+                paint_boot_card(fb, menu, &st, i);
+            }
+        }
+
+        if let Some(key) = menu_common::read_key() {
+            if st.countdown > 0 {
+                st.countdown = 0;
+                paint_boot_footer(fb, &st);
+            }
+
+            match key {
+                KeyPress::Up | KeyPress::Char('k') => {
+                    let p = st.sel;
+                    st.sel_prev();
+                    menu.selected = st.sel;
+                    repaint2(fb, menu, &st, p, st.sel);
+                }
+                KeyPress::Down | KeyPress::Char('j') => {
+                    let p = st.sel;
+                    st.sel_next();
+                    menu.selected = st.sel;
+                    repaint2(fb, menu, &st, p, st.sel);
+                }
+                KeyPress::Enter => {
+                    cursor.hide(fb);
+                    return BootResult::Selected(st.sel);
+                }
+                KeyPress::Char('s') | KeyPress::Char('S') => {
+                    cursor.hide(fb);
+                    return BootResult::Nav(NavItem::Security);
+                }
+                KeyPress::Char('f') | KeyPress::Char('F') => {
+                    cursor.hide(fb);
+                    return BootResult::Nav(NavItem::Firmware);
+                }
+                KeyPress::Char('r') | KeyPress::Char('R') => {
+                    crate::arch::reset::keyboard_controller_reset();
+                    delay_ms(100);
+                    crate::arch::reset::triple_fault();
+                }
+                #[cfg(feature = "ui")]
+                KeyPress::MouseClick { .. } => {
+                    // Check sidebar clicks first
+                    if let Some(nav) = st.sidebar_hov {
+                        if nav != NavItem::Boot {
+                            cursor.hide(fb);
+                            return BootResult::Nav(nav);
+                        }
+                    }
+                    // Then card clicks
+                    if let Some(idx) = st.hovered {
+                        if idx == st.sel {
+                            cursor.hide(fb);
+                            return BootResult::Selected(idx);
+                        }
+                        let p = st.sel;
+                        st.sel = idx;
+                        menu.selected = idx;
+                        repaint2(fb, menu, &st, p, idx);
+                    }
+                }
+                #[cfg(feature = "ui")]
+                KeyPress::MouseScroll(dz) => {
+                    let p = st.sel;
+                    if dz > 0 {
+                        st.sel_next();
+                    } else {
+                        st.sel_prev();
+                    }
+                    menu.selected = st.sel;
+                    repaint2(fb, menu, &st, p, st.sel);
+                }
+                _ => {}
+            }
+        }
+
+        if st.countdown > 0 && st.tick.is_expired() {
+            st.countdown -= 1;
+            st.tick = Timeout::from_ms(1000);
+            paint_boot_footer(fb, &st);
+            if st.countdown == 0 {
+                cursor.hide(fb);
+                return BootResult::Selected(st.sel);
+            }
+        }
+        delay_ms(8);
+    }
+}
+
+fn run_no_media(fb: &FramebufferInfo) -> ScreenNav {
+    let mut cursor = CursorRenderer::new();
+    let mut sidebar_hov: Option<NavItem> = None;
+
+    clear(fb);
+    draw_header(fb);
+    draw_sidebar(fb, NavItem::Boot, None);
+
+    let (cx, cy, cw, ch) = canvas(fb);
+
+    // Section label
+    let mut y = cy;
+    render::draw_text_spaced(
+        fb,
+        cx,
+        y,
+        "PRIORITY SEQUENCE",
+        FontSize::Small,
+        3,
+        theme::PRIMARY.darken(80),
+        None,
+    );
+    y += render::font_height(FontSize::Small) as i32 + 4;
+    render::draw_text(
+        fb,
+        cx,
+        y,
+        "Boot Selection",
+        FontSize::Display,
+        theme::TEXT,
+        None,
+    );
+
+    let mid_y = cy + ch as i32 / 2 - 30;
+    render::draw_dot(fb, cx + cw as i32 / 2, mid_y - 16, 6, theme::ERROR);
+    render::draw_text_centered(
+        fb,
+        cx,
+        mid_y + 4,
+        cw,
+        "No bootable media found",
+        FontSize::Normal,
+        theme::TEXT,
+        None,
+    );
+    render::draw_text_centered(
+        fb,
+        cx,
+        mid_y + 28,
+        cw,
+        "Connect a USB drive to continue",
+        FontSize::Small,
+        theme::TEXT_DIM,
+        None,
+    );
+    render::draw_separator(fb, cx + 40, mid_y + 56, cw - 80, theme::GHOST, theme::BG);
+    render::draw_text_centered(
+        fb,
+        cx,
+        mid_y + 72,
+        cw,
+        "Mouse active -- move to test tracking",
+        FontSize::Small,
+        theme::OUTLINE,
+        None,
+    );
+
+    draw_footer(fb, "S: Security  F: Firmware  R: Reset  Esc: Halt");
+
+    loop {
+        poll_and_render_cursor(fb, &mut cursor);
+
+        update_sidebar_hover(fb, &mut sidebar_hov, NavItem::Boot);
+
+        if let Some(key) = menu_common::read_key() {
+            match key {
+                KeyPress::Char('r') | KeyPress::Char('R') => {
+                    crate::arch::reset::keyboard_controller_reset();
+                    delay_ms(100);
+                    crate::arch::reset::triple_fault();
+                }
+                KeyPress::Char('s') | KeyPress::Char('S') => {
+                    cursor.hide(fb);
+                    return ScreenNav::Nav(NavItem::Security);
+                }
+                KeyPress::Char('f') | KeyPress::Char('F') => {
+                    cursor.hide(fb);
+                    return ScreenNav::Nav(NavItem::Firmware);
+                }
+                KeyPress::Escape => return ScreenNav::Back,
+                #[cfg(feature = "ui")]
+                KeyPress::MouseClick { .. } => {
+                    if let Some(nav) = sidebar_hov {
+                        if nav != NavItem::Boot {
+                            cursor.hide(fb);
+                            return ScreenNav::Nav(nav);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        delay_ms(8);
+    }
+}
+
+// ── Boot internals ──────────────────────────────────────────────────────
+
+/// Y for the i-th boot card.
+fn card_y(fb: &FramebufferInfo, i: usize) -> i32 {
+    let (_, cy, _, _) = canvas(fb);
+    // Section header: label(16px) + 4 + title(32px) + 12 = 64px
+    let header_h =
+        render::font_height(FontSize::Small) + 4 + render::font_height(FontSize::Display) + 12;
+    cy + header_h as i32 + (i as i32) * (theme::CARD_H as i32 + theme::GAP as i32)
+}
+
+fn card_rect(fb: &FramebufferInfo, i: usize) -> (i32, i32, u32, u32) {
+    let (cx, _, cw, _) = canvas(fb);
+    (cx, card_y(fb, i), cw, theme::CARD_H)
+}
+
+fn boot_hit(fb: &FramebufferInfo, menu: &BootMenu) -> Option<usize> {
+    let (mx, my) = mouse_cursor::position();
+    for i in 0..menu.entry_count() {
+        let (cx, cy, cw, ch) = card_rect(fb, i);
+        if mx >= cx && mx < cx + cw as i32 && my >= cy && my < cy + ch as i32 {
+            return Some(i);
+        }
+    }
+    None
+}
+
+fn paint_boot(fb: &FramebufferInfo, menu: &BootMenu, st: &BState) {
+    clear(fb);
+    draw_header(fb);
+    draw_sidebar(fb, NavItem::Boot, None);
+
+    let (cx, cy, _cw, _) = canvas(fb);
+
+    // Section label with letter-spacing
+    let mut y = cy;
+    render::draw_text_spaced(
+        fb,
+        cx,
+        y,
+        "PRIORITY SEQUENCE",
+        FontSize::Small,
+        3,
+        theme::PRIMARY.darken(80),
+        None,
+    );
+    y += render::font_height(FontSize::Small) as i32 + 4;
+    render::draw_text(
+        fb,
+        cx,
+        y,
+        "Boot Selection",
+        FontSize::Display,
+        theme::TEXT,
+        None,
+    );
+
+    for i in 0..menu.entry_count() {
+        paint_boot_card(fb, menu, st, i);
+    }
+
+    paint_boot_footer(fb, st);
+}
+
+fn paint_boot_card(fb: &FramebufferInfo, menu: &BootMenu, st: &BState, idx: usize) {
+    let (cx, cy, cw, ch) = card_rect(fb, idx);
+    let is_sel = idx == st.sel;
+    let is_hov = st.hovered == Some(idx);
+
+    // Background: tonal shift per design ("No-Line" rule)
+    let bg = if is_sel {
+        theme::SURFACE_HI
+    } else if is_hov {
+        theme::CONT_HIGH
+    } else {
+        theme::CONT_LOW
+    };
+
+    // Erase + glow
+    let gm = theme::GLOW_SPREAD as i32 + 1;
+    render::fill_rect(
+        fb,
+        cx - gm,
+        cy - gm,
+        cw + gm as u32 * 2,
+        ch + gm as u32 * 2,
+        theme::BG,
+    );
+
+    if is_sel {
+        render::draw_glow(
+            fb,
+            cx,
+            cy,
+            cw,
+            ch,
+            theme::RADIUS,
+            theme::GLOW_SPREAD,
+            theme::PRIMARY.darken(180),
+            theme::BG,
+        );
+    }
+
+    render::fill_rounded_rect(fb, cx, cy, cw, ch, theme::RADIUS, bg);
+
+    // Left accent bar for selected
+    if is_sel {
+        render::fill_rect(fb, cx, cy + 2, theme::ACCENT_BAR, ch - 4, theme::PRIMARY);
+    }
+
+    let Some(entry) = menu.entries.get(idx) else {
+        return;
+    };
+    let tx = cx
+        + theme::CARD_PAD_X as i32
+        + if is_sel {
+            theme::ACCENT_BAR as i32 + 4
+        } else {
+            0
+        };
+    let ty = cy + theme::CARD_PAD_Y as i32;
+
+    // Entry name
+    render::draw_text(
+        fb,
+        tx,
+        ty,
+        &entry.name,
+        FontSize::Normal,
+        theme::TEXT,
+        Some(bg),
+    );
+
+    // Second row: badge + path
+    let row2 = ty + render::font_height(FontSize::Normal) as i32 + 4;
+    let (badge_label, badge_bg) = match entry.category {
+        BootCategory::Uefi => ("UEFI", theme::BADGE_UEFI),
+        BootCategory::Bls => ("LINUX", theme::BADGE_LINUX),
+        BootCategory::Grub => ("GRUB", theme::BADGE_GRUB),
+        BootCategory::Payload => ("PAYLOAD", theme::BADGE_PAYLOAD),
+    };
+    render::draw_pill(fb, tx, row2, badge_label, theme::TEXT, badge_bg);
+
+    let info_x = tx + (render::text_width(badge_label, FontSize::Small) + 24) as i32;
+    render::draw_text(
+        fb,
+        info_x,
+        row2 + 3,
+        &entry.path,
+        FontSize::Small,
+        theme::TEXT_DIM,
+        Some(bg),
+    );
+
+    // Right side hint for selected
+    if is_sel {
+        let label = "SELECT >";
+        let lw = render::text_width(label, FontSize::Small);
+        render::draw_text(
+            fb,
+            cx + cw as i32 - lw as i32 - theme::PAD as i32,
+            ty + 4,
+            label,
+            FontSize::Small,
+            theme::PRIMARY,
+            Some(bg),
+        );
+    }
+}
+
+fn paint_boot_footer(fb: &FramebufferInfo, st: &BState) {
+    let w = fb.x_resolution;
+    let fy = fb.y_resolution - theme::FOOTER_H;
+    render::fill_rect(fb, 0, fy as i32, w, theme::FOOTER_H, theme::BG);
+
+    if st.countdown > 0 && st.init_timeout > 0 {
+        let bar_x = (theme::SIDEBAR_W + theme::PAD) as i32;
+        let bar_w = w - theme::SIDEBAR_W - theme::PAD * 2 - 120;
+        let frac = st.countdown as f32 / st.init_timeout as f32;
+        let bar_y = fy as i32 + (theme::FOOTER_H as i32 - theme::PROGRESS_H as i32) / 2;
+        render::draw_progress_bar(
+            fb,
+            bar_x,
+            bar_y,
+            bar_w,
+            theme::PROGRESS_H,
+            frac,
+            theme::PRIMARY,
+            theme::CONT_HIGH,
+            theme::PROGRESS_RADIUS,
+        );
+
+        let mut buf = [0u8; 16];
+        let s = fmt_cd(st.countdown, &mut buf);
+        let text_y =
+            fy as i32 + (theme::FOOTER_H as i32 - render::font_height(FontSize::Small) as i32) / 2;
+        render::draw_text(
+            fb,
+            bar_x + bar_w as i32 + 12,
+            text_y,
+            s,
+            FontSize::Small,
+            theme::PRIMARY,
+            None,
+        );
+    } else {
+        draw_footer(
+            fb,
+            "Up/Down Navigate  Enter Boot  S Security  F Firmware  R Reset",
+        );
+    }
+}
+
+fn repaint2(fb: &FramebufferInfo, menu: &BootMenu, st: &BState, a: usize, b: usize) {
+    paint_boot_card(fb, menu, st, a);
+    if a != b {
+        paint_boot_card(fb, menu, st, b);
+    }
+}
+
+fn fmt_cd(secs: u32, buf: &mut [u8; 16]) -> &str {
+    let mut p = 0;
+    for &b in b"Boot " {
+        buf[p] = b;
+        p += 1;
+    }
+    p += fmt_u32(secs, &mut buf[p..]);
+    buf[p] = b's';
+    p += 1;
+    core::str::from_utf8(&buf[..p]).unwrap_or("??")
+}
+
+/// Write decimal digits of `n` into `out`, returning the number of bytes written.
+pub(super) fn fmt_u32(n: u32, out: &mut [u8]) -> usize {
+    if n == 0 {
+        out[0] = b'0';
+        return 1;
+    }
+    // Find digit count (max 10 for u32)
+    let mut digits = 0u32;
+    let mut tmp = n;
+    while tmp > 0 {
+        digits += 1;
+        tmp /= 10;
+    }
+    let len = digits as usize;
+    let mut i = len;
+    let mut v = n;
+    while v > 0 {
+        i -= 1;
+        out[i] = b'0' + (v % 10) as u8;
+        v /= 10;
+    }
+    len
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,12 +10,12 @@ pub mod render;
 pub mod secure_boot;
 pub mod theme;
 
-use crate::coreboot::{self, FramebufferInfo};
+use crate::coreboot::FramebufferInfo;
 use crate::cursor::CursorRenderer;
 use crate::drivers::mouse_cursor;
 use crate::menu::{BootCategory, BootMenu};
 use crate::menu_common::{self, KeyPress};
-use crate::time::{delay_ms, Timeout};
+use crate::time::{Timeout, delay_ms};
 use render::{FontSize, Rgb};
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -251,7 +251,7 @@ fn sidebar_hit() -> Option<NavItem> {
 // ═══════════════════════════════════════════════════════════════════════
 
 pub fn show_graphical_menu(menu: &mut BootMenu) -> Option<usize> {
-    let fb = coreboot::get_framebuffer()?;
+    let fb: FramebufferInfo = crate::state::get_framebuffer()?.into();
     let mut screen = NavItem::Boot;
 
     loop {
@@ -273,8 +273,8 @@ pub fn show_graphical_menu(menu: &mut BootMenu) -> Option<usize> {
 }
 
 pub fn show_no_media_screen() {
-    let fb = match coreboot::get_framebuffer() {
-        Some(f) => f,
+    let fb: FramebufferInfo = match crate::state::get_framebuffer() {
+        Some(f) => f.into(),
         None => return,
     };
     let mut screen = NavItem::Boot;

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1,0 +1,524 @@
+//! Low-level framebuffer drawing primitives.
+//!
+//! Provides filled rectangles, gradients, rounded rectangles, glow effects,
+//! progress bars, pill badges, toggle switches, and multi-size anti-aliased
+//! text rendering using the Noto Sans Mono bitmap font.
+
+use crate::coreboot::FramebufferInfo;
+use noto_sans_mono_bitmap::{get_raster, get_raster_width, FontWeight, RasterHeight};
+
+/// RGB color triple.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Rgb {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+impl Rgb {
+    pub const fn new(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b }
+    }
+
+    /// Linearly interpolate between `self` and `other` by `t` (0..=255).
+    pub const fn lerp(self, other: Self, t: u8) -> Self {
+        let t16 = t as u16;
+        let inv = 255 - t16;
+        Self {
+            r: ((self.r as u16 * inv + other.r as u16 * t16) / 255) as u8,
+            g: ((self.g as u16 * inv + other.g as u16 * t16) / 255) as u8,
+            b: ((self.b as u16 * inv + other.b as u16 * t16) / 255) as u8,
+        }
+    }
+
+    /// Brighten by `amount` (0..=255).
+    pub const fn brighten(self, amount: u8) -> Self {
+        let a = amount as u16;
+        Self {
+            r: (self.r as u16 + (255 - self.r as u16) * a / 255) as u8,
+            g: (self.g as u16 + (255 - self.g as u16) * a / 255) as u8,
+            b: (self.b as u16 + (255 - self.b as u16) * a / 255) as u8,
+        }
+    }
+
+    /// Darken by `amount` (0..=255).
+    pub const fn darken(self, amount: u8) -> Self {
+        let inv = 255 - amount as u16;
+        Self {
+            r: (self.r as u16 * inv / 255) as u8,
+            g: (self.g as u16 * inv / 255) as u8,
+            b: (self.b as u16 * inv / 255) as u8,
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Font sizes
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Available font sizes for text rendering.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FontSize {
+    /// 16px — labels, pills, footer, secondary text
+    Small,
+    /// 20px — body text, card content, sidebar items
+    Normal,
+    /// 24px — section subheadings, card titles
+    Heading,
+    /// 32px — page titles, hero text
+    Display,
+}
+
+impl FontSize {
+    fn raster_height(self) -> RasterHeight {
+        match self {
+            FontSize::Small => RasterHeight::Size16,
+            FontSize::Normal => RasterHeight::Size20,
+            FontSize::Heading => RasterHeight::Size24,
+            FontSize::Display => RasterHeight::Size32,
+        }
+    }
+}
+
+/// Height of a font in pixels.
+pub fn font_height(size: FontSize) -> u32 {
+    size.raster_height().val() as u32
+}
+
+/// Width of a single glyph in pixels (monospace — same for all chars).
+pub fn font_width(size: FontSize) -> u32 {
+    get_raster_width(FontWeight::Regular, size.raster_height()) as u32
+}
+
+/// Pixel width of a string at the given size.
+pub fn text_width(s: &str, size: FontSize) -> u32 {
+    s.len() as u32 * font_width(size)
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Rectangles
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Fill a rectangle with a solid color (bounds-clipped).
+pub fn fill_rect(fb: &FramebufferInfo, x: i32, y: i32, w: u32, h: u32, c: Rgb) {
+    let x0 = x.max(0) as u32;
+    let y0 = y.max(0) as u32;
+    let x1 = ((x as i64 + w as i64) as u32).min(fb.x_resolution);
+    let y1 = ((y as i64 + h as i64) as u32).min(fb.y_resolution);
+    if x0 >= x1 || y0 >= y1 {
+        return;
+    }
+    let rpx = (x1 - x0) as usize;
+    for row in y0..y1 {
+        let off = fb.pixel_offset(x0, row);
+        // SAFETY: coordinates clipped to framebuffer bounds.
+        unsafe { fb.fill_pixels(fb.as_ptr().add(off), rpx, c.r, c.g, c.b) };
+    }
+}
+
+/// Fill a rectangle with a vertical gradient from `top` to `bottom`.
+pub fn fill_gradient_v(fb: &FramebufferInfo, x: i32, y: i32, w: u32, h: u32, top: Rgb, bot: Rgb) {
+    if h == 0 {
+        return;
+    }
+    for r in 0..h {
+        let t = ((r as u32 * 255) / (h - 1).max(1)) as u8;
+        fill_rect(fb, x, y + r as i32, w, 1, top.lerp(bot, t));
+    }
+}
+
+/// Fill with a horizontal gradient.
+pub fn fill_gradient_h(
+    fb: &FramebufferInfo,
+    x: i32,
+    y: i32,
+    w: u32,
+    h: u32,
+    left: Rgb,
+    right: Rgb,
+) {
+    if w == 0 {
+        return;
+    }
+    for c in 0..w {
+        let t = ((c as u32 * 255) / (w - 1).max(1)) as u8;
+        fill_rect(fb, x + c as i32, y, 1, h, left.lerp(right, t));
+    }
+}
+
+/// Draw a 1-pixel border.
+pub fn draw_border(fb: &FramebufferInfo, x: i32, y: i32, w: u32, h: u32, c: Rgb) {
+    fill_rect(fb, x, y, w, 1, c);
+    fill_rect(fb, x, y + h as i32 - 1, w, 1, c);
+    fill_rect(fb, x, y, 1, h, c);
+    fill_rect(fb, x + w as i32 - 1, y, 1, h, c);
+}
+
+/// Draw a border with a given thickness.
+pub fn draw_thick_border(fb: &FramebufferInfo, x: i32, y: i32, w: u32, h: u32, t: u32, c: Rgb) {
+    fill_rect(fb, x, y, w, t, c);
+    fill_rect(fb, x, y + h as i32 - t as i32, w, t, c);
+    fill_rect(fb, x, y, t, h, c);
+    fill_rect(fb, x + w as i32 - t as i32, y, t, h, c);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Rounded rectangles
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Integer square root.
+fn isqrt(n: u32) -> u32 {
+    if n == 0 {
+        return 0;
+    }
+    let mut x = n;
+    let mut y = (x + 1) / 2;
+    while y < x {
+        x = y;
+        y = (x + n / x) / 2;
+    }
+    x
+}
+
+/// Filled rounded rectangle.
+pub fn fill_rounded_rect(fb: &FramebufferInfo, x: i32, y: i32, w: u32, h: u32, r: u32, c: Rgb) {
+    if r == 0 || w < r * 2 || h < r * 2 {
+        fill_rect(fb, x, y, w, h, c);
+        return;
+    }
+    fill_rect(fb, x, y + r as i32, w, h - r * 2, c);
+    for dy in 0..r {
+        let ry = r - dy - 1;
+        let inset = r - isqrt(r * r - ry * ry);
+        let sx = x + inset as i32;
+        let sw = w - inset * 2;
+        fill_rect(fb, sx, y + dy as i32, sw, 1, c);
+        fill_rect(fb, sx, y + (h - 1 - dy) as i32, sw, 1, c);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Effects
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Draw a soft glow border around a rounded rectangle.
+pub fn draw_glow(
+    fb: &FramebufferInfo,
+    x: i32,
+    y: i32,
+    w: u32,
+    h: u32,
+    radius: u32,
+    spread: u32,
+    glow_color: Rgb,
+    bg: Rgb,
+) {
+    for s in 1..=spread {
+        let alpha = ((spread - s) * 180 / spread) as u8;
+        let c = bg.lerp(glow_color, alpha);
+        let r = radius + s;
+        let gx = x - s as i32;
+        let gy = y - s as i32;
+        let gw = w + s * 2;
+        let gh = h + s * 2;
+
+        // Top and bottom edges
+        for dy in 0..r.min(gh) {
+            let ry = r.saturating_sub(dy).saturating_sub(1);
+            let inset = r - isqrt(r * r - ry.min(r) * ry.min(r));
+            let sx = gx + inset as i32;
+            let ew = gw.saturating_sub(inset * 2);
+            if ew > 0 {
+                fill_rect(fb, sx, gy + dy as i32, ew, 1, c);
+                fill_rect(
+                    fb,
+                    sx,
+                    gy + (gh.saturating_sub(1).saturating_sub(dy)) as i32,
+                    ew,
+                    1,
+                    c,
+                );
+            }
+        }
+        // Left and right strips (excluding corners)
+        if gh > r * 2 {
+            fill_rect(fb, gx, gy + r as i32, 1, gh - r * 2, c);
+            fill_rect(fb, gx + gw as i32 - 1, gy + r as i32, 1, gh - r * 2, c);
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Widgets
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Draw a horizontal progress bar.
+pub fn draw_progress_bar(
+    fb: &FramebufferInfo,
+    x: i32,
+    y: i32,
+    w: u32,
+    h: u32,
+    fraction: f32,
+    bar_color: Rgb,
+    track_color: Rgb,
+    radius: u32,
+) {
+    // Track
+    fill_rounded_rect(fb, x, y, w, h, radius, track_color);
+    // Filled portion
+    let filled_w = ((w as f32 * fraction.clamp(0.0, 1.0)) as u32).max(if fraction > 0.0 {
+        radius * 2
+    } else {
+        0
+    });
+    if filled_w > 0 {
+        fill_rounded_rect(fb, x, y, filled_w, h, radius, bar_color);
+    }
+}
+
+/// Draw a pill-shaped badge with text.
+pub fn draw_pill(fb: &FramebufferInfo, x: i32, y: i32, label: &str, fg: Rgb, bg: Rgb) {
+    let size = FontSize::Small;
+    let tw = text_width(label, size);
+    let pad = 8u32;
+    let h = font_height(size) + 6;
+    let w = tw + pad * 2;
+    let r = h / 2;
+    fill_rounded_rect(fb, x, y, w, h, r, bg);
+    draw_text(fb, x + pad as i32, y + 3, label, size, fg, Some(bg));
+}
+
+/// Draw a toggle switch (on/off).
+pub fn draw_toggle(fb: &FramebufferInfo, x: i32, y: i32, on: bool, accent: Rgb) {
+    let w = 36u32;
+    let h = 18u32;
+    let r = h / 2;
+    let track_color = if on { accent } else { Rgb::new(60, 60, 80) };
+
+    fill_rounded_rect(fb, x, y, w, h, r, track_color);
+    draw_border(fb, x, y, w, h, track_color.brighten(40));
+
+    // Knob
+    let knob_r = 6u32;
+    let knob_y = y + (h as i32 / 2) - knob_r as i32;
+    let knob_x = if on {
+        x + w as i32 - knob_r as i32 * 2 - 3
+    } else {
+        x + 3
+    };
+    fill_rounded_rect(
+        fb,
+        knob_x,
+        knob_y,
+        knob_r * 2,
+        knob_r * 2,
+        knob_r,
+        Rgb::new(240, 240, 250),
+    );
+}
+
+/// Draw a small filled circle (dot indicator).
+pub fn draw_dot(fb: &FramebufferInfo, cx: i32, cy: i32, r: u32, c: Rgb) {
+    let r2 = (r * r) as i32;
+    for dy in -(r as i32)..=(r as i32) {
+        for dx in -(r as i32)..=(r as i32) {
+            if dx * dx + dy * dy <= r2 {
+                let px = cx + dx;
+                let py = cy + dy;
+                if px >= 0 && py >= 0 && px < fb.x_resolution as i32 && py < fb.y_resolution as i32
+                {
+                    // SAFETY: bounds checked
+                    unsafe { fb.write_pixel(px as u32, py as u32, c.r, c.g, c.b) };
+                }
+            }
+        }
+    }
+}
+
+/// Draw a thin horizontal separator with a gradient fade.
+pub fn draw_separator(fb: &FramebufferInfo, x: i32, y: i32, w: u32, c: Rgb, bg: Rgb) {
+    let fade = w / 6;
+    fill_gradient_h(fb, x, y, fade, 1, bg, c);
+    fill_rect(fb, x + fade as i32, y, w - fade * 2, 1, c);
+    fill_gradient_h(fb, x + (w - fade) as i32, y, fade, 1, c, bg);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Text rendering (Noto Sans Mono with alpha blending)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Read a framebuffer pixel as RGB (for alpha blending on unknown backgrounds).
+fn read_fb_pixel(fb: &FramebufferInfo, x: u32, y: u32) -> Rgb {
+    let off = fb.pixel_offset(x, y);
+    // SAFETY: caller ensures x,y are within bounds.
+    unsafe {
+        let ptr = fb.as_ptr().add(off);
+        match fb.bits_per_pixel {
+            32 => {
+                let b = ptr.read_volatile();
+                let g = ptr.add(1).read_volatile();
+                let r = ptr.add(2).read_volatile();
+                Rgb::new(r, g, b)
+            }
+            24 => {
+                let b = ptr.read_volatile();
+                let g = ptr.add(1).read_volatile();
+                let r = ptr.add(2).read_volatile();
+                Rgb::new(r, g, b)
+            }
+            16 => {
+                let lo = ptr.read_volatile() as u16;
+                let hi = ptr.add(1).read_volatile() as u16;
+                let v = lo | (hi << 8);
+                let r = ((v >> 11) & 0x1F) as u8;
+                let g = ((v >> 5) & 0x3F) as u8;
+                let b = (v & 0x1F) as u8;
+                Rgb::new(
+                    (r << 3) | (r >> 2),
+                    (g << 2) | (g >> 4),
+                    (b << 3) | (b >> 2),
+                )
+            }
+            _ => Rgb::new(0, 0, 0),
+        }
+    }
+}
+
+/// Draw a single character with anti-aliased alpha blending.
+///
+/// If `bg` is `Some(color)`, blends against that color (fast, no FB reads).
+/// If `bg` is `None`, reads the framebuffer pixel to blend against (correct on gradients).
+pub fn draw_char(
+    fb: &FramebufferInfo,
+    px: i32,
+    py: i32,
+    ch: char,
+    size: FontSize,
+    fg: Rgb,
+    bg: Option<Rgb>,
+) {
+    let raster = match get_raster(ch, FontWeight::Regular, size.raster_height()) {
+        Some(r) => r,
+        None => match get_raster('?', FontWeight::Regular, size.raster_height()) {
+            Some(r) => r,
+            None => return,
+        },
+    };
+
+    let rows = raster.raster();
+    let w = raster.width();
+    let h = raster.height();
+
+    for row in 0..h {
+        for col in 0..w {
+            let sx = px + col as i32;
+            let sy = py + row as i32;
+            if sx < 0 || sy < 0 || sx >= fb.x_resolution as i32 || sy >= fb.y_resolution as i32 {
+                continue;
+            }
+
+            let alpha = rows[row][col];
+            if alpha == 0 {
+                // Fully transparent — write bg if given, skip otherwise.
+                if let Some(b) = bg {
+                    unsafe { fb.write_pixel(sx as u32, sy as u32, b.r, b.g, b.b) };
+                }
+                continue;
+            }
+            if alpha == 255 {
+                // Fully opaque — just write fg.
+                unsafe { fb.write_pixel(sx as u32, sy as u32, fg.r, fg.g, fg.b) };
+                continue;
+            }
+
+            // Partial transparency — alpha blend.
+            let bg_color = match bg {
+                Some(b) => b,
+                None => read_fb_pixel(fb, sx as u32, sy as u32),
+            };
+            let a = alpha as u16;
+            let inv = 255 - a;
+            let r = ((fg.r as u16 * a + bg_color.r as u16 * inv) / 255) as u8;
+            let g = ((fg.g as u16 * a + bg_color.g as u16 * inv) / 255) as u8;
+            let b = ((fg.b as u16 * a + bg_color.b as u16 * inv) / 255) as u8;
+            unsafe { fb.write_pixel(sx as u32, sy as u32, r, g, b) };
+        }
+    }
+}
+
+/// Draw a string. Returns pixel width.
+pub fn draw_text(
+    fb: &FramebufferInfo,
+    px: i32,
+    py: i32,
+    s: &str,
+    size: FontSize,
+    fg: Rgb,
+    bg: Option<Rgb>,
+) -> u32 {
+    let gw = font_width(size) as i32;
+    let mut x = px;
+    for ch in s.chars() {
+        draw_char(fb, x, py, ch, size, fg, bg);
+        x += gw;
+    }
+    s.len() as u32 * gw as u32
+}
+
+/// Draw text with extra letter-spacing (for "tracking-widest" labels).
+pub fn draw_text_spaced(
+    fb: &FramebufferInfo,
+    px: i32,
+    py: i32,
+    s: &str,
+    size: FontSize,
+    spacing: i32,
+    fg: Rgb,
+    bg: Option<Rgb>,
+) -> u32 {
+    let gw = font_width(size) as i32 + spacing;
+    let mut x = px;
+    for ch in s.chars() {
+        draw_char(fb, x, py, ch, size, fg, bg);
+        x += gw;
+    }
+    s.len() as u32 * gw as u32
+}
+
+/// Pixel width of spaced text.
+pub fn text_width_spaced(s: &str, size: FontSize, spacing: i32) -> u32 {
+    s.len() as u32 * (font_width(size) as i32 + spacing) as u32
+}
+
+/// Draw text right-aligned ending at `rx + rw`.
+pub fn draw_text_right(
+    fb: &FramebufferInfo,
+    rx: i32,
+    ry: i32,
+    rw: u32,
+    s: &str,
+    size: FontSize,
+    fg: Rgb,
+    bg: Option<Rgb>,
+) {
+    let tw = text_width(s, size);
+    let x = rx + rw as i32 - tw as i32;
+    draw_text(fb, x, ry, s, size, fg, bg);
+}
+
+/// Draw text centered horizontally within `[rx, rx+rw)`.
+pub fn draw_text_centered(
+    fb: &FramebufferInfo,
+    rx: i32,
+    ry: i32,
+    rw: u32,
+    s: &str,
+    size: FontSize,
+    fg: Rgb,
+    bg: Option<Rgb>,
+) {
+    let tw = text_width(s, size);
+    let x = rx + (rw as i32 - tw as i32) / 2;
+    draw_text(fb, x, ry, s, size, fg, bg);
+}

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -5,7 +5,7 @@
 //! text rendering using the Noto Sans Mono bitmap font.
 
 use crate::coreboot::FramebufferInfo;
-use noto_sans_mono_bitmap::{get_raster, get_raster_width, FontWeight, RasterHeight};
+use noto_sans_mono_bitmap::{FontWeight, RasterHeight, get_raster, get_raster_width};
 
 /// RGB color triple.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/ui/secure_boot.rs
+++ b/src/ui/secure_boot.rs
@@ -1,0 +1,388 @@
+//! Graphical Secure Boot screen — Kinetic Command design.
+
+use super::{
+    canvas, clear, draw_footer, draw_header, draw_sidebar, poll_and_render_cursor, render, theme,
+    update_sidebar_hover, NavItem, ScreenNav,
+};
+use crate::coreboot::FramebufferInfo;
+use crate::cursor::CursorRenderer;
+use crate::menu_common::{self, KeyPress};
+use crate::time::delay_ms;
+use render::FontSize;
+
+const ACTION_COUNT: usize = 6;
+/// Index of the "Back to Boot Menu" action (last item).
+const ACTION_BACK: usize = ACTION_COUNT - 1;
+
+pub fn show(fb: &FramebufferInfo) -> ScreenNav {
+    let mut cursor = CursorRenderer::new();
+    let mut selected: usize = 0;
+    let mut hovered: Option<usize> = None;
+    let mut sidebar_hov: Option<NavItem> = None;
+    let mut status: Option<(&str, bool)> = None;
+
+    draw_screen(fb, selected, hovered, status);
+
+    loop {
+        poll_and_render_cursor(fb, &mut cursor);
+
+        update_sidebar_hover(fb, &mut sidebar_hov, NavItem::Security);
+
+        // ── Card hover ──
+        let new_hov = action_hit(fb);
+        if new_hov != hovered {
+            let old = hovered;
+            hovered = new_hov;
+            // Repaint only the changed cards (not the whole screen)
+            if let Some(i) = old {
+                paint_action_card(fb, i, selected, hovered);
+            }
+            if let Some(i) = new_hov {
+                paint_action_card(fb, i, selected, hovered);
+            }
+        }
+
+        if let Some(key) = menu_common::read_key() {
+            status = None;
+            match key {
+                KeyPress::Up | KeyPress::Char('k') => {
+                    if selected > 0 {
+                        selected -= 1;
+                    }
+                    draw_screen(fb, selected, hovered, status);
+                }
+                KeyPress::Down | KeyPress::Char('j') => {
+                    if selected < ACTION_COUNT - 1 {
+                        selected += 1;
+                    }
+                    draw_screen(fb, selected, hovered, status);
+                }
+                KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
+                    return ScreenNav::Back;
+                }
+                KeyPress::Enter => {
+                    status = handle_action(selected);
+                    if selected == ACTION_BACK {
+                        return ScreenNav::Back;
+                    }
+                    draw_screen(fb, selected, hovered, status);
+                }
+                #[cfg(feature = "ui")]
+                KeyPress::MouseClick { .. } => {
+                    // Sidebar click
+                    if let Some(nav) = sidebar_hov {
+                        if nav != NavItem::Security {
+                            cursor.hide(fb);
+                            return ScreenNav::Nav(nav);
+                        }
+                    }
+                    // Card click
+                    if let Some(idx) = hovered {
+                        if idx == selected {
+                            status = handle_action(selected);
+                            if selected == ACTION_BACK {
+                                return ScreenNav::Back;
+                            }
+                        } else {
+                            selected = idx;
+                        }
+                        draw_screen(fb, selected, hovered, status);
+                    }
+                }
+                #[cfg(feature = "ui")]
+                KeyPress::MouseScroll(dz) => {
+                    if dz > 0 && selected < ACTION_COUNT - 1 {
+                        selected += 1;
+                    } else if dz < 0 && selected > 0 {
+                        selected -= 1;
+                    }
+                    draw_screen(fb, selected, hovered, status);
+                }
+                _ => {}
+            }
+        }
+        delay_ms(8);
+    }
+}
+
+fn handle_action(idx: usize) -> Option<(&'static str, bool)> {
+    use crate::efi::auth;
+    match idx {
+        0 => {
+            if auth::is_secure_boot_enabled() {
+                auth::disable_secure_boot();
+                Some(("Secure Boot disabled", true))
+            } else {
+                auth::enable_secure_boot();
+                if auth::is_secure_boot_enabled() {
+                    Some(("Secure Boot enabled", true))
+                } else {
+                    Some(("Cannot enable: no PK enrolled", false))
+                }
+            }
+        }
+        1 => match auth::enrollment::enroll_default_keys() {
+            Ok(_) => Some(("Default keys enrolled", true)),
+            Err(_) => Some(("Failed to enroll keys", false)),
+        },
+        4 => match auth::boot::clear_all_keys() {
+            Ok(_) => Some(("All keys cleared", true)),
+            Err(_) => Some(("Failed to clear keys", false)),
+        },
+        ACTION_BACK => None,
+        _ => Some(("Not implemented", false)),
+    }
+}
+
+/// Hit-test action cards.
+fn action_hit(fb: &FramebufferInfo) -> Option<usize> {
+    let (mx, my) = crate::drivers::mouse_cursor::position();
+    for i in 0..ACTION_COUNT {
+        let (ax, ay, aw, ah) = action_card_rect(fb, i);
+        if mx >= ax && mx < ax + aw as i32 && my >= ay && my < ay + ah as i32 {
+            return Some(i);
+        }
+    }
+    None
+}
+
+const ACTION_ITEMS: [(&str, &str); ACTION_COUNT] = [
+    (
+        "Toggle Secure Boot",
+        "Enable or disable signature verification",
+    ),
+    (
+        "Enroll Default Keys",
+        "Install Microsoft UEFI CA certificates",
+    ),
+    ("Enroll Custom PK", "Load PK from EFI\\keys\\PK.cer on ESP"),
+    ("Import dbx Update", "Load dbx revocation list from ESP"),
+    ("Clear All Keys", "Remove all keys, return to Setup Mode"),
+    ("Back to Boot Menu", "Return to boot entry selection"),
+];
+
+/// Rect for the i-th action card.
+fn action_card_rect(fb: &FramebufferInfo, i: usize) -> (i32, i32, u32, u32) {
+    let (cx, cy, cw, _) = canvas(fb);
+    let card_h = 44u32;
+    // Section header + hero card + gap
+    let hero_h = 56u32;
+    let header_h =
+        render::font_height(FontSize::Small) + 4 + render::font_height(FontSize::Display) + 16;
+    let base_y = cy + header_h as i32 + hero_h as i32 + 16;
+    let y = base_y + (i as i32 * (card_h as i32 + theme::GAP as i32));
+    (cx, y, cw, card_h)
+}
+
+/// Repaint a single action card (avoids full-screen redraw on hover changes).
+fn paint_action_card(fb: &FramebufferInfo, i: usize, selected: usize, hovered: Option<usize>) {
+    let (cx, y, cw, card_h) = action_card_rect(fb, i);
+    let (title, desc) = ACTION_ITEMS[i];
+    let is_sel = i == selected;
+    let is_hov = hovered == Some(i) && !is_sel;
+
+    let bg = if is_sel {
+        theme::SURFACE_HI
+    } else if is_hov {
+        theme::CONT_HIGH
+    } else {
+        theme::CONTAINER
+    };
+    render::fill_rounded_rect(fb, cx, y, cw, card_h, theme::RADIUS, bg);
+
+    if is_sel {
+        render::fill_rect(fb, cx, y + 2, theme::ACCENT_BAR, card_h - 4, theme::PRIMARY);
+    }
+
+    let tx = cx
+        + theme::PAD as i32
+        + if is_sel {
+            theme::ACCENT_BAR as i32 + 4
+        } else {
+            0
+        };
+    render::draw_text(
+        fb,
+        tx,
+        y + 4,
+        title,
+        FontSize::Normal,
+        theme::TEXT,
+        Some(bg),
+    );
+    render::draw_text(
+        fb,
+        tx,
+        y + 4 + render::font_height(FontSize::Normal) as i32 + 2,
+        desc,
+        FontSize::Small,
+        theme::TEXT_DIM,
+        Some(bg),
+    );
+
+    if is_sel {
+        render::draw_text(
+            fb,
+            cx + cw as i32 - 28,
+            y + 12,
+            ">",
+            FontSize::Normal,
+            theme::PRIMARY,
+            Some(bg),
+        );
+    }
+}
+
+fn draw_screen(
+    fb: &FramebufferInfo,
+    selected: usize,
+    hovered: Option<usize>,
+    status: Option<(&str, bool)>,
+) {
+    clear(fb);
+    draw_header(fb);
+    draw_sidebar(fb, NavItem::Security, None);
+    draw_footer(fb, "Up/Down Navigate   Enter Select   Esc Back");
+
+    let (cx, cy, cw, _ch) = canvas(fb);
+    let mut y = cy;
+
+    // ── Section label ──
+    render::draw_text_spaced(
+        fb,
+        cx,
+        y,
+        "SECURITY CONFIGURATION",
+        FontSize::Small,
+        2,
+        theme::PRIMARY.darken(80),
+        None,
+    );
+    y += render::font_height(FontSize::Small) as i32 + 4;
+    render::draw_text(
+        fb,
+        cx,
+        y,
+        "Secure Boot",
+        FontSize::Display,
+        theme::TEXT,
+        None,
+    );
+    y += render::font_height(FontSize::Display) as i32 + 16;
+
+    // ── Hero state card ──
+    let sb_on = crate::efi::auth::is_secure_boot_enabled();
+    let setup_mode = crate::efi::auth::is_setup_mode();
+    let enroll = crate::efi::auth::enrollment::get_enrollment_status();
+
+    let state_h = 56u32;
+    render::fill_rounded_rect(fb, cx, y, cw, state_h, theme::RADIUS, theme::CONT_LOW);
+
+    let state_color = if sb_on {
+        theme::SECONDARY
+    } else {
+        theme::ERROR
+    };
+    render::fill_rect(fb, cx, y, theme::ACCENT_BAR, state_h, state_color);
+
+    let state_label = if sb_on { "ACTIVE" } else { "INACTIVE" };
+    render::draw_text_spaced(
+        fb,
+        cx + 16,
+        y + 6,
+        "CURRENT STATE",
+        FontSize::Small,
+        1,
+        theme::OUTLINE,
+        Some(theme::CONT_LOW),
+    );
+    render::draw_text(
+        fb,
+        cx + 16,
+        y + 6 + render::font_height(FontSize::Small) as i32 + 4,
+        state_label,
+        FontSize::Heading,
+        state_color,
+        Some(theme::CONT_LOW),
+    );
+
+    // Right side: mode + key summary
+    let mode_label = if setup_mode {
+        "SETUP MODE"
+    } else {
+        "USER MODE"
+    };
+    let mode_color = if setup_mode {
+        theme::ORANGE
+    } else {
+        theme::GREEN
+    };
+    let right_x = cx + cw as i32 / 2;
+    render::draw_text(
+        fb,
+        right_x,
+        y + 6,
+        mode_label,
+        FontSize::Small,
+        mode_color,
+        Some(theme::CONT_LOW),
+    );
+
+    let mut kx = right_x;
+    let ky = y + 6 + render::font_height(FontSize::Small) as i32 + 6;
+    let keys: [(&str, usize); 4] = [
+        ("PK", enroll.pk_count),
+        ("KEK", enroll.kek_count),
+        ("db", enroll.db_count),
+        ("dbx", enroll.dbx_count),
+    ];
+    for (name, count) in &keys {
+        let mut buf = [0u8; 16];
+        let s = fmt_kc(name, *count as u32, &mut buf);
+        let pbg = if *count > 0 {
+            theme::ACCENT_DIM
+        } else {
+            theme::GHOST
+        };
+        render::draw_pill(fb, kx, ky, s, theme::TEXT, pbg);
+        kx += (render::text_width(s, FontSize::Small) + 24) as i32;
+    }
+
+    let _ = y; // y was used to position hero card; action cards use action_card_rect()
+
+    // ── Action cards ──
+    for i in 0..ACTION_COUNT {
+        paint_action_card(fb, i, selected, hovered);
+    }
+
+    // Status toast
+    if let Some((msg, ok)) = status {
+        let msg_y = fb.y_resolution as i32 - theme::FOOTER_H as i32 - 24;
+        let color = if ok { theme::SECONDARY } else { theme::ERROR };
+        render::draw_text_centered(
+            fb,
+            0,
+            msg_y,
+            fb.x_resolution,
+            msg,
+            FontSize::Normal,
+            color,
+            None,
+        );
+    }
+}
+
+fn fmt_kc<'a>(name: &str, count: u32, buf: &'a mut [u8; 16]) -> &'a str {
+    let mut p = 0;
+    for &b in name.as_bytes() {
+        if p >= buf.len() - 6 {
+            break; // leave room for ':' + digits
+        }
+        buf[p] = b;
+        p += 1;
+    }
+    buf[p] = b':';
+    p += 1;
+    p += super::fmt_u32(count, &mut buf[p..]);
+    core::str::from_utf8(&buf[..p]).unwrap_or("??")
+}

--- a/src/ui/secure_boot.rs
+++ b/src/ui/secure_boot.rs
@@ -1,8 +1,8 @@
 //! Graphical Secure Boot screen — Kinetic Command design.
 
 use super::{
-    canvas, clear, draw_footer, draw_header, draw_sidebar, poll_and_render_cursor, render, theme,
-    update_sidebar_hover, NavItem, ScreenNav,
+    NavItem, ScreenNav, canvas, clear, draw_footer, draw_header, draw_sidebar,
+    poll_and_render_cursor, render, theme, update_sidebar_hover,
 };
 use crate::coreboot::FramebufferInfo;
 use crate::cursor::CursorRenderer;

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,0 +1,98 @@
+//! Kinetic Command design system — palette and layout tokens.
+//!
+//! Ported from the "Ethereal Machine" design spec (DESIGN.md).
+//! Hex values match the Tailwind config in the reference HTML.
+
+use super::render::Rgb;
+
+// ── Surface hierarchy (tonal layering — the "No-Line" rule) ─────────────
+
+pub const BG: Rgb = Rgb::new(0x0c, 0x0e, 0x12); // #0c0e12  void
+pub const SIDE: Rgb = Rgb::new(0x11, 0x13, 0x18); // #111318  sidebar
+pub const CONTAINER: Rgb = Rgb::new(0x17, 0x1a, 0x1f); // #171a1f  content
+pub const CONT_LOW: Rgb = Rgb::new(0x11, 0x13, 0x18); // #111318  recessed
+pub const CONT_HIGH: Rgb = Rgb::new(0x1d, 0x20, 0x25); // #1d2025  elevated
+pub const SURFACE_HI: Rgb = Rgb::new(0x23, 0x26, 0x2c); // #23262c  hover
+pub const BRIGHT: Rgb = Rgb::new(0x29, 0x2c, 0x33); // #292c33  focus
+
+// ── Accent colors ───────────────────────────────────────────────────────
+
+pub const PRIMARY: Rgb = Rgb::new(0x8f, 0xf5, 0xff); // #8ff5ff  electric cyan
+pub const PRIMARY_C: Rgb = Rgb::new(0x00, 0xee, 0xfc); // #00eefc  gradient end
+pub const SECONDARY: Rgb = Rgb::new(0x00, 0xdc, 0xfc); // #00dcfc
+pub const TERTIARY: Rgb = Rgb::new(0x65, 0xaf, 0xff); // #65afff  data blue
+pub const ERROR: Rgb = Rgb::new(0xff, 0x71, 0x6c); // #ff716c
+
+// ── Text ────────────────────────────────────────────────────────────────
+
+pub const TEXT: Rgb = Rgb::new(0xf6, 0xf6, 0xfc); // #f6f6fc  NOT pure white
+pub const TEXT_DIM: Rgb = Rgb::new(0xaa, 0xab, 0xb0); // #aaabb0  on-surface-variant
+pub const OUTLINE: Rgb = Rgb::new(0x74, 0x75, 0x7a); // #74757a
+pub const ON_PRIMARY: Rgb = Rgb::new(0x00, 0x5d, 0x63); // #005d63
+pub const GHOST: Rgb = Rgb::new(0x46, 0x48, 0x4d); // #46484d  ghost border
+
+// ── Back-compat aliases used by existing code ───────────────────────────
+
+pub const ACCENT: Rgb = PRIMARY;
+pub const ACCENT_DIM: Rgb = Rgb::new(0x00, 0x6a, 0x71);
+pub const TEXT_SECONDARY: Rgb = TEXT_DIM;
+pub const TEXT_ON_ACCENT: Rgb = Rgb::new(0xff, 0xff, 0xff);
+pub const TEXT_DISABLED: Rgb = GHOST;
+pub const TIMER: Rgb = PRIMARY;
+pub const RED: Rgb = ERROR;
+pub const GREEN: Rgb = Rgb::new(0x3f, 0xb9, 0x50); // #3FB950
+pub const ORANGE: Rgb = Rgb::new(0xd2, 0x99, 0x22); // #D29922
+pub const BORDER: Rgb = GHOST;
+pub const BORDER_SEL: Rgb = PRIMARY;
+pub const BAR_BG: Rgb = SIDE;
+pub const BAR_TOP: Rgb = Rgb::new(0x14, 0x17, 0x1c);
+pub const SURFACE_SEL: Rgb = Rgb::new(0x17, 0x22, 0x2c);
+
+pub const BADGE_UEFI: Rgb = Rgb::new(0x00, 0x6a, 0x71);
+pub const BADGE_LINUX: Rgb = Rgb::new(0x1a, 0x5e, 0x2a);
+pub const BADGE_GRUB: Rgb = Rgb::new(0x6a, 0x40, 0x10);
+pub const BADGE_PAYLOAD: Rgb = Rgb::new(0x40, 0x30, 0x6a);
+
+pub const SB_ENABLED: Rgb = SECONDARY;
+pub const SB_DISABLED: Rgb = ERROR;
+pub const SB_SETUP: Rgb = ORANGE;
+
+// ── Layout (pixels, 800×600) ────────────────────────────────────────────
+//
+// Proportions tuned for breathing room per the design spec:
+// "Prioritize Breathing Room — spacing-10 and spacing-12 for section margins."
+
+pub const SIDEBAR_W: u32 = 168;
+pub const HEADER_H: u32 = 52;
+pub const FOOTER_H: u32 = 28;
+pub const PAD: u32 = 16;
+pub const RADIUS: u32 = 6;
+pub const GAP: u32 = 8;
+pub const ACCENT_BAR: u32 = 3;
+
+// ── Sidebar navigation ─────────────────────────────────────────────────
+
+/// Height of each sidebar navigation item.
+pub const NAV_ITEM_H: u32 = 36;
+/// Vertical stride between sidebar items.
+pub const NAV_ITEM_STRIDE: u32 = 4;
+/// Vertical offset from sidebar top to first nav item.
+pub const NAV_TOP_PAD: u32 = 48;
+
+// ── Boot cards ──────────────────────────────────────────────────────────
+
+pub const CARD_H: u32 = 68;
+pub const CARD_GAP: u32 = GAP;
+pub const CARD_PAD_X: u32 = 16;
+pub const CARD_PAD_Y: u32 = 10;
+pub const CARD_RADIUS: u32 = RADIUS;
+pub const GLOW_SPREAD: u32 = 4;
+pub const INDICATOR_W: u32 = ACCENT_BAR;
+
+// ── Footer / progress ───────────────────────────────────────────────────
+
+pub const PROGRESS_H: u32 = 4;
+pub const PROGRESS_RADIUS: u32 = 2;
+
+// Back-compat layout aliases
+pub const MARGIN: u32 = PAD;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -76,6 +76,10 @@ enum Commands {
         /// Build in release mode (default, required for firmware)
         #[arg(long, default_value_t = true)]
         release: bool,
+
+        /// Enable graphical UI with mouse support
+        #[arg(long)]
+        ui: bool,
     },
 
     /// Run CrabEFI in QEMU
@@ -111,6 +115,10 @@ enum Commands {
         /// Path to existing disk image to use
         #[arg(long)]
         disk: Option<String>,
+
+        /// Enable graphical UI with mouse support
+        #[arg(long)]
+        ui: bool,
     },
 
     /// Run integration tests in QEMU
@@ -142,6 +150,10 @@ enum Commands {
         /// Timeout in seconds (default: 60)
         #[arg(long, default_value_t = 60)]
         timeout: u64,
+
+        /// Enable graphical UI with mouse support
+        #[arg(long)]
+        ui: bool,
     },
 
     /// Build a test EFI application
@@ -184,7 +196,7 @@ fn main() -> Result<()> {
     let machine = cli.machine;
 
     match cli.command {
-        Commands::Build { release } => cmd_build(release, arch, machine),
+        Commands::Build { release, ui } => cmd_build(release, ui, arch, machine),
         Commands::Run {
             coreboot_rom,
             ahci,
@@ -194,6 +206,7 @@ fn main() -> Result<()> {
             disable_kvm,
             app,
             disk,
+            ui,
         } => cmd_run(
             coreboot_rom,
             ahci,
@@ -203,6 +216,7 @@ fn main() -> Result<()> {
             disable_kvm,
             app,
             disk,
+            ui,
             arch,
             machine,
         ),
@@ -214,6 +228,7 @@ fn main() -> Result<()> {
             sdhci,
             disable_kvm,
             timeout,
+            ui,
         } => cmd_test(
             coreboot_rom,
             &app,
@@ -222,6 +237,7 @@ fn main() -> Result<()> {
             sdhci,
             disable_kvm,
             timeout,
+            ui,
             arch,
             machine,
         ),
@@ -233,7 +249,7 @@ fn main() -> Result<()> {
     }
 }
 
-fn cmd_build(release: bool, arch: Arch, machine: Machine) -> Result<()> {
+fn cmd_build(release: bool, ui: bool, arch: Arch, machine: Machine) -> Result<()> {
     let label = match (arch, machine) {
         (Arch::X86_64, _) => "x86_64".to_string(),
         (Arch::Aarch64, Machine::Sbsa) => "aarch64/sbsa".to_string(),
@@ -250,6 +266,9 @@ fn cmd_build(release: bool, arch: Arch, machine: Machine) -> Result<()> {
     cmd.arg("-p").arg("crabefi-coreboot");
     if release {
         cmd.arg("--release");
+    }
+    if ui {
+        cmd.arg("--features").arg("ui");
     }
 
     let target_triple = match arch {
@@ -292,6 +311,7 @@ fn cmd_run(
     disable_kvm: bool,
     app: Option<String>,
     disk: Option<String>,
+    ui: bool,
     arch: Arch,
     machine: Machine,
 ) -> Result<()> {
@@ -316,14 +336,14 @@ fn cmd_run(
         }
     } else {
         // Build CrabEFI first
-        cmd_build(true, arch, machine)?;
+        cmd_build(true, ui, arch, machine)?;
 
         // Prepare ROM with CrabEFI payload
         let crabefi_elf = rom::get_crabefi_elf(arch);
         rom::prepare_rom(&crabefi_elf, temp_dir.path(), arch, machine)?
     };
 
-    let config = qemu::QemuConfig {
+    let mut config = qemu::QemuConfig {
         coreboot_rom: firmware.coreboot_rom.to_string_lossy().to_string(),
         tfa_flash: firmware.tfa_flash.map(|p| p.to_string_lossy().to_string()),
         storage,
@@ -332,7 +352,18 @@ fn cmd_run(
         timeout_secs: None,
         arch,
         machine,
+        extra_devices: Vec::new(),
     };
+
+    // Add USB keyboard for UI testing.
+    // NOTE: We do NOT add -device usb-mouse because QEMU routes ALL window
+    // mouse events to the USB mouse exclusively, starving the PS/2 mouse.
+    // The PS/2 mouse (built into Q35's i8042) receives window mouse events
+    // by default when no USB pointing device is present.
+    if ui {
+        config.extra_devices.push("-device".to_string());
+        config.extra_devices.push("usb-kbd,bus=xhci.0".to_string());
+    }
 
     // If a disk is specified, use it directly
     if let Some(disk_path) = disk {
@@ -367,6 +398,7 @@ fn cmd_test(
     sdhci: bool,
     disable_kvm: bool,
     timeout: u64,
+    ui: bool,
     arch: Arch,
     machine: Machine,
 ) -> Result<()> {
@@ -391,7 +423,7 @@ fn cmd_test(
         }
     } else {
         // Build CrabEFI first
-        cmd_build(true, arch, machine)?;
+        cmd_build(true, ui, arch, machine)?;
 
         // Prepare ROM with CrabEFI payload
         let crabefi_elf = rom::get_crabefi_elf(arch);
@@ -407,6 +439,7 @@ fn cmd_test(
         timeout_secs: Some(timeout),
         arch,
         machine,
+        extra_devices: Vec::new(),
     };
 
     // Build the test app

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -41,6 +41,8 @@ pub struct QemuConfig {
     pub arch: Arch,
     /// QEMU machine type (aarch64 only)
     pub machine: Machine,
+    /// Extra QEMU device arguments (e.g., USB mouse for UI testing)
+    pub extra_devices: Vec<String>,
 }
 
 /// Test result from QEMU run
@@ -111,6 +113,11 @@ fn build_qemu_command_x86_64(config: &QemuConfig, disk_path: &Path) -> Result<Co
 
     // Debug options
     cmd.args(["-d", "guest_errors"]);
+
+    // Extra devices (e.g., USB mouse for UI testing)
+    for arg in &config.extra_devices {
+        cmd.arg(arg);
+    }
 
     // Capture stderr for QEMU errors
     cmd.stderr(Stdio::piped());


### PR DESCRIPTION
Introduces a new optional `ui` Cargo feature that enables a full graphical boot interface ("Kinetic Command" / "Ethereal Machine" design system) with mouse input support. When disabled, the firmware behaves exactly as before with the text-based menu.

**Mouse input drivers**
- `src/drivers/mouse.rs`: PS/2 mouse driver with support for standard 3-button mice and Synaptics touchpads in absolute mode, including TrackPoint pass-through (targeted at ThinkPad T480/T470s/X280/X1C5/X1C6). Handles Synaptics detection, absolute mode negotiation, pass-through packet decoding, and relative motion synthesis.
- `src/drivers/mouse_cursor.rs`: Unified cursor abstraction aggregating PS/2 and USB HID mouse deltas with configurable acceleration and fixed-point sub-pixel precision.
- `src/drivers/usb/hid_mouse.rs`: USB HID boot-protocol mouse driver using interrupt IN transfers (with GET_REPORT fallback that self-disables after repeated stalls).
- `src/cursor.rs`: 12×19 arrow cursor sprite renderer with save-under compositing so the cursor is visible on any background without corrupting content.

**USB stack extensions**
- xHCI: adds `configure_hid_mouse()` to allocate a transfer ring for the interrupt IN endpoint and issue a Configure Endpoint command; adds `interrupt_transfer_impl()` for synchronous interrupt IN transfers; adds hub enumeration (`configure_and_enumerate_hub`, `attach_device_on_hub`, `evaluate_hub_context`) with route-string-based addressing.
- `UsbController` trait gains `interrupt_transfer()`, `find_hid_mouse()`, and `get_mouse_interrupt_endpoint()` with default no-op implementations.
- `UsbDevice` / `UsbSlot` / `DeviceInfo` gain `is_hid_mouse`, `mouse_interrupt_in`, and related endpoint fields.

**EFI protocol**
- `src/efi/protocols/simple_pointer.rs`: implements `EFI_SIMPLE_POINTER_PROTOCOL` backed by the unified cursor driver, returning `NOT_READY` when there is no motion.

**Graphical UI screens** (`src/ui/`)
- `mod.rs`: top-level screen state machine with shared chrome (header, sidebar, footer, cursor rendering); boot selection screen with hero cards, countdown progress bar, and hover effects.
- `render.rs`: low-level framebuffer primitives — filled/rounded/gradient rectangles, glow, progress bar, pill badges, toggle switches, multi-size anti-aliased text via `noto-sans-mono-bitmap`.
- `theme.rs`: "Ethereal Machine" design tokens (palette, layout constants).
- `secure_boot.rs`: Secure Boot management screen with action cards and a status toast.
- `firmware_settings.rs`: CFR (coreboot firmware settings) browser screen.

**Integration points**
- `boot_manager.rs`: initializes USB mice after USB controllers are bound; routes to `ui::show_graphical_menu` / `ui::show_no_media_screen` when the feature is enabled.
- `menu.rs`: adds cursor rendering to the text menu loop; handles `MouseClick` and `MouseScroll` key events for click-to-select and scroll navigation.
- `menu_common.rs`: `read_key()` emits `MouseClick` and `MouseScroll` events from the cursor driver.
- `drivers/keyboard.rs`: forwards AUX bytes to the PS/2 mouse driver instead of discarding them; clears `AUX_DISABLE` in the controller config to keep the mouse port clock running.
- `xtask`: adds `--ui` flag to `build`, `run`, and `test` subcommands; passes `--features ui` to cargo and adds a USB keyboard device to QEMU when UI mode is active.