### PR TITLE
fix(efi): harden unsafe paths and parsers

### DIFF
--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -4,6 +4,7 @@
 //! including the 32-bit to 64-bit mode transition and page table setup.
 
 pub mod cache;
+#[cfg(feature = "platform-entry")]
 pub mod entry;
 pub mod idt;
 pub mod io;

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -84,19 +84,11 @@ pub fn install_block_io_protocols(
         }
     }
 
-    // Read GPT header and all partitions
-    let header = match fs::gpt::read_gpt_header(disk) {
-        Ok(h) => h,
-        Err(e) => {
-            log::debug!("Failed to read GPT header: {:?}", e);
-            return None;
-        }
-    };
-
-    let partitions = match fs::gpt::read_partitions(disk, &header) {
+    // Read GPT partitions, falling back to MBR for removable media.
+    let partitions = match fs::gpt::read_partitions_auto(disk) {
         Ok(p) => p,
         Err(e) => {
-            log::debug!("Failed to read partitions: {:?}", e);
+            log::debug!("Failed to read partition table: {:?}", e);
             return None;
         }
     };

--- a/src/boot_manager.rs
+++ b/src/boot_manager.rs
@@ -396,7 +396,7 @@ fn try_boot_file_on_sdhci(file_path: &str) -> bool {
 
 /// Try to boot a specific file from ESPs on a given device.
 ///
-/// Reads GPT, finds ESP partitions, mounts FAT, checks if the file exists,
+/// Reads GPT/MBR partitions, finds ESP partitions, mounts FAT, checks if the file exists,
 /// and if so, boots it through the standard UEFI boot path.
 fn try_boot_file_on_device(
     device_type: &menu::DeviceType,
@@ -406,17 +406,9 @@ fn try_boot_file_on_device(
 ) -> bool {
     use crate::fs::{fat::FatFilesystem, gpt};
 
-    // Read GPT partitions
-    let partitions = crate::with_disk(device_type, |disk| {
-        if let Ok(header) = gpt::read_gpt_header(disk)
-            && let Ok(parts) = gpt::read_partitions(disk, &header)
-        {
-            Some(parts)
-        } else {
-            None
-        }
-    })
-    .flatten();
+    // Read GPT/MBR partitions
+    let partitions =
+        crate::with_disk(device_type, |disk| gpt::read_partitions_auto(disk).ok()).flatten();
 
     let partitions = match partitions {
         Some(p) => p,

--- a/src/boot_vars.rs
+++ b/src/boot_vars.rs
@@ -288,10 +288,7 @@ fn boot_option_name(option_number: u16) -> [u16; MAX_VARIABLE_NAME_LEN] {
     name[3] = b't' as u16;
 
     // 4-digit hex number
-    let hex_chars = [
-        b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'A', b'B', b'C', b'D', b'E',
-        b'F',
-    ];
+    let hex_chars = *b"0123456789ABCDEF";
     name[4] = hex_chars[((option_number >> 12) & 0xF) as usize] as u16;
     name[5] = hex_chars[((option_number >> 8) & 0xF) as usize] as u16;
     name[6] = hex_chars[((option_number >> 4) & 0xF) as usize] as u16;

--- a/src/coreboot/framebuffer.rs
+++ b/src/coreboot/framebuffer.rs
@@ -55,7 +55,7 @@ impl From<FramebufferInfo> for crate::platform::FramebufferConfig {
             width: fb.x_resolution,
             height: fb.y_resolution,
             // Convert bytes-per-line to pixels-per-scanline
-            stride: if bpp > 0 {
+            stride: if bpp >= 8 {
                 fb.bytes_per_line / (bpp / 8)
             } else {
                 fb.x_resolution
@@ -226,19 +226,25 @@ impl FramebufferInfo {
 
     /// Encode a 32-bit pixel value
     fn encode_pixel_32(&self, r: u8, g: u8, b: u8) -> u32 {
-        // Scale down to mask size, like encode_pixel_16 does
-        let r = ((r as u32) >> (8 - self.red_mask_size)) << self.red_mask_pos;
-        let g = ((g as u32) >> (8 - self.green_mask_size)) << self.green_mask_pos;
-        let b = ((b as u32) >> (8 - self.blue_mask_size)) << self.blue_mask_pos;
+        // Scale down to mask size, like encode_pixel_16 does.
+        // Malformed coreboot records can report mask sizes > 8; saturating the
+        // shift keeps debug builds from panicking and release builds from wrapping.
+        let r = ((r as u32) >> 8u32.saturating_sub(self.red_mask_size as u32)) << self.red_mask_pos;
+        let g =
+            ((g as u32) >> 8u32.saturating_sub(self.green_mask_size as u32)) << self.green_mask_pos;
+        let b =
+            ((b as u32) >> 8u32.saturating_sub(self.blue_mask_size as u32)) << self.blue_mask_pos;
         r | g | b
     }
 
     /// Encode a 16-bit pixel value
     fn encode_pixel_16(&self, r: u8, g: u8, b: u8) -> u16 {
-        // Scale down to the mask size
-        let r = ((r as u16) >> (8 - self.red_mask_size)) << self.red_mask_pos;
-        let g = ((g as u16) >> (8 - self.green_mask_size)) << self.green_mask_pos;
-        let b = ((b as u16) >> (8 - self.blue_mask_size)) << self.blue_mask_pos;
+        // Scale down to the mask size.
+        let r = ((r as u16) >> 8u16.saturating_sub(self.red_mask_size as u16)) << self.red_mask_pos;
+        let g =
+            ((g as u16) >> 8u16.saturating_sub(self.green_mask_size as u16)) << self.green_mask_pos;
+        let b =
+            ((b as u16) >> 8u16.saturating_sub(self.blue_mask_size as u16)) << self.blue_mask_pos;
         r | g | b
     }
 

--- a/src/drivers/ahci/mod.rs
+++ b/src/drivers/ahci/mod.rs
@@ -1370,7 +1370,9 @@ impl AhciController {
         let mut dma_buffer = DmaBuffer::new(transfer_len)?;
         let dma_addr = dma_buffer.addr();
 
-        // Copy data to DMA buffer
+        // Copy data to DMA buffer. Zero-fill the rounded padding so the device
+        // never receives stale firmware memory for non-512-byte-aligned payloads.
+        dma_buffer.memory.fill(0);
         unsafe {
             core::ptr::copy_nonoverlapping(buffer.as_ptr(), dma_buffer.as_mut_ptr(), buffer.len());
         }

--- a/src/drivers/ahci/mod.rs
+++ b/src/drivers/ahci/mod.rs
@@ -7,6 +7,7 @@ pub mod regs;
 
 use crate::drivers::pci::{self, PciDevice};
 use crate::efi;
+use crate::efi::allocator::PAGE_SIZE_USIZE;
 use crate::time::{Timeout, wait_for};
 use core::ptr;
 use core::sync::atomic::{Ordering, fence};
@@ -171,8 +172,44 @@ impl PrdtEntry {
         self.dbau = (addr >> 32) as u32;
     }
 
-    fn set_byte_count(&mut self, count: u32, interrupt: bool) {
+    fn set_byte_count(&mut self, count: u32, interrupt: bool) -> Result<(), AhciError> {
+        if count == 0 {
+            return Err(AhciError::InvalidParameter);
+        }
         self.dbc = (count - 1) | if interrupt { 1u32 << 31 } else { 0 };
+        Ok(())
+    }
+}
+
+/// Page-backed DMA buffer that frees its pages on scope exit.
+struct DmaBuffer {
+    memory: &'static mut [u8],
+    pages: u64,
+}
+
+impl DmaBuffer {
+    fn new(len: usize) -> Result<Self, AhciError> {
+        let pages = len.div_ceil(PAGE_SIZE_USIZE).max(1) as u64;
+        let memory = efi::allocate_pages(pages).ok_or(AhciError::AllocationFailed)?;
+        Ok(Self { memory, pages })
+    }
+
+    fn as_ptr(&self) -> *const u8 {
+        self.memory.as_ptr()
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.memory.as_mut_ptr()
+    }
+
+    fn addr(&self) -> u64 {
+        self.memory.as_ptr() as u64
+    }
+}
+
+impl Drop for DmaBuffer {
+    fn drop(&mut self) {
+        efi::free_pages(self.memory, self.pages);
     }
 }
 
@@ -672,7 +709,7 @@ impl AhciController {
 
         // Setup PRDT
         table.prdt[0].set_address(buffer_addr);
-        table.prdt[0].set_byte_count(512, true);
+        table.prdt[0].set_byte_count(512, true)?;
 
         // Issue command
         self.issue_command(port, slot)?;
@@ -745,7 +782,7 @@ impl AhciController {
         // Setup PRDT
         let buffer_addr = buffer.as_ptr() as u64;
         table.prdt[0].set_address(buffer_addr);
-        table.prdt[0].set_byte_count(512, true);
+        table.prdt[0].set_byte_count(512, true)?;
 
         // Issue command
         self.issue_command(port, slot)?;
@@ -798,7 +835,7 @@ impl AhciController {
 
         // Setup PRDT
         table.prdt[0].set_address(buffer_addr);
-        table.prdt[0].set_byte_count(8, true);
+        table.prdt[0].set_byte_count(8, true)?;
 
         // Issue command
         if let Err(e) = self.issue_command(port, slot) {
@@ -964,7 +1001,7 @@ impl AhciController {
         // Setup PRDT - use actual sector size instead of assuming 512
         let byte_count = num_sectors * sector_size;
         table.prdt[0].set_address(buffer as u64);
-        table.prdt[0].set_byte_count(byte_count, true);
+        table.prdt[0].set_byte_count(byte_count, true)?;
 
         // Issue command
         self.issue_command_on_port(port_num, slot)?;
@@ -1026,7 +1063,7 @@ impl AhciController {
 
         // Setup PRDT
         table.prdt[0].set_address(buffer as u64);
-        table.prdt[0].set_byte_count(byte_count, true);
+        table.prdt[0].set_byte_count(byte_count, true)?;
 
         log::trace!(
             "read_sectors_atapi: LBA={}, count={}, byte_count={}, buffer={:p}",
@@ -1215,9 +1252,12 @@ impl AhciController {
             .find_free_slot(port_num)
             .ok_or(AhciError::PortNotReady)?;
 
-        // Allocate aligned buffer for DMA
-        let dma_buffer = efi::allocate_pages(1).ok_or(AhciError::AllocationFailed)?;
-        let dma_addr = dma_buffer.as_ptr() as u64;
+        // Allocate an aligned DMA buffer large enough for the protocol's
+        // 512-byte-block rounded transfer length.
+        let transfer_blocks = (buffer.len() as u32).div_ceil(512);
+        let transfer_len = (transfer_blocks as usize) * 512;
+        let dma_buffer = DmaBuffer::new(transfer_len)?;
+        let dma_addr = dma_buffer.addr();
 
         // Setup command header
         let header = unsafe { &mut *cmd_list.add(slot as usize) };
@@ -1244,7 +1284,6 @@ impl AhciController {
         fis.feature_l = protocol_id;
 
         // Transfer length in 512-byte blocks
-        let transfer_blocks = (buffer.len() as u32).div_ceil(512);
         fis.lba0 = (transfer_blocks & 0xFF) as u8;
         fis.lba1 = ((transfer_blocks >> 8) & 0xFF) as u8;
         fis.lba2 = 0;
@@ -1253,7 +1292,7 @@ impl AhciController {
 
         // Setup PRDT
         table.prdt[0].set_address(dma_addr);
-        table.prdt[0].set_byte_count(transfer_blocks * 512, true);
+        table.prdt[0].set_byte_count(transfer_blocks * 512, true)?;
 
         // Issue command
         let result = self.issue_command_on_port(port_num, slot);
@@ -1271,8 +1310,6 @@ impl AhciController {
         } else {
             0
         };
-
-        efi::free_pages(dma_buffer, 1);
 
         result.map(|_| {
             log::debug!(
@@ -1306,7 +1343,7 @@ impl AhciController {
             return Err(AhciError::InvalidParameter);
         }
 
-        if buffer.len() > 65536 {
+        if buffer.is_empty() || buffer.len() > 65536 {
             return Err(AhciError::InvalidParameter);
         }
 
@@ -1326,9 +1363,12 @@ impl AhciController {
             .find_free_slot(port_num)
             .ok_or(AhciError::PortNotReady)?;
 
-        // Allocate aligned buffer for DMA
-        let dma_buffer = efi::allocate_pages(1).ok_or(AhciError::AllocationFailed)?;
-        let dma_addr = dma_buffer.as_ptr() as u64;
+        // Allocate an aligned DMA buffer large enough for the protocol's
+        // 512-byte-block rounded transfer length.
+        let transfer_blocks = (buffer.len() as u32).div_ceil(512);
+        let transfer_len = (transfer_blocks as usize) * 512;
+        let mut dma_buffer = DmaBuffer::new(transfer_len)?;
+        let dma_addr = dma_buffer.addr();
 
         // Copy data to DMA buffer
         unsafe {
@@ -1360,7 +1400,6 @@ impl AhciController {
         fis.feature_l = protocol_id;
 
         // Transfer length in 512-byte blocks
-        let transfer_blocks = (buffer.len() as u32).div_ceil(512);
         fis.lba0 = (transfer_blocks & 0xFF) as u8;
         fis.lba1 = ((transfer_blocks >> 8) & 0xFF) as u8;
         fis.lba2 = 0;
@@ -1369,12 +1408,10 @@ impl AhciController {
 
         // Setup PRDT
         table.prdt[0].set_address(dma_addr);
-        table.prdt[0].set_byte_count(transfer_blocks * 512, true);
+        table.prdt[0].set_byte_count(transfer_blocks * 512, true)?;
 
         // Issue command
         let result = self.issue_command_on_port(port_num, slot);
-
-        efi::free_pages(dma_buffer, 1);
 
         result.map(|_| {
             log::debug!("AHCI Trusted Send: success");
@@ -1565,12 +1602,13 @@ pub fn global_read_sectors(lba: u64, buffer: &mut [u8]) -> Result<(), ()> {
 
 /// Get the sector size of the global AHCI device
 pub fn global_sector_size() -> Option<u32> {
-    let (controller_index, port_index) = match GLOBAL_AHCI_DEVICE.lock().as_ref() {
-        Some(ptr) => unsafe {
+    let (controller_index, port_index) = {
+        let guard = GLOBAL_AHCI_DEVICE.lock();
+        let ptr = guard.as_ref()?;
+        unsafe {
             let device = &*ptr.0;
             (device.controller_index, device.port_index)
-        },
-        None => return None,
+        }
     };
 
     // Safety: pointer valid for firmware lifetime; no overlapping &mut created

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -100,9 +100,10 @@ impl<T, const N: usize> ControllerRegistry<T, N> {
         let mut controllers = self.controllers.lock();
         if controllers.push(ControllerPtr(controller_box)).is_err() {
             log::warn!("{}: controller list full — freeing allocation", self.name);
-            // Note: the `T` value written via ptr::write is not dropped here. This
-            // is acceptable because current controller types do not implement Drop.
-            // If T ever gains Drop glue, this path must call ptr::drop_in_place first.
+            // Safety: `controller_box` was initialized with `ptr::write` above and
+            // has not been moved into the registry. Drop it before freeing pages so
+            // future controller types with Drop glue are handled correctly.
+            unsafe { core::ptr::drop_in_place(controller_box) };
             crate::efi::free_pages(mem, pages as u64);
             return Err(());
         }

--- a/src/drivers/nvme/mod.rs
+++ b/src/drivers/nvme/mod.rs
@@ -1371,12 +1371,13 @@ pub fn global_read_sectors(lba: u64, buffer: &mut [u8]) -> Result<(), ()> {
 
 /// Get the sector size of the global NVMe device
 pub fn global_sector_size() -> Option<u32> {
-    let (controller_index, nsid) = match GLOBAL_NVME_DEVICE.lock().as_ref() {
-        Some(ptr) => unsafe {
+    let (controller_index, nsid) = {
+        let guard = GLOBAL_NVME_DEVICE.lock();
+        let ptr = guard.as_ref()?;
+        unsafe {
             let device = &*ptr.0;
             (device.controller_index, device.nsid)
-        },
-        None => return None,
+        }
     };
 
     // Safety: pointer valid for firmware lifetime; no overlapping &mut created

--- a/src/drivers/usb/ehci.rs
+++ b/src/drivers/usb/ehci.rs
@@ -636,6 +636,94 @@ impl EhciController {
         Ok(())
     }
 
+    /// Unlink the persistent bulk QH from the async schedule.
+    fn unlink_bulk_qh(&mut self) {
+        if !self.bulk_qh_linked {
+            return;
+        }
+
+        let target_addr = (self.bulk_qh as u32) & !0x1f;
+        let mut current_addr = self.async_qh;
+        let mut unlinked = false;
+
+        for _ in 0..16 {
+            invalidate_cache_range(current_addr, 64);
+            // SAFETY: current_addr walks the EHCI async QH list, which is made
+            // only from controller-owned QHs allocated below 4 GiB.
+            let current = unsafe { &mut *(current_addr as *mut Qh) };
+            let next_link = current.qh_link;
+            if (next_link & Qh::TERMINATE) != 0 {
+                break;
+            }
+
+            let next_addr = (next_link & !0x1f) as u64;
+            if next_addr == target_addr as u64 {
+                invalidate_cache_range(self.bulk_qh, 64);
+                // SAFETY: self.bulk_qh is the persistent bulk QH allocated by
+                // this controller and linked into the async schedule.
+                let bulk_qh = unsafe { &*(self.bulk_qh as *const Qh) };
+                current.qh_link = bulk_qh.qh_link;
+                fence(Ordering::SeqCst);
+                flush_cache_range(current_addr, 4);
+                unlinked = true;
+                break;
+            }
+
+            if next_addr == self.async_qh {
+                break;
+            }
+            current_addr = next_addr;
+        }
+
+        self.bulk_qh_linked = false;
+
+        if unlinked {
+            self.op().usbsts.modify(USBSTS::IAA::SET);
+            self.op().usbcmd.modify(USBCMD::IAAD::SET);
+            let timeout = Timeout::from_ms(100);
+            while !timeout.is_expired() {
+                if self.op().usbsts.is_set(USBSTS::IAA) {
+                    self.op().usbsts.modify(USBSTS::IAA::SET);
+                    break;
+                }
+                crate::time::delay_us(10);
+            }
+        } else {
+            log::debug!("EHCI: persistent bulk QH was not found in async schedule");
+        }
+    }
+
+    /// Reset a root-hub port before retrying enumeration.
+    fn reset_port_for_retry(&mut self, port: u8) -> Result<(), UsbError> {
+        let port_reg = self.port(port);
+
+        if !port_reg.portsc.is_set(PORTSC::CCS) {
+            return Err(UsbError::Disconnected);
+        }
+
+        port_reg.portsc.modify(PORTSC::PR::SET + PORTSC::PE::CLEAR);
+        crate::time::delay_ms(50);
+        port_reg.portsc.modify(PORTSC::PR::CLEAR);
+        crate::time::delay_ms(100);
+
+        let timeout = Timeout::from_ms(250);
+        while !timeout.is_expired() {
+            if !port_reg.portsc.is_set(PORTSC::CCS) {
+                return Err(UsbError::Disconnected);
+            }
+            if port_reg.portsc.is_set(PORTSC::PE) {
+                port_reg
+                    .portsc
+                    .modify(PORTSC::CSC::SET + PORTSC::PEC::SET + PORTSC::OCC::SET);
+                crate::time::delay_ms(10);
+                return Ok(());
+            }
+            crate::time::delay_ms(1);
+        }
+
+        Err(UsbError::Timeout)
+    }
+
     /// Enumerate ports
     fn enumerate_ports(&mut self) -> Result<(), UsbError> {
         log::trace!("EHCI: Enumerating {} ports", self.num_ports);
@@ -669,13 +757,13 @@ impl EhciController {
 
             crate::time::delay_ms(50); // USB spec: 10-20ms reset, we use 50ms
 
-            // Clear reset
+            // Clear reset and let endpoint zero settle before the first setup packet.
             port_reg.portsc.modify(PORTSC::PR::CLEAR);
 
-            crate::time::delay_ms(10);
+            crate::time::delay_ms(100);
 
             // Wait for enable
-            let timeout = Timeout::from_ms(100);
+            let timeout = Timeout::from_ms(250);
             let mut enabled = false;
             while !timeout.is_expired() {
                 if port_reg.portsc.is_set(PORTSC::PE) {
@@ -706,6 +794,8 @@ impl EhciController {
                 .portsc
                 .modify(PORTSC::CSC::SET + PORTSC::PEC::SET + PORTSC::OCC::SET);
 
+            crate::time::delay_ms(50);
+
             // Device is high-speed if enabled on EHCI
             if let Err(e) = self.attach_device(port, UsbSpeed::High) {
                 log::error!("Failed to attach device on port {}: {:?}", port, e);
@@ -728,11 +818,33 @@ impl EhciController {
             .position(|d| d.is_none())
             .ok_or(UsbError::NoFreeSlots)?;
 
-        // Use the shared enumeration helper
-        let initial_device = UsbDevice::new(0, port, speed);
-        let device = enumerate_device(initial_device, address, |dev, rt, req, val, idx, data| {
-            self.control_transfer_internal(dev, rt, req, val, idx, data)
-        })?;
+        // Use the shared enumeration helper. Some USB flash drives need an
+        // extra settle/reset cycle before endpoint zero responds reliably.
+        let mut last_error = UsbError::Timeout;
+        let device = 'enumerate: {
+            for attempt in 0..3 {
+                let initial_device = UsbDevice::new(0, port, speed);
+                match enumerate_device(initial_device, address, |dev, rt, req, val, idx, data| {
+                    self.control_transfer_internal(dev, rt, req, val, idx, data)
+                }) {
+                    Ok(device) => break 'enumerate device,
+                    Err(e) => {
+                        last_error = e;
+                        if attempt == 2 {
+                            break;
+                        }
+                        log::warn!(
+                            "EHCI: device enumeration on port {} failed (attempt {}/3): {:?}; resetting port",
+                            port,
+                            attempt + 1,
+                            last_error
+                        );
+                        self.reset_port_for_retry(port)?;
+                    }
+                }
+            }
+            return Err(last_error);
+        };
 
         self.next_address += 1;
 
@@ -967,7 +1079,9 @@ impl EhciController {
         let qh = unsafe { &mut *(qh_addr as *mut Qh) };
         qh.ep_chars = ep_chars;
         qh.ep_caps = ep_caps;
-        qh.current_qtd = Qtd::TERMINATE; // T-bit=1 so HC uses overlay.next_qtd
+        // Match libpayload/U-Boot: leave Current qTD clear for a freshly
+        // linked QH. The controller owns this field once the QH is scheduled.
+        qh.current_qtd = 0;
         qh.overlay.next_qtd = qtd_setup_addr as u32;
         qh.overlay.alt_next_qtd = Qtd::TERMINATE;
         qh.overlay.token = 0; // ACTIVE=0, HALTED=0 -> fetch qTD
@@ -991,6 +1105,17 @@ impl EhciController {
 
         // Flush QH to main memory
         flush_cache_range(qh_addr, 96);
+
+        // Run one-shot control transfers on a quiet async schedule, matching
+        // libpayload/U-Boot. ICH7-era EHCI can otherwise keep stale async-list
+        // state around transient QHs.
+        if self.op().usbcmd.is_set(USBCMD::ASE) {
+            self.op().usbcmd.modify(USBCMD::ASE::CLEAR);
+            if !wait_for(100, || !self.op().usbsts.is_set(USBSTS::ASS)) {
+                log::warn!("EHCI: Async schedule failed to stop before control transfer");
+            }
+            self.async_schedule_enabled = false;
+        }
 
         // Link QH into async schedule (insert after async head)
         let async_qh = unsafe { &mut *(self.async_qh as *mut Qh) };
@@ -1039,23 +1164,20 @@ impl EhciController {
             self.op().usbcmd.get()
         );
 
-        // Enable async schedule if not already
-        if !self.op().usbcmd.is_set(USBCMD::ASE) {
-            self.op().usbcmd.modify(USBCMD::ASE::SET);
-
-            // Wait for async schedule to become active
-            if !wait_for(100, || self.op().usbsts.is_set(USBSTS::ASS)) {
-                log::error!("EHCI: Async schedule failed to start");
-                // Unlink and return error
-                async_qh.qh_link = old_link;
-                fence(Ordering::SeqCst);
-                return Err(UsbError::Timeout);
-            }
-            log::debug!(
-                "EHCI: Async schedule enabled, ASS={}",
-                self.op().usbsts.is_set(USBSTS::ASS)
-            );
+        // Enable async schedule for this transfer.
+        self.op().usbcmd.modify(USBCMD::ASE::SET);
+        if !wait_for(100, || self.op().usbsts.is_set(USBSTS::ASS)) {
+            log::error!("EHCI: Async schedule failed to start");
+            async_qh.qh_link = old_link;
+            fence(Ordering::SeqCst);
+            flush_cache_range(self.async_qh, 4);
+            return Err(UsbError::Timeout);
         }
+        self.async_schedule_enabled = true;
+        log::debug!(
+            "EHCI: Async schedule enabled, ASS={}",
+            self.op().usbsts.is_set(USBSTS::ASS)
+        );
 
         // Wait for transfer completion
         let timeout = Timeout::from_ms(5000);
@@ -1078,10 +1200,18 @@ impl EhciController {
                 // Setup done, check if we need to wait for data/status
                 if data_len > 0 {
                     let qtd_data = unsafe { &*(qtd_data_addr as *const Qtd) };
-                    if (qtd_data.token & Qtd::TOKEN_STATUS_ACTIVE) != 0 {
+                    let data_token = qtd_data.token;
+                    const ERROR_MASK: u32 = Qtd::TOKEN_STATUS_HALTED
+                        | Qtd::TOKEN_STATUS_BUFFER_ERR
+                        | Qtd::TOKEN_STATUS_BABBLE
+                        | Qtd::TOKEN_STATUS_XACT_ERR;
+                    if (data_token & ERROR_MASK) != 0 {
+                        break;
+                    }
+                    if (data_token & Qtd::TOKEN_STATUS_ACTIVE) != 0 {
                         poll_count += 1;
                         if poll_count.is_multiple_of(100000) {
-                            log::trace!("EHCI: waiting for data qTD, token={:#x}", qtd_data.token);
+                            log::trace!("EHCI: waiting for data qTD, token={:#x}", data_token);
                         }
                         crate::time::delay_us(1);
                         continue;
@@ -1108,18 +1238,13 @@ impl EhciController {
         async_qh.qh_link = old_link;
         fence(Ordering::SeqCst);
 
-        // Ring doorbell and wait for async advance
-        self.op().usbsts.modify(USBSTS::IAA::SET); // Clear any pending IAA (write 1 to clear)
-        self.op().usbcmd.modify(USBCMD::IAAD::SET);
-
-        let timeout2 = Timeout::from_ms(100);
-        while !timeout2.is_expired() {
-            if self.op().usbsts.is_set(USBSTS::IAA) {
-                self.op().usbsts.modify(USBSTS::IAA::SET); // Clear (write 1 to clear)
-                break;
-            }
-            crate::time::delay_us(10);
+        // Stop the async schedule after the one-shot transfer. This avoids
+        // relying on IAAD for transient QHs and matches libpayload's model.
+        self.op().usbcmd.modify(USBCMD::ASE::CLEAR);
+        if !wait_for(100, || !self.op().usbsts.is_set(USBSTS::ASS)) {
+            log::warn!("EHCI: Async schedule failed to stop after control transfer");
         }
+        self.async_schedule_enabled = false;
 
         // Invalidate caches one more time to get final state
         invalidate_cache_range(qtd_setup_addr, 64);
@@ -1135,15 +1260,12 @@ impl EhciController {
         // Check results (caches already invalidated above)
         let final_setup_token = qtd_setup.token;
         let final_status_token = qtd_status.token;
-
-        if (final_status_token & Qtd::TOKEN_STATUS_ACTIVE) != 0 {
-            log::error!(
-                "EHCI: transfer timeout, setup={:#x} status={:#x}",
-                final_setup_token,
-                final_status_token
-            );
-            return Err(UsbError::Timeout);
-        }
+        let final_data_token = if data_len > 0 {
+            let qtd_data = unsafe { &*(qtd_data_addr as *const Qtd) };
+            qtd_data.token
+        } else {
+            0
+        };
 
         // Check for errors (HALTED, BABBLE, BUFFER_ERR, XACT_ERR)
         const ERROR_MASK: u32 = Qtd::TOKEN_STATUS_HALTED
@@ -1151,7 +1273,19 @@ impl EhciController {
             | Qtd::TOKEN_STATUS_BABBLE
             | Qtd::TOKEN_STATUS_XACT_ERR;
 
-        if (final_setup_token & ERROR_MASK) != 0 || (final_status_token & ERROR_MASK) != 0 {
+        if (final_setup_token & ERROR_MASK) != 0
+            || (final_data_token & ERROR_MASK) != 0
+            || (final_status_token & ERROR_MASK) != 0
+        {
+            log::debug!(
+                "EHCI: transfer error, setup={:#x} data={:#x} status={:#x}",
+                final_setup_token,
+                final_data_token,
+                final_status_token
+            );
+            if (final_data_token & Qtd::TOKEN_STATUS_HALTED) != 0 {
+                return Err(UsbError::Stall);
+            }
             if (final_setup_token & Qtd::TOKEN_STATUS_HALTED) != 0
                 || (final_status_token & Qtd::TOKEN_STATUS_HALTED) != 0
             {
@@ -1160,17 +1294,17 @@ impl EhciController {
             return Err(UsbError::TransactionError);
         }
 
+        if (final_status_token & Qtd::TOKEN_STATUS_ACTIVE) != 0 {
+            log::error!(
+                "EHCI: transfer timeout, setup={:#x} data={:#x} status={:#x}",
+                final_setup_token,
+                final_data_token,
+                final_status_token
+            );
+            return Err(UsbError::Timeout);
+        }
+
         if data_len > 0 {
-            let qtd_data = unsafe { &*(qtd_data_addr as *const Qtd) };
-            let final_data_token = qtd_data.token;
-
-            if (final_data_token & ERROR_MASK) != 0 {
-                if (final_data_token & Qtd::TOKEN_STATUS_HALTED) != 0 {
-                    return Err(UsbError::Stall);
-                }
-                return Err(UsbError::TransactionError);
-            }
-
             // Copy IN data
             if let Some(d) = data
                 && is_in
@@ -1310,6 +1444,7 @@ impl EhciController {
         let token = qtd.token;
 
         if (token & Qtd::TOKEN_STATUS_ACTIVE) != 0 {
+            self.unlink_bulk_qh();
             return Err(UsbError::Timeout);
         }
 
@@ -1320,9 +1455,8 @@ impl EhciController {
                 | Qtd::TOKEN_STATUS_XACT_ERR))
             != 0
         {
+            self.unlink_bulk_qh();
             if (token & Qtd::TOKEN_STATUS_HALTED) != 0 {
-                // Clear halt by unlinking and relinking QH
-                self.bulk_qh_linked = false;
                 return Err(UsbError::Stall);
             }
             return Err(UsbError::TransactionError);

--- a/src/drivers/usb/mass_storage.rs
+++ b/src/drivers/usb/mass_storage.rs
@@ -640,17 +640,16 @@ impl UsbMassStorage {
     /// want to stall too long.
     const MAX_READ_RETRIES: u32 = 3;
 
-    /// Maximum number of sectors per SCSI READ command.
+    /// Maximum bytes per SCSI READ command.
     ///
-    /// USB mass storage devices vary in how many sectors they can handle per
-    /// command. 128 sectors (64KB) is a safe maximum that works reliably
-    /// across all devices while still being a large enough chunk to amortize
-    /// the BOT protocol overhead (CBW + CSW per command).
-    const MAX_SECTORS_PER_CMD: u32 = 128;
+    /// EHCI qTDs can describe at most five 4KiB pages. Keep transfers below
+    /// that hardware limit so high-speed USB reads do not silently truncate or
+    /// corrupt data while boot files are being loaded.
+    const MAX_BYTES_PER_CMD: usize = 16 * 1024;
 
     /// Read sectors from the device with chunking and retry logic.
     ///
-    /// Large reads are split into chunks of MAX_SECTORS_PER_CMD to ensure
+    /// Large reads are split into chunks of MAX_BYTES_PER_CMD to ensure
     /// compatibility with all USB mass storage devices. Each chunk is retried
     /// up to MAX_READ_RETRIES times on failure.
     ///
@@ -670,12 +669,13 @@ impl UsbMassStorage {
             return Err(MassStorageError::InvalidParameter);
         }
 
+        let sectors_per_cmd = (Self::MAX_BYTES_PER_CMD / block_size).max(1) as u32;
         let mut lba = start_lba;
         let mut remaining = num_sectors;
         let mut offset = 0usize;
 
         while remaining > 0 {
-            let chunk = remaining.min(Self::MAX_SECTORS_PER_CMD);
+            let chunk = remaining.min(sectors_per_cmd);
             self.read_sectors_with_retry(
                 controller,
                 lba,

--- a/src/drivers/usb/mass_storage.rs
+++ b/src/drivers/usb/mass_storage.rs
@@ -1042,12 +1042,24 @@ pub unsafe fn store_global_device_with_controller_ptr(
     }
 }
 
-/// Get a reference to the global USB mass storage device
-pub fn get_global_device() -> Option<&'static mut UsbMassStorage> {
+/// Get a raw pointer to the global USB mass storage device.
+///
+/// The pointer remains valid for the firmware lifetime. Callers must only
+/// create a temporary `&mut UsbMassStorage` for the immediate operation and
+/// must not retain it across calls that may access the same global device.
+pub fn get_global_device_ptr() -> Option<*mut UsbMassStorage> {
     GLOBAL_USB_STATE
         .lock()
         .as_ref()
-        .map(|state| unsafe { &mut *state.device_ptr })
+        .map(|state| state.device_ptr)
+}
+
+/// Access the global USB mass storage device through a scoped mutable borrow.
+pub fn with_global_device<R>(f: impl FnOnce(&mut UsbMassStorage) -> R) -> Option<R> {
+    let device_ptr = get_global_device_ptr()?;
+    // Safety: The device pointer was allocated with EFI pages and remains valid
+    // for the firmware lifetime. The borrow is scoped to this closure.
+    Some(f(unsafe { &mut *device_ptr }))
 }
 
 /// Read sectors from the global USB device

--- a/src/drivers/usb/mass_storage.rs
+++ b/src/drivers/usb/mass_storage.rs
@@ -642,10 +642,10 @@ impl UsbMassStorage {
 
     /// Maximum bytes per SCSI READ command.
     ///
-    /// EHCI qTDs can describe at most five 4KiB pages. Keep transfers below
-    /// that hardware limit so high-speed USB reads do not silently truncate or
-    /// corrupt data while boot files are being loaded.
-    const MAX_BYTES_PER_CMD: usize = 16 * 1024;
+    /// EHCI qTDs can describe at most five 4KiB pages. Keep transfers well
+    /// below that hardware limit so high-speed USB reads do not silently
+    /// truncate or corrupt data while boot files are being loaded.
+    const MAX_BYTES_PER_CMD: usize = 8 * 1024;
 
     /// Read sectors from the device with chunking and retry logic.
     ///

--- a/src/efi/boot_services.rs
+++ b/src/efi/boot_services.rs
@@ -938,7 +938,7 @@ unsafe fn device_path_node_len(dp: *mut DevicePathProtocol) -> Option<usize> {
 }
 
 unsafe fn is_device_path_end(dp: *mut DevicePathProtocol) -> bool {
-    unsafe { (*dp).r#type == 0x7f }
+    unsafe { (*dp).r#type == 0x7f && (*dp).sub_type == 0xff }
 }
 
 unsafe fn device_path_prefix_match(

--- a/src/efi/boot_services.rs
+++ b/src/efi/boot_services.rs
@@ -407,6 +407,25 @@ extern "efiapi" fn set_timer(
     })
 }
 
+fn notify_wait_event(event_id: usize, event: efi::Event) {
+    let notify_fn = state::with_efi_mut(|efi_state| {
+        let entry = &efi_state.events[event_id];
+        if !entry.signaled && entry.event_type & EVT_NOTIFY_WAIT != 0 {
+            entry.notify_function.map(|f| (f, entry.notify_context))
+        } else {
+            None
+        }
+    });
+
+    if let Some((func, context)) = notify_fn {
+        log::trace!(
+            "  -> Calling EVT_NOTIFY_WAIT function for event {}",
+            event_id
+        );
+        func(event, context);
+    }
+}
+
 extern "efiapi" fn wait_for_event(
     number_of_events: usize,
     event: *mut efi::Event,
@@ -440,6 +459,7 @@ extern "efiapi" fn wait_for_event(
 
             // Check if a regular event is signaled (including timer check)
             if event_id > 0 && event_id < MAX_EVENTS {
+                notify_wait_event(event_id, evt);
                 check_timer_event(event_id);
 
                 // Per UEFI spec: WaitForEvent clears the signaled state
@@ -520,6 +540,8 @@ extern "efiapi" fn check_event(event: efi::Event) -> Status {
 
     // Check regular events
     if event_id > 0 && event_id < MAX_EVENTS {
+        notify_wait_event(event_id, event);
+
         // Check timer expiration
         check_timer_event(event_id);
 
@@ -910,6 +932,53 @@ extern "efiapi" fn locate_handle(
     Status::SUCCESS
 }
 
+unsafe fn device_path_node_len(dp: *mut DevicePathProtocol) -> Option<usize> {
+    let len = unsafe { u16::from_le_bytes([(*dp).length[0], (*dp).length[1]]) as usize };
+    (len >= 4).then_some(len)
+}
+
+unsafe fn is_device_path_end(dp: *mut DevicePathProtocol) -> bool {
+    unsafe { (*dp).r#type == 0x7f }
+}
+
+unsafe fn device_path_prefix_match(
+    handle_dp: *mut DevicePathProtocol,
+    input_dp: *mut DevicePathProtocol,
+) -> Option<*mut DevicePathProtocol> {
+    let mut handle_node = handle_dp;
+    let mut input_node = input_dp;
+
+    // Device paths are small. Bound the walk so malformed paths cannot loop forever.
+    for _ in 0..128 {
+        if unsafe { is_device_path_end(handle_node) } {
+            return Some(input_node);
+        }
+        if unsafe { is_device_path_end(input_node) } {
+            return None;
+        }
+
+        let handle_len = unsafe { device_path_node_len(handle_node)? };
+        let input_len = unsafe { device_path_node_len(input_node)? };
+        if handle_len != input_len {
+            return None;
+        }
+
+        let handle_bytes =
+            unsafe { core::slice::from_raw_parts(handle_node as *const u8, handle_len) };
+        let input_bytes =
+            unsafe { core::slice::from_raw_parts(input_node as *const u8, input_len) };
+        if handle_bytes != input_bytes {
+            return None;
+        }
+
+        handle_node =
+            unsafe { (handle_node as *const u8).add(handle_len) as *mut DevicePathProtocol };
+        input_node = unsafe { (input_node as *const u8).add(input_len) as *mut DevicePathProtocol };
+    }
+
+    None
+}
+
 extern "efiapi" fn locate_device_path(
     protocol: *mut Guid,
     device_path: *mut *mut DevicePathProtocol,
@@ -933,53 +1002,35 @@ extern "efiapi" fn locate_device_path(
 
     let found = efi_state.handles[..efi_state.handle_count]
         .iter()
-        .filter_map(|entry| {
+        .find_map(|entry| {
             let protocols = &entry.protocols[..entry.protocol_count];
 
             let has_protocol = protocols.iter().any(|p| p.guid == guid);
+            if !has_protocol {
+                return None;
+            }
 
             let handle_dp = protocols
                 .iter()
                 .find(|p| p.guid == r_efi::protocols::device_path::PROTOCOL_GUID)
-                .map(|p| p.interface as *mut DevicePathProtocol);
-
-            match (has_protocol, handle_dp) {
-                (true, Some(dp)) if !dp.is_null() => Some((entry.handle, dp)),
-                _ => None,
+                .map(|p| p.interface as *mut DevicePathProtocol)?;
+            if handle_dp.is_null() {
+                return None;
             }
-        })
-        .next();
 
-    if let Some((handle, handle_dp)) = found {
-        // For the initrd case, GRUB installs a handle with LOAD_FILE2 and a vendor media
-        // device path. The kernel passes in that same device path to find it.
+            let remaining = unsafe { device_path_prefix_match(handle_dp, input_dp) }?;
+            Some((entry.handle, remaining))
+        });
 
+    if let Some((handle, remaining)) = found {
         log::debug!(
-            "  -> SUCCESS (handle={:?}, device_path={:?})",
+            "  -> SUCCESS (handle={:?}, remaining_device_path={:?})",
             handle,
-            handle_dp
+            remaining
         );
         unsafe {
             *device = handle;
-            // Update device_path to point to the End node of the handle's device path.
-            // The LoadFile2 protocol expects the remaining path after the match.
-            // Walk to the end of the device path and point to the End node.
-            let mut dp = handle_dp;
-            loop {
-                let dp_type = (*dp).r#type;
-                let dp_subtype = (*dp).sub_type;
-                // End of device path: type 0x7F, subtype 0xFF
-                if dp_type == 0x7f && dp_subtype == 0xff {
-                    break;
-                }
-                // Get length and move to next node
-                let len = u16::from_le_bytes([(*dp).length[0], (*dp).length[1]]) as usize;
-                if len < 4 {
-                    break; // Invalid length, stop
-                }
-                dp = (dp as *const u8).add(len) as *mut DevicePathProtocol;
-            }
-            *device_path = dp;
+            *device_path = remaining;
         }
         return Status::SUCCESS;
     }

--- a/src/efi/protocols/storage_security.rs
+++ b/src/efi/protocols/storage_security.rs
@@ -218,7 +218,7 @@ extern "efiapi" fn storage_security_send_data(
         payload_buffer_size
     );
 
-    if this.is_null() || (payload_buffer_size > 0 && payload_buffer.is_null()) {
+    if this.is_null() || payload_buffer.is_null() {
         return Status::INVALID_PARAMETER;
     }
 

--- a/src/efi/protocols/storage_security.rs
+++ b/src/efi/protocols/storage_security.rs
@@ -383,15 +383,12 @@ fn usb_security_receive(
 ) -> Result<usize, &'static str> {
     // Execute with the USB controller
     let result = usb::with_controller(controller_index, |controller| {
-        // Get the device address from the global mass storage
-        let Some(device) = usb::mass_storage::get_global_device() else {
-            return Err("No USB mass storage device configured");
-        };
-
-        // Call security_protocol_in on the device
-        device
-            .security_protocol_in(controller, protocol_id, sp_specific, buffer)
-            .map_err(|_| "USB security protocol in failed")
+        usb::mass_storage::with_global_device(|device| {
+            device
+                .security_protocol_in(controller, protocol_id, sp_specific, buffer)
+                .map_err(|_| "USB security protocol in failed")
+        })
+        .unwrap_or(Err("No USB mass storage device configured"))
     });
 
     match result {
@@ -410,15 +407,12 @@ fn usb_security_send(
 ) -> Result<(), &'static str> {
     // Execute with the USB controller
     let result = usb::with_controller(controller_index, |controller| {
-        // Get the device address from the global mass storage
-        let Some(device) = usb::mass_storage::get_global_device() else {
-            return Err("No USB mass storage device configured");
-        };
-
-        // Call security_protocol_out on the device
-        device
-            .security_protocol_out(controller, protocol_id, sp_specific, buffer)
-            .map_err(|_| "USB security protocol out failed")
+        usb::mass_storage::with_global_device(|device| {
+            device
+                .security_protocol_out(controller, protocol_id, sp_specific, buffer)
+                .map_err(|_| "USB security protocol out failed")
+        })
+        .unwrap_or(Err("No USB mass storage device configured"))
     });
 
     match result {

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -114,7 +114,7 @@ fn is_variable_accessible_at_runtime(attributes: u32) -> bool {
     // At runtime, only variables with RUNTIME_ACCESS are accessible
     (attributes & auth::attributes::RUNTIME_ACCESS) != 0
 }
-use alloc::vec::Vec;
+use alloc::vec::Vec as AllocVec;
 use core::ffi::c_void;
 use r_efi::efi::{
     self, CapsuleHeader, Guid, ResetType, Status, TableHeader, Time, TimeCapabilities,
@@ -996,24 +996,41 @@ fn copy_stored_variable_name(
     Status::SUCCESS
 }
 
+type VariableNameBuf = heapless::Vec<u16, MAX_VARIABLE_NAME_LEN>;
+type VariableDataBuf = heapless::Vec<u8, MAX_VARIABLE_DATA_SIZE>;
+
+enum PersistData {
+    Fixed(VariableDataBuf),
+    Alloc(AllocVec<u8>),
+}
+
+impl PersistData {
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Fixed(data) => data.as_slice(),
+            Self::Alloc(data) => data.as_slice(),
+        }
+    }
+}
+
 enum VariablePersistAction {
     None,
     Write {
         guid: Guid,
-        name: Vec<u16>,
+        name: VariableNameBuf,
         attributes: u32,
-        data: Vec<u8>,
+        data: PersistData,
         is_append: bool,
     },
     Delete {
         guid: Guid,
-        name: Vec<u16>,
+        name: VariableNameBuf,
     },
 }
 
 enum SecureBootDbAction {
     None,
-    Update(auth::SecureBootVariable, Vec<u8>),
+    Update(auth::SecureBootVariable, VariableDataBuf),
     Delete(auth::SecureBootVariable),
 }
 
@@ -1074,7 +1091,10 @@ extern "efiapi" fn set_variable(
         return Status::INVALID_PARAMETER;
     }
     let name_slice = unsafe { core::slice::from_raw_parts(name, name_len + 1) };
-    let name_vec: Vec<u16> = name_slice.to_vec();
+    let mut name_vec = VariableNameBuf::new();
+    if name_vec.extend_from_slice(name_slice).is_err() {
+        return Status::OUT_OF_RESOURCES;
+    }
 
     // Check data size.
     let is_auth_write = (attributes & auth::attributes::TIME_BASED_AUTHENTICATED_WRITE_ACCESS) != 0;
@@ -1121,10 +1141,15 @@ extern "efiapi" fn set_variable(
         (attributes & auth::attributes::TIME_BASED_AUTHENTICATED_WRITE_ACCESS) != 0;
     let is_append = (attributes & auth::attributes::APPEND_WRITE) != 0;
 
-    let final_data_vec: Vec<u8> = if is_authenticated && data_size > 0 {
+    let mut final_data_vec = VariableDataBuf::new();
+    if is_authenticated && data_size > 0 {
         let raw_data = unsafe { core::slice::from_raw_parts(data as *const u8, data_size) };
-        match auth::verify_authenticated_variable(name_vec.as_slice(), &guid, attributes, raw_data)
-        {
+        let verified_data: AllocVec<u8> = match auth::verify_authenticated_variable(
+            name_vec.as_slice(),
+            &guid,
+            attributes,
+            raw_data,
+        ) {
             Ok(verified_data) => verified_data,
             Err(e) => {
                 log::warn!("Authenticated variable verification failed: {:?}", e);
@@ -1136,16 +1161,23 @@ extern "efiapi" fn set_variable(
                 }
                 return e.into();
             }
+        };
+        if final_data_vec
+            .extend_from_slice(verified_data.as_slice())
+            .is_err()
+        {
+            return Status::OUT_OF_RESOURCES;
         }
-    } else if data_size > 0 {
-        unsafe { core::slice::from_raw_parts(data as *const u8, data_size) }.to_vec()
-    } else {
-        Vec::new()
-    };
+    } else if data_size > 0
+        && final_data_vec
+            .extend_from_slice(unsafe { core::slice::from_raw_parts(data as *const u8, data_size) })
+            .is_err()
+    {
+        return Status::OUT_OF_RESOURCES;
+    }
 
     let final_data_size = final_data_vec.len();
     let secure_boot_var = auth::identify_key_database(name_vec.as_slice(), &guid);
-    let exit_boot_services_called = state::is_exit_boot_services_called();
 
     let (status, persist_action, secure_boot_action) = state::with_efi_mut(|efi| {
         let variables = &mut efi.variables;
@@ -1198,18 +1230,45 @@ extern "efiapi" fn set_variable(
                         );
                     }
 
-                    variables[idx].data[..combined.len()].copy_from_slice(&combined);
+                    variables[idx].data[..combined.len()].copy_from_slice(combined.as_slice());
                     variables[idx].data_size = combined.len();
 
+                    let mut combined_buf = VariableDataBuf::new();
+                    if combined_buf.extend_from_slice(combined.as_slice()).is_err() {
+                        return (
+                            Status::OUT_OF_RESOURCES,
+                            VariablePersistAction::None,
+                            SecureBootDbAction::None,
+                        );
+                    }
+
                     let persist_action = if attributes & auth::attributes::NON_VOLATILE != 0 {
-                        let persist_attrs = attributes
-                            & !(auth::attributes::TIME_BASED_AUTHENTICATED_WRITE_ACCESS
-                                | auth::attributes::APPEND_WRITE);
+                        let (persist_attrs, persist_data) = if is_authenticated
+                            && state::is_exit_boot_services_called()
+                            && data_size > 0
+                        {
+                            (
+                                attributes,
+                                PersistData::Alloc(
+                                    unsafe {
+                                        core::slice::from_raw_parts(data as *const u8, data_size)
+                                    }
+                                    .to_vec(),
+                                ),
+                            )
+                        } else {
+                            (
+                                attributes
+                                    & !(auth::attributes::TIME_BASED_AUTHENTICATED_WRITE_ACCESS
+                                        | auth::attributes::APPEND_WRITE),
+                                PersistData::Fixed(combined_buf.clone()),
+                            )
+                        };
                         VariablePersistAction::Write {
                             guid,
                             name: name_vec.clone(),
                             attributes: persist_attrs,
-                            data: combined.clone(),
+                            data: persist_data,
                             is_append: true,
                         }
                     } else {
@@ -1219,7 +1278,7 @@ extern "efiapi" fn set_variable(
                     return (
                         Status::SUCCESS,
                         persist_action,
-                        SecureBootDbAction::Update(var_type, combined),
+                        SecureBootDbAction::Update(var_type, combined_buf),
                     );
                 }
                 Err(e) => {
@@ -1267,11 +1326,15 @@ extern "efiapi" fn set_variable(
             .unwrap_or(SecureBootDbAction::None);
 
         let persist_action = if attributes & auth::attributes::NON_VOLATILE != 0 {
-            let persist_data = if is_authenticated && exit_boot_services_called && data_size > 0 {
-                unsafe { core::slice::from_raw_parts(data as *const u8, data_size) }.to_vec()
-            } else {
-                final_data_vec.clone()
-            };
+            let persist_data =
+                if is_authenticated && state::is_exit_boot_services_called() && data_size > 0 {
+                    PersistData::Alloc(
+                        unsafe { core::slice::from_raw_parts(data as *const u8, data_size) }
+                            .to_vec(),
+                    )
+                } else {
+                    PersistData::Fixed(final_data_vec.clone())
+                };
             VariablePersistAction::Write {
                 guid,
                 name: name_vec.clone(),
@@ -1439,9 +1502,9 @@ fn append_signature_data(
     new_data: *const u8,
     new_size: usize,
     _var_type: auth::SecureBootVariable,
-) -> Result<Vec<u8>, auth::AuthError> {
+) -> Result<AllocVec<u8>, auth::AuthError> {
     // For signature databases, we concatenate the signature lists
-    let mut combined = Vec::with_capacity(existing.len() + new_size);
+    let mut combined = AllocVec::with_capacity(existing.len() + new_size);
     combined.extend_from_slice(existing);
 
     let new_slice = unsafe { core::slice::from_raw_parts(new_data, new_size) };

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -999,6 +999,7 @@ fn copy_stored_variable_name(
 type VariableNameBuf = heapless::Vec<u16, MAX_VARIABLE_NAME_LEN>;
 type VariableDataBuf = heapless::Vec<u8, MAX_VARIABLE_DATA_SIZE>;
 
+#[allow(clippy::large_enum_variant)]
 enum PersistData {
     Fixed(VariableDataBuf),
     Alloc(AllocVec<u8>),
@@ -1013,6 +1014,7 @@ impl PersistData {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum VariablePersistAction {
     None,
     Write {
@@ -1028,6 +1030,7 @@ enum VariablePersistAction {
     },
 }
 
+#[allow(clippy::large_enum_variant)]
 enum SecureBootDbAction {
     None,
     Update(auth::SecureBootVariable, VariableDataBuf),

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -996,6 +996,27 @@ fn copy_stored_variable_name(
     Status::SUCCESS
 }
 
+enum VariablePersistAction {
+    None,
+    Write {
+        guid: Guid,
+        name: Vec<u16>,
+        attributes: u32,
+        data: Vec<u8>,
+        is_append: bool,
+    },
+    Delete {
+        guid: Guid,
+        name: Vec<u16>,
+    },
+}
+
+enum SecureBootDbAction {
+    None,
+    Update(auth::SecureBootVariable, Vec<u8>),
+    Delete(auth::SecureBootVariable),
+}
+
 extern "efiapi" fn set_variable(
     variable_name: *mut u16,
     vendor_guid: *mut Guid,
@@ -1033,15 +1054,12 @@ extern "efiapi" fn set_variable(
     if state::is_exit_boot_services_called() {
         use crate::efi::rtlog;
         rtlog::append("SetVariable name=");
-        if !variable_name.is_null() {
-            // Print up to 64 UCS-2 chars as ASCII (names are always ASCII)
-            for i in 0..64usize {
-                let c = unsafe { *variable_name.add(i) };
-                if c == 0 {
-                    break;
-                }
-                rtlog::append(core::str::from_utf8(&[(c & 0x7f) as u8]).unwrap_or("?"));
+        for i in 0..64usize {
+            let c = unsafe { *variable_name.add(i) };
+            if c == 0 {
+                break;
             }
+            rtlog::append(core::str::from_utf8(&[(c & 0x7f) as u8]).unwrap_or("?"));
         }
         rtlog::append(" attr=");
         rtlog::append_hex(attributes as u64);
@@ -1055,21 +1073,12 @@ extern "efiapi" fn set_variable(
     if name_len == 0 || name_len >= MAX_VARIABLE_NAME_LEN {
         return Status::INVALID_PARAMETER;
     }
+    let name_slice = unsafe { core::slice::from_raw_parts(name, name_len + 1) };
+    let name_vec: Vec<u16> = name_slice.to_vec();
 
     // Check data size.
-    //
-    // For authenticated writes the caller passes the EFI_VARIABLE_AUTHENTICATION_2
-    // header (timestamp + WIN_CERTIFICATE with a PKCS#7 signature, typically
-    // 1-3 KB) prepended to the actual payload.  The signature is verified and
-    // discarded; only the payload is stored.  We therefore allow a generous raw
-    // input limit here and re-check the *stored* size after auth processing
-    // (see the `final_data_size > MAX_VARIABLE_DATA_SIZE` guard below).
-    //
-    // For non-authenticated writes the raw size IS the stored size, so
-    // MAX_VARIABLE_DATA_SIZE is the correct limit.
     let is_auth_write = (attributes & auth::attributes::TIME_BASED_AUTHENTICATED_WRITE_ACCESS) != 0;
     let raw_limit = if is_auth_write {
-        // Auth header (PKCS#7 signature) can add 1-3 KB on top of payload
         MAX_VARIABLE_DATA_SIZE * 3
     } else {
         MAX_VARIABLE_DATA_SIZE
@@ -1082,8 +1091,7 @@ extern "efiapi" fn set_variable(
         return Status::INVALID_PARAMETER;
     }
 
-    // Check if we're at runtime and trying to modify a boot-services-only variable
-    // Per UEFI spec, BS-only variables cannot be modified at runtime
+    // Check if we're at runtime and trying to modify a boot-services-only variable.
     if state::is_exit_boot_services_called() {
         let has_runtime_access = (attributes & auth::attributes::RUNTIME_ACCESS) != 0;
         if !has_runtime_access {
@@ -1094,9 +1102,7 @@ extern "efiapi" fn set_variable(
         }
     }
 
-    // Check if this is a read-only variable that cannot be written via SetVariable
-    // SecureBoot and SetupMode are computed status variables, not writable
-    let name_slice = unsafe { core::slice::from_raw_parts(name, name_len + 1) };
+    // SecureBoot and SetupMode are computed status variables, not writable.
     if guid == auth::EFI_GLOBAL_VARIABLE_GUID
         && (name_slice == auth::SECURE_BOOT_NAME || name_slice == auth::SETUP_MODE_NAME)
     {
@@ -1111,26 +1117,15 @@ extern "efiapi" fn set_variable(
         return Status::WRITE_PROTECTED;
     }
 
-    // Check if this is an authenticated variable write
     let is_authenticated =
         (attributes & auth::attributes::TIME_BASED_AUTHENTICATED_WRITE_ACCESS) != 0;
     let is_append = (attributes & auth::attributes::APPEND_WRITE) != 0;
 
-    // Process the data - for authenticated writes, we need to verify and extract
-    let (actual_data, actual_data_size) = if is_authenticated && data_size > 0 {
-        // Convert the data to a slice for the auth module
+    let final_data_vec: Vec<u8> = if is_authenticated && data_size > 0 {
         let raw_data = unsafe { core::slice::from_raw_parts(data as *const u8, data_size) };
-
-        // Convert name to slice for the auth module
-        let name_slice = unsafe { core::slice::from_raw_parts(name, name_len + 1) };
-
-        // Verify the authenticated variable and extract the actual data
-        match auth::verify_authenticated_variable(name_slice, &guid, attributes, raw_data) {
-            Ok(verified_data) => {
-                // Store the verified data temporarily
-                // Note: This will be copied into the variable store
-                (Some(verified_data), 0usize) // size will be taken from Vec
-            }
+        match auth::verify_authenticated_variable(name_vec.as_slice(), &guid, attributes, raw_data)
+        {
+            Ok(verified_data) => verified_data,
             Err(e) => {
                 log::warn!("Authenticated variable verification failed: {:?}", e);
                 #[cfg(feature = "rt-log")]
@@ -1142,189 +1137,198 @@ extern "efiapi" fn set_variable(
                 return e.into();
             }
         }
+    } else if data_size > 0 {
+        unsafe { core::slice::from_raw_parts(data as *const u8, data_size) }.to_vec()
     } else {
-        (None, data_size)
+        Vec::new()
     };
 
-    // Get the actual data slice to store
-    let (data_ptr, final_data_size): (*const u8, usize) = match &actual_data {
-        Some(vec) => (vec.as_ptr(), vec.len()),
-        None => (data as *const u8, actual_data_size),
-    };
+    let final_data_size = final_data_vec.len();
+    let secure_boot_var = auth::identify_key_database(name_vec.as_slice(), &guid);
+    let exit_boot_services_called = state::is_exit_boot_services_called();
 
-    // Check if this is a Secure Boot key database variable
-    let secure_boot_var = auth::identify_key_database(
-        unsafe { core::slice::from_raw_parts(name, name_len + 1) },
-        &guid,
-    );
-
-    state::with_efi_mut(|efi| {
+    let (status, persist_action, secure_boot_action) = state::with_efi_mut(|efi| {
         let variables = &mut efi.variables;
 
-        // Find existing variable using position()
-        let existing_idx = variables
-            .iter()
-            .position(|var| var.in_use && var.vendor_guid == guid && name_eq(&var.name, name));
-
-        // Find first free slot using position()
+        let existing_idx = variables.iter().position(|var| {
+            var.in_use
+                && var.vendor_guid == guid
+                && crate::efi::utils::ucs2_eq(&var.name, name_vec.as_slice())
+        });
         let free_idx = variables.iter().position(|var| !var.in_use);
 
-        // Delete variable if data_size is 0 (for authenticated vars, this means empty after header)
+        // Delete variable if data_size is 0 (for authenticated vars, this means empty after header).
         if final_data_size == 0 {
             if let Some(idx) = existing_idx {
                 variables[idx].in_use = false;
-
-                // Handle Secure Boot state changes
-                if let Some(var_type) = secure_boot_var {
-                    handle_secure_boot_variable_delete(var_type);
-                }
-
-                // Persist the deletion to storage
-                let name_slice = unsafe { core::slice::from_raw_parts(name, name_len + 1) };
-                if let Err(e) = crate::efi::varstore::delete_variable(&guid, name_slice) {
-                    log::debug!("Variable deletion not persisted: {:?}", e);
-                }
-
-                return Status::SUCCESS;
+                let secure_action = secure_boot_var
+                    .map(SecureBootDbAction::Delete)
+                    .unwrap_or(SecureBootDbAction::None);
+                let persist_action = VariablePersistAction::Delete {
+                    guid,
+                    name: name_vec.clone(),
+                };
+                return (Status::SUCCESS, persist_action, secure_action);
             }
-            return Status::NOT_FOUND;
+            return (
+                Status::NOT_FOUND,
+                VariablePersistAction::None,
+                SecureBootDbAction::None,
+            );
         }
 
-        // Handle APPEND_WRITE for signature databases
+        // Handle APPEND_WRITE for signature databases.
         if is_append
             && let Some(idx) = existing_idx
             && let Some(var_type) = secure_boot_var
         {
             let existing_data = &variables[idx].data[..variables[idx].data_size];
-
-            // Append the new signature lists to existing data
-            match append_signature_data(existing_data, data_ptr, final_data_size, var_type) {
+            match append_signature_data(
+                existing_data,
+                final_data_vec.as_ptr(),
+                final_data_size,
+                var_type,
+            ) {
                 Ok(combined) => {
                     if combined.len() > MAX_VARIABLE_DATA_SIZE {
-                        return Status::OUT_OF_RESOURCES;
+                        return (
+                            Status::OUT_OF_RESOURCES,
+                            VariablePersistAction::None,
+                            SecureBootDbAction::None,
+                        );
                     }
 
                     variables[idx].data[..combined.len()].copy_from_slice(&combined);
                     variables[idx].data_size = combined.len();
 
-                    // Update the key database
-                    update_key_database(var_type, &combined);
-
-                    // Persist the updated variable
-                    if (attributes & crate::efi::auth::attributes::NON_VOLATILE) != 0 {
-                        let name_slice = unsafe { core::slice::from_raw_parts(name, name_len + 1) };
-                        // The combined data is the fully-resolved merge of existing +
-                        // new signature lists (auth header already stripped, append
-                        // already applied).  When writing to the deferred buffer at
-                        // runtime, clear the auth/append flags so the buffer stores
-                        // it as a plain non-auth full write — the verification was
-                        // already performed above.
+                    let persist_action = if attributes & auth::attributes::NON_VOLATILE != 0 {
                         let persist_attrs = attributes
-                            & !(crate::efi::auth::attributes::TIME_BASED_AUTHENTICATED_WRITE_ACCESS
-                                | crate::efi::auth::attributes::APPEND_WRITE);
-                        match crate::efi::varstore::persist_variable(
-                            &guid,
-                            name_slice,
-                            persist_attrs,
-                            &combined,
-                        ) {
-                            Ok(()) =>
-                            {
-                                #[cfg(feature = "rt-log")]
-                                if state::is_exit_boot_services_called() {
-                                    crate::efi::rtlog::appendln("  -> persisted OK (append)");
-                                }
-                            }
-                            Err(e) => {
-                                log::debug!("Variable not persisted: {:?}", e);
-                                #[cfg(feature = "rt-log")]
-                                if state::is_exit_boot_services_called() {
-                                    use crate::efi::rtlog;
-                                    rtlog::append("  -> persist FAILED (append): ");
-                                    rtlog::appendln(alloc::format!("{:?}", e).as_str());
-                                }
-                            }
+                            & !(auth::attributes::TIME_BASED_AUTHENTICATED_WRITE_ACCESS
+                                | auth::attributes::APPEND_WRITE);
+                        VariablePersistAction::Write {
+                            guid,
+                            name: name_vec.clone(),
+                            attributes: persist_attrs,
+                            data: combined.clone(),
+                            is_append: true,
                         }
-                    }
+                    } else {
+                        VariablePersistAction::None
+                    };
 
-                    return Status::SUCCESS;
+                    return (
+                        Status::SUCCESS,
+                        persist_action,
+                        SecureBootDbAction::Update(var_type, combined),
+                    );
                 }
-                Err(e) => return e.into(),
+                Err(e) => {
+                    return (
+                        e.into(),
+                        VariablePersistAction::None,
+                        SecureBootDbAction::None,
+                    );
+                }
             }
         }
 
-        // Update or create variable
         let idx = match existing_idx {
             Some(i) => i,
             None => match free_idx {
                 Some(i) => i,
-                None => return Status::OUT_OF_RESOURCES,
+                None => {
+                    return (
+                        Status::OUT_OF_RESOURCES,
+                        VariablePersistAction::None,
+                        SecureBootDbAction::None,
+                    );
+                }
             },
         };
 
-        // Check final data size fits
         if final_data_size > MAX_VARIABLE_DATA_SIZE {
-            return Status::OUT_OF_RESOURCES;
-        }
-
-        // Copy name using slice operations
-        let src = unsafe { core::slice::from_raw_parts(name, name_len + 1) };
-        variables[idx].name[..name_len + 1].copy_from_slice(src);
-        variables[idx].name[name_len + 1..].fill(0);
-
-        // Copy data
-        unsafe {
-            core::ptr::copy_nonoverlapping(
-                data_ptr,
-                variables[idx].data.as_mut_ptr(),
-                final_data_size,
+            return (
+                Status::OUT_OF_RESOURCES,
+                VariablePersistAction::None,
+                SecureBootDbAction::None,
             );
         }
 
+        variables[idx].name[..name_vec.len()].copy_from_slice(&name_vec);
+        variables[idx].name[name_vec.len()..].fill(0);
+        variables[idx].data[..final_data_size].copy_from_slice(&final_data_vec);
         variables[idx].vendor_guid = guid;
         variables[idx].attributes = attributes;
         variables[idx].data_size = final_data_size;
         variables[idx].in_use = true;
 
-        // Update Secure Boot key databases and state
-        if let Some(var_type) = secure_boot_var {
-            let var_data = &variables[idx].data[..final_data_size];
-            update_key_database(var_type, var_data);
+        let secure_action = secure_boot_var
+            .map(|var_type| SecureBootDbAction::Update(var_type, final_data_vec.clone()))
+            .unwrap_or(SecureBootDbAction::None);
+
+        let persist_action = if attributes & auth::attributes::NON_VOLATILE != 0 {
+            let persist_data = if is_authenticated && exit_boot_services_called && data_size > 0 {
+                unsafe { core::slice::from_raw_parts(data as *const u8, data_size) }.to_vec()
+            } else {
+                final_data_vec.clone()
+            };
+            VariablePersistAction::Write {
+                guid,
+                name: name_vec.clone(),
+                attributes,
+                data: persist_data,
+                is_append: false,
+            }
+        } else {
+            VariablePersistAction::None
+        };
+
+        (Status::SUCCESS, persist_action, secure_action)
+    });
+
+    if status != Status::SUCCESS {
+        return status;
+    }
+
+    match secure_boot_action {
+        SecureBootDbAction::None => {}
+        SecureBootDbAction::Update(var_type, data) => {
+            update_key_database(var_type, data.as_slice());
             handle_secure_boot_variable_update(var_type);
         }
+        SecureBootDbAction::Delete(var_type) => handle_secure_boot_variable_delete(var_type),
+    }
 
-        // Persist variable to storage (SPI flash or ESP file)
-        // Only persist non-volatile variables
-        if (attributes & crate::efi::auth::attributes::NON_VOLATILE) != 0 {
-            let name_slice = unsafe { core::slice::from_raw_parts(name, name_len + 1) };
-
-            // For authenticated variables at runtime (after ExitBootServices), we
-            // must pass the ORIGINAL signed data (with auth header) to the deferred
-            // buffer so it can re-verify the signature on next boot and extract the
-            // timestamp.  Before ExitBootServices, we write the stripped payload
-            // directly to SPI flash (no auth header needed in storage).
-            let persist_data: &[u8] =
-                if is_authenticated && state::is_exit_boot_services_called() && data_size > 0 {
-                    // SAFETY: `data` and `data_size` are the original caller-provided
-                    // values validated at function entry; the pointer is valid for
-                    // `data_size` bytes and has not been freed.
-                    unsafe { core::slice::from_raw_parts(data as *const u8, data_size) }
-                } else {
-                    unsafe { core::slice::from_raw_parts(data_ptr, final_data_size) }
-                };
-
+    match persist_action {
+        VariablePersistAction::None => {}
+        VariablePersistAction::Delete { guid, name } => {
+            if let Err(e) = crate::efi::varstore::delete_variable(&guid, name.as_slice()) {
+                log::debug!("Variable deletion not persisted: {:?}", e);
+            }
+        }
+        VariablePersistAction::Write {
+            guid,
+            name,
+            attributes,
+            data,
+            is_append,
+        } => {
+            let _ = is_append;
             match crate::efi::varstore::persist_variable(
                 &guid,
-                name_slice,
+                name.as_slice(),
                 attributes,
-                persist_data,
+                data.as_slice(),
             ) {
                 Ok(()) =>
                 {
                     #[cfg(feature = "rt-log")]
                     if state::is_exit_boot_services_called() {
-                        use crate::efi::rtlog;
-                        rtlog::appendln("  -> persisted OK");
+                        if is_append {
+                            crate::efi::rtlog::appendln("  -> persisted OK (append)");
+                        } else {
+                            crate::efi::rtlog::appendln("  -> persisted OK");
+                        }
                     }
                 }
                 Err(e) => {
@@ -1332,15 +1336,19 @@ extern "efiapi" fn set_variable(
                     #[cfg(feature = "rt-log")]
                     if state::is_exit_boot_services_called() {
                         use crate::efi::rtlog;
-                        rtlog::append("  -> persist FAILED: ");
+                        if is_append {
+                            rtlog::append("  -> persist FAILED (append): ");
+                        } else {
+                            rtlog::append("  -> persist FAILED: ");
+                        }
                         rtlog::appendln(alloc::format!("{:?}", e).as_str());
                     }
                 }
             }
         }
+    }
 
-        Status::SUCCESS
-    })
+    Status::SUCCESS
 }
 
 /// Handle Secure Boot state changes when a key database variable is updated

--- a/src/efi/system_table.rs
+++ b/src/efi/system_table.rs
@@ -883,7 +883,7 @@ pub fn install_smbios_tables(smbios_addr: u64) {
             } else {
                 log::warn!(
                     "SMBIOS 2.1 entry has invalid intermediate anchor: {:?}",
-                    &entry.intermediate_anchor
+                    entry.intermediate_anchor
                 );
             }
         }

--- a/src/fs/gpt.rs
+++ b/src/fs/gpt.rs
@@ -296,8 +296,19 @@ pub fn read_partitions(
     };
 
     let entry_size = header.partition_entry_size as usize;
+    if entry_size < core::mem::size_of::<GptPartitionEntry>() {
+        log::warn!(
+            "GPT partition entry size too small: {} bytes (need at least {})",
+            entry_size,
+            core::mem::size_of::<GptPartitionEntry>()
+        );
+        return Err(GptError::InvalidHeader);
+    }
+
     let total_entries = header.num_partition_entries as usize;
-    let total_bytes_needed = total_entries * entry_size;
+    let total_bytes_needed = total_entries
+        .checked_mul(entry_size)
+        .ok_or(GptError::InvalidHeader)?;
 
     let mut entry_index = 0u32;
     let mut bytes_read = 0usize;

--- a/src/fs/gpt.rs
+++ b/src/fs/gpt.rs
@@ -17,7 +17,7 @@ const GPT_SIGNATURE: u64 = 0x5452415020494645;
 
 /// EFI System Partition type GUID (C12A7328-F81F-11D2-BA4B-00A0C93EC93B)
 /// Stored in mixed-endian format
-const ESP_TYPE_GUID: [u8; 16] = [
+pub const ESP_TYPE_GUID: [u8; 16] = [
     0x28, 0x73, 0x2a, 0xc1, // LE: C12A7328
     0x1f, 0xf8, // LE: F81F
     0xd2, 0x11, // LE: 11D2
@@ -173,13 +173,50 @@ impl Partition {
     }
 }
 
-/// Error type for GPT operations
+/// MBR partition entry structure
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Clone, Copy, Debug)]
+struct MbrPartitionEntry {
+    /// Boot indicator (0x80 = active)
+    boot_indicator: u8,
+    /// Starting CHS address (ignored; legacy field)
+    starting_chs: [u8; 3],
+    /// Partition type byte
+    partition_type: u8,
+    /// Ending CHS address (ignored; legacy field)
+    ending_chs: [u8; 3],
+    /// First LBA, little-endian
+    first_lba: u32,
+    /// Number of sectors, little-endian
+    sector_count: u32,
+}
+
+impl MbrPartitionEntry {
+    /// Check whether this entry describes an allocated partition.
+    fn is_used(&self) -> bool {
+        self.partition_type != 0 && self.sector_count != 0
+    }
+
+    /// Check whether this entry is the UEFI MBR ESP partition type.
+    fn is_esp(&self) -> bool {
+        self.partition_type == 0xef
+    }
+
+    /// Check whether this entry is a legacy FAT partition type.
+    fn is_fat(&self) -> bool {
+        matches!(self.partition_type, 0x01 | 0x04 | 0x06 | 0x0b | 0x0c | 0x0e)
+    }
+}
+
+/// Error type for GPT/MBR partition table operations
 #[derive(Debug)]
 pub enum GptError {
     /// Read error from storage device
     ReadError,
     /// Invalid GPT header
     InvalidHeader,
+    /// Invalid MBR sector
+    InvalidMbr,
     /// No partitions found
     NoPartitions,
     /// No EFI System Partition found
@@ -193,6 +230,7 @@ impl core::fmt::Display for GptError {
         match self {
             GptError::ReadError => write!(f, "read error"),
             GptError::InvalidHeader => write!(f, "invalid GPT header"),
+            GptError::InvalidMbr => write!(f, "invalid MBR sector"),
             GptError::NoPartitions => write!(f, "no partitions found"),
             GptError::NoEsp => write!(f, "no EFI System Partition found"),
             GptError::BufferTooSmall => write!(f, "buffer too small"),
@@ -253,7 +291,7 @@ pub fn read_gpt_header(device: &mut dyn BlockDevice) -> Result<GptHeader, GptErr
     let partition_entry_size = header.partition_entry_size;
 
     if !header.is_valid() {
-        log::error!("Invalid GPT signature: {:#018x}", signature);
+        log::debug!("Invalid GPT signature: {:#018x}", signature);
         return Err(GptError::InvalidHeader);
     }
 
@@ -398,10 +436,111 @@ pub fn read_partitions(
     Ok(partitions)
 }
 
+/// Read partitions from a legacy MBR partition table.
+///
+/// This supports removable media formatted with an MBR ESP (partition type
+/// 0xEF), which is common for USB flash drives created by firmware update and
+/// OS installer tools.
+pub fn read_mbr_partitions(
+    device: &mut dyn BlockDevice,
+) -> Result<heapless::Vec<Partition, 4>, GptError> {
+    let info = device.info();
+    let block_size = (info.block_size as usize).clamp(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE);
+    let mut buffer = [0u8; MAX_BLOCK_SIZE];
+
+    device.read_block(0, &mut buffer[..block_size])?;
+
+    if buffer[510] != 0x55 || buffer[511] != 0xaa {
+        log::debug!(
+            "Invalid MBR signature: {:#04x}{:02x}",
+            buffer[511],
+            buffer[510]
+        );
+        return Err(GptError::InvalidMbr);
+    }
+
+    let mut partitions = heapless::Vec::new();
+    for index in 0..4 {
+        let offset = 446 + index * core::mem::size_of::<MbrPartitionEntry>();
+        let entry = MbrPartitionEntry::read_from_prefix(&buffer[offset..])
+            .map_err(|_| GptError::InvalidMbr)?
+            .0;
+
+        if !entry.is_used() || entry.partition_type == 0xee {
+            continue;
+        }
+
+        let first_lba = u32::from_le(entry.first_lba) as u64;
+        let sector_count = u32::from_le(entry.sector_count) as u64;
+        let Some(last_lba) = first_lba.checked_add(sector_count.saturating_sub(1)) else {
+            return Err(GptError::InvalidMbr);
+        };
+
+        let partition_type = entry.partition_type;
+        let is_boot_candidate = entry.is_esp() || entry.is_fat();
+        let partition = Partition {
+            type_guid: if entry.is_esp() {
+                ESP_TYPE_GUID
+            } else {
+                [0u8; 16]
+            },
+            partition_guid: [0u8; 16],
+            first_lba,
+            last_lba,
+            attributes: 0,
+            // Removable-media USB sticks often use normal FAT MBR partition
+            // types instead of the UEFI-specific 0xEF type. Treat them as
+            // boot candidates and verify by mounting FAT and checking paths.
+            is_esp: is_boot_candidate,
+            block_size: block_size as u32,
+        };
+
+        log::debug!(
+            "MBR partition {}: type={:#04x} LBA {}-{} ({} MB) boot_candidate={}",
+            index + 1,
+            partition_type,
+            partition.first_lba,
+            partition.last_lba,
+            partition.size_bytes() / (1024 * 1024),
+            partition.is_esp
+        );
+
+        if partitions.push(partition).is_err() {
+            log::warn!("Too many MBR partitions, ignoring remaining");
+            break;
+        }
+    }
+
+    if partitions.is_empty() {
+        return Err(GptError::NoPartitions);
+    }
+
+    Ok(partitions)
+}
+
+/// Read partitions from GPT, falling back to MBR when no GPT is present.
+pub fn read_partitions_auto(
+    device: &mut dyn BlockDevice,
+) -> Result<heapless::Vec<Partition, 16>, GptError> {
+    match read_gpt_header(device).and_then(|header| read_partitions(device, &header)) {
+        Ok(partitions) => Ok(partitions),
+        Err(gpt_error) => {
+            log::debug!("GPT partition scan failed: {:?}; trying MBR", gpt_error);
+            let mbr_partitions = read_mbr_partitions(device)?;
+            let mut partitions = heapless::Vec::new();
+            for partition in mbr_partitions {
+                partitions
+                    .push(partition)
+                    .map_err(|_| GptError::NoPartitions)?;
+            }
+            Ok(partitions)
+        }
+    }
+}
+
 /// Find the EFI System Partition
 pub fn find_esp(device: &mut dyn BlockDevice) -> Result<Partition, GptError> {
-    let header = read_gpt_header(device)?;
-    let partitions = read_partitions(device, &header)?;
+    let partitions = read_partitions_auto(device)?;
 
     partitions
         .into_iter()

--- a/src/fs/iso9660.rs
+++ b/src/fs/iso9660.rs
@@ -98,6 +98,48 @@ impl From<BlockError> for IsoError {
     }
 }
 
+/// Read one 2048-byte ISO sector from a block device.
+fn read_iso_sector(
+    device: &mut dyn BlockDevice,
+    iso_sector: u64,
+    block_size: usize,
+    buffer: &mut [u8; ISO_SECTOR_SIZE],
+) -> Result<(), IsoError> {
+    if block_size == 0 || block_size > 4096 {
+        return Err(IsoError::NotIso9660);
+    }
+
+    if block_size <= ISO_SECTOR_SIZE {
+        if !ISO_SECTOR_SIZE.is_multiple_of(block_size) {
+            return Err(IsoError::NotIso9660);
+        }
+        let blocks_per_iso_sector = ISO_SECTOR_SIZE / block_size;
+        let first_block = iso_sector
+            .checked_mul(blocks_per_iso_sector as u64)
+            .ok_or(IsoError::ReadError)?;
+        for i in 0..blocks_per_iso_sector {
+            let offset = i * block_size;
+            device.read_block(
+                first_block + i as u64,
+                &mut buffer[offset..offset + block_size],
+            )?;
+        }
+        return Ok(());
+    }
+
+    if !block_size.is_multiple_of(ISO_SECTOR_SIZE) {
+        return Err(IsoError::NotIso9660);
+    }
+
+    let iso_per_block = block_size / ISO_SECTOR_SIZE;
+    let device_block = iso_sector / iso_per_block as u64;
+    let offset = (iso_sector as usize % iso_per_block) * ISO_SECTOR_SIZE;
+    let mut block = [0u8; 4096];
+    device.read_block(device_block, &mut block[..block_size])?;
+    buffer.copy_from_slice(&block[offset..offset + ISO_SECTOR_SIZE]);
+    Ok(())
+}
+
 /// Read the FAT BPB from the start of a boot image to determine its actual size.
 ///
 /// El Torito `sector_count` is often 0 or 1 for EFI images (meaning "entire image").
@@ -114,10 +156,16 @@ fn probe_fat_image_size(
     image_start_device_block: u64,
 ) -> Option<u64> {
     let block_size = device.info().block_size as usize;
+    if block_size == 0 || block_size > 4096 {
+        return None;
+    }
     let mut buf = [0u8; ISO_SECTOR_SIZE];
 
     // Read enough to cover the BPB (first 512 bytes minimum)
     if block_size <= ISO_SECTOR_SIZE {
+        if !ISO_SECTOR_SIZE.is_multiple_of(block_size) {
+            return None;
+        }
         let blocks_needed = ISO_SECTOR_SIZE / block_size;
         for i in 0..blocks_needed {
             let offset = i * block_size;
@@ -162,7 +210,7 @@ fn probe_fat_image_size(
         return None;
     }
 
-    let size = total_sectors * bytes_per_sector;
+    let size = total_sectors.checked_mul(bytes_per_sector)?;
     log::debug!(
         "El Torito: FAT BPB probe: {} sectors x {} bytes = {} bytes",
         total_sectors,
@@ -179,26 +227,10 @@ pub fn find_efi_boot_image(device: &mut dyn BlockDevice) -> Result<EfiBootImage,
     let info = device.info();
     let block_size = info.block_size as usize;
 
-    // For non-2048 byte devices, we need to calculate the right sector
-    let sectors_per_iso_sector = ISO_SECTOR_SIZE / block_size;
-
-    // Read the Boot Record Volume Descriptor (sector 17 in ISO terms)
-    let brvd_device_sector = BOOT_RECORD_SECTOR * sectors_per_iso_sector as u64;
-
     let mut buffer = [0u8; ISO_SECTOR_SIZE];
 
-    // Read the BRVD - may need multiple device sectors for 512-byte devices
-    if block_size < ISO_SECTOR_SIZE {
-        for i in 0..sectors_per_iso_sector {
-            let offset = i * block_size;
-            device.read_block(
-                brvd_device_sector + i as u64,
-                &mut buffer[offset..offset + block_size],
-            )?;
-        }
-    } else {
-        device.read_block(brvd_device_sector, &mut buffer[..block_size])?;
-    }
+    // Read the Boot Record Volume Descriptor (sector 17 in ISO terms)
+    read_iso_sector(device, BOOT_RECORD_SECTOR, block_size, &mut buffer)?;
 
     // Check for CD001 signature at offset 1
     if &buffer[1..6] != CD001_SIGNATURE {
@@ -223,19 +255,7 @@ pub fn find_efi_boot_image(device: &mut dyn BlockDevice) -> Result<EfiBootImage,
     log::debug!("El Torito: Boot catalog at ISO sector {}", catalog_sector);
 
     // Read the boot catalog
-    let catalog_device_sector = catalog_sector as u64 * sectors_per_iso_sector as u64;
-
-    if block_size < ISO_SECTOR_SIZE {
-        for i in 0..sectors_per_iso_sector {
-            let offset = i * block_size;
-            device.read_block(
-                catalog_device_sector + i as u64,
-                &mut buffer[offset..offset + block_size],
-            )?;
-        }
-    } else {
-        device.read_block(catalog_device_sector, &mut buffer[..block_size])?;
-    }
+    read_iso_sector(device, catalog_sector as u64, block_size, &mut buffer)?;
 
     // Parse validation entry (first 32 bytes)
     let (validation, _) =
@@ -269,7 +289,6 @@ pub fn find_efi_boot_image(device: &mut dyn BlockDevice) -> Result<EfiBootImage,
             device,
             load_rba,
             sector_count,
-            sectors_per_iso_sector,
             block_size,
         ));
     }
@@ -327,7 +346,6 @@ pub fn find_efi_boot_image(device: &mut dyn BlockDevice) -> Result<EfiBootImage,
                     device,
                     load_rba,
                     sector_count,
-                    sectors_per_iso_sector,
                     block_size,
                 ));
             }
@@ -354,17 +372,18 @@ fn build_efi_boot_image(
     device: &mut dyn BlockDevice,
     load_rba: u32,
     sector_count: u32,
-    sectors_per_iso_sector: usize,
     block_size: usize,
 ) -> EfiBootImage {
-    let start_device_block = load_rba as u64 * sectors_per_iso_sector as u64;
+    let start_byte = load_rba as u64 * ISO_SECTOR_SIZE as u64;
+    let start_device_block = start_byte / block_size as u64;
 
     if sector_count > 1 {
+        let size_bytes = sector_count as u64 * ISO_SECTOR_SIZE as u64;
         // Catalog gives a trustworthy size
         return EfiBootImage {
             start_sector: start_device_block,
-            sector_count: sector_count * sectors_per_iso_sector as u32,
-            size_bytes: sector_count as u64 * ISO_SECTOR_SIZE as u64,
+            sector_count: size_bytes.div_ceil(block_size as u64) as u32,
+            size_bytes,
         };
     }
 
@@ -389,14 +408,15 @@ fn build_efi_boot_image(
         "El Torito: could not probe FAT image size, using catalog sector_count={}",
         sector_count
     );
+    let size_bytes = sector_count as u64 * ISO_SECTOR_SIZE as u64;
     EfiBootImage {
         start_sector: start_device_block,
         sector_count: if sector_count > 0 {
-            sector_count * sectors_per_iso_sector as u32
+            size_bytes.div_ceil(block_size as u64) as u32
         } else {
             0
         },
-        size_bytes: sector_count as u64 * ISO_SECTOR_SIZE as u64,
+        size_bytes,
     }
 }
 
@@ -404,22 +424,13 @@ fn build_efi_boot_image(
 pub fn is_iso9660(device: &mut dyn BlockDevice) -> bool {
     let info = device.info();
     let block_size = info.block_size as usize;
-    let sectors_per_iso_sector = ISO_SECTOR_SIZE / block_size;
 
     // Check for Primary Volume Descriptor at sector 16
-    let pvd_sector = 16 * sectors_per_iso_sector as u64;
-
-    // Buffer must be at least block_size to avoid buffer overflow from read_block
-    let mut buffer = [0u8; 4096]; // MAX_BLOCK_SIZE
-    let read_size = block_size.min(buffer.len());
-
-    if device
-        .read_block(pvd_sector, &mut buffer[..read_size])
-        .is_err()
-    {
+    let mut buffer = [0u8; ISO_SECTOR_SIZE];
+    if read_iso_sector(device, 16, block_size, &mut buffer).is_err() {
         return false;
     }
 
     // Check for CD001 signature at offset 1
-    read_size >= 6 && &buffer[1..6] == CD001_SIGNATURE
+    &buffer[1..6] == CD001_SIGNATURE
 }

--- a/src/fs/iso9660.rs
+++ b/src/fs/iso9660.rs
@@ -375,7 +375,20 @@ fn build_efi_boot_image(
     block_size: usize,
 ) -> EfiBootImage {
     let start_byte = load_rba as u64 * ISO_SECTOR_SIZE as u64;
-    let start_device_block = start_byte / block_size as u64;
+    let block_size_u64 = block_size as u64;
+    let start_device_block = start_byte / block_size_u64;
+    if !start_byte.is_multiple_of(block_size_u64) {
+        log::warn!(
+            "El Torito: EFI image at byte offset {} is not aligned to {}-byte device blocks",
+            start_byte,
+            block_size
+        );
+        return EfiBootImage {
+            start_sector: start_device_block,
+            sector_count: 0,
+            size_bytes: 0,
+        };
+    }
 
     if sector_count > 1 {
         let size_bytes = sector_count as u64 * ISO_SECTOR_SIZE as u64;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -21,8 +21,9 @@ pub mod iso9660;
 ///
 /// FAT-style path (e.g., "boot\\vmlinuz-linux") or an error if the path is invalid
 pub fn linux_path_to_fat(path: &str) -> Result<heapless::String<128>, PathConversionError> {
-    // Reject directory traversal attempts (check each path component, not substring)
-    if path.split('/').any(|component| component == "..") {
+    // Reject directory traversal attempts (check each path component, accepting
+    // both Linux and FAT separators because callers may pass mixed paths).
+    if path.split(['/', '\\']).any(|component| component == "..") {
         return Err(PathConversionError::DirectoryTraversal);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,18 +208,20 @@ pub fn init_platform(config: PlatformConfig) -> ! {
     }
 }
 
-/// Allocate a fresh [`state::FirmwareState`] on this stack frame and
+/// Use a statically allocated [`state::FirmwareState`] for fresh starts and
 /// delegate to [`init_platform_impl`].
 ///
-/// Separated from [`init_platform`] so the ~2 MB `FirmwareState` is only
-/// on the stack when the caller didn't pre-initialize.
+/// Keeping this in static storage avoids putting the ~1 MiB state object on the
+/// firmware stack.
+static mut LOCAL_FIRMWARE_STATE: state::FirmwareState = state::FirmwareState::new();
+
 #[inline(never)]
 fn init_with_local_state(config: PlatformConfig) -> ! {
-    let mut firmware_state = state::FirmwareState::new();
-    // SAFETY: Single-threaded firmware entry point. The state lives on this
-    // stack frame which never returns (-> !).
+    // SAFETY: Single-threaded firmware entry point. This static lives for the
+    // full firmware lifetime and is only used on the fresh-start path.
     unsafe {
-        state::init(&mut firmware_state);
+        let firmware_state = core::ptr::addr_of_mut!(LOCAL_FIRMWARE_STATE);
+        state::init(&mut *firmware_state);
     }
     init_platform_impl(config)
 }
@@ -523,8 +525,9 @@ pub(crate) fn with_disk<R>(
             device_addr: _,
         } => {
             let controller_ptr = drivers::usb::get_controller_ptr(controller_id)?;
+            let device_ptr = drivers::usb::mass_storage::get_global_device_ptr()?;
             let controller = unsafe { &mut *controller_ptr };
-            let usb_device = drivers::usb::mass_storage::get_global_device()?;
+            let usb_device = unsafe { &mut *device_ptr };
             let mut disk = UsbDisk::new(usb_device, controller);
             Some(f(&mut disk))
         }

--- a/src/linux_boot/mod.rs
+++ b/src/linux_boot/mod.rs
@@ -511,6 +511,10 @@ pub fn load_linux_from_disk(
 /// Searches the memory map for a RAM region that can hold the initrd,
 /// preferring high addresses (below initrd_addr_max).
 fn find_initrd_address(boot_params: &BootParams, size: u64) -> Result<u64, LinuxBootError> {
+    if size == 0 {
+        return Err(LinuxBootError::MemoryError);
+    }
+
     // Get maximum initrd address from header, default to 0x37FFFFFF
     let initrd_addr_max = match boot_params.hdr.initrd_addr_max {
         0 => 0x37FF_FFFF,
@@ -519,57 +523,62 @@ fn find_initrd_address(boot_params: &BootParams, size: u64) -> Result<u64, Linux
 
     // Limit to 4GB identity-mapped area
     let initrd_addr_max = initrd_addr_max.min((4u64 << 30) - 1);
+    let max_exclusive = initrd_addr_max
+        .checked_add(1)
+        .ok_or(LinuxBootError::MemoryError)?;
+    let max_start = max_exclusive
+        .checked_sub(size)
+        .ok_or(LinuxBootError::MemoryError)?;
 
     // Find highest suitable RAM region
     let mut best_addr: Option<u64> = None;
 
     for i in 0..boot_params.num_e820_entries() {
-        if let Some(entry) = boot_params.e820_entry(i) {
-            // Only consider RAM regions
-            if entry.entry_type != E820Entry::RAM_TYPE {
-                continue;
-            }
+        let Some(entry) = boot_params.e820_entry(i) else {
+            continue;
+        };
 
-            // Skip regions that start beyond max
-            if entry.addr > initrd_addr_max {
-                continue;
-            }
-
-            // Skip regions that are too small
-            if entry.size < size {
-                continue;
-            }
-
-            // Skip low memory (need to be above kernel)
-            if entry.addr < 0x1000000 {
-                // 16 MB
-                continue;
-            }
-
-            // Calculate highest address in this region that fits
-            let region_end = entry.addr + entry.size;
-            let potential_addr = region_end.saturating_sub(size);
-
-            // Align to 2MB boundary
-            let potential_addr = potential_addr & !((2u64 << 20) - 1);
-
-            // Clamp to max
-            let potential_addr = potential_addr.min(initrd_addr_max + 1 - size);
-
-            // Must still be within the region
-            if potential_addr < entry.addr {
-                continue;
-            }
-
-            // Use the highest address we can find
-            if let Some(current) = best_addr {
-                if potential_addr > current {
-                    best_addr = Some(potential_addr);
-                }
-            } else {
-                best_addr = Some(potential_addr);
-            }
+        // Only consider RAM regions
+        if entry.entry_type != E820Entry::RAM_TYPE {
+            continue;
         }
+
+        // Skip regions that start beyond max
+        if entry.addr > initrd_addr_max {
+            continue;
+        }
+
+        // Skip regions that are too small
+        if entry.size < size {
+            continue;
+        }
+
+        // Skip low memory (need to be above kernel)
+        if entry.addr < 0x1000000 {
+            // 16 MB
+            continue;
+        }
+
+        // Calculate highest address in this region that fits.
+        // Treat malformed wrapping E820 regions as unusable.
+        let Some(region_end) = entry.addr.checked_add(entry.size) else {
+            continue;
+        };
+        let Some(mut potential_addr) = region_end.checked_sub(size) else {
+            continue;
+        };
+
+        // Clamp to max, then align downward to 2MB boundary
+        potential_addr = potential_addr.min(max_start);
+        potential_addr &= !((2u64 << 20) - 1);
+
+        // Must still be within the region
+        if potential_addr < entry.addr {
+            continue;
+        }
+
+        // Use the highest address we can find
+        best_addr = Some(best_addr.map_or(potential_addr, |current| current.max(potential_addr)));
     }
 
     let addr = best_addr.ok_or_else(|| {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -383,17 +383,9 @@ fn discover_entries_on_disk(
     name_prefix: &str,
     menu: &mut BootMenu,
 ) {
-    // Phase 1: Read GPT and clone partitions out (releases the disk borrow)
-    let partitions = crate::with_disk(&device_type, |disk| {
-        if let Ok(header) = gpt::read_gpt_header(disk)
-            && let Ok(parts) = gpt::read_partitions(disk, &header)
-        {
-            Some(parts)
-        } else {
-            None
-        }
-    })
-    .flatten();
+    // Phase 1: Read GPT/MBR partitions and clone them out (releases the disk borrow)
+    let partitions =
+        crate::with_disk(&device_type, |disk| gpt::read_partitions_auto(disk).ok()).flatten();
 
     let partitions = match partitions {
         Some(p) => p,
@@ -473,11 +465,12 @@ fn discover_nvme_entries(menu: &mut BootMenu) {
         nsid,
     };
 
-    // Try GPT-based discovery first
-    let had_gpt =
-        crate::with_disk(&device_type, |disk| gpt::read_gpt_header(disk).is_ok()).unwrap_or(false);
+    // Try partition-table based discovery first (GPT, then MBR).
+    let has_partitions =
+        crate::with_disk(&device_type, |disk| gpt::read_partitions_auto(disk).is_ok())
+            .unwrap_or(false);
 
-    if had_gpt {
+    if has_partitions {
         let mut name_prefix: String<32> = String::new();
         let _ = write!(name_prefix, "NVMe ns{}", nsid);
         discover_entries_on_disk(
@@ -518,11 +511,12 @@ fn discover_ahci_entries(menu: &mut BootMenu) {
         let mut name_prefix: String<32> = String::new();
         let _ = write!(name_prefix, "SATA port {}", port_index);
 
-        // Try GPT-based discovery first
-        let had_gpt = crate::with_disk(&device_type, |disk| gpt::read_gpt_header(disk).is_ok())
-            .unwrap_or(false);
+        // Try partition-table based discovery first (GPT, then MBR).
+        let has_partitions =
+            crate::with_disk(&device_type, |disk| gpt::read_partitions_auto(disk).is_ok())
+                .unwrap_or(false);
 
-        if had_gpt {
+        if has_partitions {
             discover_entries_on_disk(
                 device_type,
                 pci_addr.device,

--- a/src/payload/elf.rs
+++ b/src/payload/elf.rs
@@ -224,6 +224,10 @@ impl Elf64 {
                 phdr.p_memsz
             );
 
+            if phdr.p_filesz > phdr.p_memsz {
+                return Err(ElfError::InvalidProgramHeader);
+            }
+
             let segment = LoadSegment {
                 file_offset: phdr.p_offset,
                 load_addr: phdr.p_vaddr,

--- a/src/payload/elf.rs
+++ b/src/payload/elf.rs
@@ -191,10 +191,19 @@ impl Elf64 {
         let mut segments = heapless::Vec::new();
         let phdr_offset = header.e_phoff as usize;
         let phdr_size = header.e_phentsize as usize;
+        if phdr_size < core::mem::size_of::<Elf64Phdr>() {
+            return Err(ElfError::InvalidProgramHeader);
+        }
 
         for i in 0..header.e_phnum as usize {
-            let offset = phdr_offset + i * phdr_size;
-            if offset + phdr_size > data.len() {
+            let offset = i
+                .checked_mul(phdr_size)
+                .and_then(|rel| phdr_offset.checked_add(rel))
+                .ok_or(ElfError::InvalidProgramHeader)?;
+            let end = offset
+                .checked_add(core::mem::size_of::<Elf64Phdr>())
+                .ok_or(ElfError::InvalidProgramHeader)?;
+            if end > data.len() {
                 return Err(ElfError::InvalidProgramHeader);
             }
 
@@ -249,7 +258,10 @@ impl Elf64 {
 
             // Copy file data
             if src_size > 0 {
-                if src_offset + src_size > data.len() {
+                let src_end = src_offset
+                    .checked_add(src_size)
+                    .ok_or(ElfError::InvalidProgramHeader)?;
+                if src_end > data.len() {
                     return Err(ElfError::InvalidProgramHeader);
                 }
                 // Safety: caller guarantees dst points to valid writable memory

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -653,7 +653,7 @@ pub fn load_image(data: &[u8]) -> Result<LoadedImage, Status> {
                 image_size
             );
             // Free allocated memory and return error
-            let _ = allocator::free_pages(load_addr, num_pages);
+            let _ = allocator::free_pages(alloc_base, num_pages);
             return Err(Status::INVALID_PARAMETER);
         }
 
@@ -681,7 +681,7 @@ pub fn load_image(data: &[u8]) -> Result<LoadedImage, Status> {
 
         if data_dirs_end > data.len() {
             log::error!("PE: Data directories extend beyond file");
-            let _ = allocator::free_pages(load_addr, num_pages);
+            let _ = allocator::free_pages(alloc_base, num_pages);
             return Err(Status::INVALID_PARAMETER);
         }
 
@@ -696,7 +696,7 @@ pub fn load_image(data: &[u8]) -> Result<LoadedImage, Status> {
                 match DataDirectory::ref_from_prefix(&data_dirs_data[reloc_dir_offset..]) {
                     Ok((d, _)) => d,
                     Err(_) => {
-                        let _ = allocator::free_pages(load_addr, num_pages);
+                        let _ = allocator::free_pages(alloc_base, num_pages);
                         return Err(Status::INVALID_PARAMETER);
                     }
                 };
@@ -709,7 +709,7 @@ pub fn load_image(data: &[u8]) -> Result<LoadedImage, Status> {
                     apply_relocations(load_addr, image_size, reloc_rva, reloc_size, delta)
             {
                 log::error!("PE: Failed to apply relocations");
-                let _ = allocator::free_pages(load_addr, num_pages);
+                let _ = allocator::free_pages(alloc_base, num_pages);
                 return Err(e);
             }
         }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -857,16 +857,20 @@ impl FramebufferConfig {
     }
 
     fn encode_pixel_32(&self, r: u8, g: u8, b: u8) -> u32 {
-        let r = ((r as u32) >> (8 - self.red_mask_size)) << self.red_mask_pos;
-        let g = ((g as u32) >> (8 - self.green_mask_size)) << self.green_mask_pos;
-        let b = ((b as u32) >> (8 - self.blue_mask_size)) << self.blue_mask_pos;
+        let r = ((r as u32) >> 8u32.saturating_sub(self.red_mask_size as u32)) << self.red_mask_pos;
+        let g =
+            ((g as u32) >> 8u32.saturating_sub(self.green_mask_size as u32)) << self.green_mask_pos;
+        let b =
+            ((b as u32) >> 8u32.saturating_sub(self.blue_mask_size as u32)) << self.blue_mask_pos;
         r | g | b
     }
 
     fn encode_pixel_16(&self, r: u8, g: u8, b: u8) -> u16 {
-        let r = ((r as u16) >> (8 - self.red_mask_size)) << self.red_mask_pos;
-        let g = ((g as u16) >> (8 - self.green_mask_size)) << self.green_mask_pos;
-        let b = ((b as u16) >> (8 - self.blue_mask_size)) << self.blue_mask_pos;
+        let r = ((r as u16) >> 8u16.saturating_sub(self.red_mask_size as u16)) << self.red_mask_pos;
+        let g =
+            ((g as u16) >> 8u16.saturating_sub(self.green_mask_size as u16)) << self.green_mask_pos;
+        let b =
+            ((b as u16) >> 8u16.saturating_sub(self.blue_mask_size as u16)) << self.blue_mask_pos;
         r | g | b
     }
 }


### PR DESCRIPTION
## Summary
- avoid nested firmware-state mutable borrows in SetVariable by splitting in-memory updates from persistence
- fix AHCI trusted send/receive DMA allocation sizing and USB mass-storage global access aliasing
- harden PE, ELF, GPT, ISO9660, Linux initrd, framebuffer, event, and device-path edge cases

## Validation
- cargo check
- cargo build --release

Note: local pre-existing change in src/arch/x86_64/mod.rs was intentionally not included in this branch/commit.