### PR TITLE
spi: fix ICH8 RCBA SPI BAR offset (0x3020, not 0x3800)

### DIFF
--- a/crabefi.org
+++ b/crabefi.org
@@ -1,0 +1,1 @@
+../../org/roam/20260128133635-crabefi.org

--- a/src/drivers/spi/intel.rs
+++ b/src/drivers/spi/intel.rs
@@ -49,7 +49,7 @@
 
 use super::intel_chipsets::IchChipset;
 use super::regs::*;
-use super::{delay_us, Result, SpiController, SpiError, SpiMode};
+use super::{Result, SpiController, SpiError, SpiMode, delay_us};
 use crate::drivers::mmio::MmioRegion;
 use crate::drivers::pci::{self, PciAddress, PciDevice};
 

--- a/src/drivers/spi/intel.rs
+++ b/src/drivers/spi/intel.rs
@@ -49,7 +49,7 @@
 
 use super::intel_chipsets::IchChipset;
 use super::regs::*;
-use super::{Result, SpiController, SpiError, SpiMode, delay_us};
+use super::{delay_us, Result, SpiController, SpiError, SpiMode};
 use crate::drivers::mmio::MmioRegion;
 use crate::drivers::pci::{self, PciAddress, PciDevice};
 
@@ -183,11 +183,12 @@ impl IntelSpiController {
         // RCBA is 32-bit aligned, mask off lower bits
         let rcba_base = (rcba & !0x3FFF) as u64;
 
-        // SPI offset depends on chipset generation
-        let spi_offset = if generation == IchChipset::Ich7 {
-            RCBA_SPI_OFFSET_ICH7
-        } else {
-            RCBA_SPI_OFFSET_ICH9
+        // SPI offset within RCBA depends on chipset generation.
+        // ICH7 and ICH8 both use RCBA+0x3020; ICH9 moved the SPI BAR to RCBA+0x3800.
+        // (TunnelCreek and Centerton also use 0x3020 when they are added.)
+        let spi_offset = match generation {
+            IchChipset::Ich7 | IchChipset::Ich8 => RCBA_SPI_OFFSET_ICH7,
+            _ => RCBA_SPI_OFFSET_ICH9,
         };
 
         Ok(rcba_base + spi_offset)

--- a/src/drivers/spi/regs.rs
+++ b/src/drivers/spi/regs.rs
@@ -308,9 +308,9 @@ pub const fn freg_limit(freg: u32) -> u32 {
 /// PCI config offset for RCBA (Root Complex Base Address) - ICH7-ICH10
 pub const PCI_REG_RCBA: u8 = 0xF0;
 
-/// Offset to SPI registers within RCBA (ICH7)
+/// Offset to SPI registers within RCBA (ICH7 and ICH8)
 pub const RCBA_SPI_OFFSET_ICH7: u64 = 0x3020;
-/// Offset to SPI registers within RCBA (ICH8+)
+/// Offset to SPI registers within RCBA (ICH9+)
 pub const RCBA_SPI_OFFSET_ICH9: u64 = 0x3800;
 
 /// SPIBAR register in LPC/eSPI controller config space (PCH100+)


### PR DESCRIPTION
## Summary

- ICH8 shares the RCBA+0x3020 SPI BAR offset with ICH7; the move to RCBA+0x3800 was introduced with ICH9.
- `get_spibar_via_rcba()` was routing ICH8 to the wrong offset (0x3800), meaning the driver would read/write a completely wrong memory region on real ICH8 hardware.
- ICH8 correctly uses the ICH9-compatible SPI engine (HSFS/HSFC registers, `init_ich9()`); only the RCBA base offset was wrong.

## Reference

`flashprog/chipset_enable.c` (the authoritative reference):
```c
case CHIPSET_ICH7:
case CHIPSET_ICH8:
    spibar_offset = 0x3020;
    break;
case CHIPSET_ICH9:
default:
    spibar_offset = 0x3800;
    break;
```

## Changes

- `src/drivers/spi/intel.rs`: switch `get_spibar_via_rcba()` from an `if Ich7` branch to a `match` on `Ich7 | Ich8` for the 0x3020 case, with a note for future TunnelCreek/Centerton additions.
- `src/drivers/spi/regs.rs`: correct doc comment on `RCBA_SPI_OFFSET_ICH9` from "ICH8+" to "ICH9+".