### PR TITLE
fix: IDT CS portability, BootServicesData type, FAT read alignment

### DIFF
--- a/src/arch/x86_64/idt.rs
+++ b/src/arch/x86_64/idt.rs
@@ -43,7 +43,10 @@ impl IdtEntry {
         self.offset_low = handler as u16;
         self.offset_mid = (handler >> 16) as u16;
         self.offset_high = (handler >> 32) as u32;
-        self.selector = 0x08; // Code segment selector (from coreboot GDT)
+        // Use the current code segment selector rather than hardcoding 0x08.
+        // coreboot GDT has 64-bit code at 0x08; other firmware (e.g. fstart)
+        // may place it at 0x10.  Reading CS gives the right value regardless.
+        self.selector = read_cs();
         self.ist = 0;
         // Present, DPL=0, Interrupt Gate (0x8E)
         self.type_attr = 0x8E;
@@ -55,6 +58,16 @@ impl IdtEntry {
 struct IdtPointer {
     limit: u16,
     base: u64,
+}
+
+/// Read the current code-segment selector (CS register).
+#[inline]
+fn read_cs() -> u16 {
+    let cs: u16;
+    unsafe {
+        asm!("mov {0:x}, cs", out(reg) cs, options(nomem, nostack, preserves_flags));
+    }
+    cs
 }
 
 /// The IDT - 256 entries for all possible interrupts

--- a/src/efi/allocator.rs
+++ b/src/efi/allocator.rs
@@ -375,6 +375,7 @@ impl MemoryAllocator {
                 PlatMemType::Mmio => MemoryType::MemoryMappedIo,
                 PlatMemType::RuntimeServicesCode => MemoryType::RuntimeServicesCode,
                 PlatMemType::RuntimeServicesData => MemoryType::RuntimeServicesData,
+                PlatMemType::BootServicesData => MemoryType::BootServicesData,
             };
 
             let num_pages = match region.size.checked_add(PAGE_SIZE - 1) {

--- a/src/fs/fat.rs
+++ b/src/fs/fat.rs
@@ -825,16 +825,38 @@ impl<'a> FatFilesystem<'a> {
             return Ok(());
         }
 
-        // Calculate total device blocks for the entire run
-        let total_device_blocks = (total_bytes.div_ceil(device_block_size)) as u32;
+        // Read the device-block-aligned portion in a single multi-block read.
+        // When cluster_size < device_block_size, the total bytes may not fill
+        // a whole number of device blocks. We can only pass a buffer that is
+        // at least `device_blocks * device_block_size` bytes to read_blocks,
+        // so read the aligned prefix in bulk and the trailing clusters one by
+        // one (read_cluster handles sub-block reads via a temp buffer).
+        let aligned_bytes = (total_bytes / device_block_size) * device_block_size;
+        let aligned_device_blocks = (aligned_bytes / device_block_size) as u32;
 
-        self.device
-            .read_blocks(
-                start_device_block,
-                total_device_blocks,
-                &mut buffer[..total_bytes],
-            )
-            .map_err(|_| FatError::ReadError)
+        if aligned_device_blocks > 0 {
+            self.device
+                .read_blocks(
+                    start_device_block,
+                    aligned_device_blocks,
+                    &mut buffer[..aligned_bytes],
+                )
+                .map_err(|_| FatError::ReadError)?;
+        }
+
+        // Read remaining clusters that don't fill a complete device block
+        if aligned_bytes < total_bytes {
+            let first_tail_cluster = (aligned_bytes / cluster_size) as u32;
+            for i in first_tail_cluster..count {
+                let offset = i as usize * cluster_size;
+                self.read_cluster(
+                    start_cluster + i,
+                    &mut buffer[offset..offset + cluster_size],
+                )?;
+            }
+        }
+
+        Ok(())
     }
 
     /// Find a file by path

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -85,6 +85,12 @@ pub enum MemoryType {
     RuntimeServicesCode,
     /// Runtime services data (becomes `EfiRuntimeServicesData` with `EFI_MEMORY_RUNTIME`).
     RuntimeServicesData,
+    /// Boot services data (becomes `EfiBootServicesData`).
+    ///
+    /// Reclaimed as ConventionalMemory after `ExitBootServices`. Use for
+    /// firmware regions that are not needed at runtime (e.g., firmware
+    /// BSS/stack when CrabEFI is called as a library).
+    BootServicesData,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Three independent bug fixes:

### `fix(idt)`: Read CS register dynamically
Hardcoding `0x08` as the code-segment selector in IDT entries assumed coreboot's GDT layout. Other firmware environments (e.g. fstart) place the 64-bit code segment at a different selector. Reading the CS register at setup time makes IDT initialization portable.

### `fix(platform, allocator)`: Add `BootServicesData` memory type
`BootServicesData` was missing from the `MemoryType` enum and from the allocator's memory-region mapping. Any firmware that describes `BootServicesData` regions in its memory map would fail to compile or silently drop those regions.

### `fix(fat)`: Handle cluster reads when `cluster_size < device_block_size`
`read_clusters` used `div_ceil` to compute a device-block count, which could exceed the slice length passed to `read_blocks` when clusters are smaller than device blocks (e.g. 512-byte FAT clusters on a 4 KiB NVMe sector device), leading to a panic or corrupt read. The fix reads the device-block-aligned prefix in one bulk call and falls back to per-cluster `read_cluster` calls for any trailing partial block.