### PR TITLE
refactor: replace post_heap_init callback with heap_pre_initialized flag

### DIFF
--- a/crabefi-coreboot/Cargo.toml
+++ b/crabefi-coreboot/Cargo.toml
@@ -16,8 +16,8 @@ r-efi = "5.3"
 heapless = "0.8"
 
 # ACPI table parsing and AML interpreter for platform device discovery.
-# Used by the coreboot payload's post_heap_init callback to discover
-# ECAM, GIC, UART, and DSDT devices from ACPI tables.
+# Used by the coreboot payload to discover ECAM, GIC, UART, and DSDT
+# devices from ACPI tables before handing off to init_platform().
 acpi = { version = "6.1", default-features = false, features = ["alloc", "aml"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -24,13 +24,6 @@ use core::panic::PanicInfo;
 const MAX_MEMORY_REGIONS: usize = 96;
 
 // ============================================================================
-// Statics for passing data into the post_heap_init callback
-// ============================================================================
-
-/// Raw CFR data pointer from coreboot tables (needs heap to parse).
-static mut CFR_RAW_PTR: Option<&'static [u8]> = None;
-
-// ============================================================================
 // Platform trait implementations
 // ============================================================================
 
@@ -73,52 +66,6 @@ impl crabefi::ResetHandler for CorebootReset {
                 _ => crabefi::arch::aarch64::reset::system_reset(),
             }
         }
-    }
-}
-
-// ============================================================================
-// Post-heap initialization callback
-// ============================================================================
-
-/// Runs after `init_platform()` has initialized the EFI memory allocator and
-/// heap. Performs heap-dependent discovery that the coreboot payload needs:
-///
-/// 1. ACPI table discovery (MADT, MCFG, SPCR, DSDT via AML interpreter)
-/// 2. Platform MMIO region registration (aarch64)
-/// 3. CFR (Coreboot Form Representation) parsing
-fn coreboot_post_heap_init() {
-    // ---- 1. ACPI platform discovery ----
-    //
-    // The AML interpreter allocates, so this must run after heap::init().
-    // Results go into state.drivers.acpi_info which init_platform() reads
-    // for ECAM base and add_platform_mmio_regions() reads for MMIO.
-    if let Some(rsdp) = crabefi::state::drivers().platform.acpi_rsdp {
-        let acpi_info = unsafe { acpi::discover_platform(rsdp) };
-        crabefi::state::with_drivers_mut(|d| d.acpi_info = acpi_info);
-    }
-
-    // ---- 2. Platform MMIO regions (aarch64) ----
-    //
-    // Coreboot's lb_memory table omits MMIO regions. Add them from the
-    // ACPI/FDT info we just discovered.
-    #[cfg(target_arch = "aarch64")]
-    crabefi::efi::add_platform_mmio_regions();
-
-    // ---- 3. CFR parsing ----
-    //
-    // Parse coreboot firmware configuration options now that the heap is
-    // available. The raw data pointer was saved during table parsing.
-    //
-    // SAFETY: single-threaded firmware; CFR_RAW_PTR set once in rust_main().
-    if let Some(cfr_raw) = unsafe { CFR_RAW_PTR }
-        && let Some(cfr) = crabefi::coreboot::cfr::parse_cfr(cfr_raw)
-    {
-        log::info!(
-            "CFR: {} forms, {} options",
-            cfr.forms.len(),
-            cfr.total_options()
-        );
-        crabefi::coreboot::store_cfr(cfr);
     }
 }
 
@@ -240,21 +187,13 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
     }
 
     // Store memory regions and ACPI RSDP (used by direct Linux boot path
-    // and by the post_heap_init callback for ACPI discovery).
+    // and by ACPI discovery after heap init).
     crabefi::state::with_drivers_mut(|drivers| {
         for region in cb_info.memory_map.iter() {
             let _ = drivers.platform.memory_regions.push(*region);
         }
         drivers.platform.acpi_rsdp = cb_info.acpi_rsdp;
     });
-
-    // Save CFR raw data pointer for the post-heap callback.
-    // SAFETY: single-threaded firmware; pointer valid for firmware lifetime.
-    if let Some(cfr_raw) = cb_info.cfr_raw {
-        unsafe {
-            CFR_RAW_PTR = Some(cfr_raw);
-        }
-    }
 
     // ================================================================
     // Phase 4: Initialize serial and logging
@@ -282,7 +221,7 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
     crabefi::time::init(cb_info.acpi_rsdp);
 
     // ================================================================
-    // Phase 6: Build PlatformConfig and hand off to the library
+    // Phase 6: Build PlatformConfig
     // ================================================================
 
     // Convert coreboot memory map to platform format.
@@ -306,7 +245,7 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
         unsafe { core::slice::from_raw_parts(addr as *const u8, size as usize) }
     });
 
-    let config = crabefi::PlatformConfig {
+    let mut config = crabefi::PlatformConfig {
         memory_map: &memory_regions[..region_count],
         timer: &timer,
         reset: &reset,
@@ -319,13 +258,69 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
         smbios: cb_info.smbios,
         fdt: fdt_slice,
         rng: None,
-        ecam_base: None,       // Discovered by post_heap_init callback via ACPI MCFG
-        deferred_buffer: None, // Uses linker-symbol fallback in init_platform()
-        runtime_region: None,  // Uses linker-symbol fallback (platform-entry feature)
-        post_heap_init: Some(coreboot_post_heap_init),
+        ecam_base: None,             // May be filled from ACPI MCFG below
+        deferred_buffer: None,       // Uses linker-symbol fallback in init_platform()
+        runtime_region: None,        // Uses linker-symbol fallback (platform-entry feature)
+        heap_pre_initialized: false, // Set to true after Phase 7
     };
 
-    // This never returns — the boot manager takes over.
+    // ================================================================
+    // Phase 7: Bootstrap page allocator and heap early
+    //
+    // We only need the page allocator (for heap::init) and the heap
+    // (for ACPI AML / CFR parsing).  The full EFI environment (system
+    // table, config tables, runtime reservations) is set up later by
+    // init_platform() — its allocator init is idempotent so the second
+    // call is a no-op.
+    // ================================================================
+    crabefi::efi::allocator::init_from_platform(config.memory_map);
+    if !crabefi::heap::init() {
+        log::error!("Failed to initialize heap allocator!");
+    }
+    config.heap_pre_initialized = true;
+
+    // ================================================================
+    // Phase 8: Post-heap platform discovery
+    //
+    // Now that the heap is available we can run ACPI AML interpretation,
+    // register MMIO regions, and parse CFR options.
+    // ================================================================
+
+    // ---- ACPI platform discovery ----
+    //
+    // The AML interpreter allocates, so this must run after heap::init().
+    // Results go into state.drivers.acpi_info which init_platform() reads
+    // for ECAM base and add_platform_mmio_regions() reads for MMIO.
+    if let Some(rsdp) = crabefi::state::drivers().platform.acpi_rsdp {
+        let acpi_info = unsafe { acpi::discover_platform(rsdp) };
+        crabefi::state::with_drivers_mut(|d| d.acpi_info = acpi_info);
+    }
+
+    // ---- Platform MMIO regions (aarch64) ----
+    //
+    // Coreboot's lb_memory table omits MMIO regions. Add them from the
+    // ACPI/FDT info we just discovered.
+    #[cfg(target_arch = "aarch64")]
+    crabefi::efi::add_platform_mmio_regions();
+
+    // ---- CFR parsing ----
+    //
+    // Parse coreboot firmware configuration options now that the heap is
+    // available. cb_info.cfr_raw is still in scope — no static needed.
+    if let Some(cfr_raw) = cb_info.cfr_raw
+        && let Some(cfr) = crabefi::coreboot::cfr::parse_cfr(cfr_raw)
+    {
+        log::info!(
+            "CFR: {} forms, {} options",
+            cfr.forms.len(),
+            cfr.total_options()
+        );
+        crabefi::coreboot::store_cfr(cfr);
+    }
+
+    // ================================================================
+    // Phase 9: Hand off to the library (never returns)
+    // ================================================================
     crabefi::init_platform(config)
 }
 

--- a/src/efi/allocator.rs
+++ b/src/efi/allocator.rs
@@ -347,7 +347,16 @@ impl MemoryAllocator {
     ///
     /// This is the `init_platform()` counterpart to `init_from_coreboot()`.
     /// Converts `platform::MemoryRegion` entries into EFI memory descriptors.
+    ///
+    /// Idempotent: if the allocator already has entries (e.g., the caller
+    /// bootstrapped the page allocator before [`crate::init_platform()`] to
+    /// get a heap), this is a no-op.
     pub fn init_from_platform(&mut self, regions: &[crate::platform::MemoryRegion]) {
+        if !self.entries.is_empty() {
+            log::info!("Page allocator already initialized, skipping re-init");
+            return;
+        }
+
         use crate::platform::MemoryType as PlatMemType;
 
         self.entries.clear();

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -31,8 +31,8 @@ pub fn init_from_platform(config: &crate::platform::PlatformConfig) {
     // entries. This avoids duplicate memory map entries and removes the need
     // for ACPI/FDT parsing inside the library for this purpose.
     //
-    // For the coreboot payload specifically, the post_heap_init callback calls
-    // efi::add_platform_mmio_regions() after ACPI discovery.
+    // Platforms that discover MMIO regions via ACPI (e.g., coreboot) call
+    // efi::add_platform_mmio_regions() themselves before init_platform().
 
     // On aarch64, reserve EL2 page tables if running at EL2.
     // When called from fstart (which typically runs at EL1), this is a no-op.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,26 +320,26 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
     drivers::keyboard_common::init();
 
     // ---- 8. Initialize EFI environment ----
+    //
+    // Always runs — sets up the EFI memory map, system table, ACPI/SMBIOS
+    // configuration tables, and runtime region reservations.  The page
+    // allocator is idempotent: if the caller already bootstrapped it
+    // (to get a heap before entry), re-initialization is skipped.
     efi::init_from_platform(&config);
 
     log::info!("CrabEFI initialized successfully!");
     log::info!("EFI System Table at: {:p}", efi::get_system_table());
 
     // ---- 9. Initialize heap ----
-    if !heap::init() {
+    //
+    // Skipped when the platform already set up the heap before entry
+    // (heap_pre_initialized == true).  The rest of the init sequence is
+    // identical regardless of this flag.
+    if !config.heap_pre_initialized && !heap::init() {
         log::error!("Failed to initialize heap allocator!");
     }
 
-    // ---- 10. Post-heap initialization callback ----
-    //
-    // Allows the caller to perform heap-dependent work (e.g., ACPI AML
-    // parsing, CFR parsing, MMIO region discovery) before PCI enumeration
-    // and the boot manager.
-    if let Some(hook) = config.post_heap_init {
-        hook();
-    }
-
-    // ---- 10b. Runtime log support ----
+    // ---- 10. Runtime log support ----
     #[cfg(feature = "rt-log")]
     {
         efi::rtlog::register_region();
@@ -349,7 +349,9 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
     // ---- 11. Discover PCI ECAM and initialize PCI ----
     //
     // Priority: config.ecam_base > acpi_info.ecam_base > fdt_info.ecam_base.
-    // acpi_info is populated by the post_heap_init callback (ACPI discovery).
+    // acpi_info is populated by the platform before entry (when
+    // heap_pre_initialized is true) or left empty for library consumers
+    // that provide ecam_base directly.
     if let Some(ecam) = config.ecam_base {
         log::info!("PCI ECAM base from platform: {:#x}", ecam);
         drivers::pci::set_ecam_base(ecam);

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1018,26 +1018,17 @@ pub struct PlatformConfig<'a> {
     /// cannot provide runtime services after `ExitBootServices`.
     pub runtime_region: Option<RuntimeRegion>,
 
-    // ---- Hooks ----
-    /// Optional callback invoked after heap initialization but before the
-    /// boot manager.
+    // ---- Pre-initialization ----
+    /// Whether the EFI environment and heap allocator were already set up
+    /// before calling [`crate::init_platform()`].
     ///
-    /// This allows the caller to perform heap-dependent initialization
-    /// (e.g., ACPI AML parsing, firmware configuration parsing) that cannot
-    /// happen before [`crate::init_platform()`] sets up the memory allocator.
+    /// When `true`, `init_platform()` skips [`efi::init_from_platform()`]
+    /// and [`heap::init()`]. The caller is responsible for having called
+    /// both before entry, so that `alloc` works and the EFI memory map /
+    /// system table are ready.
     ///
-    /// The callback runs after:
-    /// - EFI memory allocator is initialized (from `memory_map`)
-    /// - Heap allocator is ready (global `alloc` works)
-    /// - Timer is calibrated
-    /// - FDT is parsed (if provided)
-    ///
-    /// The callback runs before:
-    /// - PCI ECAM setup and enumeration
-    /// - Block device registration
-    /// - Variable persistence and boot manager
-    ///
-    /// Use this to populate `DriverState.acpi_info` (via ACPI table
-    /// discovery) so that PCI ECAM can be discovered from ACPI MCFG.
-    pub post_heap_init: Option<fn()>,
+    /// This allows platforms to perform heap-dependent initialization
+    /// (e.g., ACPI AML parsing, firmware configuration parsing) *before*
+    /// handing off to the library, removing the need for a callback.
+    pub heap_pre_initialized: bool,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -653,10 +653,10 @@ pub struct DriverState {
 
     /// Platform info from ACPI tables (GIC from MADT, UART from SPCR, ECAM from MCFG).
     ///
-    /// Populated by the coreboot payload's `post_heap_init` callback, which
-    /// runs ACPI discovery after the heap is available. Library consumers
-    /// provide MMIO regions via `PlatformConfig.memory_map` and ECAM via
-    /// `PlatformConfig.ecam_base`, so this field is empty for them.
+    /// Populated by platforms that perform ACPI discovery before calling
+    /// [`crate::init_platform()`] (using `heap_pre_initialized`).  Library
+    /// consumers that provide MMIO regions via `PlatformConfig.memory_map`
+    /// and ECAM via `PlatformConfig.ecam_base` leave this empty.
     ///
     /// `init_platform()` checks `acpi_info.ecam_base` as a fallback for PCI
     /// ECAM discovery (after `config.ecam_base`, before `fdt_info.ecam_base`).


### PR DESCRIPTION
## Summary

- Replace `post_heap_init: Option<fn()>` callback on `PlatformConfig` with a `heap_pre_initialized: bool` flag, allowing platforms to set up the heap and perform heap-dependent work (ACPI, CFR) before calling `init_platform()`
- Library init sequence is identical regardless of the flag: `efi::init_from_platform()` always runs (page allocator made idempotent), only `heap::init()` is skipped when the flag is set — no coreboot-specific codepaths in the library
- Coreboot payload restructured to bootstrap just the page allocator + heap early, do ACPI/CFR discovery inline, then hand off — eliminates the `unsafe` `CFR_RAW_PTR` static since `cb_info` stays in scope