### PR TITLE
efi: align ACPI device path text with EDK2

### DIFF
--- a/src/efi/protocols/device_path_from_text.rs
+++ b/src/efi/protocols/device_path_from_text.rs
@@ -43,6 +43,8 @@ const MEDIA_SUBTYPE_VENDOR: u8 = 0x03;
 // PNP IDs
 const EISA_PNP_ID_PCI_ROOT: u32 = 0x0a0341d0;
 const EISA_PNP_ID_PCIE_ROOT: u32 = 0x0a0841d0;
+// EISA PNP IDs are encoded as (numeric_id << 16) | "PNP".
+const EISA_PNP_VENDOR: u32 = 0x41d0;
 
 /// Signature types for HD() nodes
 const SIGNATURE_TYPE_MBR: u8 = 0x01;
@@ -142,6 +144,16 @@ fn skip_separator(s: &[u8], pos: usize) -> usize {
 // GUID parsing
 // ============================================================================
 
+/// Return the numeric value of an ASCII hex digit.
+fn hex_digit(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
 /// Parse a hex byte from 2 ASCII chars.
 fn parse_hex_byte(s: &[u8], off: usize) -> u8 {
     let hi = match s.get(off) {
@@ -165,6 +177,19 @@ fn parse_hex_byte(s: &[u8], off: usize) -> u8 {
     (hi << 4) | lo
 }
 
+/// Parse a PNP EISA ID from text like `PNP0A03`.
+fn parse_eisa_pnp_id(s: &[u8]) -> Option<u32> {
+    if s.len() < 7 || !ascii_prefix_eq(s, b"PNP") {
+        return None;
+    }
+
+    let mut id = 0u32;
+    for &ch in &s[3..7] {
+        id = (id << 4) | hex_digit(ch)? as u32;
+    }
+    Some((id << 16) | EISA_PNP_VENDOR)
+}
+
 /// Parse a GUID from text like `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`.
 ///
 /// Returns the GUID bytes in mixed-endian format (matching UEFI layout).
@@ -173,6 +198,16 @@ fn parse_guid(s: &[u8]) -> Option<[u8; 16]> {
     if s.len() < 36 {
         return None;
     }
+    if s[8] != b'-' || s[13] != b'-' || s[18] != b'-' || s[23] != b'-' {
+        return None;
+    }
+    for &idx in &[
+        0usize, 2, 4, 6, 9, 11, 14, 16, 19, 21, 24, 26, 28, 30, 32, 34,
+    ] {
+        hex_digit(s[idx])?;
+        hex_digit(s[idx + 1])?;
+    }
+
     let mut guid = [0u8; 16];
 
     // Data1: 8 hex chars, little-endian u32
@@ -463,7 +498,11 @@ fn parse_vendor_media(args: &[u8]) -> *mut device_path::Protocol {
 
 /// Parse an ACPI node: `Acpi(HID,UID)` -> ACPI node
 fn parse_acpi(args: &[u8]) -> *mut device_path::Protocol {
-    let (hid, consumed) = parse_number(args);
+    let (hid, consumed) = if let Some(hid) = parse_eisa_pnp_id(args) {
+        (hid as u64, 7)
+    } else {
+        parse_number(args)
+    };
     let rest = skip_separator(args, consumed);
     let (uid, _) = parse_number(&args[rest..]);
     let node = alloc_node(TYPE_ACPI, ACPI_SUBTYPE_ACPI, 12);

--- a/src/efi/protocols/device_path_to_text.rs
+++ b/src/efi/protocols/device_path_to_text.rs
@@ -51,6 +51,8 @@ const MEDIA_SUBTYPE_FILEPATH: u8 = 0x04;
 const EISA_PNP_ID_PCI_ROOT: u32 = 0x0a0341d0;
 // PNP ID for PCIe root bridge (EISA encoded PNP0A08)
 const EISA_PNP_ID_PCIE_ROOT: u32 = 0x0a0841d0;
+// EISA PNP IDs are encoded as (numeric_id << 16) | "PNP".
+const EISA_PNP_VENDOR: u32 = 0x41d0;
 
 /// Signature type constants for HD() nodes
 const SIGNATURE_TYPE_MBR: u8 = 0x01;
@@ -192,8 +194,11 @@ unsafe fn fmt_acpi(node: *const u8, buf: &mut AsciiBuffer) {
         EISA_PNP_ID_PCIE_ROOT => {
             let _ = write!(buf, "PcieRoot(0x{:X})", uid);
         }
+        _ if (hid & 0xffff) == EISA_PNP_VENDOR => {
+            let _ = write!(buf, "Acpi(PNP{:04X},0x{:X})", hid >> 16, uid);
+        }
         _ => {
-            let _ = write!(buf, "Acpi(0x{:X},0x{:X})", hid, uid);
+            let _ = write!(buf, "Acpi(0x{:08X},0x{:X})", hid, uid);
         }
     }
 }

--- a/test-apps/device-path-test/src/main.rs
+++ b/test-apps/device-path-test/src/main.rs
@@ -11,7 +11,9 @@
 use core::ffi::c_void;
 use core::panic::PanicInfo;
 use r_efi::efi::{self, Boolean, Char16, Guid, Handle, Status, SystemTable};
-use r_efi::protocols::{device_path, device_path_from_text, device_path_to_text, device_path_utilities};
+use r_efi::protocols::{
+    device_path, device_path_from_text, device_path_to_text, device_path_utilities,
+};
 
 static mut BOOT_SERVICES: *mut efi::BootServices = core::ptr::null_mut();
 static mut CON_OUT: *mut r_efi::protocols::simple_text_output::Protocol = core::ptr::null_mut();
@@ -109,7 +111,7 @@ fn ucs2_to_ascii_print(text: *const Char16) {
         if ch == 0 {
             break;
         }
-        if ch >= 0x20 && ch < 0x7F {
+        if (0x20..0x7F).contains(&ch) {
             let byte = [ch as u8];
             let s = unsafe { core::str::from_utf8_unchecked(&byte) };
             print(s);
@@ -139,6 +141,20 @@ fn ucs2_strlen(text: *const Char16) -> usize {
             return i;
         }
     }
+}
+
+fn ucs2_equals_ascii(text: *const Char16, expected: &str) -> bool {
+    if text.is_null() {
+        return false;
+    }
+    let expected = expected.as_bytes();
+    for (i, &byte) in expected.iter().enumerate() {
+        let ch = unsafe { *(text as *const u16).add(i) };
+        if ch != byte as u16 {
+            return false;
+        }
+    }
+    unsafe { *(text as *const u16).add(expected.len()) == 0 }
 }
 
 /// Free a pool allocation
@@ -527,7 +543,37 @@ fn test_device_path_to_text(
         }
     }
 
-    // Test 3: Convert NULL should return NULL
+    // Test 3: Convert a generic EISA ACPI node using EDK2-compatible PNPxxxx text
+    {
+        let acpi = (dpu.create_device_node)(0x02, 0x01, 12);
+        if !acpi.is_null() {
+            unsafe {
+                let hid_bytes = 0xb0c041d0u32.to_le_bytes(); // PNPB0C0
+                core::ptr::copy_nonoverlapping(hid_bytes.as_ptr(), (acpi as *mut u8).add(4), 4);
+                let uid_bytes = 1u32.to_le_bytes();
+                core::ptr::copy_nonoverlapping(uid_bytes.as_ptr(), (acpi as *mut u8).add(8), 4);
+            }
+            let text = (dpt.convert_device_node_to_text)(acpi, Boolean::FALSE, Boolean::FALSE);
+            if !text.is_null() {
+                if ucs2_equals_ascii(text, "Acpi(PNPB0C0,0x1)") {
+                    println("[PASS] node_to_text_acpi_pnp: ACPI PNP node converted to text");
+                    passed += 1;
+                } else {
+                    print("[FAIL] node_to_text_acpi_pnp: Got \"");
+                    ucs2_to_ascii_print(text);
+                    println("\"");
+                    failed += 1;
+                }
+                free_pool(text as *mut c_void);
+            } else {
+                println("[FAIL] node_to_text_acpi_pnp: Returned NULL");
+                failed += 1;
+            }
+            free_pool(acpi as *mut c_void);
+        }
+    }
+
+    // Test 4: Convert NULL should return NULL
     {
         let text = (dpt.convert_device_path_to_text)(
             core::ptr::null_mut(),
@@ -601,7 +647,53 @@ fn test_device_path_from_text(
         }
     }
 
-    // Test 2: ConvertTextToDevicePath for "PciRoot(0x0)/Pci(0x1,0x0)"
+    // Test 2: ConvertTextToDeviceNode for EDK2-style Acpi(PNPxxxx,UID)
+    {
+        let text: [u16; 18] = [
+            b'A' as u16,
+            b'c' as u16,
+            b'p' as u16,
+            b'i' as u16,
+            b'(' as u16,
+            b'P' as u16,
+            b'N' as u16,
+            b'P' as u16,
+            b'B' as u16,
+            b'0' as u16,
+            b'C' as u16,
+            b'0' as u16,
+            b',' as u16,
+            b'0' as u16,
+            b'x' as u16,
+            b'1' as u16,
+            b')' as u16,
+            0,
+        ];
+        let node = (dpft.convert_text_to_device_node)(text.as_ptr() as *const Char16);
+        if !node.is_null() {
+            let hid = unsafe {
+                u32::from_le_bytes([
+                    *(node as *const u8).add(4),
+                    *(node as *const u8).add(5),
+                    *(node as *const u8).add(6),
+                    *(node as *const u8).add(7),
+                ])
+            };
+            if hid == 0xb0c041d0 {
+                println("[PASS] text_to_node_acpi_pnp: Acpi(PNPB0C0,0x1) parsed correctly");
+                passed += 1;
+            } else {
+                println("[FAIL] text_to_node_acpi_pnp: Wrong HID");
+                failed += 1;
+            }
+            free_pool(node as *mut c_void);
+        } else {
+            println("[FAIL] text_to_node_acpi_pnp: Returned NULL");
+            failed += 1;
+        }
+    }
+
+    // Test 3: ConvertTextToDevicePath for "PciRoot(0x0)/Pci(0x1,0x0)"
     {
         let text: [u16; 27] = [
             b'P' as u16,

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -675,7 +675,9 @@ pub fn run_tests(config: &QemuConfig, disk_path: &Path, app_name: &str) -> Resul
                 "get_next_instance_2",
                 "node_to_text_pci",
                 "path_to_text_pci_root",
+                "node_to_text_acpi_pnp",
                 "text_to_node_pci_root",
+                "text_to_node_acpi_pnp",
                 "text_to_path_pci",
                 "round_trip",
             ] {


### PR DESCRIPTION
## Summary
- format generic EISA ACPI device path nodes as EDK2-compatible PNPxxxx text
- parse Acpi(PNPxxxx,UID) text back into EISA-encoded HID values
- reject malformed GUID strings in Device Path From Text
- add device-path-test regressions and xtask checks for ACPI PNP text

## Testing
- cargo fmt --check
- cargo check
- cargo build --release
- cargo clippy
- ./crabefi build-test-app device-path-test
- ./crabefi test --app device-path-test --disable-kvm