### PR TITLE
fix(usb/uhci): support low-speed devices, deferred port enumeration, and hub support

### DIFF
--- a/crabefi-coreboot/Cargo.toml
+++ b/crabefi-coreboot/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 description = "CrabEFI as a coreboot payload binary"
 
+[features]
+ui = ["crabefi/ui"]
+
 [dependencies]
 crabefi = { path = "..", features = ["global-allocator", "platform-entry"] }
 crabefi-drivers = { path = "../crabefi-drivers" }

--- a/src/boot_manager.rs
+++ b/src/boot_manager.rs
@@ -28,6 +28,11 @@ fn init_storage_subsystem() {
     // This uses the table-driven driver model instead of hardcoded init calls
     drivers::pci::bind_drivers();
 
+    // Rescan UHCI/OHCI companion controller ports for devices that EHCI
+    // released after the initial scan (ICH8/9/10 chipsets initialize UHCI
+    // before EHCI due to PCI BDF ordering)
+    drivers::usb::rescan_companion_ports();
+
     // Initialize USB keyboards (needs to happen after USB controllers are bound)
     drivers::usb::init_keyboards_public();
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -8,7 +8,7 @@
 //! Windows/X11 cursor shape. It uses XOR-like compositing (black outline
 //! with white fill) so it is visible on any background.
 
-use crate::coreboot::FramebufferInfo;
+use crate::FramebufferConfig as FramebufferInfo;
 
 /// Cursor width in pixels
 pub const CURSOR_W: usize = 12;
@@ -62,6 +62,12 @@ pub struct CursorRenderer {
     save_valid: [[bool; CURSOR_W]; CURSOR_H],
 }
 
+impl Default for CursorRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CursorRenderer {
     /// Create a new cursor renderer.
     pub const fn new() -> Self {
@@ -105,9 +111,8 @@ impl CursorRenderer {
             row.fill(false);
         }
 
-        for row in 0..CURSOR_H {
-            for col in 0..CURSOR_W {
-                let pixel = CURSOR_BITMAP[row][col];
+        for (row, bitmap_row) in CURSOR_BITMAP.iter().enumerate() {
+            for (col, &pixel) in bitmap_row.iter().enumerate() {
                 if pixel == 0 {
                     continue; // Transparent
                 }
@@ -116,8 +121,7 @@ impl CursorRenderer {
                 let py = y + row as i32;
 
                 // Bounds check
-                if px < 0 || py < 0 || px >= fb.x_resolution as i32 || py >= fb.y_resolution as i32
-                {
+                if px < 0 || py < 0 || px >= fb.width as i32 || py >= fb.height as i32 {
                     continue;
                 }
 
@@ -177,30 +181,30 @@ impl CursorRenderer {
 /// This reads raw bytes from the framebuffer and converts to a canonical
 /// format for save-under buffering.
 fn read_pixel(fb: &FramebufferInfo, x: u32, y: u32) -> u32 {
-    let offset = (y * fb.bytes_per_line + x * (fb.bits_per_pixel as u32 / 8)) as usize;
-    let base = fb.physical_address as *const u8;
+    let offset = fb.pixel_offset(x, y);
 
-    // SAFETY: The framebuffer address and dimensions come from coreboot tables
-    // and have been validated. x,y are bounds-checked by the caller.
+    // SAFETY: The framebuffer address and dimensions have been validated.
+    // x,y are bounds-checked by the caller.
     unsafe {
+        let base = fb.as_ptr() as *const u8;
         match fb.bits_per_pixel {
             32 => {
                 let ptr = base.add(offset);
-                let b = *ptr;
-                let g = *ptr.add(1);
-                let r = *ptr.add(2);
+                let b = ptr.read_volatile();
+                let g = ptr.add(1).read_volatile();
+                let r = ptr.add(2).read_volatile();
                 ((r as u32) << 16) | ((g as u32) << 8) | b as u32
             }
             24 => {
                 let ptr = base.add(offset);
-                let b = *ptr;
-                let g = *ptr.add(1);
-                let r = *ptr.add(2);
+                let b = ptr.read_volatile();
+                let g = ptr.add(1).read_volatile();
+                let r = ptr.add(2).read_volatile();
                 ((r as u32) << 16) | ((g as u32) << 8) | b as u32
             }
             16 => {
                 let ptr = base.add(offset) as *const u16;
-                let pixel = *ptr;
+                let pixel = ptr.read_volatile();
                 // RGB565: RRRRRGGGGGGBBBBB
                 let r = ((pixel >> 11) & 0x1F) as u32;
                 let g = ((pixel >> 5) & 0x3F) as u32;

--- a/src/drivers/keyboard.rs
+++ b/src/drivers/keyboard.rs
@@ -172,17 +172,14 @@ impl PS2Ports {
 // ============================================================================
 
 /// Maximum time (ms) to wait for the keyboard BAT (Basic Assurance Test)
-/// response after sending the RESET command. Some keyboards (especially
-/// laptop EC-emulated ones) need several seconds to respond.
+/// response after sending the RESET command.
 ///
-/// Modelled after SeaBIOS's `etc/ps2-keyboard-spinup` mechanism: we send
-/// the reset during `init()` and check for the BAT result lazily on every
-/// `has_key()` / `try_read_key()` poll, so boot is never blocked.
-const BAT_SPINUP_TIMEOUT_MS: u64 = 4000;
-
-/// Maximum number of RESET retries within the spinup window.
-/// Each retry re-sends 0xFF if the previous attempt got no response.
-const BAT_MAX_RETRIES: u8 = 10;
+/// Laptop EC-emulated keyboards (ThinkPad H8 etc.) may need up to a second
+/// to respond. We use a 5 s window matching SeaBIOS's BAT read timeout.
+/// If the deadline expires we enable scanning anyway — GRUB on coreboot
+/// targets does the same ("just configure and go") because the EC may not
+/// be ready to respond at all when we run as a coreboot payload.
+const BAT_SPINUP_TIMEOUT_MS: u64 = 5000;
 
 /// Two-phase initialization state for the PS/2 keyboard.
 ///
@@ -199,8 +196,8 @@ enum InitState {
     /// No controller detected or init not yet called.
     NotStarted,
     /// Controller self-test passed. RESET (0xFF) has been sent; waiting
-    /// for ACK + BAT result. Fields: (spinup deadline, retries remaining).
-    WaitingForBat { deadline: u64, retries_left: u8 },
+    /// for ACK + BAT result (0xAA). Deadline is an absolute TSC value.
+    WaitingForBat { deadline: u64 },
     /// Keyboard fully initialized and ready for scancodes.
     Ready,
     /// Initialization failed (controller absent, self-test failed, or
@@ -473,104 +470,95 @@ pub fn init() {
     let deadline = Timeout::from_ms(BAT_SPINUP_TIMEOUT_MS);
     kb.init_state = InitState::WaitingForBat {
         deadline: deadline.raw_deadline(),
-        retries_left: BAT_MAX_RETRIES,
     };
     log::debug!("PS/2 keyboard RESET sent, waiting for BAT (deferred)");
 }
 
 /// Drive the deferred keyboard BAT state machine forward.
 ///
-/// Called from `has_key()` and `try_read_key()` on every poll. Checks
-/// whether the keyboard has responded to the RESET command. If not yet
-/// ready, returns without blocking. Once the BAT completes (or times
-/// out), transitions to `Ready` or `Failed`.
+/// Called from `has_key()`, `try_read_key()`, and `cleanup()` on every poll.
+/// Does not block. Transitions to `Ready` or `Failed` when the BAT completes,
+/// fails, or times out.
+///
+/// # AUX byte routing
+/// AUX (mouse/touchpad) bytes that arrive while we wait for BAT are forwarded
+/// to the mouse driver rather than discarded. On ThinkPads and other laptops
+/// the EC may start sending touchpad data before the keyboard BAT completes —
+/// SeaBIOS `ps2_recvbyte` shows the same pattern: check `I8042_STR_AUXDATA`
+/// before deciding what to do with a byte.
+///
+/// # Timeout behaviour
+/// On deadline expiry we enable scanning without a successful BAT. This mirrors
+/// GRUB's coreboot target behaviour: "just configure and go" — if the controller
+/// passed self-test the keyboard is most likely functional regardless of whether
+/// the EC responded to RESET in time.
 fn poll_bat_completion(kb: &mut KeyboardState) {
-    let (raw_deadline, retries_left) = match kb.init_state {
-        InitState::WaitingForBat {
-            deadline,
-            retries_left,
-        } => (deadline, retries_left),
+    let raw_deadline = match kb.init_state {
+        InitState::WaitingForBat { deadline } => deadline,
         _ => return,
     };
 
     let deadline = Timeout::from_raw(raw_deadline);
 
-    // Check if data is available from the keyboard
-    if kb.ports.status_cmd.is_set(Status::OUTPUT_FULL) {
+    // Read status once so OUTPUT_FULL and AUX_DATA are checked atomically.
+    let status = kb.ports.status_cmd.get();
+
+    if (status & masks::OUTPUT_FULL) != 0 {
+        if (status & masks::AUX_DATA) != 0 {
+            // A mouse/touchpad byte arrived while we were waiting for BAT.
+            // Route it to the AUX FIFO so the mouse driver can process it;
+            // do NOT treat it as a keyboard BAT response.
+            let byte = kb.ports.data.get();
+            #[cfg(feature = "ui")]
+            crate::drivers::mouse::push_aux_byte(byte);
+            #[cfg(not(feature = "ui"))]
+            let _ = byte;
+            return; // keep waiting for BAT
+        }
+
         let byte = kb.ports.data.get();
         match byte {
             response::ACK => {
-                // ACK for the RESET command — still waiting for BAT result.
-                // Stay in WaitingForBat.
-                return;
+                // ACK for the RESET command — still waiting for 0xAA.
             }
             response::SELF_TEST_PASS => {
-                // BAT passed (0xAA). Finish initialization.
+                // BAT passed (0xAA) — keyboard is ready.
                 finish_init(kb);
-                return;
             }
             response::RESEND => {
-                // Keyboard wants us to resend. Retry the RESET if we
-                // have retries left.
-                if retries_left > 0 && !deadline.is_expired() {
-                    if kb.wait_input_ready() {
-                        kb.ports.data.set(kb_cmd::RESET);
-                        kb.init_state = InitState::WaitingForBat {
-                            deadline: raw_deadline,
-                            retries_left: retries_left - 1,
-                        };
-                    }
+                // Keyboard requests retransmission of RESET.
+                if !deadline.is_expired() && kb.wait_input_ready() {
+                    kb.ports.data.set(kb_cmd::RESET);
+                    log::debug!("PS/2 keyboard BAT: RESEND, retrying RESET");
                 } else {
-                    log::warn!("PS/2 keyboard BAT: too many RESENDs");
-                    kb.init_state = InitState::Failed;
+                    // Deadline expired or controller busy — proceed without BAT.
+                    log::debug!("PS/2 keyboard BAT: RESEND past deadline, enabling anyway");
+                    finish_init(kb);
                 }
-                return;
             }
             0xFC | 0xFD => {
-                // BAT failed
+                // BAT self-test failed.
                 log::warn!("PS/2 keyboard BAT failed: {:#x}", byte);
                 kb.init_state = InitState::Failed;
-                return;
             }
             _ => {
-                // Spurious byte (e.g. leftover scancode). Discard and
-                // keep waiting.
-                log::debug!("PS/2 BAT: discarding spurious byte {:#x}", byte);
-                return;
+                // Spurious byte (e.g. leftover scancode from before RESET).
+                log::debug!("PS/2 BAT: ignoring spurious byte {:#x}", byte);
             }
         }
+        return;
     }
 
-    // No data yet — check if we timed out
+    // No data yet — check deadline.
     if deadline.is_expired() {
-        if retries_left > 0 {
-            // Retry: re-send RESET
-            if kb.wait_input_ready() {
-                kb.ports.data.set(kb_cmd::RESET);
-                let new_deadline = Timeout::from_ms(BAT_SPINUP_TIMEOUT_MS);
-                kb.init_state = InitState::WaitingForBat {
-                    deadline: new_deadline.raw_deadline(),
-                    retries_left: retries_left - 1,
-                };
-                log::debug!(
-                    "PS/2 keyboard BAT timeout, retrying ({} left)",
-                    retries_left - 1
-                );
-            } else {
-                log::warn!("PS/2 keyboard not ready for RESET retry");
-                kb.init_state = InitState::Failed;
-            }
-        } else {
-            // Some keyboards (QEMU, many real ones) don't need RESET to
-            // work — they were already scanning before we sent 0xFF. If
-            // the controller passed self-test and port-test, the keyboard
-            // is likely fine; just enable scanning and proceed.
-            log::debug!(
-                "PS/2 keyboard BAT timeout after all retries, \
-                 enabling scanning without BAT"
-            );
-            finish_init(kb);
-        }
+        // The keyboard did not respond in time. Proceed without BAT like
+        // GRUB does on coreboot: controller passed self-test so the keyboard
+        // is most likely functional (EC may simply not have been ready yet).
+        log::debug!(
+            "PS/2 keyboard BAT timeout ({}ms), enabling scanning without BAT",
+            BAT_SPINUP_TIMEOUT_MS,
+        );
+        finish_init(kb);
     }
 }
 
@@ -619,10 +607,14 @@ pub fn has_key() -> bool {
 pub fn cleanup() {
     let mut kb = KEYBOARD.lock();
 
-    // If BAT is still in progress, finalize now before OS handoff
+    // Drive the BAT state machine one last time before handoff.
     poll_bat_completion(&mut kb);
 
-    if !kb.is_ready() {
+    // Skip only if init() was never called (no hardware was probed).
+    // Even if BAT never completed we must write KB_INT so the OS keyboard
+    // driver can receive IRQ1 — both SeaBIOS and GRUB restore the config
+    // byte unconditionally before handing off to the OS.
+    if matches!(kb.init_state, InitState::NotStarted) {
         return;
     }
 

--- a/src/drivers/keyboard.rs
+++ b/src/drivers/keyboard.rs
@@ -18,6 +18,7 @@ use tock_registers::interfaces::{Readable, Writeable};
 use tock_registers::register_bitfields;
 
 use crate::arch::x86_64::port_regs::{PortAliased8, PortReadWrite8};
+use crate::time::Timeout;
 
 // ============================================================================
 // Register Definitions using tock-registers
@@ -170,6 +171,43 @@ impl PS2Ports {
 // Keyboard State
 // ============================================================================
 
+/// Maximum time (ms) to wait for the keyboard BAT (Basic Assurance Test)
+/// response after sending the RESET command. Some keyboards (especially
+/// laptop EC-emulated ones) need several seconds to respond.
+///
+/// Modelled after SeaBIOS's `etc/ps2-keyboard-spinup` mechanism: we send
+/// the reset during `init()` and check for the BAT result lazily on every
+/// `has_key()` / `try_read_key()` poll, so boot is never blocked.
+const BAT_SPINUP_TIMEOUT_MS: u64 = 4000;
+
+/// Maximum number of RESET retries within the spinup window.
+/// Each retry re-sends 0xFF if the previous attempt got no response.
+const BAT_MAX_RETRIES: u8 = 10;
+
+/// Two-phase initialization state for the PS/2 keyboard.
+///
+/// Phase 1 (synchronous, in `init()`):
+///   Controller detection, self-test, port test, config setup.
+///   Fast — takes microseconds.
+///
+/// Phase 2 (deferred, driven by polling):
+///   Keyboard RESET (0xFF) + BAT self-test (expects 0xAA back).
+///   Can take seconds on slow keyboards. Checked lazily on each
+///   `has_key()` / `try_read_key()` call so boot is not blocked.
+#[derive(Clone, Copy)]
+enum InitState {
+    /// No controller detected or init not yet called.
+    NotStarted,
+    /// Controller self-test passed. RESET (0xFF) has been sent; waiting
+    /// for ACK + BAT result. Fields: (spinup deadline, retries remaining).
+    WaitingForBat { deadline: u64, retries_left: u8 },
+    /// Keyboard fully initialized and ready for scancodes.
+    Ready,
+    /// Initialization failed (controller absent, self-test failed, or
+    /// BAT timed out). No further attempts will be made.
+    Failed,
+}
+
 /// Modifier key state
 #[derive(Clone, Copy, Default)]
 struct Modifiers {
@@ -181,8 +219,8 @@ struct Modifiers {
 
 /// Keyboard driver state
 struct KeyboardState {
-    /// Whether the keyboard has been initialized
-    initialized: bool,
+    /// Two-phase initialization state
+    init_state: InitState,
     /// Current modifier key state
     modifiers: Modifiers,
     /// Whether we're in an extended scancode sequence (0xE0 prefix)
@@ -194,7 +232,7 @@ struct KeyboardState {
 impl KeyboardState {
     const fn new() -> Self {
         KeyboardState {
-            initialized: false,
+            init_state: InitState::NotStarted,
             modifiers: Modifiers {
                 shift: false,
                 ctrl: false,
@@ -204,6 +242,11 @@ impl KeyboardState {
             extended: false,
             ports: PS2Ports::new(),
         }
+    }
+
+    /// Whether the keyboard is fully initialized and ready for scancodes.
+    fn is_ready(&self) -> bool {
+        matches!(self.init_state, InitState::Ready)
     }
 
     /// Wait for the controller input buffer to be empty (ready to accept commands)
@@ -295,11 +338,21 @@ static KEYBOARD: Mutex<KeyboardState> = Mutex::new(KeyboardState::new());
 // Public API
 // ============================================================================
 
-/// Initialize the keyboard controller and keyboard
+/// Initialize the PS/2 keyboard controller (phase 1) and start deferred
+/// keyboard reset (phase 2).
+///
+/// Phase 1 runs synchronously and is fast (microseconds): controller
+/// detection, self-test, port test, configuration.
+///
+/// Phase 2 sends the keyboard RESET command (0xFF) and returns immediately.
+/// The BAT (Basic Assurance Test) response is checked lazily on each
+/// `has_key()` / `try_read_key()` poll, so boot is never blocked waiting
+/// for a slow keyboard. This mirrors SeaBIOS's `etc/ps2-keyboard-spinup`
+/// approach.
 pub fn init() {
     let mut kb = KEYBOARD.lock();
 
-    if kb.initialized {
+    if !matches!(kb.init_state, InitState::NotStarted) {
         return;
     }
 
@@ -308,8 +361,11 @@ pub fn init() {
     // Check if controller exists (0xFF means no hardware)
     if kb.ports.status_cmd.get() == 0xFF {
         log::warn!("No PS/2 keyboard controller found");
+        kb.init_state = InitState::Failed;
         return;
     }
+
+    // ---- Phase 1: controller-side init (synchronous, fast) ----
 
     // Disable both ports during initialization
     kb.send_controller_cmd(cmd::DISABLE_KB);
@@ -321,34 +377,40 @@ pub fn init() {
     // Perform controller self-test
     if !kb.send_controller_cmd(cmd::SELF_TEST) {
         log::warn!("PS/2 controller self-test command failed");
+        kb.init_state = InitState::Failed;
         return;
     }
 
     if !kb.wait_output_ready() {
         log::warn!("PS/2 controller self-test timeout");
+        kb.init_state = InitState::Failed;
         return;
     }
 
     let result = kb.ports.data.get();
     if result != 0x55 {
         log::warn!("PS/2 controller self-test failed: {:#x}", result);
+        kb.init_state = InitState::Failed;
         return;
     }
 
     // Test keyboard port
     if !kb.send_controller_cmd(cmd::TEST_KB) {
         log::warn!("PS/2 keyboard port test command failed");
+        kb.init_state = InitState::Failed;
         return;
     }
 
     if !kb.wait_output_ready() {
         log::warn!("PS/2 keyboard port test timeout");
+        kb.init_state = InitState::Failed;
         return;
     }
 
     let result = kb.ports.data.get();
     if result != 0x00 {
         log::warn!("PS/2 keyboard port test failed: {:#x}", result);
+        kb.init_state = InitState::Failed;
         return;
     }
 
@@ -358,11 +420,13 @@ pub fn init() {
     // Read and modify controller configuration
     if !kb.send_controller_cmd(cmd::READ_CONFIG) {
         log::warn!("Failed to read PS/2 controller config");
+        kb.init_state = InitState::Failed;
         return;
     }
 
     if !kb.wait_output_ready() {
         log::warn!("PS/2 controller config read timeout");
+        kb.init_state = InitState::Failed;
         return;
     }
 
@@ -380,22 +444,149 @@ pub fn init() {
 
     if !kb.send_controller_cmd(cmd::WRITE_CONFIG) {
         log::warn!("Failed to write PS/2 controller config");
+        kb.init_state = InitState::Failed;
         return;
     }
 
     if !kb.wait_input_ready() {
+        kb.init_state = InitState::Failed;
         return;
     }
 
     kb.ports.data.set(config_byte);
 
+    // ---- Phase 2: keyboard-side reset (deferred) ----
+    //
+    // Send RESET (0xFF) to the keyboard. The keyboard will respond with
+    // ACK (0xFA) then perform its BAT, eventually sending 0xAA (pass)
+    // or 0xFC (fail). On slow keyboards this can take seconds.
+    //
+    // We don't wait here — poll_bat_completion() checks for the result
+    // on every has_key()/try_read_key() call.
+    if !kb.wait_input_ready() {
+        log::warn!("PS/2 keyboard not ready for RESET command");
+        kb.init_state = InitState::Failed;
+        return;
+    }
+    kb.ports.data.set(kb_cmd::RESET);
+
+    let deadline = Timeout::from_ms(BAT_SPINUP_TIMEOUT_MS);
+    kb.init_state = InitState::WaitingForBat {
+        deadline: deadline.raw_deadline(),
+        retries_left: BAT_MAX_RETRIES,
+    };
+    log::debug!("PS/2 keyboard RESET sent, waiting for BAT (deferred)");
+}
+
+/// Drive the deferred keyboard BAT state machine forward.
+///
+/// Called from `has_key()` and `try_read_key()` on every poll. Checks
+/// whether the keyboard has responded to the RESET command. If not yet
+/// ready, returns without blocking. Once the BAT completes (or times
+/// out), transitions to `Ready` or `Failed`.
+fn poll_bat_completion(kb: &mut KeyboardState) {
+    let (raw_deadline, retries_left) = match kb.init_state {
+        InitState::WaitingForBat {
+            deadline,
+            retries_left,
+        } => (deadline, retries_left),
+        _ => return,
+    };
+
+    let deadline = Timeout::from_raw(raw_deadline);
+
+    // Check if data is available from the keyboard
+    if kb.ports.status_cmd.is_set(Status::OUTPUT_FULL) {
+        let byte = kb.ports.data.get();
+        match byte {
+            response::ACK => {
+                // ACK for the RESET command — still waiting for BAT result.
+                // Stay in WaitingForBat.
+                return;
+            }
+            response::SELF_TEST_PASS => {
+                // BAT passed (0xAA). Finish initialization.
+                finish_init(kb);
+                return;
+            }
+            response::RESEND => {
+                // Keyboard wants us to resend. Retry the RESET if we
+                // have retries left.
+                if retries_left > 0 && !deadline.is_expired() {
+                    if kb.wait_input_ready() {
+                        kb.ports.data.set(kb_cmd::RESET);
+                        kb.init_state = InitState::WaitingForBat {
+                            deadline: raw_deadline,
+                            retries_left: retries_left - 1,
+                        };
+                    }
+                } else {
+                    log::warn!("PS/2 keyboard BAT: too many RESENDs");
+                    kb.init_state = InitState::Failed;
+                }
+                return;
+            }
+            0xFC | 0xFD => {
+                // BAT failed
+                log::warn!("PS/2 keyboard BAT failed: {:#x}", byte);
+                kb.init_state = InitState::Failed;
+                return;
+            }
+            _ => {
+                // Spurious byte (e.g. leftover scancode). Discard and
+                // keep waiting.
+                log::debug!("PS/2 BAT: discarding spurious byte {:#x}", byte);
+                return;
+            }
+        }
+    }
+
+    // No data yet — check if we timed out
+    if deadline.is_expired() {
+        if retries_left > 0 {
+            // Retry: re-send RESET
+            if kb.wait_input_ready() {
+                kb.ports.data.set(kb_cmd::RESET);
+                let new_deadline = Timeout::from_ms(BAT_SPINUP_TIMEOUT_MS);
+                kb.init_state = InitState::WaitingForBat {
+                    deadline: new_deadline.raw_deadline(),
+                    retries_left: retries_left - 1,
+                };
+                log::debug!(
+                    "PS/2 keyboard BAT timeout, retrying ({} left)",
+                    retries_left - 1
+                );
+            } else {
+                log::warn!("PS/2 keyboard not ready for RESET retry");
+                kb.init_state = InitState::Failed;
+            }
+        } else {
+            // Some keyboards (QEMU, many real ones) don't need RESET to
+            // work — they were already scanning before we sent 0xFF. If
+            // the controller passed self-test and port-test, the keyboard
+            // is likely fine; just enable scanning and proceed.
+            log::debug!(
+                "PS/2 keyboard BAT timeout after all retries, \
+                 enabling scanning without BAT"
+            );
+            finish_init(kb);
+        }
+    }
+}
+
+/// Complete keyboard initialization after BAT (or after BAT timeout
+/// fallback). Enables scanning and transitions to `Ready`.
+fn finish_init(kb: &mut KeyboardState) {
+    // Flush any remaining BAT bytes (some keyboards send extra data)
+    kb.flush_output();
+
     // Enable keyboard scanning
     if !kb.send_keyboard_cmd(kb_cmd::ENABLE) {
         log::warn!("Failed to enable keyboard scanning");
-        // Continue anyway - might still work
+        // Continue anyway — might still work
     }
 
-    kb.initialized = true;
+    kb.init_state = InitState::Ready;
     log::info!("PS/2 keyboard initialized");
 }
 
@@ -409,9 +600,11 @@ pub fn has_key() -> bool {
         return true;
     }
 
-    // Check PS/2 keyboard
-    let kb = KEYBOARD.lock();
-    if !kb.initialized {
+    // Drive deferred BAT state machine, then check PS/2
+    let mut kb = KEYBOARD.lock();
+    poll_bat_completion(&mut kb);
+
+    if !kb.is_ready() {
         return false;
     }
 
@@ -424,8 +617,12 @@ pub fn has_key() -> bool {
 /// initialize the i8042 driver. Without this, the keyboard may not
 /// work after booting Linux.
 pub fn cleanup() {
-    let kb = KEYBOARD.lock();
-    if !kb.initialized {
+    let mut kb = KEYBOARD.lock();
+
+    // If BAT is still in progress, finalize now before OS handoff
+    poll_bat_completion(&mut kb);
+
+    if !kb.is_ready() {
         return;
     }
 
@@ -498,7 +695,7 @@ pub fn get_efi_key_state() -> (u32, u8) {
     // PS/2 keyboard modifier state
     {
         let kb = KEYBOARD.lock();
-        if kb.initialized {
+        if kb.is_ready() {
             if kb.modifiers.shift {
                 shift_state |= LEFT_SHIFT_PRESSED;
             }
@@ -537,10 +734,11 @@ pub fn try_read_key() -> Option<(u16, u16)> {
         return Some(key);
     }
 
-    // Fall back to PS/2 keyboard
+    // Drive deferred BAT, then try PS/2 keyboard
     let mut kb = KEYBOARD.lock();
+    poll_bat_completion(&mut kb);
 
-    if !kb.initialized {
+    if !kb.is_ready() {
         return None;
     }
 

--- a/src/drivers/mouse.rs
+++ b/src/drivers/mouse.rs
@@ -476,9 +476,9 @@ impl MouseState {
     ///
     /// 2. **Synaptics touchpad** (absolute position):
     ///    NEWABS format:
-    ///      X = ((buf[3]&0x10)<<8) | ((buf[1]&0x0f)<<8) | buf[4]
-    ///      Y = ((buf[3]&0x20)<<7) | ((buf[1]&0xf0)<<4) | buf[5]
-    ///      Z = buf[2]
+    ///    X = ((buf[3]&0x10)<<8) | ((buf[1]&0x0f)<<8) | buf[4]
+    ///    Y = ((buf[3]&0x20)<<7) | ((buf[1]&0xf0)<<4) | buf[5]
+    ///    Z = buf[2]
     ///    Converted to relative motion by differencing consecutive positions
     ///    while Z > threshold.
     ///
@@ -571,15 +571,13 @@ pub fn init() {
     // ── Ensure AUX clock is running ───────────────────────────────────────────
     // keyboard::init() may have left AUX_DISABLE (bit 5) set in the
     // controller config byte, preventing any AUX communication.
-    if mouse.send_controller_cmd(0x20) {
-        if mouse.wait_output_ready() {
-            let mut cfg = mouse.data_port.get();
-            if cfg & (1 << 5) != 0 {
-                cfg &= !(1 << 5);
-                if mouse.send_controller_cmd(0x60) {
-                    let _ = mouse.wait_input_ready();
-                    mouse.data_port.set(cfg);
-                }
+    if mouse.send_controller_cmd(0x20) && mouse.wait_output_ready() {
+        let mut cfg = mouse.data_port.get();
+        if cfg & (1 << 5) != 0 {
+            cfg &= !(1 << 5);
+            if mouse.send_controller_cmd(0x60) {
+                let _ = mouse.wait_input_ready();
+                mouse.data_port.set(cfg);
             }
         }
     }

--- a/src/drivers/usb/controller.rs
+++ b/src/drivers/usb/controller.rs
@@ -11,6 +11,7 @@
 //! - The core layer handles enumeration and device management
 
 use crate::efi;
+use crate::time::Timeout;
 use core::ptr;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
@@ -1329,4 +1330,208 @@ where
     }
 
     Ok(device)
+}
+
+// ============================================================================
+// Hub Enumeration Helper
+// ============================================================================
+
+/// Maximum number of downstream hub ports tracked per hub.
+///
+/// USB 2.0 compound devices may have up to 7 ports; USB 3.x hubs up to 15.
+/// 16 covers all realistic cases without heap allocation.
+const MAX_HUB_PORTS: usize = 16;
+
+/// Enumerate devices connected to an external USB hub.
+///
+/// Encapsulates the protocol sequence shared by EHCI and UHCI: fetch the hub
+/// descriptor, power all downstream ports, wait for power stabilisation, then
+/// for each port that has a device connected — clear the connection-change bit,
+/// issue a port reset, and record the result.
+///
+/// The second closure problem (two `&mut self` borrows at once) is avoided by
+/// returning the list of ready ports rather than calling a second closure
+/// inline. The caller iterates the returned list and enumerates each device
+/// separately, after `enumerate_hub_ports` has returned and released the
+/// `do_control` borrow.
+///
+/// # Arguments
+/// * `hub_device` - The hub's [`UsbDevice`] (used as the transfer target)
+/// * `do_control` - Performs a control transfer on behalf of the caller
+/// * `supports_high_speed` - `true` for EHCI; `false` for UHCI (USB 1.1 only)
+///
+/// # Returns
+/// `Ok((num_ports, ready_ports))` where `ready_ports` is the list of
+/// `(port, speed)` pairs for ports whose reset completed successfully.
+pub fn enumerate_hub_ports<C>(
+    hub_device: &UsbDevice,
+    mut do_control: C,
+    supports_high_speed: bool,
+) -> Result<(u8, heapless::Vec<(u8, UsbSpeed), MAX_HUB_PORTS>), UsbError>
+where
+    C: FnMut(&UsbDevice, u8, u8, u16, u16, Option<&mut [u8]>) -> Result<usize, UsbError>,
+{
+    // Fetch hub class descriptor (bmRequestType = 0xA0: D→H, Class, Device).
+    let mut hub_desc_buf = [0u8; 9];
+    do_control(
+        hub_device,
+        req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_DEVICE,
+        request::GET_DESCRIPTOR,
+        (HUB_DESCRIPTOR_TYPE as u16) << 8,
+        0,
+        Some(&mut hub_desc_buf),
+    )?;
+
+    let (hub_desc, _) =
+        HubDescriptor::read_from_prefix(&hub_desc_buf).map_err(|_| UsbError::TransferFailed(0))?;
+    let num_ports = hub_desc.num_ports;
+    let power_on_delay = (hub_desc.power_on_to_power_good as u64) * 2; // 2 ms units
+
+    log::info!(
+        "  Hub has {} ports, power-on delay: {}ms",
+        num_ports,
+        power_on_delay
+    );
+
+    let mut ready_ports: heapless::Vec<(u8, UsbSpeed), MAX_HUB_PORTS> = heapless::Vec::new();
+
+    // Power on all downstream ports (SET_FEATURE PORT_POWER).
+    for port in 1..=num_ports {
+        let _ = do_control(
+            hub_device,
+            req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+            request::SET_FEATURE,
+            hub_feature::PORT_POWER,
+            port as u16,
+            None,
+        );
+    }
+
+    // Wait for power to stabilise (spec minimum 100 ms).
+    crate::time::delay_ms(power_on_delay.max(100));
+
+    // Check each port for a connected device and enumerate it.
+    for port in 1..=num_ports {
+        let mut status_buf = [0u8; 4];
+        if do_control(
+            hub_device,
+            req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+            request::GET_STATUS,
+            0,
+            port as u16,
+            Some(&mut status_buf),
+        )
+        .is_err()
+        {
+            continue;
+        }
+
+        let port_status = u16::from_le_bytes([status_buf[0], status_buf[1]]);
+        let port_change = u16::from_le_bytes([status_buf[2], status_buf[3]]);
+
+        log::debug!(
+            "  Hub port {} status: {:#06x}, change: {:#06x}",
+            port,
+            port_status,
+            port_change
+        );
+
+        if (port_status & hub_port_status::CONNECTION) == 0 {
+            continue;
+        }
+
+        log::info!("  Device detected on hub port {}", port);
+
+        // Clear the connection-change bit if set.
+        if port_change & hub_port_change::C_CONNECTION != 0 {
+            let _ = do_control(
+                hub_device,
+                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                request::CLEAR_FEATURE,
+                hub_feature::C_PORT_CONNECTION,
+                port as u16,
+                None,
+            );
+        }
+
+        // Issue a port reset (SET_FEATURE PORT_RESET).
+        if do_control(
+            hub_device,
+            req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+            request::SET_FEATURE,
+            hub_feature::PORT_RESET,
+            port as u16,
+            None,
+        )
+        .is_err()
+        {
+            continue;
+        }
+
+        // Wait at least 50 ms then poll for C_PORT_RESET.
+        crate::time::delay_ms(50);
+
+        let mut reset_complete = false;
+        let timeout = Timeout::from_ms(500);
+        while !timeout.is_expired() {
+            let mut status_buf = [0u8; 4];
+            if do_control(
+                hub_device,
+                req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                request::GET_STATUS,
+                0,
+                port as u16,
+                Some(&mut status_buf),
+            )
+            .is_err()
+            {
+                break;
+            }
+
+            let port_status = u16::from_le_bytes([status_buf[0], status_buf[1]]);
+            let port_change = u16::from_le_bytes([status_buf[2], status_buf[3]]);
+
+            if port_change & hub_port_change::C_RESET != 0 {
+                // Acknowledge the reset-complete change bit.
+                let _ = do_control(
+                    hub_device,
+                    req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                    request::CLEAR_FEATURE,
+                    hub_feature::C_PORT_RESET,
+                    port as u16,
+                    None,
+                );
+
+                if (port_status & hub_port_status::ENABLE) != 0 {
+                    // Determine device speed from port status bits.
+                    let speed = if supports_high_speed
+                        && (port_status & hub_port_status::HIGH_SPEED) != 0
+                    {
+                        UsbSpeed::High
+                    } else if (port_status & hub_port_status::LOW_SPEED) != 0 {
+                        UsbSpeed::Low
+                    } else {
+                        UsbSpeed::Full
+                    };
+
+                    log::info!("  Hub port {} reset complete, speed: {:?}", port, speed);
+
+                    crate::time::delay_ms(10); // USB spec reset-recovery time
+                    // Overflow is silently ignored: more than MAX_HUB_PORTS
+                    // ready devices on a single hub is not realistic.
+                    let _ = ready_ports.push((port, speed));
+                    reset_complete = true;
+                }
+                break;
+            }
+
+            crate::time::delay_ms(10);
+        }
+
+        if !reset_complete {
+            log::warn!("  Hub port {} reset timed out", port);
+        }
+    }
+
+    Ok((num_ports, ready_ports))
 }

--- a/src/drivers/usb/ehci.rs
+++ b/src/drivers/usb/ehci.rs
@@ -18,6 +18,10 @@
 //! - U-Boot drivers/usb/host/ehci-hcd.c
 //! - libpayload ehci.c
 
+use super::controller::{
+    SetupPacket, UsbController, UsbDevice, UsbError, UsbSpeed, enumerate_device,
+    enumerate_hub_ports,
+};
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::cache::{flush_cache_range, invalidate_cache_range};
 #[cfg(target_arch = "x86_64")]
@@ -28,12 +32,6 @@ use crate::time::{Timeout, wait_for};
 use core::ptr;
 use core::sync::atomic::{Ordering, fence};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
-use zerocopy::FromBytes;
-
-use super::controller::{
-    HUB_DESCRIPTOR_TYPE, HubDescriptor, SetupPacket, UsbController, UsbDevice, UsbError, UsbSpeed,
-    enumerate_device, hub_feature, hub_port_status, req_type, request,
-};
 
 // Import register definitions from ehci_regs module
 use super::ehci_regs::{
@@ -790,195 +788,33 @@ impl EhciController {
         Ok(())
     }
 
-    /// Enumerate devices connected to a USB hub
+    /// Enumerate devices connected to a USB hub.
     ///
-    /// This gets the hub descriptor, powers on all ports, and enumerates
-    /// any connected devices.
+    /// Delegates to the shared [`enumerate_hub_ports`] helper in the
+    /// controller abstraction layer.
     fn enumerate_hub(&mut self, hub_slot: usize, hub_addr: u8) -> Result<(), UsbError> {
-        log::info!("Enumerating hub at address {}", hub_addr);
+        log::info!("EHCI: Enumerating hub at address {}", hub_addr);
 
-        // Get the hub device
         let hub_device = self.devices[hub_slot]
             .as_ref()
             .ok_or(UsbError::DeviceNotFound)?
             .clone();
 
-        // Get hub descriptor (class-specific request)
-        // Request type: Device-to-Host | Class | Device = 0xA0
-        let mut hub_desc_buf = [0u8; 9];
-        self.control_transfer_internal(
+        let (num_ports, ready_ports) = enumerate_hub_ports(
             &hub_device,
-            req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_DEVICE,
-            request::GET_DESCRIPTOR,
-            (HUB_DESCRIPTOR_TYPE as u16) << 8,
-            0,
-            Some(&mut hub_desc_buf),
+            |dev, rt, req, val, idx, data| {
+                self.control_transfer_internal(dev, rt, req, val, idx, data)
+            },
+            true, // EHCI supports high-speed devices
         )?;
 
-        let (hub_desc, _) = HubDescriptor::read_from_prefix(&hub_desc_buf)
-            .map_err(|_| UsbError::TransferFailed(0))?;
-        let num_ports = hub_desc.num_ports;
-        let power_on_delay = (hub_desc.power_on_to_power_good as u32) * 2; // Convert to ms
-
-        log::info!(
-            "  Hub has {} ports, power-on delay: {}ms",
-            num_ports,
-            power_on_delay
-        );
-
-        // Update the device's hub port count
         if let Some(ref mut dev) = self.devices[hub_slot] {
             dev.num_hub_ports = num_ports;
         }
 
-        // Power on all hub ports
-        // Request type: Host-to-Device | Class | Other = 0x23
-        for port in 1..=num_ports {
-            log::debug!("  Powering on hub port {}", port);
-            let result = self.control_transfer_internal(
-                &hub_device,
-                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
-                request::SET_FEATURE,
-                hub_feature::PORT_POWER,
-                port as u16,
-                None,
-            );
-            if let Err(e) = result {
-                log::warn!("  Failed to power on hub port {}: {:?}", port, e);
-            }
-        }
-
-        // Wait for power to stabilize
-        let delay = power_on_delay.max(100) as u64; // At least 100ms
-        crate::time::delay_ms(delay);
-
-        // Check each port for connected devices
-        for port in 1..=num_ports {
-            // Get port status
-            // Request type: Device-to-Host | Class | Other = 0xA3
-            let mut status_buf = [0u8; 4];
-            let result = self.control_transfer_internal(
-                &hub_device,
-                req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
-                request::GET_STATUS,
-                0,
-                port as u16,
-                Some(&mut status_buf),
-            );
-
-            if let Err(e) = result {
-                log::debug!("  Failed to get status for hub port {}: {:?}", port, e);
-                continue;
-            }
-
-            let port_status = u16::from_le_bytes([status_buf[0], status_buf[1]]);
-            let port_change = u16::from_le_bytes([status_buf[2], status_buf[3]]);
-
-            log::debug!(
-                "  Hub port {} status: {:#06x}, change: {:#06x}",
-                port,
-                port_status,
-                port_change
-            );
-
-            // Check if device is connected
-            if (port_status & hub_port_status::CONNECTION) == 0 {
-                continue;
-            }
-
-            log::info!("  Device detected on hub port {}", port);
-
-            // Clear connection change bit if set
-            if port_change & 0x01 != 0 {
-                let _ = self.control_transfer_internal(
-                    &hub_device,
-                    req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
-                    request::CLEAR_FEATURE,
-                    hub_feature::C_PORT_CONNECTION,
-                    port as u16,
-                    None,
-                );
-            }
-
-            // Reset the port
-            log::debug!("  Resetting hub port {}", port);
-            self.control_transfer_internal(
-                &hub_device,
-                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
-                request::SET_FEATURE,
-                hub_feature::PORT_RESET,
-                port as u16,
-                None,
-            )?;
-
-            // Wait for reset to complete (poll port status)
-            crate::time::delay_ms(50);
-
-            // Poll for reset completion
-            let mut reset_complete = false;
-            let timeout = Timeout::from_ms(500);
-            while !timeout.is_expired() {
-                let mut status_buf = [0u8; 4];
-                if self
-                    .control_transfer_internal(
-                        &hub_device,
-                        req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
-                        request::GET_STATUS,
-                        0,
-                        port as u16,
-                        Some(&mut status_buf),
-                    )
-                    .is_err()
-                {
-                    break;
-                }
-
-                let port_status = u16::from_le_bytes([status_buf[0], status_buf[1]]);
-                let port_change = u16::from_le_bytes([status_buf[2], status_buf[3]]);
-
-                // Check if reset is complete (C_PORT_RESET bit in change)
-                if port_change & 0x10 != 0 {
-                    // Clear the reset change bit
-                    let _ = self.control_transfer_internal(
-                        &hub_device,
-                        req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
-                        request::CLEAR_FEATURE,
-                        hub_feature::C_PORT_RESET,
-                        port as u16,
-                        None,
-                    );
-
-                    // Check if port is enabled
-                    if (port_status & hub_port_status::ENABLE) != 0 {
-                        reset_complete = true;
-
-                        // Determine device speed
-                        let speed = if (port_status & hub_port_status::HIGH_SPEED) != 0 {
-                            UsbSpeed::High
-                        } else if (port_status & hub_port_status::LOW_SPEED) != 0 {
-                            UsbSpeed::Low
-                        } else {
-                            UsbSpeed::Full
-                        };
-
-                        log::info!("  Hub port {} reset complete, speed: {:?}", port, speed);
-
-                        // Recovery time after reset
-                        crate::time::delay_ms(10);
-
-                        // Enumerate the device
-                        if let Err(e) = self.attach_device_on_hub(port, speed, hub_addr, port) {
-                            log::warn!("  Failed to attach device on hub port {}: {:?}", port, e);
-                        }
-                    }
-                    break;
-                }
-
-                crate::time::delay_ms(10);
-            }
-
-            if !reset_complete {
-                log::warn!("  Hub port {} reset timed out", port);
+        for (port, speed) in ready_ports {
+            if let Err(e) = self.attach_device_on_hub(port, speed, hub_addr, port) {
+                log::warn!("  Failed to attach device on hub port {}: {:?}", port, e);
             }
         }
 

--- a/src/drivers/usb/hid_mouse.rs
+++ b/src/drivers/usb/hid_mouse.rs
@@ -56,8 +56,10 @@ pub struct UsbHidMouse {
     /// Interrupt endpoint number
     endpoint: u8,
     /// Max packet size
+    #[allow(dead_code)]
     max_packet: u16,
     /// Polling interval in ms
+    #[allow(dead_code)]
     interval: u8,
     /// Accumulated X relative motion
     rel_x: i32,

--- a/src/drivers/usb/mod.rs
+++ b/src/drivers/usb/mod.rs
@@ -256,6 +256,34 @@ pub fn init_all() {
     init_keyboards();
 }
 
+/// Enumerate UHCI companion controller ports (deferred phase)
+///
+/// On ICH8/9/10 chipsets, UHCI companion controllers appear at lower PCI BDFs
+/// than their EHCI companion (UHCI at functions 0-2, EHCI at function 7).
+/// Since PCI drivers bind in ascending BDF order, UHCI hardware is initialized
+/// before EHCI. EHCI must set CONFIGFLAG and release companion ports before
+/// UHCI can see the correct devices and speeds.
+///
+/// UHCI port enumeration is therefore deferred to this function, which must be
+/// called after all USB controllers are initialized (i.e., after
+/// `bind_drivers()`) but before keyboard/device discovery.
+pub fn rescan_companion_ports() {
+    let controllers = ALL_CONTROLLERS.lock();
+
+    for handle in controllers.iter() {
+        match handle {
+            #[cfg(target_arch = "x86_64")]
+            UsbControllerHandle::Uhci(ptr) => {
+                // SAFETY: pointer is valid for the firmware's lifetime and we hold
+                // the ALL_CONTROLLERS lock, serializing access.
+                let controller = unsafe { &mut **ptr };
+                controller.rescan_ports();
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Initialize USB keyboards from all controllers
 ///
 /// Can be called separately after controller initialization via the PCI

--- a/src/drivers/usb/uhci.rs
+++ b/src/drivers/usb/uhci.rs
@@ -7,19 +7,17 @@
 //! - UHCI Design Guide Revision 1.1
 //! - libpayload uhci.c
 
+use super::controller::{
+    SetupPacket, UsbController, UsbDevice, UsbError, UsbSpeed, enumerate_device,
+    enumerate_hub_ports,
+};
+use super::uhci_regs::{PORTSC, USBCMD, USBSTS, UhciRegs};
 use crate::drivers::pci::{self, PciAddress, PciDevice};
 use crate::efi;
 use crate::time::{Timeout, wait_for};
 use core::ptr;
 use core::sync::atomic::{Ordering, fence};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
-use zerocopy::FromBytes;
-
-use super::controller::{
-    HUB_DESCRIPTOR_TYPE, HubDescriptor, SetupPacket, UsbController, UsbDevice, UsbError, UsbSpeed,
-    enumerate_device, hub_feature, hub_port_change, hub_port_status, req_type, request,
-};
-use super::uhci_regs::{PORTSC, USBCMD, USBSTS, UhciRegs};
 
 // ============================================================================
 // UHCI Data Structures
@@ -575,11 +573,10 @@ impl UhciController {
         Ok(())
     }
 
-    /// Enumerate devices connected to an external USB hub
+    /// Enumerate devices connected to an external USB hub.
     ///
-    /// Gets the hub descriptor, powers on all ports, resets ports with
-    /// connected devices, and enumerates them. UHCI is USB 1.1 only, so
-    /// devices behind hubs are always low-speed or full-speed.
+    /// UHCI is USB 1.1 only so devices behind hubs are low-speed or
+    /// full-speed. Delegates to the shared [`enumerate_hub_ports`] helper.
     fn enumerate_hub(&mut self, hub_slot: usize, hub_addr: u8) -> Result<(), UsbError> {
         log::info!("UHCI: Enumerating hub at address {}", hub_addr);
 
@@ -588,176 +585,21 @@ impl UhciController {
             .ok_or(UsbError::DeviceNotFound)?
             .clone();
 
-        // Get hub descriptor (class-specific request)
-        let mut hub_desc_buf = [0u8; 9];
-        self.control_transfer_internal(
+        let (num_ports, ready_ports) = enumerate_hub_ports(
             &hub_device,
-            req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_DEVICE,
-            request::GET_DESCRIPTOR,
-            (HUB_DESCRIPTOR_TYPE as u16) << 8,
-            0,
-            Some(&mut hub_desc_buf),
+            |dev, rt, req, val, idx, data| {
+                self.control_transfer_internal(dev, rt, req, val, idx, data)
+            },
+            false, // UHCI is USB 1.1: low-speed or full-speed only
         )?;
 
-        let (hub_desc, _) = HubDescriptor::read_from_prefix(&hub_desc_buf)
-            .map_err(|_| UsbError::TransferFailed(0))?;
-        let num_ports = hub_desc.num_ports;
-        let power_on_delay = (hub_desc.power_on_to_power_good as u32) * 2;
-
-        log::info!(
-            "  Hub has {} ports, power-on delay: {}ms",
-            num_ports,
-            power_on_delay
-        );
-
-        // Update the device's hub port count
         if let Some(ref mut dev) = self.devices[hub_slot] {
             dev.num_hub_ports = num_ports;
         }
 
-        // Power on all hub ports
-        for port in 1..=num_ports {
-            log::debug!("  Powering on hub port {}", port);
-            let result = self.control_transfer_internal(
-                &hub_device,
-                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
-                request::SET_FEATURE,
-                hub_feature::PORT_POWER,
-                port as u16,
-                None,
-            );
-            if let Err(e) = result {
-                log::warn!("  Failed to power on hub port {}: {:?}", port, e);
-            }
-        }
-
-        // Wait for power to stabilize
-        let delay = power_on_delay.max(100) as u64;
-        crate::time::delay_ms(delay);
-
-        // Check each port for connected devices
-        for port in 1..=num_ports {
-            // Get port status
-            let mut status_buf = [0u8; 4];
-            let result = self.control_transfer_internal(
-                &hub_device,
-                req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
-                request::GET_STATUS,
-                0,
-                port as u16,
-                Some(&mut status_buf),
-            );
-
-            if let Err(e) = result {
-                log::debug!("  Failed to get status for hub port {}: {:?}", port, e);
-                continue;
-            }
-
-            let port_status = u16::from_le_bytes([status_buf[0], status_buf[1]]);
-            let port_change = u16::from_le_bytes([status_buf[2], status_buf[3]]);
-
-            log::debug!(
-                "  Hub port {} status: {:#06x}, change: {:#06x}",
-                port,
-                port_status,
-                port_change
-            );
-
-            if (port_status & hub_port_status::CONNECTION) == 0 {
-                continue;
-            }
-
-            log::info!("  Device detected on hub port {}", port);
-
-            // Clear connection change bit if set
-            if port_change & hub_port_change::C_CONNECTION != 0 {
-                let _ = self.control_transfer_internal(
-                    &hub_device,
-                    req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
-                    request::CLEAR_FEATURE,
-                    hub_feature::C_PORT_CONNECTION,
-                    port as u16,
-                    None,
-                );
-            }
-
-            // Reset the port
-            log::debug!("  Resetting hub port {}", port);
-            self.control_transfer_internal(
-                &hub_device,
-                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
-                request::SET_FEATURE,
-                hub_feature::PORT_RESET,
-                port as u16,
-                None,
-            )?;
-
-            // Wait for reset (USB spec requires at least 10ms, use 50ms for margin)
-            crate::time::delay_ms(50);
-
-            // Poll for reset completion
-            let mut reset_complete = false;
-            let timeout = Timeout::from_ms(500);
-            while !timeout.is_expired() {
-                let mut status_buf = [0u8; 4];
-                if self
-                    .control_transfer_internal(
-                        &hub_device,
-                        req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
-                        request::GET_STATUS,
-                        0,
-                        port as u16,
-                        Some(&mut status_buf),
-                    )
-                    .is_err()
-                {
-                    break;
-                }
-
-                let port_status = u16::from_le_bytes([status_buf[0], status_buf[1]]);
-                let port_change = u16::from_le_bytes([status_buf[2], status_buf[3]]);
-
-                // Check if reset is complete (C_PORT_RESET bit in change)
-                if port_change & hub_port_change::C_RESET != 0 {
-                    // Clear the reset change bit
-                    let _ = self.control_transfer_internal(
-                        &hub_device,
-                        req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
-                        request::CLEAR_FEATURE,
-                        hub_feature::C_PORT_RESET,
-                        port as u16,
-                        None,
-                    );
-
-                    // Check if port is enabled
-                    if (port_status & hub_port_status::ENABLE) != 0 {
-                        reset_complete = true;
-
-                        // UHCI is USB 1.1 only: low-speed or full-speed
-                        let speed = if (port_status & hub_port_status::LOW_SPEED) != 0 {
-                            UsbSpeed::Low
-                        } else {
-                            UsbSpeed::Full
-                        };
-
-                        log::info!("  Hub port {} reset complete, speed: {:?}", port, speed);
-
-                        // Recovery time after reset
-                        crate::time::delay_ms(10);
-
-                        // Enumerate the device
-                        if let Err(e) = self.attach_device_on_hub(port, speed, hub_addr, port) {
-                            log::warn!("  Failed to attach device on hub port {}: {:?}", port, e);
-                        }
-                    }
-                    break;
-                }
-
-                crate::time::delay_ms(10);
-            }
-
-            if !reset_complete {
-                log::warn!("  Hub port {} reset timed out", port);
+        for (port, speed) in ready_ports {
+            if let Err(e) = self.attach_device_on_hub(port, speed, hub_addr, port) {
+                log::warn!("  Failed to attach device on hub port {}: {:?}", port, e);
             }
         }
 
@@ -798,13 +640,19 @@ impl UhciController {
         // DMA buffer layout:
         //   [0..8)       setup packet
         //   [64..)       TDs: setup(1) + data(N) + status(1), each 32 bytes
-        //   [2048..)     data buffer
-        debug_assert!(
-            data_len <= Self::DMA_BUFFER_SIZE - 2048,
-            "control transfer data ({data_len} bytes) exceeds DMA buffer"
-        );
+        //   [2048..)     data buffer  (DMA_BUFFER_SIZE - 2048 bytes available)
+        const DATA_BUF_OFFSET: usize = 2048;
+        let data_buf_capacity = Self::DMA_BUFFER_SIZE - DATA_BUF_OFFSET;
+        if data_len > data_buf_capacity {
+            log::warn!(
+                "UHCI: control transfer data ({} bytes) exceeds DMA buffer ({})",
+                data_len,
+                data_buf_capacity,
+            );
+            return Err(UsbError::InvalidParameter);
+        }
         let td_base = self.dma_buffer + 64;
-        let data_buffer = self.dma_buffer + 2048;
+        let data_buffer = self.dma_buffer + DATA_BUF_OFFSET as u64;
 
         // Copy data for OUT transfers
         if let Some(ref d) = data
@@ -815,9 +663,20 @@ impl UhciController {
             }
         }
 
-        // Calculate number of data TDs (one per packet)
+        // Calculate number of data TDs (one per packet).
+        // Reject transfers that would require more TDs than we support rather
+        // than silently truncating the data.
         let num_data_tds = if data_len > 0 {
-            data_len.div_ceil(max_packet).min(Self::MAX_DATA_TDS)
+            let n = data_len.div_ceil(max_packet);
+            if n > Self::MAX_DATA_TDS {
+                log::warn!(
+                    "UHCI: control transfer needs {} TDs, max is {}",
+                    n,
+                    Self::MAX_DATA_TDS,
+                );
+                return Err(UsbError::InvalidParameter);
+            }
+            n
         } else {
             0
         };

--- a/src/drivers/usb/uhci.rs
+++ b/src/drivers/usb/uhci.rs
@@ -13,9 +13,11 @@ use crate::time::{Timeout, wait_for};
 use core::ptr;
 use core::sync::atomic::{Ordering, fence};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
+use zerocopy::FromBytes;
 
 use super::controller::{
-    SetupPacket, UsbController, UsbDevice, UsbError, UsbSpeed, enumerate_device,
+    HUB_DESCRIPTOR_TYPE, HubDescriptor, SetupPacket, UsbController, UsbDevice, UsbError, UsbSpeed,
+    enumerate_device, hub_feature, hub_port_change, hub_port_status, req_type, request,
 };
 use super::uhci_regs::{PORTSC, USBCMD, USBSTS, UhciRegs};
 
@@ -315,7 +317,13 @@ impl UhciController {
         };
 
         controller.init()?;
-        controller.enumerate_ports()?;
+
+        // Port enumeration is deferred to rescan_ports(), called after all
+        // USB controllers are initialized. On ICH8/9/10 chipsets, UHCI
+        // companion controllers appear at lower PCI BDFs than their EHCI
+        // companion, so they are initialized first.  EHCI must set
+        // CONFIGFLAG and release companion ports before UHCI can see
+        // the correct devices and speeds on its ports.
 
         Ok(controller)
     }
@@ -487,7 +495,7 @@ impl UhciController {
         Ok(())
     }
 
-    /// Attach a device
+    /// Attach a device on a root hub port
     fn attach_device(&mut self, port: u8, speed: UsbSpeed) -> Result<(), UsbError> {
         let address = self.next_address;
         if address >= 128 {
@@ -503,20 +511,269 @@ impl UhciController {
         let initial_device = UsbDevice::new(0, port, speed);
 
         // Use the common enumeration helper with a closure for control transfers
-        let device = enumerate_device(
-            initial_device,
-            address,
-            |dev, req_type, req, value, index, data| {
-                self.control_transfer_internal(dev, req_type, req, value, index, data)
-            },
-        )?;
+        let device = enumerate_device(initial_device, address, |dev, rt, req, val, idx, data| {
+            self.control_transfer_internal(dev, rt, req, val, idx, data)
+        })?;
 
         self.next_address += 1;
+
+        // Store the device and check if it's a hub
+        let is_hub = device.is_hub;
+        let hub_address = device.address;
         self.devices[slot] = Some(device);
+
+        // If this is a hub, enumerate its downstream ports
+        if is_hub && let Err(e) = self.enumerate_hub(slot, hub_address) {
+            log::warn!("Failed to enumerate hub ports: {:?}", e);
+            // Don't fail the device attachment, hub is still registered
+        }
+
         Ok(())
     }
 
+    /// Attach a device connected through an external hub
+    ///
+    /// # Arguments
+    /// * `hub_port` - Hub port number (1-based)
+    /// * `speed` - Detected device speed
+    /// * `hub_addr` - USB address of the parent hub
+    /// * `hub_port_num` - Hub port number for tracking
+    fn attach_device_on_hub(
+        &mut self,
+        hub_port: u8,
+        speed: UsbSpeed,
+        hub_addr: u8,
+        hub_port_num: u8,
+    ) -> Result<(), UsbError> {
+        let address = self.next_address;
+        if address >= 128 {
+            return Err(UsbError::NoFreeSlots);
+        }
+
+        let slot = self
+            .devices
+            .iter()
+            .position(|d| d.is_none())
+            .ok_or(UsbError::NoFreeSlots)?;
+
+        let initial_device = UsbDevice::new_on_hub(0, hub_port, speed, hub_addr, hub_port_num);
+        let device = enumerate_device(initial_device, address, |dev, rt, req, val, idx, data| {
+            self.control_transfer_internal(dev, rt, req, val, idx, data)
+        })?;
+
+        self.next_address += 1;
+
+        // Store the device and check for nested hubs
+        let is_hub = device.is_hub;
+        let new_hub_address = device.address;
+        self.devices[slot] = Some(device);
+
+        if is_hub && let Err(e) = self.enumerate_hub(slot, new_hub_address) {
+            log::warn!("Failed to enumerate nested hub ports: {:?}", e);
+        }
+
+        Ok(())
+    }
+
+    /// Enumerate devices connected to an external USB hub
+    ///
+    /// Gets the hub descriptor, powers on all ports, resets ports with
+    /// connected devices, and enumerates them. UHCI is USB 1.1 only, so
+    /// devices behind hubs are always low-speed or full-speed.
+    fn enumerate_hub(&mut self, hub_slot: usize, hub_addr: u8) -> Result<(), UsbError> {
+        log::info!("UHCI: Enumerating hub at address {}", hub_addr);
+
+        let hub_device = self.devices[hub_slot]
+            .as_ref()
+            .ok_or(UsbError::DeviceNotFound)?
+            .clone();
+
+        // Get hub descriptor (class-specific request)
+        let mut hub_desc_buf = [0u8; 9];
+        self.control_transfer_internal(
+            &hub_device,
+            req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_DEVICE,
+            request::GET_DESCRIPTOR,
+            (HUB_DESCRIPTOR_TYPE as u16) << 8,
+            0,
+            Some(&mut hub_desc_buf),
+        )?;
+
+        let (hub_desc, _) = HubDescriptor::read_from_prefix(&hub_desc_buf)
+            .map_err(|_| UsbError::TransferFailed(0))?;
+        let num_ports = hub_desc.num_ports;
+        let power_on_delay = (hub_desc.power_on_to_power_good as u32) * 2;
+
+        log::info!(
+            "  Hub has {} ports, power-on delay: {}ms",
+            num_ports,
+            power_on_delay
+        );
+
+        // Update the device's hub port count
+        if let Some(ref mut dev) = self.devices[hub_slot] {
+            dev.num_hub_ports = num_ports;
+        }
+
+        // Power on all hub ports
+        for port in 1..=num_ports {
+            log::debug!("  Powering on hub port {}", port);
+            let result = self.control_transfer_internal(
+                &hub_device,
+                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                request::SET_FEATURE,
+                hub_feature::PORT_POWER,
+                port as u16,
+                None,
+            );
+            if let Err(e) = result {
+                log::warn!("  Failed to power on hub port {}: {:?}", port, e);
+            }
+        }
+
+        // Wait for power to stabilize
+        let delay = power_on_delay.max(100) as u64;
+        crate::time::delay_ms(delay);
+
+        // Check each port for connected devices
+        for port in 1..=num_ports {
+            // Get port status
+            let mut status_buf = [0u8; 4];
+            let result = self.control_transfer_internal(
+                &hub_device,
+                req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                request::GET_STATUS,
+                0,
+                port as u16,
+                Some(&mut status_buf),
+            );
+
+            if let Err(e) = result {
+                log::debug!("  Failed to get status for hub port {}: {:?}", port, e);
+                continue;
+            }
+
+            let port_status = u16::from_le_bytes([status_buf[0], status_buf[1]]);
+            let port_change = u16::from_le_bytes([status_buf[2], status_buf[3]]);
+
+            log::debug!(
+                "  Hub port {} status: {:#06x}, change: {:#06x}",
+                port,
+                port_status,
+                port_change
+            );
+
+            if (port_status & hub_port_status::CONNECTION) == 0 {
+                continue;
+            }
+
+            log::info!("  Device detected on hub port {}", port);
+
+            // Clear connection change bit if set
+            if port_change & hub_port_change::C_CONNECTION != 0 {
+                let _ = self.control_transfer_internal(
+                    &hub_device,
+                    req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                    request::CLEAR_FEATURE,
+                    hub_feature::C_PORT_CONNECTION,
+                    port as u16,
+                    None,
+                );
+            }
+
+            // Reset the port
+            log::debug!("  Resetting hub port {}", port);
+            self.control_transfer_internal(
+                &hub_device,
+                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                request::SET_FEATURE,
+                hub_feature::PORT_RESET,
+                port as u16,
+                None,
+            )?;
+
+            // Wait for reset (USB spec requires at least 10ms, use 50ms for margin)
+            crate::time::delay_ms(50);
+
+            // Poll for reset completion
+            let mut reset_complete = false;
+            let timeout = Timeout::from_ms(500);
+            while !timeout.is_expired() {
+                let mut status_buf = [0u8; 4];
+                if self
+                    .control_transfer_internal(
+                        &hub_device,
+                        req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                        request::GET_STATUS,
+                        0,
+                        port as u16,
+                        Some(&mut status_buf),
+                    )
+                    .is_err()
+                {
+                    break;
+                }
+
+                let port_status = u16::from_le_bytes([status_buf[0], status_buf[1]]);
+                let port_change = u16::from_le_bytes([status_buf[2], status_buf[3]]);
+
+                // Check if reset is complete (C_PORT_RESET bit in change)
+                if port_change & hub_port_change::C_RESET != 0 {
+                    // Clear the reset change bit
+                    let _ = self.control_transfer_internal(
+                        &hub_device,
+                        req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                        request::CLEAR_FEATURE,
+                        hub_feature::C_PORT_RESET,
+                        port as u16,
+                        None,
+                    );
+
+                    // Check if port is enabled
+                    if (port_status & hub_port_status::ENABLE) != 0 {
+                        reset_complete = true;
+
+                        // UHCI is USB 1.1 only: low-speed or full-speed
+                        let speed = if (port_status & hub_port_status::LOW_SPEED) != 0 {
+                            UsbSpeed::Low
+                        } else {
+                            UsbSpeed::Full
+                        };
+
+                        log::info!("  Hub port {} reset complete, speed: {:?}", port, speed);
+
+                        // Recovery time after reset
+                        crate::time::delay_ms(10);
+
+                        // Enumerate the device
+                        if let Err(e) = self.attach_device_on_hub(port, speed, hub_addr, port) {
+                            log::warn!("  Failed to attach device on hub port {}: {:?}", port, e);
+                        }
+                    }
+                    break;
+                }
+
+                crate::time::delay_ms(10);
+            }
+
+            if !reset_complete {
+                log::warn!("  Hub port {} reset timed out", port);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Maximum number of data TDs per control transfer
+    ///
+    /// Supports up to 256-byte transfers with 8-byte packets (low-speed worst case).
+    const MAX_DATA_TDS: usize = 32;
+
     /// Internal control transfer
+    ///
+    /// In UHCI, each TD handles exactly one USB packet. Control transfers with
+    /// data larger than max_packet_size require multiple data TDs, each carrying
+    /// up to max_packet_size bytes with alternating DATA0/DATA1 toggles.
     fn control_transfer_internal(
         &mut self,
         device: &UsbDevice,
@@ -529,19 +786,27 @@ impl UhciController {
         let is_in = (request_type & 0x80) != 0;
         let data_len = data.as_ref().map(|d| d.len()).unwrap_or(0);
         let is_low_speed = device.speed == UsbSpeed::Low;
+        let max_packet = device.ep0_max_packet.max(8) as usize;
 
-        // Build setup packet
+        // Build setup packet at start of DMA buffer
         let setup_addr = self.dma_buffer;
         let setup_packet = SetupPacket::new(request_type, request, value, index, data_len as u16);
         unsafe {
             ptr::copy_nonoverlapping(setup_packet.as_bytes().as_ptr(), setup_addr as *mut u8, 8);
         }
 
-        // Allocate TDs
+        // DMA buffer layout:
+        //   [0..8)       setup packet
+        //   [64..)       TDs: setup(1) + data(N) + status(1), each 32 bytes
+        //   [2048..)     data buffer
+        debug_assert!(
+            data_len <= Self::DMA_BUFFER_SIZE - 2048,
+            "control transfer data ({data_len} bytes) exceeds DMA buffer"
+        );
         let td_base = self.dma_buffer + 64;
-        let data_buffer = td_base + 256;
+        let data_buffer = self.dma_buffer + 2048;
 
-        // Copy data for OUT
+        // Copy data for OUT transfers
         if let Some(ref d) = data
             && !is_in
         {
@@ -550,49 +815,64 @@ impl UhciController {
             }
         }
 
-        // Create TDs
+        // Calculate number of data TDs (one per packet)
+        let num_data_tds = if data_len > 0 {
+            data_len.div_ceil(max_packet).min(Self::MAX_DATA_TDS)
+        } else {
+            0
+        };
+
+        // TD addresses
         let setup_td_addr = td_base;
-        let status_td_addr;
+        let first_data_td_addr = td_base + 32;
+        let status_td_addr = td_base + 32 * (1 + num_data_tds) as u64;
 
-        if data_len > 0 {
-            let data_td_addr = td_base + 32;
-            status_td_addr = td_base + 64;
+        // Build setup TD
+        let next_after_setup = if num_data_tds > 0 {
+            first_data_td_addr as u32
+        } else {
+            status_td_addr as u32
+        };
+        let setup_td = unsafe { &mut *(setup_td_addr as *mut TransferDescriptor) };
+        *setup_td = TransferDescriptor::setup(
+            device.address,
+            setup_addr as u32,
+            next_after_setup,
+            is_low_speed,
+        );
 
-            let setup_td = unsafe { &mut *(setup_td_addr as *mut TransferDescriptor) };
-            let data_td = unsafe { &mut *(data_td_addr as *mut TransferDescriptor) };
-            let status_td = unsafe { &mut *(status_td_addr as *mut TransferDescriptor) };
+        // Build data TDs (one per packet, alternating DATA1/DATA0)
+        let mut toggle = true; // First data packet after SETUP is DATA1
+        let mut remaining = data_len;
+        for i in 0..num_data_tds {
+            let chunk = remaining.min(max_packet);
+            let td_addr = first_data_td_addr + (i as u64) * 32;
+            let next_td = if i + 1 < num_data_tds {
+                (td_addr + 32) as u32
+            } else {
+                status_td_addr as u32
+            };
+            let buf_offset = i * max_packet;
 
-            *setup_td = TransferDescriptor::setup(
-                device.address,
-                setup_addr as u32,
-                data_td_addr as u32,
-                is_low_speed,
-            );
-            *data_td = TransferDescriptor::data(
+            let td = unsafe { &mut *(td_addr as *mut TransferDescriptor) };
+            *td = TransferDescriptor::data(
                 device.address,
                 0,
-                data_buffer as u32,
-                data_len,
+                (data_buffer + buf_offset as u64) as u32,
+                chunk,
                 is_in,
-                true,
-                status_td_addr as u32,
+                toggle,
+                next_td,
                 is_low_speed,
             );
-            *status_td = TransferDescriptor::status(device.address, !is_in, 0, is_low_speed);
-        } else {
-            status_td_addr = td_base + 32;
-
-            let setup_td = unsafe { &mut *(setup_td_addr as *mut TransferDescriptor) };
-            let status_td = unsafe { &mut *(status_td_addr as *mut TransferDescriptor) };
-
-            *setup_td = TransferDescriptor::setup(
-                device.address,
-                setup_addr as u32,
-                status_td_addr as u32,
-                is_low_speed,
-            );
-            *status_td = TransferDescriptor::status(device.address, true, 0, is_low_speed);
+            toggle = !toggle;
+            remaining -= chunk;
         }
+
+        // Build status TD (opposite direction from data, DATA1 toggle)
+        let status_td = unsafe { &mut *(status_td_addr as *mut TransferDescriptor) };
+        let status_dir_in = if data_len > 0 { !is_in } else { true };
+        *status_td = TransferDescriptor::status(device.address, status_dir_in, 0, is_low_speed);
 
         fence(Ordering::SeqCst);
 
@@ -601,14 +881,19 @@ impl UhciController {
         qh.element_link = setup_td_addr as u32;
         fence(Ordering::SeqCst);
 
-        // Wait for completion
-        let status_td = unsafe { &*(status_td_addr as *const TransferDescriptor) };
+        // Wait for status TD completion
         let timeout = Timeout::from_ms(5000);
-
-        while !timeout.is_expired() {
+        loop {
             fence(Ordering::SeqCst);
-            if !status_td.is_active() {
+            let sts = unsafe { ptr::read_volatile(&status_td.ctrl_sts) };
+            if sts & TransferDescriptor::CS_ACTIVE == 0 {
                 break;
+            }
+            if timeout.is_expired() {
+                // Clear QH before returning
+                qh.element_link = QueueHead::TERMINATE;
+                fence(Ordering::SeqCst);
+                return Err(UsbError::Timeout);
             }
             core::hint::spin_loop();
         }
@@ -617,33 +902,62 @@ impl UhciController {
         qh.element_link = QueueHead::TERMINATE;
         fence(Ordering::SeqCst);
 
-        // Check result
-        if status_td.is_active() {
-            return Err(UsbError::Timeout);
-        }
-
+        // Check setup TD and all data TDs for errors
         let setup_td = unsafe { &*(setup_td_addr as *const TransferDescriptor) };
-        if setup_td.has_error() || status_td.has_error() {
-            if setup_td.is_stalled() || status_td.is_stalled() {
-                return Err(UsbError::Stall);
+        if setup_td.has_error() {
+            return Err(if setup_td.is_stalled() {
+                UsbError::Stall
+            } else {
+                UsbError::TransactionError
+            });
+        }
+        for i in 0..num_data_tds {
+            let td_addr = first_data_td_addr + (i as u64) * 32;
+            let td = unsafe { &*(td_addr as *const TransferDescriptor) };
+            if td.has_error() {
+                return Err(if td.is_stalled() {
+                    UsbError::Stall
+                } else {
+                    UsbError::TransactionError
+                });
             }
-            return Err(UsbError::TransactionError);
+        }
+        let status_sts = unsafe { ptr::read_volatile(&status_td.ctrl_sts) };
+        if status_sts & TransferDescriptor::CS_ERROR_MASK != 0 {
+            return Err(if status_sts & TransferDescriptor::CS_STALLED != 0 {
+                UsbError::Stall
+            } else {
+                UsbError::TransactionError
+            });
         }
 
-        // Copy data for IN
+        // Copy received data for IN transfers
         if let Some(d) = data
             && is_in
         {
-            let data_td = unsafe { &*((td_base + 32) as *const TransferDescriptor) };
-            let transferred = data_td.actual_length();
-            unsafe {
-                ptr::copy_nonoverlapping(
-                    data_buffer as *const u8,
-                    d.as_mut_ptr(),
-                    transferred.min(d.len()),
-                );
+            let mut total = 0usize;
+            for i in 0..num_data_tds {
+                let td_addr = first_data_td_addr + (i as u64) * 32;
+                let td = unsafe { &*(td_addr as *const TransferDescriptor) };
+                let chunk_transferred = td.actual_length();
+                let buf_offset = i * max_packet;
+                let copy_len = chunk_transferred.min(d.len() - total);
+                if copy_len > 0 {
+                    unsafe {
+                        ptr::copy_nonoverlapping(
+                            (data_buffer + buf_offset as u64) as *const u8,
+                            d.as_mut_ptr().add(total),
+                            copy_len,
+                        );
+                    }
+                }
+                total += chunk_transferred;
+                // Short packet means device has no more data
+                if chunk_transferred < max_packet {
+                    break;
+                }
             }
-            return Ok(transferred);
+            return Ok(total);
         }
 
         Ok(data_len)
@@ -835,6 +1149,21 @@ impl UsbController for UhciController {
 }
 
 impl UhciController {
+    /// Enumerate ports (deferred initialization)
+    ///
+    /// On ICH8/9/10 chipsets, UHCI companion controllers are initialized before
+    /// their EHCI companion due to PCI BDF ordering (UHCI at functions 0-2,
+    /// EHCI at function 7). EHCI must set CONFIGFLAG and release companion ports
+    /// before UHCI can see correct devices and speeds on its ports.
+    ///
+    /// This is called from `rescan_companion_ports()` after all USB controllers
+    /// have been initialized, ensuring EHCI has already released its companions.
+    pub fn rescan_ports(&mut self) {
+        if let Err(e) = self.enumerate_ports() {
+            log::error!("UHCI: Port enumeration failed: {:?}", e);
+        }
+    }
+
     /// Clean up the controller before handing off to the OS
     ///
     /// This must be called before ExitBootServices to ensure Linux's UHCI

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -32,13 +32,13 @@ use heapless::{String, Vec};
 #[cfg(feature = "ui")]
 fn update_cursor(
     cursor_renderer: &mut crate::cursor::CursorRenderer,
-    fb_info: &Option<crate::coreboot::FramebufferInfo>, // FramebufferInfo is the rendering type
+    fb_info: &Option<crate::FramebufferConfig>,
 ) {
-    if let Some(fb) = fb_info {
-        if crate::drivers::mouse_cursor::is_initialized() {
-            let (x, y) = crate::drivers::mouse_cursor::position();
-            cursor_renderer.update(fb, x, y);
-        }
+    if let Some(fb) = fb_info
+        && crate::drivers::mouse_cursor::is_initialized()
+    {
+        let (x, y) = crate::drivers::mouse_cursor::position();
+        cursor_renderer.update(fb, x, y);
     }
 }
 
@@ -946,11 +946,10 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
         return None;
     }
 
-    // Get framebuffer.  FramebufferConsole uses platform::FramebufferConfig
-    // directly; the ui cursor renderer uses coreboot::FramebufferInfo.
+    // Get framebuffer for console and cursor rendering.
     let fb_config = crate::state::get_framebuffer();
     #[cfg(feature = "ui")]
-    let fb_info: Option<crate::coreboot::FramebufferInfo> = fb_config.map(Into::into);
+    let fb_info = fb_config;
     #[cfg(not(feature = "ui"))]
     let _ = (); // fb_info unused without ui
 

--- a/src/menu_common.rs
+++ b/src/menu_common.rs
@@ -22,6 +22,7 @@ pub enum KeyPress {
     /// Mouse click at pixel coordinates.
     #[cfg(feature = "ui")]
     MouseClick {
+        #[allow(dead_code)]
         x: u32,
         y: u32,
     },

--- a/src/time.rs
+++ b/src/time.rs
@@ -450,6 +450,24 @@ impl Timeout {
         Self::from_us(ms * 1000)
     }
 
+    /// Reconstruct a `Timeout` from a raw deadline value previously
+    /// obtained via [`raw_deadline()`](Self::raw_deadline).
+    ///
+    /// This is useful for storing a deadline in a state machine that
+    /// cannot hold a `Timeout` directly (e.g. inside an enum stored
+    /// in a `Mutex`).
+    #[inline]
+    pub fn from_raw(deadline: u64) -> Self {
+        Self { deadline }
+    }
+
+    /// Return the raw counter deadline for later reconstruction via
+    /// [`from_raw()`](Self::from_raw).
+    #[inline]
+    pub fn raw_deadline(&self) -> u64 {
+        self.deadline
+    }
+
     /// Check if the timeout has expired
     #[inline]
     pub fn is_expired(&self) -> bool {

--- a/src/ui/firmware_settings.rs
+++ b/src/ui/firmware_settings.rs
@@ -4,7 +4,7 @@ use super::{
     NavItem, ScreenNav, canvas, clear, draw_footer, draw_header, draw_sidebar,
     poll_and_render_cursor, render, theme, update_sidebar_hover,
 };
-use crate::coreboot::FramebufferInfo;
+use crate::FramebufferConfig as FramebufferInfo;
 use crate::cursor::CursorRenderer;
 use crate::menu_common::{self, KeyPress};
 use crate::time::delay_ms;
@@ -47,9 +47,7 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
         if let Some(key) = menu_common::read_key() {
             match key {
                 KeyPress::Up | KeyPress::Char('k') => {
-                    if selected > 0 {
-                        selected -= 1;
-                    }
+                    selected = selected.saturating_sub(1);
                     if selected < scroll {
                         scroll = selected;
                     }
@@ -76,11 +74,11 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
                     // Sidebar click
-                    if let Some(nav) = sidebar_hov {
-                        if nav != NavItem::Firmware {
-                            cursor.hide(fb);
-                            return ScreenNav::Nav(nav);
-                        }
+                    if let Some(nav) = sidebar_hov
+                        && nav != NavItem::Firmware
+                    {
+                        cursor.hide(fb);
+                        return ScreenNav::Nav(nav);
                     }
                     // Card click
                     if let Some(idx) = hovered {
@@ -315,7 +313,7 @@ fn draw_settings(
         );
     }
     if scroll + mv < cfr.forms.len() {
-        let ay = fb.y_resolution as i32 - theme::FOOTER_H as i32 - 20;
+        let ay = fb.height as i32 - theme::FOOTER_H as i32 - 20;
         render::draw_text_centered(fb, cx, ay, cw, "v", FontSize::Small, theme::PRIMARY, None);
     }
 }
@@ -364,11 +362,11 @@ fn show_no_cfr(fb: &FramebufferInfo) -> ScreenNav {
                 KeyPress::Escape | KeyPress::Char('q') => return ScreenNav::Back,
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
-                    if let Some(nav) = sidebar_hov {
-                        if nav != NavItem::Firmware {
-                            cursor.hide(fb);
-                            return ScreenNav::Nav(nav);
-                        }
+                    if let Some(nav) = sidebar_hov
+                        && nav != NavItem::Firmware
+                    {
+                        cursor.hide(fb);
+                        return ScreenNav::Nav(nav);
                     }
                 }
                 _ => {}
@@ -378,7 +376,7 @@ fn show_no_cfr(fb: &FramebufferInfo) -> ScreenNav {
     }
 }
 
-fn fmt_opts<'a>(n: u32, buf: &'a mut [u8; 16]) -> &'a str {
+fn fmt_opts(n: u32, buf: &mut [u8; 16]) -> &str {
     let mut p = 0;
     p += super::fmt_u32(n, &mut buf[p..]);
     for &b in b" opts" {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,7 +10,7 @@ pub mod render;
 pub mod secure_boot;
 pub mod theme;
 
-use crate::coreboot::FramebufferInfo;
+use crate::FramebufferConfig as FramebufferInfo;
 use crate::cursor::CursorRenderer;
 use crate::drivers::mouse_cursor;
 use crate::menu::{BootCategory, BootMenu};
@@ -70,7 +70,7 @@ pub fn clear(fb: &FramebufferInfo) {
 
 /// Draw the top header bar (branding + version).
 pub fn draw_header(fb: &FramebufferInfo) {
-    let w = fb.x_resolution;
+    let w = fb.width;
     render::fill_gradient_v(
         fb,
         0,
@@ -100,7 +100,7 @@ pub fn draw_header(fb: &FramebufferInfo) {
 pub fn draw_sidebar(fb: &FramebufferInfo, active: NavItem, hovered: Option<NavItem>) {
     let sw = theme::SIDEBAR_W;
     let sy = theme::HEADER_H;
-    let sh = fb.y_resolution - theme::HEADER_H - theme::FOOTER_H;
+    let sh = fb.height - theme::HEADER_H - theme::FOOTER_H;
 
     render::fill_rect(fb, 0, sy as i32, sw, sh, theme::SIDE);
 
@@ -169,8 +169,8 @@ fn paint_sidebar_item(
 
 /// Draw the bottom footer bar.
 pub fn draw_footer(fb: &FramebufferInfo, hint: &str) {
-    let w = fb.x_resolution;
-    let fy = fb.y_resolution - theme::FOOTER_H;
+    let w = fb.width;
+    let fy = fb.height - theme::FOOTER_H;
     render::fill_rect(fb, 0, fy as i32, w, theme::FOOTER_H, theme::BG);
     let text_y =
         (fy as i32) + ((theme::FOOTER_H as i32 - render::font_height(FontSize::Small) as i32) / 2);
@@ -196,8 +196,8 @@ pub fn poll_and_render_cursor(fb: &FramebufferInfo, cursor: &mut CursorRenderer)
 fn canvas(fb: &FramebufferInfo) -> (i32, i32, u32, u32) {
     let x = theme::SIDEBAR_W as i32 + theme::PAD as i32;
     let y = (theme::HEADER_H + theme::PAD) as i32;
-    let w = fb.x_resolution - theme::SIDEBAR_W - theme::PAD * 2;
-    let h = fb.y_resolution - theme::HEADER_H - theme::FOOTER_H - theme::PAD * 2;
+    let w = fb.width - theme::SIDEBAR_W - theme::PAD * 2;
+    let h = fb.height - theme::HEADER_H - theme::FOOTER_H - theme::PAD * 2;
     (x, y, w, h)
 }
 
@@ -251,7 +251,7 @@ fn sidebar_hit() -> Option<NavItem> {
 // ═══════════════════════════════════════════════════════════════════════
 
 pub fn show_graphical_menu(menu: &mut BootMenu) -> Option<usize> {
-    let fb: FramebufferInfo = crate::state::get_framebuffer()?.into();
+    let fb = crate::state::get_framebuffer()?;
     let mut screen = NavItem::Boot;
 
     loop {
@@ -273,8 +273,8 @@ pub fn show_graphical_menu(menu: &mut BootMenu) -> Option<usize> {
 }
 
 pub fn show_no_media_screen() {
-    let fb: FramebufferInfo = match crate::state::get_framebuffer() {
-        Some(f) => f.into(),
+    let fb = match crate::state::get_framebuffer() {
+        Some(f) => f,
         None => return,
     };
     let mut screen = NavItem::Boot;
@@ -398,11 +398,11 @@ fn run_boot(fb: &FramebufferInfo, menu: &mut BootMenu) -> BootResult {
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
                     // Check sidebar clicks first
-                    if let Some(nav) = st.sidebar_hov {
-                        if nav != NavItem::Boot {
-                            cursor.hide(fb);
-                            return BootResult::Nav(nav);
-                        }
+                    if let Some(nav) = st.sidebar_hov
+                        && nav != NavItem::Boot
+                    {
+                        cursor.hide(fb);
+                        return BootResult::Nav(nav);
                     }
                     // Then card clicks
                     if let Some(idx) = st.hovered {
@@ -536,11 +536,11 @@ fn run_no_media(fb: &FramebufferInfo) -> ScreenNav {
                 KeyPress::Escape => return ScreenNav::Back,
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
-                    if let Some(nav) = sidebar_hov {
-                        if nav != NavItem::Boot {
-                            cursor.hide(fb);
-                            return ScreenNav::Nav(nav);
-                        }
+                    if let Some(nav) = sidebar_hov
+                        && nav != NavItem::Boot
+                    {
+                        cursor.hide(fb);
+                        return ScreenNav::Nav(nav);
                     }
                 }
                 _ => {}
@@ -721,8 +721,8 @@ fn paint_boot_card(fb: &FramebufferInfo, menu: &BootMenu, st: &BState, idx: usiz
 }
 
 fn paint_boot_footer(fb: &FramebufferInfo, st: &BState) {
-    let w = fb.x_resolution;
-    let fy = fb.y_resolution - theme::FOOTER_H;
+    let w = fb.width;
+    let fy = fb.height - theme::FOOTER_H;
     render::fill_rect(fb, 0, fy as i32, w, theme::FOOTER_H, theme::BG);
 
     if st.countdown > 0 && st.init_timeout > 0 {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -4,7 +4,7 @@
 //! progress bars, pill badges, toggle switches, and multi-size anti-aliased
 //! text rendering using the Noto Sans Mono bitmap font.
 
-use crate::coreboot::FramebufferInfo;
+use crate::FramebufferConfig as FramebufferInfo;
 use noto_sans_mono_bitmap::{FontWeight, RasterHeight, get_raster, get_raster_width};
 
 /// RGB color triple.
@@ -103,8 +103,8 @@ pub fn text_width(s: &str, size: FontSize) -> u32 {
 pub fn fill_rect(fb: &FramebufferInfo, x: i32, y: i32, w: u32, h: u32, c: Rgb) {
     let x0 = x.max(0) as u32;
     let y0 = y.max(0) as u32;
-    let x1 = ((x as i64 + w as i64) as u32).min(fb.x_resolution);
-    let y1 = ((y as i64 + h as i64) as u32).min(fb.y_resolution);
+    let x1 = ((x as i64 + w as i64) as u32).min(fb.width);
+    let y1 = ((y as i64 + h as i64) as u32).min(fb.height);
     if x0 >= x1 || y0 >= y1 {
         return;
     }
@@ -122,7 +122,7 @@ pub fn fill_gradient_v(fb: &FramebufferInfo, x: i32, y: i32, w: u32, h: u32, top
         return;
     }
     for r in 0..h {
-        let t = ((r as u32 * 255) / (h - 1).max(1)) as u8;
+        let t = ((r * 255) / (h - 1).max(1)) as u8;
         fill_rect(fb, x, y + r as i32, w, 1, top.lerp(bot, t));
     }
 }
@@ -141,7 +141,7 @@ pub fn fill_gradient_h(
         return;
     }
     for c in 0..w {
-        let t = ((c as u32 * 255) / (w - 1).max(1)) as u8;
+        let t = ((c * 255) / (w - 1).max(1)) as u8;
         fill_rect(fb, x + c as i32, y, 1, h, left.lerp(right, t));
     }
 }
@@ -172,7 +172,7 @@ fn isqrt(n: u32) -> u32 {
         return 0;
     }
     let mut x = n;
-    let mut y = (x + 1) / 2;
+    let mut y = x.div_ceil(2);
     while y < x {
         x = y;
         y = (x + n / x) / 2;
@@ -326,8 +326,7 @@ pub fn draw_dot(fb: &FramebufferInfo, cx: i32, cy: i32, r: u32, c: Rgb) {
             if dx * dx + dy * dy <= r2 {
                 let px = cx + dx;
                 let py = cy + dy;
-                if px >= 0 && py >= 0 && px < fb.x_resolution as i32 && py < fb.y_resolution as i32
-                {
+                if px >= 0 && py >= 0 && px < fb.width as i32 && py < fb.height as i32 {
                     // SAFETY: bounds checked
                     unsafe { fb.write_pixel(px as u32, py as u32, c.r, c.g, c.b) };
                 }
@@ -410,15 +409,13 @@ pub fn draw_char(
     let w = raster.width();
     let h = raster.height();
 
-    for row in 0..h {
-        for col in 0..w {
+    for (row, raster_row) in rows.iter().enumerate().take(h) {
+        for (col, &alpha) in raster_row.iter().enumerate().take(w) {
             let sx = px + col as i32;
             let sy = py + row as i32;
-            if sx < 0 || sy < 0 || sx >= fb.x_resolution as i32 || sy >= fb.y_resolution as i32 {
+            if sx < 0 || sy < 0 || sx >= fb.width as i32 || sy >= fb.height as i32 {
                 continue;
             }
-
-            let alpha = rows[row][col];
             if alpha == 0 {
                 // Fully transparent — write bg if given, skip otherwise.
                 if let Some(b) = bg {

--- a/src/ui/secure_boot.rs
+++ b/src/ui/secure_boot.rs
@@ -4,7 +4,7 @@ use super::{
     NavItem, ScreenNav, canvas, clear, draw_footer, draw_header, draw_sidebar,
     poll_and_render_cursor, render, theme, update_sidebar_hover,
 };
-use crate::coreboot::FramebufferInfo;
+use crate::FramebufferConfig as FramebufferInfo;
 use crate::cursor::CursorRenderer;
 use crate::menu_common::{self, KeyPress};
 use crate::time::delay_ms;
@@ -46,9 +46,7 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
             status = None;
             match key {
                 KeyPress::Up | KeyPress::Char('k') => {
-                    if selected > 0 {
-                        selected -= 1;
-                    }
+                    selected = selected.saturating_sub(1);
                     draw_screen(fb, selected, hovered, status);
                 }
                 KeyPress::Down | KeyPress::Char('j') => {
@@ -70,11 +68,11 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
                     // Sidebar click
-                    if let Some(nav) = sidebar_hov {
-                        if nav != NavItem::Security {
-                            cursor.hide(fb);
-                            return ScreenNav::Nav(nav);
-                        }
+                    if let Some(nav) = sidebar_hov
+                        && nav != NavItem::Security
+                    {
+                        cursor.hide(fb);
+                        return ScreenNav::Nav(nav);
                     }
                     // Card click
                     if let Some(idx) = hovered {
@@ -357,18 +355,9 @@ fn draw_screen(
 
     // Status toast
     if let Some((msg, ok)) = status {
-        let msg_y = fb.y_resolution as i32 - theme::FOOTER_H as i32 - 24;
+        let msg_y = fb.height as i32 - theme::FOOTER_H as i32 - 24;
         let color = if ok { theme::SECONDARY } else { theme::ERROR };
-        render::draw_text_centered(
-            fb,
-            0,
-            msg_y,
-            fb.x_resolution,
-            msg,
-            FontSize::Normal,
-            color,
-            None,
-        );
+        render::draw_text_centered(fb, 0, msg_y, fb.width, msg, FontSize::Normal, color, None);
     }
 }
 


### PR DESCRIPTION
## Summary

- **Fix UHCI multi-packet control transfers**: Each UHCI TD handles exactly one USB packet, but `control_transfer_internal` created a single data TD for the entire data phase. For low-speed devices (max_packet=8), the 18-byte GET_DESCRIPTOR only captured 8 bytes, leaving VID/PID as zeros. Now creates one TD per packet with proper DATA0/DATA1 toggle alternation.
- **Defer UHCI port enumeration**: On ICH8/9/10 chipsets, UHCI companions (functions 0-2) initialize before EHCI (function 7) due to PCI BDF ordering. Port scanning is now deferred to `rescan_companion_ports()` which runs after all controllers are initialized, so EHCI has already set CONFIGFLAG and released companion ports.
- **Add UHCI hub support**: `enumerate_hub()` discovers devices behind external USB hubs using standard hub class control transfers, matching the existing EHCI implementation.
- **Defer PS/2 keyboard BAT**: Move the blocking BAT wait to a polling state machine so it doesn't delay USB initialization.

## Testing

Tested on ThinkPad with ICH8 (8086:2835 UHCI) and IBM NetVista keyboard (04b3:3025, low-speed). Keyboard is now detected and functional.