### PR TITLE
refactor: decouple UI/cursor/menu from coreboot::FramebufferInfo

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -8,7 +8,7 @@
 //! Windows/X11 cursor shape. It uses XOR-like compositing (black outline
 //! with white fill) so it is visible on any background.
 
-use crate::coreboot::FramebufferInfo;
+use crate::FramebufferConfig as FramebufferInfo;
 
 /// Cursor width in pixels
 pub const CURSOR_W: usize = 12;
@@ -62,6 +62,12 @@ pub struct CursorRenderer {
     save_valid: [[bool; CURSOR_W]; CURSOR_H],
 }
 
+impl Default for CursorRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CursorRenderer {
     /// Create a new cursor renderer.
     pub const fn new() -> Self {
@@ -105,9 +111,8 @@ impl CursorRenderer {
             row.fill(false);
         }
 
-        for row in 0..CURSOR_H {
-            for col in 0..CURSOR_W {
-                let pixel = CURSOR_BITMAP[row][col];
+        for (row, bitmap_row) in CURSOR_BITMAP.iter().enumerate() {
+            for (col, &pixel) in bitmap_row.iter().enumerate() {
                 if pixel == 0 {
                     continue; // Transparent
                 }
@@ -116,8 +121,7 @@ impl CursorRenderer {
                 let py = y + row as i32;
 
                 // Bounds check
-                if px < 0 || py < 0 || px >= fb.x_resolution as i32 || py >= fb.y_resolution as i32
-                {
+                if px < 0 || py < 0 || px >= fb.width as i32 || py >= fb.height as i32 {
                     continue;
                 }
 
@@ -177,30 +181,30 @@ impl CursorRenderer {
 /// This reads raw bytes from the framebuffer and converts to a canonical
 /// format for save-under buffering.
 fn read_pixel(fb: &FramebufferInfo, x: u32, y: u32) -> u32 {
-    let offset = (y * fb.bytes_per_line + x * (fb.bits_per_pixel as u32 / 8)) as usize;
-    let base = fb.physical_address as *const u8;
+    let offset = fb.pixel_offset(x, y);
 
-    // SAFETY: The framebuffer address and dimensions come from coreboot tables
-    // and have been validated. x,y are bounds-checked by the caller.
+    // SAFETY: The framebuffer address and dimensions have been validated.
+    // x,y are bounds-checked by the caller.
     unsafe {
+        let base = fb.as_ptr() as *const u8;
         match fb.bits_per_pixel {
             32 => {
                 let ptr = base.add(offset);
-                let b = *ptr;
-                let g = *ptr.add(1);
-                let r = *ptr.add(2);
+                let b = ptr.read_volatile();
+                let g = ptr.add(1).read_volatile();
+                let r = ptr.add(2).read_volatile();
                 ((r as u32) << 16) | ((g as u32) << 8) | b as u32
             }
             24 => {
                 let ptr = base.add(offset);
-                let b = *ptr;
-                let g = *ptr.add(1);
-                let r = *ptr.add(2);
+                let b = ptr.read_volatile();
+                let g = ptr.add(1).read_volatile();
+                let r = ptr.add(2).read_volatile();
                 ((r as u32) << 16) | ((g as u32) << 8) | b as u32
             }
             16 => {
                 let ptr = base.add(offset) as *const u16;
-                let pixel = *ptr;
+                let pixel = ptr.read_volatile();
                 // RGB565: RRRRRGGGGGGBBBBB
                 let r = ((pixel >> 11) & 0x1F) as u32;
                 let g = ((pixel >> 5) & 0x3F) as u32;

--- a/src/drivers/mouse.rs
+++ b/src/drivers/mouse.rs
@@ -476,9 +476,9 @@ impl MouseState {
     ///
     /// 2. **Synaptics touchpad** (absolute position):
     ///    NEWABS format:
-    ///      X = ((buf[3]&0x10)<<8) | ((buf[1]&0x0f)<<8) | buf[4]
-    ///      Y = ((buf[3]&0x20)<<7) | ((buf[1]&0xf0)<<4) | buf[5]
-    ///      Z = buf[2]
+    ///    X = ((buf[3]&0x10)<<8) | ((buf[1]&0x0f)<<8) | buf[4]
+    ///    Y = ((buf[3]&0x20)<<7) | ((buf[1]&0xf0)<<4) | buf[5]
+    ///    Z = buf[2]
     ///    Converted to relative motion by differencing consecutive positions
     ///    while Z > threshold.
     ///
@@ -571,15 +571,13 @@ pub fn init() {
     // ── Ensure AUX clock is running ───────────────────────────────────────────
     // keyboard::init() may have left AUX_DISABLE (bit 5) set in the
     // controller config byte, preventing any AUX communication.
-    if mouse.send_controller_cmd(0x20) {
-        if mouse.wait_output_ready() {
-            let mut cfg = mouse.data_port.get();
-            if cfg & (1 << 5) != 0 {
-                cfg &= !(1 << 5);
-                if mouse.send_controller_cmd(0x60) {
-                    let _ = mouse.wait_input_ready();
-                    mouse.data_port.set(cfg);
-                }
+    if mouse.send_controller_cmd(0x20) && mouse.wait_output_ready() {
+        let mut cfg = mouse.data_port.get();
+        if cfg & (1 << 5) != 0 {
+            cfg &= !(1 << 5);
+            if mouse.send_controller_cmd(0x60) {
+                let _ = mouse.wait_input_ready();
+                mouse.data_port.set(cfg);
             }
         }
     }

--- a/src/drivers/usb/hid_mouse.rs
+++ b/src/drivers/usb/hid_mouse.rs
@@ -56,8 +56,10 @@ pub struct UsbHidMouse {
     /// Interrupt endpoint number
     endpoint: u8,
     /// Max packet size
+    #[allow(dead_code)]
     max_packet: u16,
     /// Polling interval in ms
+    #[allow(dead_code)]
     interval: u8,
     /// Accumulated X relative motion
     rel_x: i32,

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -32,13 +32,13 @@ use heapless::{String, Vec};
 #[cfg(feature = "ui")]
 fn update_cursor(
     cursor_renderer: &mut crate::cursor::CursorRenderer,
-    fb_info: &Option<crate::coreboot::FramebufferInfo>, // FramebufferInfo is the rendering type
+    fb_info: &Option<crate::FramebufferConfig>,
 ) {
-    if let Some(fb) = fb_info {
-        if crate::drivers::mouse_cursor::is_initialized() {
-            let (x, y) = crate::drivers::mouse_cursor::position();
-            cursor_renderer.update(fb, x, y);
-        }
+    if let Some(fb) = fb_info
+        && crate::drivers::mouse_cursor::is_initialized()
+    {
+        let (x, y) = crate::drivers::mouse_cursor::position();
+        cursor_renderer.update(fb, x, y);
     }
 }
 
@@ -946,11 +946,10 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
         return None;
     }
 
-    // Get framebuffer.  FramebufferConsole uses platform::FramebufferConfig
-    // directly; the ui cursor renderer uses coreboot::FramebufferInfo.
+    // Get framebuffer for console and cursor rendering.
     let fb_config = crate::state::get_framebuffer();
     #[cfg(feature = "ui")]
-    let fb_info: Option<crate::coreboot::FramebufferInfo> = fb_config.map(Into::into);
+    let fb_info = fb_config;
     #[cfg(not(feature = "ui"))]
     let _ = (); // fb_info unused without ui
 

--- a/src/menu_common.rs
+++ b/src/menu_common.rs
@@ -22,6 +22,7 @@ pub enum KeyPress {
     /// Mouse click at pixel coordinates.
     #[cfg(feature = "ui")]
     MouseClick {
+        #[allow(dead_code)]
         x: u32,
         y: u32,
     },

--- a/src/ui/firmware_settings.rs
+++ b/src/ui/firmware_settings.rs
@@ -4,7 +4,7 @@ use super::{
     NavItem, ScreenNav, canvas, clear, draw_footer, draw_header, draw_sidebar,
     poll_and_render_cursor, render, theme, update_sidebar_hover,
 };
-use crate::coreboot::FramebufferInfo;
+use crate::FramebufferConfig as FramebufferInfo;
 use crate::cursor::CursorRenderer;
 use crate::menu_common::{self, KeyPress};
 use crate::time::delay_ms;
@@ -47,9 +47,7 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
         if let Some(key) = menu_common::read_key() {
             match key {
                 KeyPress::Up | KeyPress::Char('k') => {
-                    if selected > 0 {
-                        selected -= 1;
-                    }
+                    selected = selected.saturating_sub(1);
                     if selected < scroll {
                         scroll = selected;
                     }
@@ -76,11 +74,11 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
                     // Sidebar click
-                    if let Some(nav) = sidebar_hov {
-                        if nav != NavItem::Firmware {
-                            cursor.hide(fb);
-                            return ScreenNav::Nav(nav);
-                        }
+                    if let Some(nav) = sidebar_hov
+                        && nav != NavItem::Firmware
+                    {
+                        cursor.hide(fb);
+                        return ScreenNav::Nav(nav);
                     }
                     // Card click
                     if let Some(idx) = hovered {
@@ -315,7 +313,7 @@ fn draw_settings(
         );
     }
     if scroll + mv < cfr.forms.len() {
-        let ay = fb.y_resolution as i32 - theme::FOOTER_H as i32 - 20;
+        let ay = fb.height as i32 - theme::FOOTER_H as i32 - 20;
         render::draw_text_centered(fb, cx, ay, cw, "v", FontSize::Small, theme::PRIMARY, None);
     }
 }
@@ -364,11 +362,11 @@ fn show_no_cfr(fb: &FramebufferInfo) -> ScreenNav {
                 KeyPress::Escape | KeyPress::Char('q') => return ScreenNav::Back,
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
-                    if let Some(nav) = sidebar_hov {
-                        if nav != NavItem::Firmware {
-                            cursor.hide(fb);
-                            return ScreenNav::Nav(nav);
-                        }
+                    if let Some(nav) = sidebar_hov
+                        && nav != NavItem::Firmware
+                    {
+                        cursor.hide(fb);
+                        return ScreenNav::Nav(nav);
                     }
                 }
                 _ => {}
@@ -378,7 +376,7 @@ fn show_no_cfr(fb: &FramebufferInfo) -> ScreenNav {
     }
 }
 
-fn fmt_opts<'a>(n: u32, buf: &'a mut [u8; 16]) -> &'a str {
+fn fmt_opts(n: u32, buf: &mut [u8; 16]) -> &str {
     let mut p = 0;
     p += super::fmt_u32(n, &mut buf[p..]);
     for &b in b" opts" {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,7 +10,7 @@ pub mod render;
 pub mod secure_boot;
 pub mod theme;
 
-use crate::coreboot::FramebufferInfo;
+use crate::FramebufferConfig as FramebufferInfo;
 use crate::cursor::CursorRenderer;
 use crate::drivers::mouse_cursor;
 use crate::menu::{BootCategory, BootMenu};
@@ -70,7 +70,7 @@ pub fn clear(fb: &FramebufferInfo) {
 
 /// Draw the top header bar (branding + version).
 pub fn draw_header(fb: &FramebufferInfo) {
-    let w = fb.x_resolution;
+    let w = fb.width;
     render::fill_gradient_v(
         fb,
         0,
@@ -100,7 +100,7 @@ pub fn draw_header(fb: &FramebufferInfo) {
 pub fn draw_sidebar(fb: &FramebufferInfo, active: NavItem, hovered: Option<NavItem>) {
     let sw = theme::SIDEBAR_W;
     let sy = theme::HEADER_H;
-    let sh = fb.y_resolution - theme::HEADER_H - theme::FOOTER_H;
+    let sh = fb.height - theme::HEADER_H - theme::FOOTER_H;
 
     render::fill_rect(fb, 0, sy as i32, sw, sh, theme::SIDE);
 
@@ -169,8 +169,8 @@ fn paint_sidebar_item(
 
 /// Draw the bottom footer bar.
 pub fn draw_footer(fb: &FramebufferInfo, hint: &str) {
-    let w = fb.x_resolution;
-    let fy = fb.y_resolution - theme::FOOTER_H;
+    let w = fb.width;
+    let fy = fb.height - theme::FOOTER_H;
     render::fill_rect(fb, 0, fy as i32, w, theme::FOOTER_H, theme::BG);
     let text_y =
         (fy as i32) + ((theme::FOOTER_H as i32 - render::font_height(FontSize::Small) as i32) / 2);
@@ -196,8 +196,8 @@ pub fn poll_and_render_cursor(fb: &FramebufferInfo, cursor: &mut CursorRenderer)
 fn canvas(fb: &FramebufferInfo) -> (i32, i32, u32, u32) {
     let x = theme::SIDEBAR_W as i32 + theme::PAD as i32;
     let y = (theme::HEADER_H + theme::PAD) as i32;
-    let w = fb.x_resolution - theme::SIDEBAR_W - theme::PAD * 2;
-    let h = fb.y_resolution - theme::HEADER_H - theme::FOOTER_H - theme::PAD * 2;
+    let w = fb.width - theme::SIDEBAR_W - theme::PAD * 2;
+    let h = fb.height - theme::HEADER_H - theme::FOOTER_H - theme::PAD * 2;
     (x, y, w, h)
 }
 
@@ -251,7 +251,7 @@ fn sidebar_hit() -> Option<NavItem> {
 // ═══════════════════════════════════════════════════════════════════════
 
 pub fn show_graphical_menu(menu: &mut BootMenu) -> Option<usize> {
-    let fb: FramebufferInfo = crate::state::get_framebuffer()?.into();
+    let fb = crate::state::get_framebuffer()?;
     let mut screen = NavItem::Boot;
 
     loop {
@@ -273,8 +273,8 @@ pub fn show_graphical_menu(menu: &mut BootMenu) -> Option<usize> {
 }
 
 pub fn show_no_media_screen() {
-    let fb: FramebufferInfo = match crate::state::get_framebuffer() {
-        Some(f) => f.into(),
+    let fb = match crate::state::get_framebuffer() {
+        Some(f) => f,
         None => return,
     };
     let mut screen = NavItem::Boot;
@@ -398,11 +398,11 @@ fn run_boot(fb: &FramebufferInfo, menu: &mut BootMenu) -> BootResult {
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
                     // Check sidebar clicks first
-                    if let Some(nav) = st.sidebar_hov {
-                        if nav != NavItem::Boot {
-                            cursor.hide(fb);
-                            return BootResult::Nav(nav);
-                        }
+                    if let Some(nav) = st.sidebar_hov
+                        && nav != NavItem::Boot
+                    {
+                        cursor.hide(fb);
+                        return BootResult::Nav(nav);
                     }
                     // Then card clicks
                     if let Some(idx) = st.hovered {
@@ -536,11 +536,11 @@ fn run_no_media(fb: &FramebufferInfo) -> ScreenNav {
                 KeyPress::Escape => return ScreenNav::Back,
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
-                    if let Some(nav) = sidebar_hov {
-                        if nav != NavItem::Boot {
-                            cursor.hide(fb);
-                            return ScreenNav::Nav(nav);
-                        }
+                    if let Some(nav) = sidebar_hov
+                        && nav != NavItem::Boot
+                    {
+                        cursor.hide(fb);
+                        return ScreenNav::Nav(nav);
                     }
                 }
                 _ => {}
@@ -721,8 +721,8 @@ fn paint_boot_card(fb: &FramebufferInfo, menu: &BootMenu, st: &BState, idx: usiz
 }
 
 fn paint_boot_footer(fb: &FramebufferInfo, st: &BState) {
-    let w = fb.x_resolution;
-    let fy = fb.y_resolution - theme::FOOTER_H;
+    let w = fb.width;
+    let fy = fb.height - theme::FOOTER_H;
     render::fill_rect(fb, 0, fy as i32, w, theme::FOOTER_H, theme::BG);
 
     if st.countdown > 0 && st.init_timeout > 0 {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -4,7 +4,7 @@
 //! progress bars, pill badges, toggle switches, and multi-size anti-aliased
 //! text rendering using the Noto Sans Mono bitmap font.
 
-use crate::coreboot::FramebufferInfo;
+use crate::FramebufferConfig as FramebufferInfo;
 use noto_sans_mono_bitmap::{FontWeight, RasterHeight, get_raster, get_raster_width};
 
 /// RGB color triple.
@@ -103,8 +103,8 @@ pub fn text_width(s: &str, size: FontSize) -> u32 {
 pub fn fill_rect(fb: &FramebufferInfo, x: i32, y: i32, w: u32, h: u32, c: Rgb) {
     let x0 = x.max(0) as u32;
     let y0 = y.max(0) as u32;
-    let x1 = ((x as i64 + w as i64) as u32).min(fb.x_resolution);
-    let y1 = ((y as i64 + h as i64) as u32).min(fb.y_resolution);
+    let x1 = ((x as i64 + w as i64) as u32).min(fb.width);
+    let y1 = ((y as i64 + h as i64) as u32).min(fb.height);
     if x0 >= x1 || y0 >= y1 {
         return;
     }
@@ -122,7 +122,7 @@ pub fn fill_gradient_v(fb: &FramebufferInfo, x: i32, y: i32, w: u32, h: u32, top
         return;
     }
     for r in 0..h {
-        let t = ((r as u32 * 255) / (h - 1).max(1)) as u8;
+        let t = ((r * 255) / (h - 1).max(1)) as u8;
         fill_rect(fb, x, y + r as i32, w, 1, top.lerp(bot, t));
     }
 }
@@ -141,7 +141,7 @@ pub fn fill_gradient_h(
         return;
     }
     for c in 0..w {
-        let t = ((c as u32 * 255) / (w - 1).max(1)) as u8;
+        let t = ((c * 255) / (w - 1).max(1)) as u8;
         fill_rect(fb, x + c as i32, y, 1, h, left.lerp(right, t));
     }
 }
@@ -172,7 +172,7 @@ fn isqrt(n: u32) -> u32 {
         return 0;
     }
     let mut x = n;
-    let mut y = (x + 1) / 2;
+    let mut y = x.div_ceil(2);
     while y < x {
         x = y;
         y = (x + n / x) / 2;
@@ -326,8 +326,7 @@ pub fn draw_dot(fb: &FramebufferInfo, cx: i32, cy: i32, r: u32, c: Rgb) {
             if dx * dx + dy * dy <= r2 {
                 let px = cx + dx;
                 let py = cy + dy;
-                if px >= 0 && py >= 0 && px < fb.x_resolution as i32 && py < fb.y_resolution as i32
-                {
+                if px >= 0 && py >= 0 && px < fb.width as i32 && py < fb.height as i32 {
                     // SAFETY: bounds checked
                     unsafe { fb.write_pixel(px as u32, py as u32, c.r, c.g, c.b) };
                 }
@@ -410,15 +409,13 @@ pub fn draw_char(
     let w = raster.width();
     let h = raster.height();
 
-    for row in 0..h {
-        for col in 0..w {
+    for (row, raster_row) in rows.iter().enumerate().take(h) {
+        for (col, &alpha) in raster_row.iter().enumerate().take(w) {
             let sx = px + col as i32;
             let sy = py + row as i32;
-            if sx < 0 || sy < 0 || sx >= fb.x_resolution as i32 || sy >= fb.y_resolution as i32 {
+            if sx < 0 || sy < 0 || sx >= fb.width as i32 || sy >= fb.height as i32 {
                 continue;
             }
-
-            let alpha = rows[row][col];
             if alpha == 0 {
                 // Fully transparent — write bg if given, skip otherwise.
                 if let Some(b) = bg {

--- a/src/ui/secure_boot.rs
+++ b/src/ui/secure_boot.rs
@@ -4,7 +4,7 @@ use super::{
     NavItem, ScreenNav, canvas, clear, draw_footer, draw_header, draw_sidebar,
     poll_and_render_cursor, render, theme, update_sidebar_hover,
 };
-use crate::coreboot::FramebufferInfo;
+use crate::FramebufferConfig as FramebufferInfo;
 use crate::cursor::CursorRenderer;
 use crate::menu_common::{self, KeyPress};
 use crate::time::delay_ms;
@@ -46,9 +46,7 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
             status = None;
             match key {
                 KeyPress::Up | KeyPress::Char('k') => {
-                    if selected > 0 {
-                        selected -= 1;
-                    }
+                    selected = selected.saturating_sub(1);
                     draw_screen(fb, selected, hovered, status);
                 }
                 KeyPress::Down | KeyPress::Char('j') => {
@@ -70,11 +68,11 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
                     // Sidebar click
-                    if let Some(nav) = sidebar_hov {
-                        if nav != NavItem::Security {
-                            cursor.hide(fb);
-                            return ScreenNav::Nav(nav);
-                        }
+                    if let Some(nav) = sidebar_hov
+                        && nav != NavItem::Security
+                    {
+                        cursor.hide(fb);
+                        return ScreenNav::Nav(nav);
                     }
                     // Card click
                     if let Some(idx) = hovered {
@@ -357,18 +355,9 @@ fn draw_screen(
 
     // Status toast
     if let Some((msg, ok)) = status {
-        let msg_y = fb.y_resolution as i32 - theme::FOOTER_H as i32 - 24;
+        let msg_y = fb.height as i32 - theme::FOOTER_H as i32 - 24;
         let color = if ok { theme::SECONDARY } else { theme::ERROR };
-        render::draw_text_centered(
-            fb,
-            0,
-            msg_y,
-            fb.x_resolution,
-            msg,
-            FontSize::Normal,
-            color,
-            None,
-        );
+        render::draw_text_centered(fb, 0, msg_y, fb.width, msg, FontSize::Normal, color, None);
     }
 }
 


### PR DESCRIPTION
## Summary

PR #34 (UI feature) introduced direct dependencies on `crate::coreboot::FramebufferInfo` throughout the core library's UI, cursor, and menu modules. This conflicts with PR #31's library restructuring, which introduced `platform::FramebufferConfig` as the platform-agnostic framebuffer type.

This PR replaces all `coreboot::FramebufferInfo` usage in core library code with `FramebufferConfig`, ensuring the UI code is fully decoupled from coreboot-specific types.

## Changes

**Core decoupling (6 files):**
- `src/cursor.rs`: Use `FramebufferConfig`, fix field names (`width`/`height`), use `pixel_offset()` and `as_ptr()` instead of manual byte math, switch to `read_volatile()` for correctness
- `src/ui/{mod,render,secure_boot,firmware_settings}.rs`: Use `FramebufferConfig`, fix `x_resolution`→`width`, `y_resolution`→`height` field accesses
- `src/menu.rs`: Remove unnecessary `FramebufferConfig→FramebufferInfo` conversion, use `FramebufferConfig` directly for cursor rendering

**Clippy fixes in `ui`-gated code (3 files):**
- `collapsible_if` in mouse.rs, menu.rs, ui/mod.rs, ui/secure_boot.rs, ui/firmware_settings.rs
- `implicit_saturating_sub` in ui/secure_boot.rs, ui/firmware_settings.rs
- `needless_range_loop` in cursor.rs, ui/render.rs
- `unnecessary_cast`, `manual_div_ceil` in ui/render.rs
- `needless_lifetimes` in ui/firmware_settings.rs
- `dead_code` on USB HID mouse fields, menu_common MouseClick.x

## Result

After this change, `coreboot::FramebufferInfo` is only referenced in:
- `src/coreboot/` (table parsing — where it belongs)
- `crabefi-coreboot/src/main.rs` (payload binary)

Zero references remain in the core library's UI/cursor/menu code.

**Note:** `ui/firmware_settings.rs` still references `crate::coreboot::CfrInfo`/`get_cfr()` — this is acceptable since CFR is inherently a coreboot concept. A platform trait for firmware settings would be a separate effort.

## Verification

- `cargo build --release` (no ui): pass
- `cargo build --release --features crabefi/ui`: pass
- `cargo clippy -D warnings` (no ui): pass
- `cargo clippy -D warnings --features crabefi/ui`: pass
- `cargo fmt --check`: pass
- `./crabefi test --app hello`: 3/3 pass