### PR TITLE
Harden variable backend runtime handling

### DIFF
--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -144,8 +144,31 @@ impl CorebootVariableBackend {
             smmstore_info.mmap_addr
         );
 
+        if smmstore_info.mmap_addr == 0
+            || smmstore_info.num_blocks == 0
+            || smmstore_info.block_size == 0
+        {
+            log::warn!("Ignoring invalid SMMSTORE v2 record; falling back to FMAP");
+            return false;
+        }
+
+        let Some(size) = smmstore_info
+            .num_blocks
+            .checked_mul(smmstore_info.block_size)
+        else {
+            log::warn!("Ignoring overflowing SMMSTORE v2 size; falling back to FMAP");
+            return false;
+        };
         let base = calculate_spi_offset(smmstore_info.mmap_addr, storage.get_bios_region());
-        let size = smmstore_info.num_blocks * smmstore_info.block_size;
+        if base == 0 {
+            log::warn!("Ignoring SMMSTORE v2 record at flash offset 0; falling back to FMAP");
+            return false;
+        }
+        if base.checked_add(size).is_none() {
+            log::warn!("Ignoring overflowing SMMSTORE v2 flash range; falling back to FMAP");
+            return false;
+        }
+
         storage.set_base_offset(base);
         storage.set_storage_size(size);
 

--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -79,6 +79,172 @@ impl crabefi::ResetHandler for CorebootReset {
     }
 }
 
+/// Coreboot variable backend backed by the SPI flash SMMSTORE region.
+///
+/// This keeps coreboot-specific discovery (SMMSTORE v2 records, FMAP probing,
+/// and chipset SPI controller detection) in the coreboot integration crate.
+/// The CrabEFI library only sees the generic [`crabefi::VariableBackend`]
+/// trait object.
+struct CorebootVariableBackend {
+    storage: Option<crabefi::efi::varstore::SpiStorageBackend>,
+    unavailable: bool,
+}
+
+impl CorebootVariableBackend {
+    const fn new() -> Self {
+        Self {
+            storage: None,
+            unavailable: false,
+        }
+    }
+
+    fn ensure_storage(
+        &mut self,
+    ) -> Result<&mut crabefi::efi::varstore::SpiStorageBackend, crabefi::VarBackendError> {
+        if self.storage.is_none() && !self.unavailable {
+            self.storage = self.detect_storage();
+            self.unavailable = self.storage.is_none();
+        }
+
+        self.storage
+            .as_mut()
+            .ok_or(crabefi::VarBackendError::NotAvailable)
+    }
+
+    fn detect_storage(&mut self) -> Option<crabefi::efi::varstore::SpiStorageBackend> {
+        use crabefi::drivers::spi::SpiController;
+
+        let controller = crabefi::drivers::spi::detect_and_init()?;
+        log::info!("Storage backend: {}", controller.name());
+
+        let mut storage = crabefi::efi::varstore::SpiStorageBackend::new(controller, 0, 0);
+        if self.configure_from_smmstorev2(&mut storage) || self.configure_from_fmap(&mut storage) {
+            Some(storage)
+        } else {
+            log::warn!(
+                "No SMMSTORE region found in coreboot tables or FMAP - variable persistence disabled"
+            );
+            None
+        }
+    }
+
+    fn configure_from_smmstorev2(
+        &self,
+        storage: &mut crabefi::efi::varstore::SpiStorageBackend,
+    ) -> bool {
+        let Some(smmstore_info) = crabefi::coreboot::get_smmstorev2() else {
+            log::debug!("No SMMSTORE v2 record in coreboot tables");
+            return false;
+        };
+
+        log::info!(
+            "Found SMMSTORE v2 in coreboot tables: {} blocks x {} KB at {:#x}",
+            smmstore_info.num_blocks,
+            smmstore_info.block_size / 1024,
+            smmstore_info.mmap_addr
+        );
+
+        let base = calculate_spi_offset(smmstore_info.mmap_addr, storage.get_bios_region());
+        let size = smmstore_info.num_blocks * smmstore_info.block_size;
+        storage.set_base_offset(base);
+        storage.set_storage_size(size);
+
+        log::info!(
+            "Variable store configured: base={:#x}, size={} KB",
+            base,
+            size / 1024
+        );
+        true
+    }
+
+    fn configure_from_fmap(&self, storage: &mut crabefi::efi::varstore::SpiStorageBackend) -> bool {
+        log::info!("Looking for variable store region in FMAP...");
+        let Some(region) =
+            crabefi::coreboot::fmap::get_smmstore_from_fmap(storage.controller_mut())
+        else {
+            log::debug!("Variable store region not found in FMAP");
+            return false;
+        };
+
+        storage.set_base_offset(region.offset);
+        storage.set_storage_size(region.size);
+        log::info!(
+            "Found '{}' in FMAP: offset={:#x}, size={} KB",
+            region.name.as_str(),
+            region.offset,
+            region.size / 1024
+        );
+        true
+    }
+
+    fn with_edk2_store<R>(
+        &mut self,
+        f: impl FnOnce(
+            &mut crabefi::efi::varstore::Edk2VarStore<'_>,
+        ) -> Result<R, crabefi::VarBackendError>,
+    ) -> Result<R, crabefi::VarBackendError> {
+        let storage = self.ensure_storage()?;
+        let mut store = crabefi::efi::varstore::Edk2VarStore::new(storage);
+        f(&mut store)
+    }
+}
+
+impl crabefi::VariableBackend for CorebootVariableBackend {
+    fn load(
+        &mut self,
+        visitor: &mut dyn crabefi::VariableVisitor,
+    ) -> Result<(), crabefi::VarBackendError> {
+        self.with_edk2_store(|store| store.load(visitor))
+    }
+
+    fn write(
+        &mut self,
+        name: &[u16],
+        vendor: &r_efi::efi::Guid,
+        attributes: u32,
+        data: &[u8],
+    ) -> Result<(), crabefi::VarBackendError> {
+        self.with_edk2_store(|store| store.write(name, vendor, attributes, data))
+    }
+
+    fn delete(
+        &mut self,
+        name: &[u16],
+        vendor: &r_efi::efi::Guid,
+    ) -> Result<(), crabefi::VarBackendError> {
+        self.with_edk2_store(|store| store.delete(name, vendor))
+    }
+
+    fn runtime_capable(&self) -> bool {
+        false
+    }
+
+    fn notify_exit_boot_services(&mut self) {
+        log::debug!("CorebootVariableBackend: ExitBootServices");
+    }
+}
+
+fn calculate_spi_offset(mmap_addr: u64, bios_region: Option<(u32, u32)>) -> u32 {
+    if let Some((bios_base, bios_limit)) = bios_region {
+        let bios_size = (bios_limit - bios_base + 1) as u64;
+        let mmap_base = 0x1_0000_0000u64 - bios_size;
+
+        if mmap_addr >= mmap_base && mmap_addr < 0x1_0000_0000u64 {
+            return bios_base + (mmap_addr - mmap_base) as u32;
+        }
+    }
+
+    if mmap_addr >= 0xFF00_0000 {
+        (mmap_addr - 0xFF00_0000) as u32
+    } else if mmap_addr >= 0xFE00_0000 {
+        (mmap_addr - 0xFE00_0000) as u32
+    } else if mmap_addr >= 0xFC00_0000 {
+        (mmap_addr - 0xFC00_0000) as u32
+    } else {
+        mmap_addr as u32
+    }
+}
+
 // ============================================================================
 // Memory map conversion
 // ============================================================================
@@ -522,6 +688,7 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
     };
 
     let reset = CorebootReset;
+    let mut coreboot_variable_backend = CorebootVariableBackend::new();
 
     // Extract FDT bytes slice.
     //
@@ -552,7 +719,7 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
         timer: &timer,
         reset: &reset,
         block_devices: &mut [],
-        variable_backend: None,
+        variable_backend: Some(&mut coreboot_variable_backend),
         debug_output: None, // Already set up via init_from_coreboot()
         console_input: None,
         framebuffer: cb_info.framebuffer.map(crabefi::FramebufferConfig::from),

--- a/src/arch/aarch64/rng.rs
+++ b/src/arch/aarch64/rng.rs
@@ -89,7 +89,6 @@ fn check_smccc_trng() -> bool {
             out("x1") _,
             out("x2") _,
             out("x3") _,
-            options(nomem, nostack)
         );
     }
     // Version should be >= 1.0 (0x10000)
@@ -113,7 +112,6 @@ fn smccc_trng_rnd64() -> Option<u64> {
             val = out(reg) val,
             out("x1") _,
             out("x2") _,
-            options(nomem, nostack)
         );
     }
     // SUCCESS = 0

--- a/src/arch/riscv64/sbi.rs
+++ b/src/arch/riscv64/sbi.rs
@@ -66,7 +66,6 @@ pub fn sbi_call(eid: u64, fid: u64, a0: u64, a1: u64, a2: u64) -> SbiRet {
             in("a2") a2,
             in("a6") fid,
             in("a7") eid,
-            options(nostack)
         );
     }
     SbiRet { error, value }

--- a/src/arch/x86_64/cache.rs
+++ b/src/arch/x86_64/cache.rs
@@ -39,17 +39,19 @@ pub fn flush_cache_range(addr: u64, size: usize) {
     fence(Ordering::SeqCst);
 }
 
-/// Invalidate a memory range in CPU cache
+/// Synchronize before reading a DMA-written memory range.
 ///
-/// This ensures the CPU sees data written by DMA-capable devices.
-/// On x86, CLFLUSH both writes back and invalidates, so we use the same
-/// instruction as flush_cache_range.
+/// x86 cache coherency makes device writes visible to CPU loads without an
+/// explicit invalidation instruction.  Do not use `CLFLUSH` here: it is a
+/// write-back invalidate operation, so polling code can race a device DMA
+/// update and write an older CPU cache line back over the device's completion
+/// status.  A full fence is sufficient to order subsequent descriptor reads.
 ///
 /// # Arguments
 ///
-/// * `addr` - Starting address of the memory range
-/// * `size` - Size of the memory range in bytes
+/// * `_addr` - Starting address of the memory range
+/// * `_size` - Size of the memory range in bytes
 #[inline]
-pub fn invalidate_cache_range(addr: u64, size: usize) {
-    flush_cache_range(addr, size);
+pub fn invalidate_cache_range(_addr: u64, _size: usize) {
+    fence(Ordering::SeqCst);
 }

--- a/src/arch/x86_64/rng.rs
+++ b/src/arch/x86_64/rng.rs
@@ -18,7 +18,8 @@ const RDRAND_MIN_CHANGE: usize = 5;
 fn cpuid_has_rdrand() -> bool {
     let ecx: u32;
 
-    // rbx is reserved by LLVM, so we must save/restore it around CPUID
+    // RBX is reserved by LLVM, so save/restore it around CPUID. Do not use
+    // `options(nostack)`: the assembly intentionally uses push/pop.
     unsafe {
         core::arch::asm!(
             "push rbx",
@@ -28,7 +29,6 @@ fn cpuid_has_rdrand() -> bool {
             out("ecx") ecx,
             out("eax") _,
             out("edx") _,
-            options(nostack),
         );
     }
 

--- a/src/drivers/pci/mod.rs
+++ b/src/drivers/pci/mod.rs
@@ -178,7 +178,7 @@ impl PciDevice {
     /// Get the MMIO base address for the device (typically BAR0)
     pub fn mmio_base(&self) -> Option<u64> {
         for bar in &self.bars {
-            if matches!(bar.bar_type, BarType::Memory32 | BarType::Memory64) {
+            if matches!(bar.bar_type, BarType::Memory32 | BarType::Memory64) && bar.address != 0 {
                 return Some(bar.address);
             }
         }
@@ -190,7 +190,7 @@ impl PciDevice {
     /// This is used by controllers like UHCI that use I/O ports instead of MMIO.
     pub fn io_base(&self) -> Option<u64> {
         for bar in &self.bars {
-            if bar.bar_type == BarType::Io {
+            if bar.bar_type == BarType::Io && bar.address != 0 {
                 return Some(bar.address);
             }
         }
@@ -218,77 +218,46 @@ fn get_device_ids(access: &AnyPciAccess, addr: PciAddress) -> (u16, u16) {
     ((data & 0xFFFF) as u16, (data >> 16) as u16)
 }
 
-/// Probe a single BAR and return its type, address, and size
-fn probe_bar(access: &AnyPciAccess, addr: PciAddress, bar_index: usize) -> PciBar {
+/// Read a BAR without sizing it.
+///
+/// CrabEFI is commonly launched by firmware that has already enumerated PCI and
+/// programmed BARs.  Re-sizing with the classic all-ones write is not harmless
+/// on real chipsets: some integrated functions and bridges react badly to BAR
+/// probe writes after firmware setup.  Treat PCI resources as firmware-owned and
+/// just record the bases that are already programmed.
+fn read_bar(access: &AnyPciAccess, addr: PciAddress, bar_index: usize) -> PciBar {
     let bar_offset = (0x10 + bar_index * 4) as u16;
     let original = access.read32(addr, bar_offset);
 
-    // Empty BAR
-    if original == 0 {
+    if original == 0 || original == 0xFFFF_FFFF {
         return PciBar::default();
     }
 
-    // Check if it's I/O or memory
     if original & 1 == 1 {
-        // I/O BAR
-        access.write32(addr, bar_offset, 0xFFFFFFFF);
-        let sized = access.read32(addr, bar_offset);
-        access.write32(addr, bar_offset, original);
-
-        let io_mask = sized | 0x3;
-        let size = (!io_mask).wrapping_add(1) as u64;
-
         return PciBar {
             bar_type: BarType::Io,
             address: (original & 0xFFFFFFFC) as u64,
-            size,
+            size: 0,
             prefetchable: false,
         };
     }
 
-    // Memory BAR - check type (bits 2:1)
     let mem_type = (original >> 1) & 0x3;
     let prefetchable = (original & 0x8) != 0;
-
     match mem_type {
-        0 => {
-            // 32-bit memory
-            access.write32(addr, bar_offset, 0xFFFFFFFF);
-            let sized = access.read32(addr, bar_offset);
-            access.write32(addr, bar_offset, original);
-
-            let mem_mask = sized | 0xF;
-            let size = (!mem_mask).wrapping_add(1) as u64;
-
-            PciBar {
-                bar_type: BarType::Memory32,
-                address: (original & 0xFFFFFFF0) as u64,
-                size,
-                prefetchable,
-            }
-        }
+        0 => PciBar {
+            bar_type: BarType::Memory32,
+            address: (original & 0xFFFFFFF0) as u64,
+            size: 0,
+            prefetchable,
+        },
         2 => {
-            // 64-bit memory (consumes two BARs)
-            let bar_offset_hi = bar_offset + 4;
-            let original_hi = access.read32(addr, bar_offset_hi);
-
-            access.write32(addr, bar_offset, 0xFFFFFFFF);
-            access.write32(addr, bar_offset_hi, 0xFFFFFFFF);
-            let sized_lo = access.read32(addr, bar_offset);
-            let sized_hi = access.read32(addr, bar_offset_hi);
-            access.write32(addr, bar_offset, original);
-            access.write32(addr, bar_offset_hi, original_hi);
-
-            let sized = ((sized_hi as u64) << 32) | (sized_lo as u64);
-            let mem_mask = sized | 0xF;
-            let size = (!mem_mask).wrapping_add(1);
-
+            let original_hi = access.read32(addr, bar_offset + 4);
             let address = ((original_hi as u64) << 32) | ((original & 0xFFFFFFF0) as u64);
-
             PciBar {
                 bar_type: BarType::Memory64,
                 address,
-                size,
+                size: 0,
                 prefetchable,
             }
         }
@@ -329,7 +298,7 @@ fn scan_device(access: &AnyPciAccess, bus: u8, device: u8, function: u8) -> Opti
     if (dev.header_type & 0x7F) == HEADER_TYPE_NORMAL {
         let mut bar_index = 0;
         while bar_index < 6 {
-            let bar = probe_bar(access, addr, bar_index);
+            let bar = read_bar(access, addr, bar_index);
             dev.bars[bar_index] = bar;
 
             // 64-bit BARs consume two slots
@@ -555,7 +524,7 @@ pub fn print_devices() {
         );
 
         for (i, bar) in dev.bars.iter().enumerate() {
-            if bar.bar_type != BarType::Unused {
+            if bar.bar_type != BarType::Unused && bar.address != 0 {
                 log::info!(
                     "    BAR{}: {:?} addr={:#x} size={:#x} pf={}",
                     i,

--- a/src/drivers/usb/ehci.rs
+++ b/src/drivers/usb/ehci.rs
@@ -1103,12 +1103,10 @@ impl EhciController {
         }
         flush_cache_range(qtd_status_addr, 64);
 
-        // Flush QH to main memory
-        flush_cache_range(qh_addr, 96);
-
         // Run one-shot control transfers on a quiet async schedule, matching
-        // libpayload/U-Boot. ICH7-era EHCI can otherwise keep stale async-list
-        // state around transient QHs.
+        // libpayload. Some ICH-era controllers do not reliably pick up a
+        // transient QH spliced into an already-programmed async ring; pointing
+        // ASYNCLISTADDR directly at the transfer QH avoids stale list state.
         if self.op().usbcmd.is_set(USBCMD::ASE) {
             self.op().usbcmd.modify(USBCMD::ASE::CLEAR);
             if !wait_for(100, || !self.op().usbsts.is_set(USBSTS::ASS)) {
@@ -1117,23 +1115,16 @@ impl EhciController {
             self.async_schedule_enabled = false;
         }
 
-        // Link QH into async schedule (insert after async head)
-        let async_qh = unsafe { &mut *(self.async_qh as *mut Qh) };
-        let old_link = async_qh.qh_link;
-        qh.qh_link = old_link;
+        // Use a single-QH circular async list for this transfer.
+        qh.qh_link = (qh_addr as u32) | Qh::TYPE_QH;
         fence(Ordering::SeqCst);
-        flush_cache_range(qh_addr, 4);
-
-        // Now link our QH into the schedule
-        async_qh.qh_link = (qh_addr as u32) | Qh::TYPE_QH;
-        fence(Ordering::SeqCst);
-        flush_cache_range(self.async_qh, 4);
+        flush_cache_range(qh_addr, 96);
+        self.op().asynclistaddr.set(qh_addr as u32);
 
         // Read back for debug
-        invalidate_cache_range(self.async_qh, 64);
         invalidate_cache_range(qh_addr, 64);
         invalidate_cache_range(qtd_setup_addr, 64);
-        let async_link = async_qh.qh_link;
+        let async_link = qh.qh_link;
         let qh_ep_chars = qh.ep_chars;
         let qh_current = qh.current_qtd;
         let qh_overlay_next = qh.overlay.next_qtd;
@@ -1168,9 +1159,7 @@ impl EhciController {
         self.op().usbcmd.modify(USBCMD::ASE::SET);
         if !wait_for(100, || self.op().usbsts.is_set(USBSTS::ASS)) {
             log::error!("EHCI: Async schedule failed to start");
-            async_qh.qh_link = old_link;
-            fence(Ordering::SeqCst);
-            flush_cache_range(self.async_qh, 4);
+            self.op().asynclistaddr.set(self.async_qh as u32);
             return Err(UsbError::Timeout);
         }
         self.async_schedule_enabled = true;
@@ -1234,17 +1223,13 @@ impl EhciController {
             crate::time::delay_us(1);
         }
 
-        // Unlink QH from schedule
-        async_qh.qh_link = old_link;
-        fence(Ordering::SeqCst);
-
-        // Stop the async schedule after the one-shot transfer. This avoids
-        // relying on IAAD for transient QHs and matches libpayload's model.
+        // Stop the one-shot async schedule before reusing transfer memory.
         self.op().usbcmd.modify(USBCMD::ASE::CLEAR);
         if !wait_for(100, || !self.op().usbsts.is_set(USBSTS::ASS)) {
             log::warn!("EHCI: Async schedule failed to stop after control transfer");
         }
         self.async_schedule_enabled = false;
+        self.op().asynclistaddr.set(self.async_qh as u32);
 
         // Invalidate caches one more time to get final state
         invalidate_cache_range(qtd_setup_addr, 64);

--- a/src/efi/boot_services.rs
+++ b/src/efi/boot_services.rs
@@ -1517,9 +1517,12 @@ extern "efiapi" fn exit_boot_services(image_handle: Handle, map_key: usize) -> S
     if status == Status::SUCCESS {
         log::info!("ExitBootServices SUCCESS - transitioning to OS");
 
-        // Mark that ExitBootServices has been called
-        // After this, SPI flash is locked and variable writes go to ESP file
+        // Mark that ExitBootServices has been called. Non-runtime-capable
+        // variable backends will defer later writes to the warm-reboot buffer.
         crate::state::set_exit_boot_services_called();
+        let _ = crate::state::with_variable_backend_mut(|backend| {
+            backend.notify_exit_boot_services();
+        });
 
         // Clean up hardware state for OS handoff
         // Re-enable keyboard interrupts so Linux's i8042 driver works

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -255,6 +255,79 @@ static mut VIRTUAL_MAP_ENTRY_COUNT: usize = 0;
 /// The actual write is a one-shot during SetVirtualAddressMap.
 static VIRTUAL_MODE: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 
+fn clear_virtual_map_globals() {
+    unsafe {
+        VIRTUAL_MAP_PTR = core::ptr::null();
+        VIRTUAL_MAP_DESCRIPTOR_SIZE = 0;
+        VIRTUAL_MAP_ENTRY_COUNT = 0;
+    }
+}
+
+fn relocate_configured_deferred_buffer() -> Status {
+    let mut deferred_ptr = crate::efi::varstore::deferred::deferred_buffer_base() as *mut c_void;
+    if deferred_ptr.is_null() {
+        return Status::SUCCESS;
+    }
+
+    let status = convert_pointer_internal(0, &mut deferred_ptr);
+    if status != Status::SUCCESS {
+        log::error!(
+            "SetVirtualAddressMap: deferred buffer at {:p} is not in a runtime mapping",
+            deferred_ptr
+        );
+        return status;
+    }
+
+    crate::efi::varstore::deferred::relocate_buffer_base(deferred_ptr as u64);
+    Status::SUCCESS
+}
+
+fn relocate_runtime_variable_backend() -> Status {
+    if !state::variable_backend_runtime_capable() {
+        return Status::SUCCESS;
+    }
+
+    let Some(raw) = state::variable_backend_raw() else {
+        return Status::SUCCESS;
+    };
+
+    // SAFETY: A trait object raw pointer is represented as (data pointer,
+    // vtable pointer). We convert each component through the EFI virtual map
+    // and rebuild the same trait object with virtual addresses.
+    let (mut data, mut vtable): (*mut c_void, *mut c_void) = unsafe { core::mem::transmute(raw) };
+
+    let status = convert_pointer_internal(0, &mut data);
+    if status != Status::SUCCESS {
+        log::error!(
+            "SetVirtualAddressMap: variable backend object at {:p} is not in a runtime mapping",
+            data
+        );
+        return status;
+    }
+
+    let status = convert_pointer_internal(0, &mut vtable);
+    if status != Status::SUCCESS {
+        log::error!(
+            "SetVirtualAddressMap: variable backend vtable at {:p} is not in a runtime mapping",
+            vtable
+        );
+        return status;
+    }
+
+    // SAFETY: `data` and `vtable` are the converted components of the same
+    // trait object pointer obtained above.
+    let relocated = unsafe {
+        core::mem::transmute::<(*mut c_void, *mut c_void), *mut dyn crate::platform::VariableBackend>(
+            (data, vtable),
+        )
+    };
+    unsafe {
+        state::replace_variable_backend_raw(relocated);
+    }
+
+    Status::SUCCESS
+}
+
 extern "efiapi" fn set_virtual_address_map(
     memory_map_size: usize,
     descriptor_size: usize,
@@ -301,17 +374,32 @@ extern "efiapi" fn set_virtual_address_map(
     // and would page-fault after the OS switches to virtual addressing.
     crate::coreboot::cbmem_console::disable();
 
-    // Step 1: Commit to virtual mode
-    VIRTUAL_MODE.store(true, core::sync::atomic::Ordering::Release);
-
-    // Step 2: Set up globals so ConvertPointer can access the virtual map
+    // Step 1: Set up globals so ConvertPointer can access the virtual map.
     unsafe {
         VIRTUAL_MAP_PTR = virtual_map as *const u8;
         VIRTUAL_MAP_DESCRIPTOR_SIZE = descriptor_size;
         VIRTUAL_MAP_ENTRY_COUNT = num_entries;
     }
 
-    // Step 3: Signal EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE events
+    // Step 2: Relocate runtime-private raw pointers before committing to
+    // virtual mode. If a configured runtime pointer is not covered by an EFI
+    // runtime mapping, fail SVAM instead of leaving a stale physical pointer
+    // that a later runtime service could dereference.
+    let status = relocate_configured_deferred_buffer();
+    if status != Status::SUCCESS {
+        clear_virtual_map_globals();
+        return status;
+    }
+    let status = relocate_runtime_variable_backend();
+    if status != Status::SUCCESS {
+        clear_virtual_map_globals();
+        return status;
+    }
+
+    // Step 3: Commit to virtual mode.
+    VIRTUAL_MODE.store(true, core::sync::atomic::Ordering::Release);
+
+    // Step 4: Signal EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE events
     {
         use crate::efi::boot_services::{
             EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE, signal_event_group_for_runtime,
@@ -529,11 +617,7 @@ extern "efiapi" fn set_virtual_address_map(
     }
 
     // Step 7: Clear virtual map globals
-    unsafe {
-        VIRTUAL_MAP_PTR = core::ptr::null();
-        VIRTUAL_MAP_DESCRIPTOR_SIZE = 0;
-        VIRTUAL_MAP_ENTRY_COUNT = 0;
-    }
+    clear_virtual_map_globals();
 
     log::info!("SetVirtualAddressMap: complete, disabling log crate for virtual mode");
 

--- a/src/efi/varstore/deferred.rs
+++ b/src/efi/varstore/deferred.rs
@@ -75,15 +75,18 @@ unsafe extern "C" {
 /// platform-configured base or 0 if no deferred buffer is configured.
 #[inline]
 pub fn deferred_buffer_base() -> u64 {
+    let ovr = BUFFER_BASE_OVERRIDE.load(core::sync::atomic::Ordering::Relaxed);
+    if ovr != 0 {
+        return ovr;
+    }
+
     #[cfg(feature = "platform-entry")]
     {
         unsafe { &_deferred_buffer_start as *const u8 as u64 }
     }
     #[cfg(not(feature = "platform-entry"))]
     {
-        // In library mode, use the override if configured, otherwise 0.
-        let ovr = BUFFER_BASE_OVERRIDE.load(core::sync::atomic::Ordering::Relaxed);
-        if ovr != 0 { ovr } else { 0 }
+        0
     }
 }
 
@@ -258,6 +261,17 @@ pub fn configure_buffer_with_size(base_addr: u64, size: usize) {
     );
 }
 
+/// Update the deferred buffer base after `SetVirtualAddressMap`.
+///
+/// The buffer itself is runtime data, but a platform-configured base is stored
+/// as a raw address in this module. Runtime `SetVariable` calls must append to
+/// the OS-provided virtual address after SVAM rather than the physical address.
+pub fn relocate_buffer_base(new_base: u64) {
+    if new_base != 0 {
+        BUFFER_BASE_OVERRIDE.store(new_base, Ordering::SeqCst);
+    }
+}
+
 /// Get the buffer base address
 ///
 /// Returns the override address if configured, otherwise the linker-allocated buffer.
@@ -366,13 +380,13 @@ pub fn check_pending() -> usize {
 
 /// Process all pending deferred writes
 ///
-/// This reads each entry from the buffer, applies it to SPI flash,
-/// then clears the buffer.
+/// This reads each entry from the buffer, applies it to persistent storage,
+/// then clears the buffer only if every entry was durably applied.
 ///
 /// For authenticated variables:
 /// - The signature is verified against the current key databases
 /// - Only if verification succeeds is the variable written to NVS
-/// - If verification fails, the entry is skipped (security policy)
+/// - If verification fails, replay stops and the buffer is preserved
 ///
 /// Returns the number of entries processed.
 pub fn process_pending() -> Result<usize, VarStoreError> {
@@ -382,17 +396,23 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
     }
 
     let base = buffer_base();
+    let size = buffer_size();
+    if !buffer_available(base, size) {
+        return Ok(0);
+    }
+
     let header = unsafe { core::ptr::read(base as *const DeferredHeader) };
 
     let mut offset = HEADER_SIZE;
     let mut processed = 0usize;
+    let mut failure = None;
     let entry_header_size = core::mem::size_of::<EntryHeader>();
 
     for i in 0..header.entry_count {
         // Bounds check: ensure we can read the entry header
         if offset
             .checked_add(entry_header_size)
-            .is_none_or(|end| end > buffer_size())
+            .is_none_or(|end| end > size)
         {
             log::warn!(
                 "Entry header at index {} would exceed buffer bounds (offset={}, header_size={})",
@@ -400,6 +420,7 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
                 offset,
                 entry_header_size
             );
+            failure = Some(VarStoreError::InvalidArgument);
             break;
         }
 
@@ -414,22 +435,21 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
 
         if record_len == 0 || record_len > MAX_ENTRY_SIZE {
             log::warn!("Invalid record length {} at index {}", record_len, i);
+            failure = Some(VarStoreError::InvalidArgument);
             break;
         }
 
         offset += entry_header_size;
 
         // Bounds check: ensure we can read the record data
-        if offset
-            .checked_add(record_len)
-            .is_none_or(|end| end > buffer_size())
-        {
+        if offset.checked_add(record_len).is_none_or(|end| end > size) {
             log::warn!(
                 "Record data at index {} would exceed buffer bounds (offset={}, record_len={})",
                 i,
                 offset,
                 record_len
             );
+            failure = Some(VarStoreError::InvalidArgument);
             break;
         }
 
@@ -446,16 +466,19 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
 
                 if is_deletion {
                     // Delete from the configured variable backend.
-                    if let Err(e) =
-                        super::persistence::delete_variable(&guid, record.name.as_slice())
-                    {
-                        log::warn!("Failed to apply deferred variable deletion: {:?}", e);
-                    } else {
-                        super::persistence::delete_variable_from_memory(
-                            &guid,
-                            record.name.as_slice(),
-                        );
-                        processed += 1;
+                    match super::persistence::delete_variable(&guid, record.name.as_slice()) {
+                        Ok(()) => {
+                            super::persistence::delete_variable_from_memory(
+                                &guid,
+                                record.name.as_slice(),
+                            );
+                            processed += 1;
+                        }
+                        Err(e) => {
+                            log::warn!("Failed to apply deferred variable deletion: {:?}", e);
+                            failure = Some(e);
+                            break;
+                        }
                     }
                 } else if record.is_active() {
                     // Determine the actual data to write and timestamp to preserve
@@ -476,11 +499,11 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
                             }
                             Err(e) => {
                                 log::warn!(
-                                    "Deferred authenticated variable verification failed: {:?}, skipping",
+                                    "Deferred authenticated variable verification failed: {:?}",
                                     e
                                 );
-                                offset += record_len;
-                                continue;
+                                failure = Some(VarStoreError::InvalidArgument);
+                                break;
                             }
                         }
                     } else {
@@ -507,33 +530,48 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
                         )
                     };
 
-                    if let Err(e) = write_result {
-                        log::warn!("Failed to apply deferred variable write: {:?}", e);
-                    } else {
-                        // Also update in-memory (timestamp is handled by persist functions)
-                        super::persistence::update_variable_in_memory(
-                            &guid,
-                            record.name.as_slice(),
-                            record.attributes,
-                            actual_data.as_slice(),
-                        );
-                        processed += 1;
+                    match write_result {
+                        Ok(()) => {
+                            // Also update in-memory (timestamp is handled by persist functions)
+                            super::persistence::update_variable_in_memory(
+                                &guid,
+                                record.name.as_slice(),
+                                record.attributes,
+                                actual_data.as_slice(),
+                            );
+                            processed += 1;
+                        }
+                        Err(e) => {
+                            log::warn!("Failed to apply deferred variable write: {:?}", e);
+                            failure = Some(e);
+                            break;
+                        }
                     }
                 }
             }
             Err(e) => {
                 log::warn!("Failed to deserialize deferred entry {}: {:?}", i, e);
+                failure = Some(VarStoreError::SerdeError);
+                break;
             }
         }
 
         offset += record_len;
     }
 
-    // Clear the buffer
-    init_buffer();
-
-    log::info!("Processed {} deferred variable writes", processed);
-    Ok(processed)
+    if processed == pending_count && failure.is_none() {
+        init_buffer();
+        log::info!("Processed {} deferred variable writes", processed);
+        Ok(processed)
+    } else {
+        let error = failure.unwrap_or(VarStoreError::InvalidArgument);
+        log::warn!(
+            "Deferred variable replay incomplete: processed {}/{}; preserving buffer",
+            processed,
+            pending_count
+        );
+        Err(error)
+    }
 }
 
 /// Queue a variable write for deferred processing

--- a/src/efi/varstore/deferred.rs
+++ b/src/efi/varstore/deferred.rs
@@ -275,6 +275,11 @@ fn buffer_size() -> usize {
     deferred_buffer_size()
 }
 
+/// Check whether a deferred buffer is configured and large enough for a header.
+fn buffer_available(base: *mut u8, size: usize) -> bool {
+    !base.is_null() && size >= HEADER_SIZE
+}
+
 /// Initialize the deferred buffer
 ///
 /// This clears any existing data and writes a fresh header.
@@ -284,7 +289,7 @@ pub fn init_buffer() {
 
     // No deferred buffer configured (library mode without platform-entry
     // and no explicit deferred_buffer in PlatformConfig).
-    if base.is_null() || size == 0 {
+    if !buffer_available(base, size) {
         log::debug!("No deferred variable buffer — skipping init");
         return;
     }
@@ -311,6 +316,10 @@ pub fn init_buffer() {
 /// Returns the number of pending entries, or 0 if none/invalid.
 pub fn check_pending() -> usize {
     let base = buffer_base();
+    let size = buffer_size();
+    if !buffer_available(base, size) {
+        return 0;
+    }
 
     // Read header
     let header = unsafe { core::ptr::read(base as *const DeferredHeader) };
@@ -326,7 +335,7 @@ pub fn check_pending() -> usize {
 
     // Verify data size is within buffer bounds
     let total_size = header.total_size as usize;
-    if HEADER_SIZE.saturating_add(total_size) > buffer_size() {
+    if HEADER_SIZE.saturating_add(total_size) > size {
         log::warn!(
             "Deferred buffer header total_size ({}) exceeds buffer bounds",
             total_size
@@ -436,13 +445,16 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
                 let guid = record.guid.to_guid();
 
                 if is_deletion {
-                    // Delete from storage
+                    // Delete from the configured variable backend.
                     if let Err(e) =
-                        super::persistence::write_variable_deletion_internal(&guid, &record.name)
+                        super::persistence::delete_variable(&guid, record.name.as_slice())
                     {
                         log::warn!("Failed to apply deferred variable deletion: {:?}", e);
                     } else {
-                        super::persistence::delete_variable_from_memory(&guid, &record.name);
+                        super::persistence::delete_variable_from_memory(
+                            &guid,
+                            record.name.as_slice(),
+                        );
                         processed += 1;
                     }
                 } else if record.is_active() {
@@ -452,10 +464,10 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
                         // The timestamp was extracted and stored in record.timestamp when queued
                         // Verify it against current key databases before writing to NVS
                         match auth::verify_authenticated_variable(
-                            &record.name,
+                            record.name.as_slice(),
                             &guid,
                             record.attributes,
-                            &record.data,
+                            record.data.as_slice(),
                         ) {
                             Ok(verified_data) => {
                                 log::info!("Deferred authenticated variable verified successfully");
@@ -476,22 +488,22 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
                         (record.data.clone(), None)
                     };
 
-                    // Write to storage (with timestamp for authenticated variables)
+                    // Write to the configured variable backend (with timestamp
+                    // preserved while the record is queued for authenticated variables).
                     let write_result = if let Some(ref timestamp) = timestamp_to_use {
-                        // Use persist_variable_with_timestamp to preserve the timestamp
                         super::persistence::persist_variable_with_timestamp(
                             &guid,
-                            &record.name,
+                            record.name.as_slice(),
                             record.attributes,
-                            &actual_data,
+                            actual_data.as_slice(),
                             *timestamp,
                         )
                     } else {
-                        super::persistence::write_variable_to_storage_internal(
+                        super::persistence::persist_variable(
                             &guid,
-                            &record.name,
+                            record.name.as_slice(),
                             record.attributes,
-                            &actual_data,
+                            actual_data.as_slice(),
                         )
                     };
 
@@ -501,9 +513,9 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
                         // Also update in-memory (timestamp is handled by persist functions)
                         super::persistence::update_variable_in_memory(
                             &guid,
-                            &record.name,
+                            record.name.as_slice(),
                             record.attributes,
-                            &actual_data,
+                            actual_data.as_slice(),
                         );
                         processed += 1;
                     }
@@ -592,6 +604,11 @@ pub fn queue_deletion(guid: &r_efi::efi::Guid, name: &[u16]) -> Result<(), VarSt
 /// Queue a variable record with flags
 fn queue_record_with_flags(record: &VariableRecord, flags: u8) -> Result<(), VarStoreError> {
     let base = buffer_base();
+    let size = buffer_size();
+    if !buffer_available(base, size) {
+        log::debug!("No deferred variable buffer configured");
+        return Err(VarStoreError::NotInitialized);
+    }
 
     // Serialize the record
     let record_bytes = record.serialize()?;
@@ -633,7 +650,7 @@ fn queue_record_with_flags(record: &VariableRecord, flags: u8) -> Result<(), Var
         }
     };
 
-    if required_space > buffer_size() {
+    if required_space > size {
         log::warn!("Deferred buffer full");
         return Err(VarStoreError::StoreFull);
     }
@@ -697,14 +714,19 @@ pub fn is_initialized() -> bool {
 /// Get statistics about the deferred buffer
 pub fn get_stats() -> (usize, usize, usize) {
     let base = buffer_base();
+    let size = buffer_size();
+    if !buffer_available(base, size) {
+        return (0, 0, 0);
+    }
+
     let header = unsafe { core::ptr::read(base as *const DeferredHeader) };
 
     if !header.is_valid() {
-        return (0, 0, buffer_size() - HEADER_SIZE);
+        return (0, 0, size - HEADER_SIZE);
     }
 
     let used = header.total_size as usize;
-    let free = buffer_size() - HEADER_SIZE - used;
+    let free = size.saturating_sub(HEADER_SIZE).saturating_sub(used);
 
     (header.entry_count as usize, used, free)
 }

--- a/src/efi/varstore/deferred.rs
+++ b/src/efi/varstore/deferred.rs
@@ -465,9 +465,11 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
                 let guid = record.guid.to_guid();
 
                 if is_deletion {
-                    // Delete from the configured variable backend.
+                    // Delete from the configured variable backend. Treat NotFound as
+                    // success because the desired durable state is already achieved;
+                    // otherwise one stale deletion can block deferred replay forever.
                     match super::persistence::delete_variable(&guid, record.name.as_slice()) {
-                        Ok(()) => {
+                        Ok(()) | Err(VarStoreError::NotFound) => {
                             super::persistence::delete_variable_from_memory(
                                 &guid,
                                 record.name.as_slice(),

--- a/src/efi/varstore/edk2_backend.rs
+++ b/src/efi/varstore/edk2_backend.rs
@@ -20,10 +20,25 @@
 //! platform with direct byte-level access to a NOR flash or similar storage.
 //! Platforms using SMM or TF-A MM should implement [`VariableBackend`] directly.
 
+use alloc::vec::Vec;
+
 use crate::platform::{StorageBackend, VarBackendError, VariableBackend, VariableVisitor};
 use r_efi::efi::Guid;
 
 use super::edk2;
+
+fn guid_bytes_to_efi(bytes: &[u8; 16]) -> Guid {
+    Guid::from_fields(
+        u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+        u16::from_le_bytes([bytes[4], bytes[5]]),
+        u16::from_le_bytes([bytes[6], bytes[7]]),
+        bytes[8],
+        bytes[9],
+        &[
+            bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
+        ],
+    )
+}
 
 /// EDK2 Firmware Volume format variable store.
 ///
@@ -82,6 +97,138 @@ impl<'a> Edk2VarStore<'a> {
     /// Check if the store has been initialized (load() called successfully).
     pub fn is_initialized(&self) -> bool {
         self.initialized
+    }
+
+    /// Read all variable records from the store.
+    fn walk_variables(&mut self) -> Vec<edk2::FvVariable> {
+        let auth_format = self.auth_format;
+        let data_size = self.data_size;
+        let storage = &mut self.storage;
+        let mut read_fn =
+            |offset: u32, buf: &mut [u8]| -> bool { storage.read(offset, buf).is_ok() };
+        edk2::walk_variables(&mut read_fn, auth_format, data_size)
+    }
+
+    /// Mark any existing active record for `guid_bytes` and `name` as deleted.
+    fn delete_existing_record(
+        &mut self,
+        guid_bytes: &[u8; 16],
+        name: &[u16],
+    ) -> Result<(), VarBackendError> {
+        let vars = self.walk_variables();
+        for var in &vars {
+            if edk2::is_var_added(var.state)
+                && var.guid == *guid_bytes
+                && edk2::name_matches(&var.name, name)
+            {
+                let _ = self.storage.enable_writes();
+                let storage = &mut self.storage;
+                let mut write_fn =
+                    |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
+                if !edk2::mark_deleted(&mut write_fn, var.state_offset) {
+                    return Err(VarBackendError::IoError);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Compact the store by rewriting the latest active copy of each variable.
+    fn compact(&mut self) -> Result<(), VarBackendError> {
+        struct ActiveVar {
+            guid: [u8; 16],
+            name: Vec<u16>,
+            attributes: u32,
+            data: Vec<u8>,
+        }
+
+        let vars = self.walk_variables();
+        let mut active: Vec<ActiveVar> = Vec::new();
+        for var in vars {
+            if !edk2::is_var_added(var.state) {
+                continue;
+            }
+            active.retain(|existing| {
+                !(existing.guid == var.guid && edk2::name_matches(&existing.name, &var.name))
+            });
+            active.push(ActiveVar {
+                guid: var.guid,
+                name: var.name,
+                attributes: var.attributes,
+                data: var.data,
+            });
+        }
+
+        let storage_size = self.storage.size();
+        let fv_headers = edk2::build_fv_headers(storage_size);
+        let _ = self.storage.enable_writes();
+        self.storage
+            .erase(0, storage_size)
+            .map_err(|_| VarBackendError::IoError)?;
+        self.storage
+            .write(0, &fv_headers)
+            .map_err(|_| VarBackendError::IoError)?;
+
+        self.auth_format = false;
+        self.data_size = storage_size - (edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32;
+        self.write_offset = (edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32;
+
+        for var in active {
+            let storage = &mut self.storage;
+            let mut write_fn =
+                |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
+            self.write_offset = edk2::write_variable(
+                &mut write_fn,
+                self.write_offset,
+                &var.guid,
+                &var.name,
+                var.attributes,
+                &var.data,
+            )
+            .ok_or(VarBackendError::IoError)?;
+        }
+
+        Ok(())
+    }
+
+    /// Append a variable record, compacting once if necessary.
+    fn append_variable(
+        &mut self,
+        name: &[u16],
+        vendor: &Guid,
+        attributes: u32,
+        data: &[u8],
+    ) -> Result<(), VarBackendError> {
+        self.ensure_initialized()?;
+
+        let guid_bytes = edk2::guid_to_bytes(vendor);
+        self.delete_existing_record(&guid_bytes, name)?;
+
+        let record_len =
+            edk2::build_variable_record(&guid_bytes, name, attributes, data).len() as u32;
+        if self.write_offset + record_len > self.storage.size() {
+            log::info!("Variable store full, compacting");
+            self.compact()?;
+        }
+        if self.write_offset + record_len > self.storage.size() {
+            return Err(VarBackendError::StoreFull);
+        }
+
+        let _ = self.storage.enable_writes();
+        let storage = &mut self.storage;
+        let mut write_fn =
+            |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
+        self.write_offset = edk2::write_variable(
+            &mut write_fn,
+            self.write_offset,
+            &guid_bytes,
+            name,
+            attributes,
+            data,
+        )
+        .ok_or(VarBackendError::IoError)?;
+
+        Ok(())
     }
 
     /// Validate or format the FV headers.
@@ -147,151 +294,26 @@ impl VariableBackend for Edk2VarStore<'_> {
     fn load(&mut self, visitor: &mut dyn VariableVisitor) -> Result<(), VarBackendError> {
         self.ensure_initialized()?;
 
-        // Read variable records from the FV and call visitor for each
-        let auth_format = self.auth_format;
-        let data_size = self.data_size;
-        let header_offset = (edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32;
-        let storage = &mut self.storage;
-
-        // Walk the variable store records
-        let mut offset = header_offset;
-        let end = header_offset + data_size;
-
-        while offset < end {
-            // Read variable header
-            let header_len = if auth_format {
-                edk2::AUTH_VAR_HEADER_SIZE
-            } else {
-                edk2::VAR_HEADER_SIZE
-            };
-
-            if offset + header_len as u32 > end {
-                break;
+        let vars = self.walk_variables();
+        let mut active: Vec<&edk2::FvVariable> = Vec::new();
+        for var in &vars {
+            if !edk2::is_var_added(var.state) {
+                continue;
             }
+            active.retain(|existing| {
+                !(existing.guid == var.guid && edk2::name_matches(&existing.name, &var.name))
+            });
+            active.push(var);
+        }
 
-            let mut header_buf = [0u8; 80]; // Large enough for auth header
-            if storage.read(offset, &mut header_buf[..header_len]).is_err() {
-                break;
-            }
-
-            // Check magic and state
-            let start_id = u16::from_le_bytes([header_buf[0], header_buf[1]]);
-            if start_id != 0xAA55 {
-                break; // End of valid records (free space)
-            }
-
-            let state = header_buf[2];
-            let attributes =
-                u32::from_le_bytes([header_buf[3], header_buf[4], header_buf[5], header_buf[6]]);
-
-            let (name_size, data_size_field) = if auth_format {
-                let ns = u32::from_le_bytes([
-                    header_buf[40],
-                    header_buf[41],
-                    header_buf[42],
-                    header_buf[43],
-                ]);
-                let ds = u32::from_le_bytes([
-                    header_buf[44],
-                    header_buf[45],
-                    header_buf[46],
-                    header_buf[47],
-                ]);
-                (ns, ds)
-            } else {
-                let ns = u32::from_le_bytes([
-                    header_buf[24],
-                    header_buf[25],
-                    header_buf[26],
-                    header_buf[27],
-                ]);
-                let ds = u32::from_le_bytes([
-                    header_buf[28],
-                    header_buf[29],
-                    header_buf[30],
-                    header_buf[31],
-                ]);
-                (ns, ds)
-            };
-
-            // Extract vendor GUID
-            let guid_offset = if auth_format { 48 } else { 32 };
-            let vendor_guid = if guid_offset + 16 <= header_len {
-                let guid_bytes = &header_buf[guid_offset..guid_offset + 16];
-                // Parse GUID from mixed-endian format (first 3 fields LE, last 2 BE)
-                let data1 = u32::from_le_bytes([
-                    guid_bytes[0],
-                    guid_bytes[1],
-                    guid_bytes[2],
-                    guid_bytes[3],
-                ]);
-                let data2 = u16::from_le_bytes([guid_bytes[4], guid_bytes[5]]);
-                let data3 = u16::from_le_bytes([guid_bytes[6], guid_bytes[7]]);
-                let data4_hi = u8::from_le_bytes([guid_bytes[8]]);
-                let data4_lo = u8::from_le_bytes([guid_bytes[9]]);
-                Guid::from_fields(
-                    data1,
-                    data2,
-                    data3,
-                    data4_hi,
-                    data4_lo,
-                    &[
-                        guid_bytes[10],
-                        guid_bytes[11],
-                        guid_bytes[12],
-                        guid_bytes[13],
-                        guid_bytes[14],
-                        guid_bytes[15],
-                    ],
-                )
-            } else {
-                break;
-            };
-
-            // Calculate total record size (header + name + data, padded to 4 bytes)
-            let record_data_start = offset + header_len as u32;
-            let total_payload = name_size + data_size_field;
-            let record_size = header_len as u32 + total_payload + ((4 - (total_payload % 4)) % 4); // 4-byte align
-
-            // Only process valid (non-deleted) records
-            if state == 0x3F || state == 0x7F {
-                // Read name and data
-                if total_payload > 0 && record_data_start + total_payload <= end {
-                    // Use a stack buffer for small records, skip huge ones
-                    const MAX_PAYLOAD: usize = 32 * 1024;
-                    if (total_payload as usize) <= MAX_PAYLOAD {
-                        let mut payload = [0u8; MAX_PAYLOAD];
-                        let payload_slice = &mut payload[..total_payload as usize];
-                        if storage.read(record_data_start, payload_slice).is_ok() {
-                            // Name is UTF-16LE, data follows
-                            let name_bytes = &payload_slice[..name_size as usize];
-                            let data_bytes =
-                                &payload_slice[name_size as usize..total_payload as usize];
-
-                            // Convert name bytes to &[u16]
-                            let name_u16_count = name_size as usize / 2;
-                            // SAFETY: name_bytes is aligned to u8, we manually convert
-                            let mut name_u16 = [0u16; 128];
-                            let name_len = name_u16_count.min(128);
-                            for i in 0..name_len {
-                                name_u16[i] =
-                                    u16::from_le_bytes([name_bytes[i * 2], name_bytes[i * 2 + 1]]);
-                            }
-                            // Strip null terminator if present
-                            let name_slice = if name_len > 0 && name_u16[name_len - 1] == 0 {
-                                &name_u16[..name_len - 1]
-                            } else {
-                                &name_u16[..name_len]
-                            };
-
-                            visitor.visit(name_slice, &vendor_guid, attributes, data_bytes);
-                        }
-                    }
-                }
-            }
-
-            // Advance to next record
-            offset += record_size;
+        for var in active {
+            let vendor = guid_bytes_to_efi(&var.guid);
+            let name_len = var
+                .name
+                .iter()
+                .position(|&c| c == 0)
+                .unwrap_or(var.name.len());
+            visitor.visit(&var.name[..name_len], &vendor, var.attributes, &var.data);
         }
 
         Ok(())
@@ -299,32 +321,18 @@ impl VariableBackend for Edk2VarStore<'_> {
 
     fn write(
         &mut self,
-        _name: &[u16],
-        _vendor: &Guid,
-        _attributes: u32,
-        _data: &[u8],
+        name: &[u16],
+        vendor: &Guid,
+        attributes: u32,
+        data: &[u8],
     ) -> Result<(), VarBackendError> {
-        if !self.initialized {
-            return Err(VarBackendError::NotAvailable);
-        }
-
-        // TODO: Delegate to the existing edk2 persistence code for writing.
-        // This requires refactoring persistence.rs to work with a borrowed
-        // StorageBackend rather than the global state accessor.
-        //
-        // For now, the legacy init() path handles writes through the existing
-        // persistence module. This stub will be completed when the full
-        // migration from init() to init_platform() happens.
-        Err(VarBackendError::Other)
+        self.append_variable(name, vendor, attributes, data)
     }
 
-    fn delete(&mut self, _name: &[u16], _vendor: &Guid) -> Result<(), VarBackendError> {
-        if !self.initialized {
-            return Err(VarBackendError::NotAvailable);
-        }
-
-        // TODO: Same as write() — pending persistence.rs refactoring.
-        Err(VarBackendError::Other)
+    fn delete(&mut self, name: &[u16], vendor: &Guid) -> Result<(), VarBackendError> {
+        self.ensure_initialized()?;
+        let guid_bytes = edk2::guid_to_bytes(vendor);
+        self.delete_existing_record(&guid_bytes, name)
     }
 
     fn runtime_capable(&self) -> bool {

--- a/src/efi/varstore/edk2_backend.rs
+++ b/src/efi/varstore/edk2_backend.rs
@@ -40,6 +40,13 @@ fn guid_bytes_to_efi(bytes: &[u8; 16]) -> Guid {
     )
 }
 
+struct ActiveVar {
+    guid: [u8; 16],
+    name: Vec<u16>,
+    attributes: u32,
+    data: Vec<u8>,
+}
+
 /// EDK2 Firmware Volume format variable store.
 ///
 /// Wraps a [`StorageBackend`] (e.g., SPI flash) and implements the
@@ -133,19 +140,20 @@ impl<'a> Edk2VarStore<'a> {
         Ok(())
     }
 
-    /// Compact the store by rewriting the latest active copy of each variable.
-    fn compact(&mut self) -> Result<(), VarBackendError> {
-        struct ActiveVar {
-            guid: [u8; 16],
-            name: Vec<u16>,
-            attributes: u32,
-            data: Vec<u8>,
-        }
-
+    /// Return the latest active variables, optionally excluding one variable.
+    fn active_variables_excluding(
+        &mut self,
+        exclude: Option<(&[u8; 16], &[u16])>,
+    ) -> Vec<ActiveVar> {
         let vars = self.walk_variables();
         let mut active: Vec<ActiveVar> = Vec::new();
         for var in vars {
             if !edk2::is_var_added(var.state) {
+                continue;
+            }
+            if exclude.is_some_and(|(guid, name)| {
+                var.guid == *guid && edk2::name_matches(&var.name, name)
+            }) {
                 continue;
             }
             active.retain(|existing| {
@@ -158,8 +166,39 @@ impl<'a> Edk2VarStore<'a> {
                 data: var.data,
             });
         }
+        active
+    }
 
+    fn record_len(
+        guid: &[u8; 16],
+        name: &[u16],
+        attributes: u32,
+        data: &[u8],
+    ) -> Result<u32, VarBackendError> {
+        let len = edk2::build_variable_record(guid, name, attributes, data).len();
+        if len > u32::MAX as usize {
+            return Err(VarBackendError::DataTooLarge);
+        }
+        Ok(len as u32)
+    }
+
+    fn compacted_end(active: &[ActiveVar]) -> Result<u32, VarBackendError> {
+        let mut offset = edk2::VARIABLE_DATA_OFFSET;
+        for var in active {
+            let len = Self::record_len(&var.guid, &var.name, var.attributes, &var.data)?;
+            offset = offset.checked_add(len).ok_or(VarBackendError::StoreFull)?;
+        }
+        Ok(offset)
+    }
+
+    /// Compact the store by rewriting the provided active variables.
+    fn compact_active(&mut self, active: Vec<ActiveVar>) -> Result<(), VarBackendError> {
         let storage_size = self.storage.size();
+        let final_offset = Self::compacted_end(&active)?;
+        if final_offset > storage_size {
+            return Err(VarBackendError::StoreFull);
+        }
+
         let fv_headers = edk2::build_fv_headers(storage_size);
         let _ = self.storage.enable_writes();
         self.storage
@@ -171,7 +210,7 @@ impl<'a> Edk2VarStore<'a> {
 
         self.auth_format = false;
         self.data_size = storage_size - (edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32;
-        self.write_offset = (edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32;
+        self.write_offset = edk2::VARIABLE_DATA_OFFSET;
 
         for var in active {
             let storage = &mut self.storage;
@@ -202,16 +241,36 @@ impl<'a> Edk2VarStore<'a> {
         self.ensure_initialized()?;
 
         let guid_bytes = edk2::guid_to_bytes(vendor);
-        self.delete_existing_record(&guid_bytes, name)?;
-
-        let record_len =
-            edk2::build_variable_record(&guid_bytes, name, attributes, data).len() as u32;
-        if self.write_offset + record_len > self.storage.size() {
-            log::info!("Variable store full, compacting");
-            self.compact()?;
-        }
-        if self.write_offset + record_len > self.storage.size() {
+        let record_len = Self::record_len(&guid_bytes, name, attributes, data)?;
+        let storage_size = self.storage.size();
+        let data_capacity = storage_size
+            .checked_sub(edk2::VARIABLE_DATA_OFFSET)
+            .ok_or(VarBackendError::StoreFull)?;
+        if record_len > data_capacity {
             return Err(VarBackendError::StoreFull);
+        }
+
+        // Preflight the compacted layout before deleting the existing record or
+        // erasing flash. If the replacement cannot fit even after compaction,
+        // leave the current store untouched.
+        let compacted_active = self.active_variables_excluding(Some((&guid_bytes, name)));
+        let compacted_end = Self::compacted_end(&compacted_active)?;
+        if compacted_end
+            .checked_add(record_len)
+            .is_none_or(|end| end > storage_size)
+        {
+            return Err(VarBackendError::StoreFull);
+        }
+
+        if self
+            .write_offset
+            .checked_add(record_len)
+            .is_some_and(|end| end <= storage_size)
+        {
+            self.delete_existing_record(&guid_bytes, name)?;
+        } else {
+            log::info!("Variable store full, compacting");
+            self.compact_active(compacted_active)?;
         }
 
         let _ = self.storage.enable_writes();

--- a/src/efi/varstore/mod.rs
+++ b/src/efi/varstore/mod.rs
@@ -1,8 +1,9 @@
 //! UEFI Variable Store
 //!
-//! This module provides persistent storage for UEFI variables using SPI flash.
-//! Variables are stored in EDK2-compatible Firmware Volume (FV) format, matching
-//! what coreboot's `get_uint_option()` / `set_uint_option()` expect.
+//! This module provides UEFI variable persistence through the platform-provided
+//! [`crate::platform::VariableBackend`] trait. Platforms may store variables in
+//! EDK2-compatible Firmware Volume (FV) format, SMM/TF-A services, RAM-only test
+//! stores, or any other backend-specific representation.
 //!
 //! # On-Disk Format (EDK2 FV)
 //!
@@ -23,22 +24,24 @@
 //! +--------------------------------------------+
 //! ```
 //!
-//! The persistence layer (persistence.rs) reads and writes this format using
-//! helpers in the edk2 submodule. When a variable is updated, the old record
+//! The optional [`Edk2VarStore`] backend reads and writes this format using
+//! helpers in the `edk2` submodule. When a variable is updated, the old record
 //! is marked as deleted and a new record is appended. When the store is full,
 //! compaction erases the region and rewrites only active variables.
 //!
-//! # Dual-Storage Mode
+//! # Runtime writes
 //!
-//! - **Before ExitBootServices**: Write directly to SPI flash (EDK2 FV format)
-//! - **After ExitBootServices**: SPI is locked; queue to deferred buffer in RAM
-//! - **On Reset**: Deferred buffer is read, changes applied to SPI flash
+//! - **Before ExitBootServices**: Write directly through the configured backend.
+//! - **After ExitBootServices**: Runtime-capable backends are called directly;
+//!   other backends queue changes to the deferred buffer.
+//! - **On Reset**: Deferred records are replayed through the configured backend.
 //!
 //! # Deferred Buffer (in-memory, transient)
 //!
 //! The deferred module uses postcard-serialized `VariableRecord`s in a RAM
-//! buffer. This is an internal format that never touches flash — it bridges
-//! variable writes across warm reboots when SPI is locked.
+//! buffer. This is an internal format that never touches persistent storage —
+//! it bridges variable writes across warm reboots when the backend is not
+//! runtime-capable.
 
 pub mod deferred;
 pub mod edk2;

--- a/src/efi/varstore/mod.rs
+++ b/src/efi/varstore/mod.rs
@@ -49,8 +49,9 @@ pub mod edk2_backend;
 pub mod persistence;
 pub mod storage;
 
-// Re-export storage types
-pub use storage::{SpiStorageBackend, StorageBackend, StorageError};
+// Re-export storage types used with Edk2VarStore.
+pub use crate::platform::{StorageBackend, StorageError};
+pub use storage::SpiStorageBackend;
 
 // Re-export the EDK2 variable backend for use by platforms with raw flash
 pub use edk2_backend::Edk2VarStore;

--- a/src/efi/varstore/persistence.rs
+++ b/src/efi/varstore/persistence.rs
@@ -1,461 +1,116 @@
 //! Variable Store Persistence Layer
 //!
-//! This module handles persisting UEFI variables to storage (SPI flash, etc.)
-//! and ESP files. It bridges the in-memory variable storage in
-//! `state::EfiState::variables` with persistent storage.
+//! This module bridges CrabEFI's in-memory EFI variable cache with a
+//! platform-provided [`crate::platform::VariableBackend`].  The core library
+//! never probes chipset flash, coreboot tables, FMAP, SMMSTORE, TF-A, or SMM
+//! services directly; those details belong to the integration layer that
+//! implements the backend trait.
 //!
-//! # Storage Format
+//! # Lifecycle
 //!
-//! Variables are stored in EDK2-compatible Firmware Volume (FV) format,
-//! matching what coreboot's `get_uint_option()` and `set_uint_option()` expect.
-//! This replaces the previous CRAB/postcard format which was incompatible
-//! with coreboot's SMMSTORE reader.
-//!
-//! # Storage Strategy
-//!
-//! - **Before ExitBootServices**: Variables are written to storage (SPI flash)
-//! - **After ExitBootServices**: Storage may be locked; variables are queued for ESP file
-//! - **On Reset**: ESP file is read, authenticated, applied to storage, then deleted
-//!
-//! # Persistent Config Region
-//!
-//! The location of the variable store region is determined at runtime from:
-//! 1. Coreboot tables (SMMSTORE v2 record)
-//! 2. FMAP (SMMSTORE region)
+//! - During initialization, [`init`] asks the backend to enumerate persisted
+//!   variables and imports them into `state::EfiState::variables`.
+//! - Before `ExitBootServices`, non-volatile writes are passed to the backend.
+//! - After `ExitBootServices`, writes go directly to runtime-capable backends
+//!   and otherwise are queued in the deferred warm-reboot buffer.
+//! - On the next boot, deferred records are replayed through the same backend
+//!   abstraction.
 
-use alloc::vec::Vec;
-
-use crate::coreboot;
-use crate::drivers::spi::{self, SpiController};
+use crate::platform::{VarBackendError, VariableVisitor};
 use crate::state::{self, MAX_VARIABLE_DATA_SIZE, MAX_VARIABLE_NAME_LEN};
 
 use super::VarStoreError;
-use super::edk2;
-use super::storage::{SpiStorageBackend, StorageBackend};
 
-/// Default variable store base address in SPI flash
-/// This is typically at the end of the flash region
-/// Used only as fallback if coreboot tables don't provide config info
-pub const DEFAULT_VARSTORE_BASE: u32 = 0x00F00000; // 15MB offset (for 16MB flash)
-
-/// Default variable store size (256KB)
-/// Used only as fallback if coreboot tables don't provide config info
-pub const DEFAULT_VARSTORE_SIZE: u32 = 256 * 1024;
-
-/// Initialize the variable store persistence layer
+/// Initialize the variable store persistence layer.
 ///
-/// This should be called early in boot to:
-/// 1. Detect and initialize the storage backend (SPI controller)
-/// 2. Check for persistent config region from coreboot tables or FMAP
-/// 3. Read existing variables from storage
-/// 4. Load them into the in-memory variable cache
+/// This loads variables from the platform-provided
+/// [`crate::platform::VariableBackend`] into CrabEFI's in-memory variable cache.
+/// Hardware discovery is the platform integration's responsibility; library
+/// initialization never probes platform-specific storage.
 pub fn init() -> Result<(), VarStoreError> {
     log::info!("Initializing variable store persistence...");
 
-    // Detect SPI controller first (we need it for FMAP parsing)
-    let controller = match spi::detect_and_init() {
-        Some(c) => c,
-        None => {
-            log::warn!("No SPI controller found - variables will not be persistent");
-            return Err(VarStoreError::NotInitialized);
-        }
-    };
-
-    log::info!("Storage backend: {}", controller.name());
-
-    // Create storage backend with default values (will be updated after config detection)
-    let mut backend =
-        SpiStorageBackend::new(controller, DEFAULT_VARSTORE_BASE, DEFAULT_VARSTORE_SIZE);
-
-    // Try to get persistent config region from multiple sources:
-    // 1. Coreboot tables (SMMSTORE v2 record)
-    // 2. FMAP in SPI flash
-    // 3. Fall back to defaults (DISABLED for safety)
-    let config_found =
-        configure_from_coreboot_tables(&mut backend) || configure_from_fmap(&mut backend);
-
-    if !config_found {
-        // DANGER: Using default base address without verification
-        // could overwrite boot code on small flash chips!
-        // For safety, we disable persistence if we can't find config info.
-        log::warn!(
-            "No persistent config region found in coreboot tables or FMAP - persistence DISABLED"
-        );
-        log::warn!("Variables will be lost on reboot. Add SMMSTORE region to your FMAP.");
-        return Err(VarStoreError::NotInitialized);
-    }
-
-    // Store the backend in global state
-    state::with_mut(|s| {
-        s.drivers.platform.storage = Some(backend);
-    });
-
-    // Initialize the variable store region
-    init_varstore()?;
-
-    // Load existing variables from storage into memory
-    load_variables_from_storage()?;
-
-    log::info!("Variable store persistence initialized");
-    Ok(())
-}
-
-/// Try to configure variable store from coreboot tables (SMMSTORE v2 record)
-///
-/// Returns true if configuration was found and applied.
-fn configure_from_coreboot_tables(backend: &mut SpiStorageBackend) -> bool {
-    if let Some(smmstore_info) = coreboot::get_smmstorev2() {
-        log::info!(
-            "Found SMMSTORE v2 in coreboot tables: {} blocks x {} KB at {:#x}",
-            smmstore_info.num_blocks,
-            smmstore_info.block_size / 1024,
-            smmstore_info.mmap_addr
-        );
-
-        // The mmap_addr is the memory-mapped address for read-only access
-        // For SPI flash writes, we need to convert to the flash offset
-        // Use the BIOS region from IFD to calculate the correct offset
-        let base_addr = calculate_spi_offset(smmstore_info.mmap_addr, backend.get_bios_region());
-        let size = smmstore_info.num_blocks * smmstore_info.block_size;
-
-        // Update the storage backend with the region location
-        backend.set_base_offset(base_addr);
-        backend.set_storage_size(size);
-
-        log::info!(
-            "Variable store configured: base={:#x}, size={} KB",
-            base_addr,
-            size / 1024
-        );
-        return true;
-    }
-
-    log::debug!("No SMMSTORE v2 record in coreboot tables");
-    false
-}
-
-/// Try to configure variable store from FMAP in SPI flash
-///
-/// This is a fallback when coreboot tables don't provide SMMSTORE v2 info.
-/// We read the FMAP structure from flash and look for the SMMSTORE region.
-///
-/// Returns true if configuration was found and applied.
-fn configure_from_fmap(backend: &mut SpiStorageBackend) -> bool {
-    use crate::coreboot::fmap;
-
-    log::info!("Looking for variable store region in FMAP...");
-
-    // Read FMAP from flash (uses boot_media_params if available, otherwise probes)
-    // Note: fmap::get_smmstore_from_fmap expects an AnySpiController, so we access
-    // the underlying controller directly
-    if let Some(region_info) = fmap::get_smmstore_from_fmap(backend.controller_mut()) {
-        log::info!(
-            "Found '{}' in FMAP: offset={:#x}, size={} KB",
-            region_info.name.as_str(),
-            region_info.offset,
-            region_info.size / 1024
-        );
-
-        // Update the storage backend with the region location
-        backend.set_base_offset(region_info.offset);
-        backend.set_storage_size(region_info.size);
-
-        log::info!(
-            "Variable store configured: base={:#x}, size={} KB",
-            region_info.offset,
-            region_info.size / 1024
-        );
-        return true;
-    }
-
-    log::debug!("Variable store region not found in FMAP");
-    false
-}
-
-/// Calculate SPI flash offset from memory-mapped address
-///
-/// Coreboot's SMMSTORE v2 provides a memory-mapped address for read-only access.
-/// We need to convert this to the SPI flash offset for write operations.
-///
-/// On x86 systems, the BIOS region of the flash is memory-mapped to end at 4GB
-/// (0x100000000). The `bios_region` parameter provides the base and limit of the
-/// BIOS region from the Intel Flash Descriptor (IFD), which allows us to calculate
-/// the correct offset.
-fn calculate_spi_offset(mmap_addr: u64, bios_region: Option<(u32, u32)>) -> u32 {
-    // If we have BIOS region info from IFD, use it for accurate calculation
-    if let Some((bios_base, bios_limit)) = bios_region {
-        let bios_size = (bios_limit - bios_base + 1) as u64;
-        // BIOS region is mapped to end at 4GB
-        let mmap_base = 0x1_0000_0000u64 - bios_size;
-
-        if mmap_addr >= mmap_base && mmap_addr < 0x1_0000_0000u64 {
-            // Calculate offset within BIOS region, then add BIOS base in flash
-            let offset_in_bios = (mmap_addr - mmap_base) as u32;
-            let flash_offset = bios_base + offset_in_bios;
-            log::debug!(
-                "SPI offset calculation: mmap_addr={:#x}, bios_base={:#x}, bios_size={:#x}, mmap_base={:#x}, flash_offset={:#x}",
-                mmap_addr,
-                bios_base,
-                bios_size,
-                mmap_base,
-                flash_offset
-            );
-            return flash_offset;
-        }
-    }
-
-    // Fallback: assume the address is in a standard memory-mapped range
-    // This is a heuristic based on common flash sizes
-    log::warn!("No BIOS region info available, using fallback address calculation");
-
-    if mmap_addr >= 0xFF000000 {
-        // Assume 16MB flash mapped at 0xFF000000
-        (mmap_addr - 0xFF000000) as u32
-    } else if mmap_addr >= 0xFE000000 {
-        // Assume 32MB flash mapped at 0xFE000000
-        (mmap_addr - 0xFE000000) as u32
-    } else if mmap_addr >= 0xFC000000 {
-        // Assume 64MB flash mapped at 0xFC000000
-        (mmap_addr - 0xFC000000) as u32
-    } else if mmap_addr == 0 {
-        // No address provided, use default
-        DEFAULT_VARSTORE_BASE
-    } else {
-        // Assume the address is already a flash offset
-        mmap_addr as u32
-    }
-}
-
-/// Initialize the variable store region
-///
-/// Reads the FV header to validate the region, or formats it if invalid.
-/// This uses EDK2 Firmware Volume format compatible with coreboot's SMMSTORE.
-fn init_varstore() -> Result<(), VarStoreError> {
-    // Read enough bytes for FV header + VS header
-    let header_size = edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH;
-    let mut header_bytes = [0u8; 128]; // Enough for FV + VS headers (100 bytes needed)
-    let storage_size = state::with_storage_mut(|storage| {
-        storage
-            .read(0, &mut header_bytes[..header_size])
-            .map_err(|_| VarStoreError::SpiError)?;
-        Ok::<u32, VarStoreError>(storage.size())
-    })
-    .ok_or(VarStoreError::NotInitialized)??;
-
-    // Log raw header bytes for debugging
-    log::debug!(
-        "Variable store header bytes: {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x}",
-        header_bytes[0],
-        header_bytes[1],
-        header_bytes[2],
-        header_bytes[3],
-        header_bytes[4],
-        header_bytes[5],
-        header_bytes[6],
-        header_bytes[7],
-        header_bytes[8],
-        header_bytes[9],
-        header_bytes[10],
-        header_bytes[11],
-        header_bytes[12],
-        header_bytes[13],
-        header_bytes[14],
-        header_bytes[15]
-    );
-
-    // Validate EDK2 FV header
-    let validation = edk2::validate_fv(&header_bytes[..header_size], storage_size);
-
-    if validation.valid {
-        log::info!(
-            "EDK2 FV found: auth_format={}, data_size={} KB",
-            validation.auth_format,
-            validation.data_size / 1024
-        );
-
-        // Store format info in varstore state
-        state::with_varstore_mut(|vs| {
-            vs.initialized = true;
-            vs.auth_format = validation.auth_format;
-            vs.data_size = validation.data_size;
-        });
-
-        // Find the write offset (first free byte)
-        let auth_format = validation.auth_format;
-        let data_size = validation.data_size;
-        let write_offset = state::with_storage_mut(|storage| {
-            let mut read_fn =
-                |offset: u32, buf: &mut [u8]| -> bool { storage.read(offset, buf).is_ok() };
-            edk2::find_write_offset(&mut read_fn, auth_format, data_size)
-        })
-        .ok_or(VarStoreError::NotInitialized)?;
-
-        state::with_varstore_mut(|vs| {
-            vs.write_offset = write_offset;
-        });
-
-        log::info!("Variable store write offset: {:#x}", write_offset);
+    if state::has_variable_backend() {
+        load_variables_from_platform_backend()?;
+        log::info!("Variable store persistence initialized");
         return Ok(());
     }
 
-    // FV header invalid or missing - format the store with EDK2 FV headers
+    log::info!("No platform variable backend configured - variables are volatile");
+    Err(VarStoreError::NotInitialized)
+}
+
+/// Visitor that imports variables from a [`crate::platform::VariableBackend`]
+/// into CrabEFI's in-memory EFI variable cache.
+struct MemoryVariableLoader {
+    loaded: usize,
+}
+
+impl VariableVisitor for MemoryVariableLoader {
+    fn visit(&mut self, name: &[u16], vendor: &r_efi::efi::Guid, attributes: u32, data: &[u8]) {
+        update_variable_in_memory(vendor, name, attributes, data);
+        self.loaded += 1;
+    }
+}
+
+/// Load persisted variables from the platform-provided backend.
+fn load_variables_from_platform_backend() -> Result<(), VarStoreError> {
+    let mut loader = MemoryVariableLoader { loaded: 0 };
+    state::with_variable_backend_mut(|backend| backend.load(&mut loader))
+        .ok_or(VarStoreError::NotInitialized)?
+        .map_err(var_backend_error_to_varstore)?;
     log::info!(
-        "Formatting variable store as EDK2 FV (size {} KB)...",
-        storage_size / 1024
+        "Loaded {} variables from platform variable backend",
+        loader.loaded
     );
-
-    // Build EDK2 FV + VS headers
-    let fv_headers = edk2::build_fv_headers(storage_size);
-
-    // Try to enable writes, erase, and write headers
-    state::with_storage_mut(|storage| {
-        if let Err(e) = storage.enable_writes() {
-            log::warn!("Could not enable storage writes: {:?}", e);
-            // Continue anyway - the erase/write will fail if truly locked
-        }
-
-        // Erase the region
-        storage
-            .erase(0, storage_size)
-            .map_err(|_| VarStoreError::SpiError)?;
-
-        // Write new FV + VS headers
-        storage
-            .write(0, &fv_headers)
-            .map_err(|_| VarStoreError::SpiError)?;
-
-        Ok::<(), VarStoreError>(())
-    })
-    .ok_or(VarStoreError::NotInitialized)??;
-
-    // Non-auth format (we always create non-auth stores)
-    let data_size = storage_size - edk2::FV_HEADER_LENGTH as u32 - edk2::VS_HEADER_LENGTH as u32;
-
-    state::with_varstore_mut(|vs| {
-        vs.initialized = true;
-        vs.auth_format = false;
-        vs.data_size = data_size;
-        vs.write_offset = edk2::VARIABLE_DATA_OFFSET;
-    });
-
-    log::info!("Variable store formatted as EDK2 FV successfully");
     Ok(())
 }
 
-/// Load variables from storage into the in-memory cache
-fn load_variables_from_storage() -> Result<(), VarStoreError> {
-    let vs = state::varstore();
-    if !vs.initialized {
-        return Err(VarStoreError::NotInitialized);
+fn var_backend_error_to_varstore(error: VarBackendError) -> VarStoreError {
+    match error {
+        VarBackendError::NotAvailable => VarStoreError::NotInitialized,
+        VarBackendError::StoreFull => VarStoreError::StoreFull,
+        VarBackendError::IoError => VarStoreError::SpiError,
+        VarBackendError::Locked => VarStoreError::Locked,
+        VarBackendError::NotFound => VarStoreError::NotFound,
+        VarBackendError::DataTooLarge => VarStoreError::DataTooLarge,
+        VarBackendError::NameTooLong => VarStoreError::NameTooLong,
+        VarBackendError::Other => VarStoreError::InvalidArgument,
     }
-    let auth_format = vs.auth_format;
-    let data_size = vs.data_size;
-
-    // Walk all variable records in the FV
-    let vars = state::with_storage_mut(|storage| {
-        let mut read_fn =
-            |offset: u32, buf: &mut [u8]| -> bool { storage.read(offset, buf).is_ok() };
-        edk2::walk_variables(&mut read_fn, auth_format, data_size)
-    })
-    .ok_or(VarStoreError::NotInitialized)?;
-
-    // Filter to only VAR_ADDED records and deduplicate (keep latest)
-    // Build a list of active variables
-    let mut active_vars: Vec<&edk2::FvVariable> = Vec::new();
-    for var in &vars {
-        if !edk2::is_var_added(var.state) {
-            continue;
-        }
-        // Remove any existing entry with same GUID + name
-        active_vars.retain(|existing| {
-            !(existing.guid == var.guid && edk2::name_matches(&existing.name, &var.name))
-        });
-        active_vars.push(var);
-    }
-
-    // Load active variables into in-memory cache
-    state::with_efi_mut(|efi| {
-        for var in &active_vars {
-            // Find a free slot
-            if let Some(slot) = efi.variables.iter_mut().find(|v| !v.in_use) {
-                // Copy name (UTF-16, strip trailing null for the fixed-size buffer)
-                let name_len = var.name.len().min(MAX_VARIABLE_NAME_LEN);
-                slot.name[..name_len].copy_from_slice(&var.name[..name_len]);
-                if name_len < MAX_VARIABLE_NAME_LEN {
-                    slot.name[name_len..].fill(0);
-                }
-
-                // Convert GUID bytes to r_efi::efi::Guid
-                slot.vendor_guid = guid_bytes_to_efi(&var.guid);
-                slot.attributes = var.attributes;
-
-                let data_len = var.data.len().min(MAX_VARIABLE_DATA_SIZE);
-                slot.data[..data_len].copy_from_slice(&var.data[..data_len]);
-                slot.data_size = data_len;
-                slot.in_use = true;
-
-                // Log the loaded variable name
-                let name_str: Vec<u8> = var
-                    .name
-                    .iter()
-                    .take_while(|&&c| c != 0)
-                    .map(|&c| c as u8)
-                    .collect();
-                log::debug!("Loaded variable: {:?}", core::str::from_utf8(&name_str));
-            } else {
-                log::warn!("No free variable slots - some variables may be lost");
-                break;
-            }
-        }
-    });
-
-    log::info!("Loaded {} variables from storage", active_vars.len());
-    Ok(())
 }
 
-/// Get the timestamp of a stored variable
+/// Get the timestamp of a stored variable.
 ///
-/// EDK2 non-auth format does not store timestamps. Auth format embeds them
-/// in the header, but we don't currently parse them during walk.
-/// Returns None for all records in the current implementation.
+/// The generic backend trait currently persists variable payloads only. EDK2
+/// non-auth format does not store timestamps, and authenticated timestamps are
+/// preserved only while records are queued in the deferred buffer.
 pub fn get_variable_timestamp(
     _guid: &r_efi::efi::Guid,
     _name: &[u16],
 ) -> Option<super::SerializedTime> {
-    // EDK2 non-auth format has no timestamps.
-    // Auth format timestamps could be extracted but we currently write non-auth.
     None
 }
 
-/// Persist a variable to storage
+/// Persist a variable.
 ///
-/// Before ExitBootServices: writes to storage directly
-/// After ExitBootServices: queues write for deferred processing on next boot
+/// Before `ExitBootServices`, this calls the platform backend directly. After
+/// `ExitBootServices`, runtime-capable backends are still called directly;
+/// other backends receive the write on the next boot through the deferred
+/// buffer.
 pub fn persist_variable(
     guid: &r_efi::efi::Guid,
     name: &[u16],
     attributes: u32,
     data: &[u8],
 ) -> Result<(), VarStoreError> {
-    if state::is_exit_boot_services_called() {
-        // After ExitBootServices - queue for deferred processing
-        queue_variable_for_deferred(guid, name, attributes, data)
-    } else {
-        // Before ExitBootServices - write to storage
-        write_variable_to_storage_internal(guid, name, attributes, data)
+    if !state::has_variable_backend() {
+        return Err(VarStoreError::NotInitialized);
     }
+
+    persist_variable_via_platform_backend(guid, name, attributes, data)
 }
 
-/// Persist a variable to storage with a specific timestamp
-///
-/// This version preserves the authenticated variable timestamp for proper
-/// monotonic timestamp validation on subsequent updates.
-///
-/// Note: In EDK2 non-auth format (which we write), timestamps are not stored
-/// on disk. The timestamp is only preserved in the deferred write path.
-///
-/// Before ExitBootServices: writes to storage directly
-/// After ExitBootServices: queues write for deferred processing on next boot
+/// Persist a variable while preserving a deferred authenticated timestamp.
 pub fn persist_variable_with_timestamp(
     guid: &r_efi::efi::Guid,
     name: &[u16],
@@ -463,171 +118,49 @@ pub fn persist_variable_with_timestamp(
     data: &[u8],
     _timestamp: super::SerializedTime,
 ) -> Result<(), VarStoreError> {
-    if state::is_exit_boot_services_called() {
-        // After ExitBootServices - queue for deferred processing
-        queue_variable_for_deferred(guid, name, attributes, data)
-    } else {
-        // Before ExitBootServices - write to storage
-        // Note: non-auth EDK2 format doesn't store timestamps on disk
-        write_variable_to_storage_internal(guid, name, attributes, data)
-    }
+    persist_variable(guid, name, attributes, data)
 }
 
-/// Delete a variable from storage
+/// Delete a persisted variable.
 pub fn delete_variable(guid: &r_efi::efi::Guid, name: &[u16]) -> Result<(), VarStoreError> {
-    if state::is_exit_boot_services_called() {
-        // After ExitBootServices - queue deletion for deferred processing
-        queue_variable_deletion_for_deferred(guid, name)
-    } else {
-        // Before ExitBootServices - mark deleted in storage
-        write_variable_deletion_internal(guid, name)
+    if !state::has_variable_backend() {
+        return Err(VarStoreError::NotInitialized);
     }
+
+    delete_variable_via_platform_backend(guid, name)
 }
 
-/// Write a variable to storage using EDK2 FV format
-///
-/// This is the internal function that actually writes to storage.
-/// It's exposed to the deferred module for applying queued changes.
-///
-/// Steps:
-/// 1. Walk existing records to find and delete any old version
-/// 2. Append new record at write_offset using multi-stage protocol
-/// 3. If store is full, compact and retry
-pub(super) fn write_variable_to_storage_internal(
+/// Persist a variable through the platform-provided backend.
+fn persist_variable_via_platform_backend(
     guid: &r_efi::efi::Guid,
     name: &[u16],
     attributes: u32,
     data: &[u8],
 ) -> Result<(), VarStoreError> {
-    let vs = state::varstore();
-    if !vs.initialized {
-        return Err(VarStoreError::NotInitialized);
+    if state::is_exit_boot_services_called() && !state::variable_backend_runtime_capable() {
+        return queue_variable_for_deferred(guid, name, attributes, data);
     }
 
-    let guid_bytes = edk2::guid_to_bytes(guid);
-
-    // First, mark any existing record with same GUID+name as deleted
-    delete_existing_record(&guid_bytes, name)?;
-
-    // Check if we have space for the new record
-    let record = edk2::build_variable_record(&guid_bytes, name, attributes, data);
-    let record_len = record.len() as u32;
-
-    let vs = state::varstore();
-    let storage_size =
-        state::with_storage_mut(|s| s.size()).ok_or(VarStoreError::NotInitialized)?;
-
-    if vs.write_offset + record_len > storage_size {
-        log::info!("Variable store full, triggering compaction");
-        compact_varstore()?;
-    }
-
-    let vs = state::varstore();
-    if vs.write_offset + record_len > storage_size {
-        log::error!("Variable store still full after compaction");
-        return Err(VarStoreError::StoreFull);
-    }
-
-    let write_offset = vs.write_offset;
-
-    // Write the new record using multi-stage protocol
-    let new_offset = state::with_storage_mut(|storage| {
-        if let Err(e) = storage.enable_writes() {
-            log::warn!("Could not enable storage writes: {:?}", e);
-        }
-        let mut write_fn =
-            |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
-        edk2::write_variable(
-            &mut write_fn,
-            write_offset,
-            &guid_bytes,
-            name,
-            attributes,
-            data,
-        )
-    })
-    .ok_or(VarStoreError::NotInitialized)?
-    .ok_or(VarStoreError::SpiError)?;
-
-    state::with_varstore_mut(|vs| {
-        vs.write_offset = new_offset;
-    });
-
-    log::debug!("Variable persisted at offset {:#x}", write_offset);
-    Ok(())
+    state::with_variable_backend_mut(|backend| backend.write(name, guid, attributes, data))
+        .ok_or(VarStoreError::NotInitialized)?
+        .map_err(var_backend_error_to_varstore)
 }
 
-/// Delete a variable from storage by marking its record as deleted
-///
-/// This is the internal function that actually writes the deletion.
-/// It's exposed to the deferred module for applying queued changes.
-pub(super) fn write_variable_deletion_internal(
+/// Delete a variable through the platform-provided backend.
+fn delete_variable_via_platform_backend(
     guid: &r_efi::efi::Guid,
     name: &[u16],
 ) -> Result<(), VarStoreError> {
-    let vs = state::varstore();
-    if !vs.initialized {
-        return Err(VarStoreError::NotInitialized);
+    if state::is_exit_boot_services_called() && !state::variable_backend_runtime_capable() {
+        return queue_variable_deletion_for_deferred(guid, name);
     }
 
-    let guid_bytes = edk2::guid_to_bytes(guid);
-    delete_existing_record(&guid_bytes, name)
+    state::with_variable_backend_mut(|backend| backend.delete(name, guid))
+        .ok_or(VarStoreError::NotInitialized)?
+        .map_err(var_backend_error_to_varstore)
 }
 
-/// Find and mark as deleted any existing record with the given GUID+name
-fn delete_existing_record(guid_bytes: &[u8; 16], name: &[u16]) -> Result<(), VarStoreError> {
-    let vs = state::varstore();
-    let auth_format = vs.auth_format;
-    let data_size = vs.data_size;
-
-    // Walk all records to find matching ones
-    let vars = state::with_storage_mut(|storage| {
-        let mut read_fn =
-            |offset: u32, buf: &mut [u8]| -> bool { storage.read(offset, buf).is_ok() };
-        edk2::walk_variables(&mut read_fn, auth_format, data_size)
-    })
-    .ok_or(VarStoreError::NotInitialized)?;
-
-    // Find and delete matching VAR_ADDED records
-    for var in &vars {
-        if edk2::is_var_added(var.state)
-            && var.guid == *guid_bytes
-            && edk2::name_matches(&var.name, name)
-        {
-            // Mark as deleted by writing to the state byte
-            let deleted = state::with_storage_mut(|storage| {
-                if let Err(e) = storage.enable_writes() {
-                    log::warn!("Could not enable storage writes: {:?}", e);
-                }
-                let mut write_fn =
-                    |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
-                edk2::mark_deleted(&mut write_fn, var.state_offset)
-            })
-            .ok_or(VarStoreError::NotInitialized)?;
-
-            if !deleted {
-                log::warn!(
-                    "Failed to mark variable as deleted at state_offset {:#x}",
-                    var.state_offset
-                );
-                return Err(VarStoreError::SpiError);
-            }
-
-            log::debug!(
-                "Marked existing variable as deleted at state_offset {:#x}",
-                var.state_offset
-            );
-        }
-    }
-
-    Ok(())
-}
-
-/// Queue a variable write for deferred processing (after ExitBootServices)
-///
-/// When storage is locked, variable changes are stored in a reserved memory
-/// region that survives warm reboot. On next boot, these changes are
-/// applied to storage.
+/// Queue a variable write for deferred processing after `ExitBootServices`.
 fn queue_variable_for_deferred(
     guid: &r_efi::efi::Guid,
     name: &[u16],
@@ -639,7 +172,7 @@ fn queue_variable_for_deferred(
     Ok(())
 }
 
-/// Queue a variable deletion for deferred processing (after ExitBootServices)
+/// Queue a variable deletion for deferred processing after `ExitBootServices`.
 fn queue_variable_deletion_for_deferred(
     guid: &r_efi::efi::Guid,
     name: &[u16],
@@ -649,160 +182,43 @@ fn queue_variable_deletion_for_deferred(
     Ok(())
 }
 
-/// Check if storage backend is available
+/// Check if a persistent variable backend is available.
 pub fn is_storage_available() -> bool {
-    state::with_storage_mut(|_| ()).is_some()
+    state::has_variable_backend()
 }
 
-/// Check if variable store is initialized
+/// Check if variable persistence is configured.
 pub fn is_varstore_initialized() -> bool {
-    state::varstore().initialized
+    state::has_variable_backend()
 }
 
-/// Get variable store statistics
+/// Get variable store statistics.
 ///
-/// Returns (base_offset, size, write_offset)
+/// The generic [`crate::platform::VariableBackend`] trait intentionally does
+/// not require capacity reporting. Backends that can report detailed capacity
+/// should expose that through a backend-specific diagnostic interface.
 pub fn get_varstore_stats() -> Option<(u32, u32, u32)> {
-    let vs = state::varstore();
-    let (base, size) = state::with_storage_mut(|s| (s.base_offset(), s.size()))?;
-    Some((base, size, vs.write_offset))
+    None
 }
 
-/// Compact the variable store by rewriting only active variables
+/// Compact the variable store.
 ///
-/// This is called when the store is full. It:
-/// 1. Reads all active variables from storage into memory
-/// 2. Erases the entire region
-/// 3. Writes fresh EDK2 FV + VS headers
-/// 4. Rewrites all active variables
-///
-/// Returns the number of bytes reclaimed.
+/// Compaction is backend-specific. The built-in EDK2 FV backend compacts
+/// automatically when a write does not fit.
 pub fn compact_varstore() -> Result<u32, VarStoreError> {
-    log::info!("Compacting variable store...");
-
-    let vs = state::varstore();
-    if !vs.initialized {
-        return Err(VarStoreError::NotInitialized);
-    }
-
-    let old_write_offset = vs.write_offset;
-    let auth_format = vs.auth_format;
-    let data_size = vs.data_size;
-    let size = state::with_storage_mut(|s| s.size()).ok_or(VarStoreError::NotInitialized)?;
-
-    // Step 1: Collect all active variable records
-    let vars = state::with_storage_mut(|storage| {
-        let mut read_fn =
-            |offset: u32, buf: &mut [u8]| -> bool { storage.read(offset, buf).is_ok() };
-        edk2::walk_variables(&mut read_fn, auth_format, data_size)
-    })
-    .ok_or(VarStoreError::NotInitialized)?;
-
-    // Keep only VAR_ADDED records, deduplicated (latest wins)
-    let mut active_vars: Vec<edk2::FvVariable> = Vec::new();
-    for var in vars {
-        if !edk2::is_var_added(var.state) {
-            continue;
-        }
-        active_vars.retain(|existing| {
-            !(existing.guid == var.guid && edk2::name_matches(&existing.name, &var.name))
-        });
-        active_vars.push(var);
-    }
-
-    log::info!(
-        "Found {} active variables to preserve during compaction",
-        active_vars.len()
-    );
-
-    // Step 2: Enable writes and erase the region
-    // Step 3: Write fresh EDK2 FV + VS headers
-    let fv_headers = edk2::build_fv_headers(size);
-
-    state::with_storage_mut(|storage| {
-        if let Err(e) = storage.enable_writes() {
-            log::warn!("Could not enable storage writes for compaction: {:?}", e);
-        }
-
-        storage
-            .erase(0, size)
-            .map_err(|_| VarStoreError::SpiError)?;
-
-        storage
-            .write(0, &fv_headers)
-            .map_err(|_| VarStoreError::SpiError)?;
-
-        Ok::<(), VarStoreError>(())
-    })
-    .ok_or(VarStoreError::NotInitialized)??;
-
-    // Step 4: Rewrite all active variables
-    let mut new_offset = edk2::VARIABLE_DATA_OFFSET;
-
-    for var in &active_vars {
-        // Check if we have space
-        let record = edk2::build_variable_record(&var.guid, &var.name, var.attributes, &var.data);
-        if new_offset + record.len() as u32 > size {
-            log::error!("Variable store full even after compaction - data loss!");
-            state::with_varstore_mut(|vs| vs.write_offset = new_offset);
-            return Err(VarStoreError::StoreFull);
-        }
-
-        let result = state::with_storage_mut(|storage| {
-            let mut write_fn =
-                |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
-            edk2::write_variable(
-                &mut write_fn,
-                new_offset,
-                &var.guid,
-                &var.name,
-                var.attributes,
-                &var.data,
-            )
-        })
-        .ok_or(VarStoreError::NotInitialized)?;
-
-        match result {
-            Some(next_offset) => {
-                new_offset = next_offset;
-            }
-            None => {
-                log::error!("Failed to write variable during compaction");
-                return Err(VarStoreError::SpiError);
-            }
-        }
-    }
-
-    // Update varstore state (non-auth format since we wrote fresh headers)
-    let new_data_size = size - edk2::FV_HEADER_LENGTH as u32 - edk2::VS_HEADER_LENGTH as u32;
-    state::with_varstore_mut(|vs| {
-        vs.write_offset = new_offset;
-        vs.auth_format = false;
-        vs.data_size = new_data_size;
-    });
-
-    let reclaimed = old_write_offset - new_offset;
-    log::info!(
-        "Variable store compaction complete: reclaimed {} bytes, new write offset {:#x}",
-        reclaimed,
-        new_offset
-    );
-
-    Ok(reclaimed)
+    Err(VarStoreError::NotInitialized)
 }
 
-/// Update a variable in the in-memory cache
+/// Update a variable in the in-memory cache.
 ///
-/// This is used when applying deferred variable changes on boot,
-/// or when directly updating a variable without going through SetVariable.
+/// This is used when loading variables from a backend or applying deferred
+/// variable changes on boot.
 pub fn update_variable_in_memory(
     guid: &r_efi::efi::Guid,
     name: &[u16],
     attributes: u32,
     data: &[u8],
 ) {
-    use crate::state::{self, MAX_VARIABLE_DATA_SIZE, MAX_VARIABLE_NAME_LEN};
-
     state::with_efi_mut(|efi| {
         // Find existing or free slot
         let existing_idx = efi.variables.iter().position(|var| {
@@ -838,12 +254,10 @@ pub fn update_variable_in_memory(
     });
 }
 
-/// Delete a variable from the in-memory cache
+/// Delete a variable from the in-memory cache.
 ///
 /// This is used when applying deferred variable deletions on boot.
 pub(super) fn delete_variable_from_memory(guid: &r_efi::efi::Guid, name: &[u16]) {
-    use crate::state;
-
     state::with_efi_mut(|efi| {
         if let Some(var) = efi.variables.iter_mut().find(|var| {
             var.in_use && var.vendor_guid == *guid && crate::efi::utils::ucs2_eq(&var.name, name)
@@ -852,23 +266,3 @@ pub(super) fn delete_variable_from_memory(guid: &r_efi::efi::Guid, name: &[u16])
         }
     });
 }
-
-// ============================================================================
-// Helper functions
-// ============================================================================
-
-/// Convert 16-byte on-disk GUID to r_efi::efi::Guid
-fn guid_bytes_to_efi(bytes: &[u8; 16]) -> r_efi::efi::Guid {
-    r_efi::efi::Guid::from_fields(
-        u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
-        u16::from_le_bytes([bytes[4], bytes[5]]),
-        u16::from_le_bytes([bytes[6], bytes[7]]),
-        bytes[8],
-        bytes[9],
-        &[
-            bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
-        ],
-    )
-}
-
-// name_eq_slice consolidated into crate::efi::utils::ucs2_eq

--- a/src/efi/varstore/storage.rs
+++ b/src/efi/varstore/storage.rs
@@ -286,6 +286,60 @@ impl StorageBackend for SpiStorageBackend {
     }
 }
 
+fn map_storage_error(error: StorageError) -> crate::platform::StorageError {
+    match error {
+        StorageError::NotInitialized => crate::platform::StorageError::NotInitialized,
+        StorageError::WriteProtected => crate::platform::StorageError::WriteProtected,
+        StorageError::AccessDenied => crate::platform::StorageError::AccessDenied,
+        StorageError::Timeout => crate::platform::StorageError::Timeout,
+        StorageError::InvalidArgument => crate::platform::StorageError::InvalidArgument,
+        StorageError::IoError => crate::platform::StorageError::IoError,
+        StorageError::NotSupported => crate::platform::StorageError::NotSupported,
+    }
+}
+
+impl crate::platform::StorageBackend for SpiStorageBackend {
+    fn name(&self) -> &str {
+        <Self as StorageBackend>::name(self)
+    }
+
+    fn size(&self) -> u32 {
+        <Self as StorageBackend>::size(self)
+    }
+
+    fn is_write_protected(&self) -> bool {
+        <Self as StorageBackend>::is_write_protected(self)
+    }
+
+    fn enable_writes(&mut self) -> core::result::Result<(), crate::platform::StorageError> {
+        <Self as StorageBackend>::enable_writes(self).map_err(map_storage_error)
+    }
+
+    fn read(
+        &mut self,
+        offset: u32,
+        buffer: &mut [u8],
+    ) -> core::result::Result<(), crate::platform::StorageError> {
+        <Self as StorageBackend>::read(self, offset, buffer).map_err(map_storage_error)
+    }
+
+    fn write(
+        &mut self,
+        offset: u32,
+        data: &[u8],
+    ) -> core::result::Result<(), crate::platform::StorageError> {
+        <Self as StorageBackend>::write(self, offset, data).map_err(map_storage_error)
+    }
+
+    fn erase(
+        &mut self,
+        offset: u32,
+        size: u32,
+    ) -> core::result::Result<(), crate::platform::StorageError> {
+        <Self as StorageBackend>::erase(self, offset, size).map_err(map_storage_error)
+    }
+}
+
 /// Memory-backed storage backend for testing
 ///
 /// This backend stores data in memory, simulating flash behavior:
@@ -330,19 +384,19 @@ impl MemoryBackend {
 
     /// Get a reference to the underlying data
     pub fn data(&self) -> &[u8] {
-        &self.data
+        self.data.as_slice()
     }
 
     /// Get a mutable reference to the underlying data (bypasses flash semantics)
     pub fn data_mut(&mut self) -> &mut [u8] {
-        &mut self.data
+        self.data.as_mut_slice()
     }
 }
 
 #[cfg(test)]
 impl StorageBackend for MemoryBackend {
     fn name(&self) -> &str {
-        &self.name
+        self.name.as_str()
     }
 
     fn size(&self) -> u32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,8 +198,8 @@ fn init_persistence_and_boot() -> ! {
 /// ```
 pub fn init_platform(config: PlatformConfig) -> ! {
     if state::is_initialized() {
-        // Caller pre-initialized state (e.g., coreboot payload storing
-        // SMMSTORE/SPI/CBMEM info before calling us). Their FirmwareState
+        // Caller pre-initialized state (e.g., an integration crate storing
+        // platform metadata before calling us). Their FirmwareState
         // lives on a -> ! frame so it outlives us.
         init_platform_impl(config)
     } else {
@@ -288,13 +288,36 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
         env!("CARGO_PKG_VERSION")
     );
 
-    // ---- 4. Store ACPI RSDP in driver state ----
+    // ---- 4. Store platform variable backend in driver state ----
+    //
+    // The backend is supplied by the integration layer (coreboot payload,
+    // fstart, TF-A/MM, tests, ...).  Keep it in state before the shared boot
+    // tail so init_persistence_and_boot() can load variables without probing
+    // platform-specific hardware from the library core.
+    if let Some(ref mut var_backend) = config.variable_backend {
+        let runtime_capable = var_backend.runtime_capable();
+        // SAFETY: init_platform() is -> ! (never returns). The caller's stack
+        // frame — where the VariableBackend lives — is never unwound, so the
+        // erased-lifetime trait object pointer remains valid for the firmware
+        // lifetime.
+        let raw: *mut dyn crate::platform::VariableBackend = unsafe {
+            core::mem::transmute::<
+                &mut dyn crate::platform::VariableBackend,
+                *mut dyn crate::platform::VariableBackend,
+            >(*var_backend)
+        };
+        unsafe {
+            state::set_variable_backend_raw(raw, runtime_capable);
+        }
+    }
+
+    // ---- 5. Store ACPI RSDP in driver state ----
     if let Some(rsdp) = config.acpi_rsdp {
         state::with_drivers_mut(|d| d.platform.acpi_rsdp = Some(rsdp));
         log::info!("ACPI RSDP: {:#x}", rsdp);
     }
 
-    // ---- 5. Parse FDT if provided ----
+    // ---- 6. Parse FDT if provided ----
     //
     // Must happen before efi::init_from_platform() which uses fdt_info for
     // MMIO regions on aarch64 (GIC, PCIe windows, UART).
@@ -314,7 +337,7 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
         }
     }
 
-    // ---- 6. Initialize timing subsystem from platform timer ----
+    // ---- 7. Initialize timing subsystem from platform timer ----
     //
     // In library mode the platform-provided Timer is the source of truth.
     // This works on any architecture (x86, aarch64, riscv64) without
@@ -330,10 +353,10 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
         .sum();
     log::info!("Total RAM: {} MB", total_ram / (1024 * 1024));
 
-    // ---- 7. Initialize keyboard subsystem ----
+    // ---- 8. Initialize keyboard subsystem ----
     drivers::keyboard_common::init();
 
-    // ---- 8. Initialize EFI environment ----
+    // ---- 9. Initialize EFI environment ----
     //
     // Always runs — sets up the EFI memory map, system table, ACPI/SMBIOS
     // configuration tables, and runtime region reservations.  The page
@@ -352,7 +375,7 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
     log::info!("CrabEFI initialized successfully!");
     log::info!("EFI System Table at: {:p}", efi::get_system_table());
 
-    // ---- 9. Initialize heap ----
+    // ---- 10. Initialize heap ----
     //
     // Skipped when the platform already set up the heap before entry
     // (heap_pre_initialized == true).  The rest of the init sequence is
@@ -361,14 +384,14 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
         log::error!("Failed to initialize heap allocator!");
     }
 
-    // ---- 10. Runtime log support ----
+    // ---- 11. Runtime log support ----
     #[cfg(feature = "rt-log")]
     {
         efi::rtlog::register_region();
         efi::rtlog::dump();
     }
 
-    // ---- 11. Discover PCI ECAM and initialize PCI ----
+    // ---- 12. Discover PCI ECAM and initialize PCI ----
     //
     // Priority: config.ecam_base > acpi_info.ecam_base > fdt_info.ecam_base.
     // acpi_info is populated by the platform before entry (when
@@ -387,7 +410,7 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
 
     drivers::pci::init();
 
-    // ---- 12. Register deferred variable buffer if provided ----
+    // ---- 13. Register deferred variable buffer if provided ----
     if let Some(buf) = config.deferred_buffer {
         use efi::allocator::{MemoryType as AllocMemType, PAGE_SIZE};
         efi::varstore::deferred::configure_buffer_with_size(buf.base, buf.size);
@@ -451,7 +474,7 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
         }
     }
 
-    // ---- 13. Register platform block devices ----
+    // ---- 14. Register platform block devices ----
     if !config.block_devices.is_empty() {
         // SAFETY: init_platform() is -> !, so the block device references in
         // config.block_devices live forever.
@@ -460,11 +483,11 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
         }
     }
 
-    // ---- 14. Runtime log init ----
+    // ---- 15. Runtime log init ----
     #[cfg(feature = "rt-log")]
     efi::rtlog::init();
 
-    // ---- 15. Variable persistence, Secure Boot, and boot manager ----
+    // ---- 16. Variable persistence, Secure Boot, and boot manager ----
     init_persistence_and_boot();
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ pub fn display_secure_boot_error() {
 /// two entry points.
 fn init_persistence_and_boot() -> ! {
     // ---- Variable persistence ----
+    let mut clear_deferred_buffer = false;
     match efi::varstore::init_persistence() {
         Ok(()) => {
             log::info!("Variable store persistence initialized");
@@ -126,9 +127,14 @@ fn init_persistence_and_boot() -> ! {
                     pending_count
                 );
                 match efi::varstore::process_deferred_pending() {
-                    Ok(n) => log::info!("Applied {} deferred variable writes", n),
+                    Ok(n) => {
+                        log::info!("Applied {} deferred variable writes", n);
+                        clear_deferred_buffer = true;
+                    }
                     Err(e) => log::warn!("Failed to process deferred writes: {:?}", e),
                 }
+            } else {
+                clear_deferred_buffer = true;
             }
 
             match efi::auth::boot::init_secure_boot_default() {
@@ -142,10 +148,19 @@ fn init_persistence_and_boot() -> ! {
                 Err(e) => log::warn!("Secure Boot init failed: {:?}", e),
             }
         }
-        Err(e) => log::info!("Variable persistence not available: {:?}", e),
+        Err(e) => {
+            log::info!("Variable persistence not available: {:?}", e);
+            if efi::varstore::check_deferred_pending() == 0 {
+                clear_deferred_buffer = true;
+            } else {
+                log::warn!("Preserving pending deferred variable writes");
+            }
+        }
     }
 
-    efi::varstore::init_deferred_buffer();
+    if clear_deferred_buffer {
+        efi::varstore::init_deferred_buffer();
+    }
 
     // ---- Boot manager ----
     let boot_var_state = boot_vars::read_boot_var_state();
@@ -234,7 +249,11 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
     // during shim/GRUB execution would vector to address 0x0 (fstart's
     // _start), causing silent infinite loops instead of a diagnostic halt.
     //
-    // On x86_64: install the IDT for exception handling.
+    // On x86_64 library integrations, the calling firmware owns the CPU
+    // descriptor tables.  fstart's ramstage entry already runs on the
+    // linker-defined stack and installs the stage IDT before calling CrabEFI;
+    // do not replace it here.  That keeps exception handling, GDT/segments,
+    // and any IST/TSS policy under the stage's control.
     //
     // On riscv64 with platform-entry: stvec is set by entry assembly.
     // On riscv64 without platform-entry (library mode): the calling
@@ -245,8 +264,6 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
     unsafe {
         arch::aarch64::exceptions::install_exception_vectors_auto();
     }
-    #[cfg(target_arch = "x86_64")]
-    arch::x86_64::idt::init();
     #[cfg(target_arch = "riscv64")]
     arch::riscv64::trap::install_trap_vectors();
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -285,9 +285,9 @@ pub trait VariableVisitor {
 ///    when `ExitBootServices` succeeds. The backend can release resources or
 ///    adjust its strategy (e.g., direct-flash backends note that flash is now locked).
 ///
-/// 4. [`flush_deferred()`](Self::flush_deferred) — Called on the *next* boot
-///    (after `load()`) to commit any writes that were buffered during the
-///    previous boot's runtime phase. Only relevant for non-runtime-capable backends.
+/// Deferred writes from a previous boot are replayed by CrabEFI's deferred
+/// buffer code after [`load()`](Self::load), using [`write()`](Self::write) and
+/// [`delete()`](Self::delete) for each authenticated and validated record.
 ///
 /// # Example: SMM Backend
 ///
@@ -353,8 +353,11 @@ pub trait VariableBackend {
     ///
     /// - `true`: CrabEFI calls `write()`/`delete()` directly at runtime.
     ///   Suitable for SMM, TF-A MM, or any backend with a privileged agent.
+    ///   The backend object, its vtable, and any code/data it needs after
+    ///   `SetVirtualAddressMap` must reside in EFI runtime-mapped regions so
+    ///   CrabEFI can convert the trait-object pointer to virtual addresses.
     /// - `false` (default): CrabEFI buffers runtime writes in the deferred
-    ///   buffer and calls `flush_deferred()` on the next boot.
+    ///   buffer and replays them through `write()`/`delete()` on the next boot.
     fn runtime_capable(&self) -> bool {
         false
     }
@@ -364,36 +367,6 @@ pub trait VariableBackend {
     /// For direct-flash backends, this signals that flash may now be locked.
     /// For SMM/MM backends, this is typically a no-op.
     fn notify_exit_boot_services(&mut self) {}
-
-    /// Commit deferred writes from a previous boot.
-    ///
-    /// Called after `load()` on the next boot when the previous boot had
-    /// buffered runtime variable writes (because `runtime_capable()` was false).
-    ///
-    /// # Arguments
-    /// * `records` - Iterator of (name, vendor, attributes, data) for each
-    ///   deferred write. Empty data means delete.
-    ///
-    /// The default implementation calls `write()` or `delete()` for each record.
-    fn flush_deferred(
-        &mut self,
-        records: &mut dyn Iterator<Item = (&[u16], &Guid, u32, &[u8])>,
-    ) -> Result<usize, VarBackendError> {
-        let mut count = 0;
-        for (name, vendor, attrs, data) in records {
-            if data.is_empty() {
-                // Ignore NotFound for deletes — variable may not exist
-                match self.delete(name, vendor) {
-                    Ok(()) | Err(VarBackendError::NotFound) => {}
-                    Err(e) => return Err(e),
-                }
-            } else {
-                self.write(name, vendor, attrs, data)?;
-            }
-            count += 1;
-        }
-        Ok(count)
-    }
 }
 
 // ============================================================================
@@ -889,10 +862,10 @@ impl FramebufferConfig {
 /// 2. Is in a memory region marked as `RuntimeServicesData` so the OS
 ///    preserves the mapping after `ExitBootServices`.
 ///
-/// On the next boot, CrabEFI reads the buffer and commits the writes via
-/// [`VariableBackend::flush_deferred()`].
-///
-/// Not needed if the variable backend is runtime-capable (SMM, TF-A MM).
+/// On the next boot, CrabEFI reads the buffer and commits authenticated,
+/// validated records through [`VariableBackend::write`] and
+/// [`VariableBackend::delete`]. Not needed if the variable backend is
+/// runtime-capable (SMM, TF-A MM).
 #[derive(Debug, Clone, Copy)]
 pub struct DeferredBufferConfig {
     /// Physical base address of the buffer.

--- a/src/state.rs
+++ b/src/state.rs
@@ -608,8 +608,8 @@ impl Default for EfiState {
 // Driver State
 // ============================================================================
 
-use crate::drivers::pci::access::AnyPciAccess;
 use crate::drivers::pci::PciDevice;
+use crate::drivers::pci::access::AnyPciAccess;
 use crate::drivers::serial::AnySerial;
 use crate::drivers::storage::StorageRegistry;
 use crate::efi::protocols::serial_io::SerialIoMode;
@@ -1237,6 +1237,25 @@ pub fn variable_backend_runtime_capable() -> bool {
 #[inline]
 pub fn has_variable_backend() -> bool {
     try_get().is_some_and(|state| state.drivers.platform.variable_backend.is_some())
+}
+
+/// Get the raw platform variable backend trait object pointer.
+#[inline]
+pub fn variable_backend_raw() -> Option<*mut dyn crate::platform::VariableBackend> {
+    try_get().and_then(|state| state.drivers.platform.variable_backend)
+}
+
+/// Replace the raw platform variable backend trait object pointer.
+///
+/// # Safety
+///
+/// `raw` must point to the same backend object as the pointer originally passed
+/// to [`set_variable_backend_raw`], adjusted for the current address mode.
+#[inline]
+pub unsafe fn replace_variable_backend_raw(raw: *mut dyn crate::platform::VariableBackend) {
+    with_mut(|state| {
+        state.drivers.platform.variable_backend = Some(raw);
+    });
 }
 
 /// Access the platform-provided variable backend mutably through a closure.

--- a/src/state.rs
+++ b/src/state.rs
@@ -483,11 +483,10 @@ impl VariableEntry {
     }
 }
 
-/// Variable store persistence state
+/// Variable store persistence state.
 ///
-/// Tracks the runtime state of the persistent variable store region.
-/// The actual storage location is determined at runtime from coreboot
-/// tables (SMMSTORE v2) or FMAP (SMMSTORE region).
+/// Tracks runtime metadata for backends that use CrabEFI's EDK2 FV helper.
+/// Generic platform backends may keep their own metadata internally.
 #[derive(Clone, Copy)]
 pub struct VarStoreState {
     /// Whether the store header has been validated/written
@@ -542,7 +541,7 @@ pub struct EfiState {
     /// EFI variables
     pub variables: [VariableEntry; MAX_VARIABLES],
 
-    /// Variable store persistence state (SMMSTORE tracking)
+    /// Variable store persistence state
     pub varstore: VarStoreState,
 
     /// Memory allocator
@@ -609,8 +608,8 @@ impl Default for EfiState {
 // Driver State
 // ============================================================================
 
-use crate::drivers::pci::PciDevice;
 use crate::drivers::pci::access::AnyPciAccess;
+use crate::drivers::pci::PciDevice;
 use crate::drivers::serial::AnySerial;
 use crate::drivers::storage::StorageRegistry;
 use crate::efi::protocols::serial_io::SerialIoMode;
@@ -816,10 +815,10 @@ impl Default for TimingState {
 /// Platform hardware info sourced from coreboot tables or platform config.
 ///
 /// Shared fields (framebuffer, ACPI RSDP) are used by both integration paths.
-/// Coreboot-specific fields (SMMSTORE, SPI flash, FMAP, CBMEM) are only
-/// populated by the coreboot payload's `init()` path and remain `None`/zero
-/// in library mode. They should be gated behind a feature once the SPI
-/// variable persistence code is fully abstracted behind `VariableBackend`.
+/// Coreboot-specific metadata (SMMSTORE, SPI flash, FMAP, CBMEM) is only
+/// populated by the coreboot payload and remains `None`/zero in library mode.
+/// Generic services consume the platform-provided trait objects rather than
+/// probing those coreboot fields directly.
 pub struct PlatformInfo {
     /// Global framebuffer info
     pub framebuffer: Option<FramebufferConfig>,
@@ -838,12 +837,19 @@ pub struct PlatformInfo {
     /// Boot media params (FMAP location, etc.)
     pub boot_media: Option<crate::coreboot::BootMediaInfo>,
 
-    /// Storage backend for variable persistence (SPI flash).
+    /// Platform-provided EFI variable persistence backend.
     ///
-    /// Initialized during boot from detected SPI controller.
-    /// Handles offset translation so reads/writes are relative to
-    /// the variable store region.
-    pub storage: Option<crate::efi::varstore::SpiStorageBackend>,
+    /// Stored as a raw pointer because [`crate::init_platform()`] never
+    /// returns, so the platform-owned backend remains live for the full
+    /// firmware lifetime. Access it through [`with_variable_backend_mut`].
+    pub(crate) variable_backend: Option<*mut dyn crate::platform::VariableBackend>,
+
+    /// Whether the platform variable backend can be called after ExitBootServices.
+    ///
+    /// Cached in runtime-safe firmware state before ExitBootServices so
+    /// non-runtime backends do not need to be dereferenced from runtime
+    /// `SetVariable` calls merely to decide whether to defer writes.
+    pub(crate) variable_backend_runtime_capable: bool,
 
     /// Memory regions (for direct Linux boot)
     pub memory_regions: HeaplessVec<crate::coreboot::memory::MemoryRegion, MAX_MEMORY_REGIONS>,
@@ -863,7 +869,8 @@ impl PlatformInfo {
             smmstorev2: None,
             spi_flash: None,
             boot_media: None,
-            storage: None,
+            variable_backend: None,
+            variable_backend_runtime_capable: false,
             memory_regions: HeaplessVec::new(),
             acpi_rsdp: None,
             cbmem_console_addr: 0,
@@ -1202,15 +1209,52 @@ where
     with_mut(|state| state.efi.block_device.as_mut().map(f))
 }
 
-/// Access the storage backend mutably through a closure.
+/// Store the platform-provided variable backend raw pointer.
 ///
-/// Returns `None` if no storage backend is configured.
+/// # Safety
+///
+/// The pointer must remain valid for the entire firmware lifetime. This is
+/// satisfied by [`crate::init_platform()`], which never returns, when the
+/// backend is borrowed from the caller's non-returning stack frame.
 #[inline]
-pub fn with_storage_mut<F, R>(f: F) -> Option<R>
+pub unsafe fn set_variable_backend_raw(
+    raw: *mut dyn crate::platform::VariableBackend,
+    runtime_capable: bool,
+) {
+    with_mut(|state| {
+        state.drivers.platform.variable_backend = Some(raw);
+        state.drivers.platform.variable_backend_runtime_capable = runtime_capable;
+    });
+}
+
+/// Check whether the platform-provided variable backend is runtime-capable.
+#[inline]
+pub fn variable_backend_runtime_capable() -> bool {
+    try_get().is_some_and(|state| state.drivers.platform.variable_backend_runtime_capable)
+}
+
+/// Check whether a platform-provided variable backend is configured.
+#[inline]
+pub fn has_variable_backend() -> bool {
+    try_get().is_some_and(|state| state.drivers.platform.variable_backend.is_some())
+}
+
+/// Access the platform-provided variable backend mutably through a closure.
+///
+/// Returns `None` if no platform backend is configured. This intentionally
+/// fetches the raw pointer first and calls the closure after the immutable
+/// state borrow ends, so backend methods may update [`FirmwareState`] through
+/// the normal state helpers without tripping the re-entrancy guard.
+#[inline]
+pub fn with_variable_backend_mut<F, R>(f: F) -> Option<R>
 where
-    F: FnOnce(&mut crate::efi::varstore::SpiStorageBackend) -> R,
+    F: FnOnce(&mut dyn crate::platform::VariableBackend) -> R,
 {
-    with_mut(|state| state.drivers.platform.storage.as_mut().map(f))
+    let raw = try_get().and_then(|state| state.drivers.platform.variable_backend)?;
+    // SAFETY: `set_variable_backend_raw` documents the lifetime requirement.
+    // Firmware execution is single-threaded, so this mutable borrow is unique
+    // for the duration of the closure.
+    Some(unsafe { f(&mut *raw) })
 }
 
 /// Get a reference to the varstore state.


### PR DESCRIPTION
## Summary

This PR hardens the variable backend abstraction and the paths around runtime variable persistence.

Highlights:
- abstract variable persistence behind platform-provided storage/variable backends
- preserve deferred runtime variable writes unless replay completes durably
- preflight EDK2 varstore compaction before destructive flash changes
- relocate runtime-capable variable backend pointers during `SetVirtualAddressMap`
- avoid disruptive PCI BAR sizing writes after firmware PCI enumeration
- use safer EHCI one-shot async control transfers
- fix low-level cache/inline-asm invariants relevant to DMA and firmware calls

## Testing

- `cargo fmt --check`
- `cargo check`
- `cargo build --release`

## Notes

The recent fixes are split into signed-off commits for easier review.
