### PR TITLE
spi: fix ICH8 RCBA SPI BAR offset to 0x3020, not 0x3800

### DIFF
--- a/src/drivers/spi/intel.rs
+++ b/src/drivers/spi/intel.rs
@@ -183,11 +183,12 @@ impl IntelSpiController {
         // RCBA is 32-bit aligned, mask off lower bits
         let rcba_base = (rcba & !0x3FFF) as u64;
 
-        // SPI offset depends on chipset generation
-        let spi_offset = if generation == IchChipset::Ich7 {
-            RCBA_SPI_OFFSET_ICH7
-        } else {
-            RCBA_SPI_OFFSET_ICH9
+        // SPI offset within RCBA depends on chipset generation.
+        // ICH7 and ICH8 both use RCBA+0x3020; ICH9 moved the SPI BAR to RCBA+0x3800.
+        // (TunnelCreek and Centerton also use 0x3020 when they are added.)
+        let spi_offset = match generation {
+            IchChipset::Ich7 | IchChipset::Ich8 => RCBA_SPI_OFFSET_ICH7,
+            _ => RCBA_SPI_OFFSET_ICH9,
         };
 
         Ok(rcba_base + spi_offset)

--- a/src/drivers/spi/regs.rs
+++ b/src/drivers/spi/regs.rs
@@ -308,9 +308,9 @@ pub const fn freg_limit(freg: u32) -> u32 {
 /// PCI config offset for RCBA (Root Complex Base Address) - ICH7-ICH10
 pub const PCI_REG_RCBA: u8 = 0xF0;
 
-/// Offset to SPI registers within RCBA (ICH7)
+/// Offset to SPI registers within RCBA (ICH7 and ICH8)
 pub const RCBA_SPI_OFFSET_ICH7: u64 = 0x3020;
-/// Offset to SPI registers within RCBA (ICH8+)
+/// Offset to SPI registers within RCBA (ICH9+)
 pub const RCBA_SPI_OFFSET_ICH9: u64 = 0x3800;
 
 /// SPIBAR register in LPC/eSPI controller config space (PCH100+)


### PR DESCRIPTION
ICH8 shares the RCBA+0x3020 SPI BAR offset with ICH7.  The move to RCBA+0x3800 was introduced with ICH9.  Despite using the ICH9-compatible register engine (HSFS/HSFC), ICH8 keeps the older RCBA base address.

This matches flashprog/chipset_enable.c which places both CHIPSET_ICH7 and CHIPSET_ICH8 in the 0x3020 case and only falls through to 0x3800 for CHIPSET_ICH9 and later.

Also fix the doc comment on RCBA_SPI_OFFSET_ICH9 which incorrectly said 'ICH8+' instead of 'ICH9+'.