### PR TITLE
spi: add ICH7 and ICH8 software sequencing

### DIFF
--- a/src/drivers/spi/intel.rs
+++ b/src/drivers/spi/intel.rs
@@ -7,9 +7,11 @@
 //! # Supported Chipsets
 //!
 //! - ICH7: Original SPI controller (swseq only)
-//! - ICH8-ICH10: Hardware sequencing introduced
-//! - 5-9 Series (Ibex Peak through Wildcat Point)
-//! - 100+ Series (Sunrise Point and later): New register layout
+//! - ICH8: ICH9-like registers at the ICH7 RCBA offset; uses swseq here
+//!   because the hardware-sequencing FPB is undocumented
+//! - ICH9-ICH10 and 5-9 Series (Ibex Peak through Wildcat Point): hwseq when
+//!   descriptor-backed, swseq otherwise
+//! - 100+ Series (Sunrise Point and later): New register layout, hwseq only
 //!
 //! # Operating Modes
 //!
@@ -22,26 +24,6 @@
 //!
 //! The following features are implemented in rflasher but not yet here:
 //!
-//! ## Software Sequencing (HIGH priority)
-//! - `ich9_run_opcode()` - Core swseq execution for ICH9+
-//! - `ich7_run_opcode()` - Core swseq execution for ICH7
-//! - `swseq_send_command()` / `ich7_swseq_send_command()` - Raw SPI command interface
-//! - `swseq_read/write/erase()` and `ich7_swseq_read/write/erase()`
-//! - `swseq_wait_wip()` / `ich7_swseq_wait_wip()` - Poll for Write-In-Progress
-//! - Without swseq, ICH7 systems won't work at all
-//!
-//! ## Opcode Table Management (required for swseq)
-//! - `Opcodes` struct with `preop[2]` (WREN, EWSR) and `opcode[8]` arrays
-//! - `generate_opcodes()` / `generate_ich7_opcodes()` - Read from locked controller
-//! - `program_opcodes()` / `program_ich7_opcodes()` - Program PREOP/OPTYPE/OPMENU
-//! - `find_opcode_index()` - Find opcode in OPMENU table
-//! - `get_atomic_for_opcode()` - Determine if WREN preop is needed
-//! - `missing_opcodes()` - Check if READ/RDSR are available
-//!
-//! ## BBAR Handling (MEDIUM priority)
-//! - `set_bbar()` - Set BIOS Base Address Register to 0 to allow full flash access
-//! - Currently we don't manipulate BBAR at all
-//!
 //! ## Access Permission Handling (MEDIUM priority)
 //! - `handle_access_permissions()` - Check FRAP/FREG for region access
 //! - `handle_protected_ranges()` - Check/clear PRx registers when not locked
@@ -52,6 +34,111 @@ use super::regs::*;
 use super::{Result, SpiController, SpiError, SpiMode, delay_us};
 use crate::drivers::mmio::MmioRegion;
 use crate::drivers::pci::{self, PciAddress, PciDevice};
+
+const SWSEQ_MAX_DATA: usize = 64;
+const SPI_WRITE_TIMEOUT_US: u32 = 60_000_000;
+const SPI_CYCLE_TIMEOUT_US: u32 = 60_000;
+const SWSEQ_3B_ADDR_MASK: u32 = 0x00ff_ffff;
+const ICH7_REG_BBAR: u64 = 0x50;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OpcodeType {
+    Read,
+    Write,
+    AddressRead,
+    AddressWrite,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Opcode {
+    code: u8,
+    kind: OpcodeType,
+    atomic: u8,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Opcodes {
+    preop: [u8; 2],
+    table: [Opcode; 8],
+}
+
+impl Default for Opcodes {
+    fn default() -> Self {
+        Self {
+            preop: [JEDEC_WREN, JEDEC_EWSR],
+            table: [
+                Opcode {
+                    code: JEDEC_BYTE_PROGRAM,
+                    kind: OpcodeType::AddressWrite,
+                    atomic: 1,
+                },
+                Opcode {
+                    code: JEDEC_READ,
+                    kind: OpcodeType::AddressRead,
+                    atomic: 0,
+                },
+                Opcode {
+                    code: JEDEC_SE,
+                    kind: OpcodeType::AddressWrite,
+                    atomic: 1,
+                },
+                Opcode {
+                    code: JEDEC_RDSR,
+                    kind: OpcodeType::Read,
+                    atomic: 0,
+                },
+                Opcode {
+                    code: JEDEC_REMS,
+                    kind: OpcodeType::AddressRead,
+                    atomic: 0,
+                },
+                Opcode {
+                    code: JEDEC_WRSR,
+                    kind: OpcodeType::Write,
+                    atomic: 2,
+                },
+                Opcode {
+                    code: JEDEC_RDID,
+                    kind: OpcodeType::Read,
+                    atomic: 0,
+                },
+                Opcode {
+                    code: JEDEC_CE_C7,
+                    kind: OpcodeType::Write,
+                    atomic: 1,
+                },
+            ],
+        }
+    }
+}
+
+impl Opcodes {
+    fn find(&self, code: u8) -> Option<Opcode> {
+        self.table.iter().copied().find(|op| op.code == code)
+    }
+
+    fn opmenu(&self) -> u64 {
+        let mut value = 0u64;
+        for (i, op) in self.table.iter().enumerate() {
+            value |= (op.code as u64) << (i * 8);
+        }
+        value
+    }
+
+    fn optype(&self) -> u16 {
+        let mut value = 0u16;
+        for (i, op) in self.table.iter().enumerate() {
+            let ty = match op.kind {
+                OpcodeType::Read => 0,
+                OpcodeType::Write => 1,
+                OpcodeType::AddressRead => 2,
+                OpcodeType::AddressWrite => 3,
+            };
+            value |= ty << (i * 2);
+        }
+        value
+    }
+}
 
 /// Intel ICH/PCH SPI Controller
 pub struct IntelSpiController {
@@ -77,12 +164,10 @@ pub struct IntelSpiController {
     hsfc_fcycle_mask: u16,
     /// Total flash size in bytes (derived from flash descriptor or address mask)
     flash_size: u32,
-    // TODO: Add opcode table for swseq support:
-    // /// Current opcodes (for software sequencing)
-    // opcodes: Option<Opcodes>,
-    // TODO: Add BBAR tracking:
-    // /// BBAR value (BIOS Base Address Register)
-    // bbar: u32,
+    /// Current opcodes (for software sequencing)
+    opcodes: Opcodes,
+    /// Effective software-sequencing lower address bound from BBAR, when applicable.
+    swseq_bbar_lower_bound: Option<u32>,
 }
 
 impl IntelSpiController {
@@ -128,6 +213,8 @@ impl IntelSpiController {
             },
             // Default to max addressable size; will be refined from flash descriptor
             flash_size: hwseq_addr_mask + 1,
+            opcodes: Opcodes::default(),
+            swseq_bbar_lower_bound: None,
         };
 
         // Initialize the controller
@@ -197,7 +284,7 @@ impl IntelSpiController {
     /// Initialize the SPI controller
     fn init(&mut self, requested_mode: SpiMode) -> Result<()> {
         if self.generation == IchChipset::Ich7 {
-            self.init_ich7()
+            self.init_ich7(requested_mode)
         } else if self.generation.is_ich9_compatible() {
             self.init_ich9(requested_mode)
         } else {
@@ -205,14 +292,16 @@ impl IntelSpiController {
         }
     }
 
-    /// Initialize ICH7 SPI controller
+    /// Initialize ICH7 SPI controller.
     ///
-    /// TODO: ICH7 swseq implementation needed (see rflasher ichspi.rs):
-    /// - Read/program PREOP, OPTYPE, OPMENU registers at ICH7 offsets (0x54-0x5f)
-    /// - Log PBR (Protected BIOS Range) registers at 0x60-0x68
-    /// - Set BBAR to 0 at offset 0x50 if not locked (allow full flash access)
-    /// - Store opcode table for later use in swseq operations
-    fn init_ich7(&mut self) -> Result<()> {
+    /// ICH7 only supports software sequencing. Opcode tables are programmed
+    /// when unlocked and read back when locked; BBAR is cleared when possible
+    /// and then tracked as a lower bound for swseq accesses.
+    fn init_ich7(&mut self, requested_mode: SpiMode) -> Result<()> {
+        if requested_mode == SpiMode::HardwareSequencing {
+            log::error!("Hardware sequencing requested but not supported on ICH7");
+            return Err(SpiError::NotSupported);
+        }
         let spis = self.spibar.read16(ICH7_REG_SPIS);
         log::debug!("ICH7 SPIS: {:#06x}", spis);
 
@@ -222,13 +311,9 @@ impl IntelSpiController {
             self.locked = true;
         }
 
-        // TODO: Initialize opcodes - if locked, read from hardware; if not, program defaults
-        // See init_ich7_opcodes() in rflasher
+        self.init_ich7_opcodes();
 
-        // TODO: Set BBAR to 0 if not locked
-        // let bbar = self.spibar.read32(0x50);
-        // log::debug!("ICH7 BBAR: {:#010x}", bbar);
-        // if !self.locked { self.spibar.write32(0x50, 0); }
+        self.update_ich7_bbar_lower_bound();
 
         // ICH7 only supports swseq
         self.mode = SpiMode::SoftwareSequencing;
@@ -241,10 +326,8 @@ impl IntelSpiController {
     /// Initialize ICH9+ SPI controller (including PCH100+)
     ///
     /// TODO: Additional init steps from rflasher:
-    /// - init_opcodes() - Read/program PREOP, OPTYPE, OPMENU for swseq
     /// - handle_access_permissions() - Check FRAP/FREG region access
     /// - handle_protected_ranges() - Check/clear PRx registers
-    /// - Set BBAR to 0 for non-PCH100+ if not locked (ICH9_REG_BBAR = 0xA0)
     /// - Log SSFS/SSFC registers for debugging
     fn init_ich9(&mut self, requested_mode: SpiMode) -> Result<()> {
         // Read HSFS
@@ -264,10 +347,9 @@ impl IntelSpiController {
             log::debug!("Flash Descriptor is valid");
         }
 
-        // TODO: Initialize opcodes for swseq
-        // self.init_opcodes()?;
-
-        // PCH100+ specific: check DLOCK.SSEQ_LOCKDN
+        // PCH100+ specific: check DLOCK.SSEQ_LOCKDN before any possible
+        // software-sequencing setup. PCH100 uses different swseq offsets, so
+        // never touch ICH9 PREOP/OPTYPE/OPMENU offsets on those chipsets.
         if self.generation.is_pch100_compatible() {
             let dlock = self.spibar.read32(PCH100_REG_DLOCK);
             log::debug!("DLOCK: {:#010x}", dlock);
@@ -295,20 +377,140 @@ impl IntelSpiController {
             self.spibar.write16(ICH9_REG_HSFS, HSFS_FCERR);
         }
 
-        // TODO: Handle BBAR for older chipsets (non-PCH100+)
-        // if self.desc_valid && !self.generation.is_pch100_compatible() && !self.locked {
-        //     self.bbar = self.spibar.read32(ICH9_REG_BBAR);
-        //     self.set_bbar(0); // Allow access to all flash addresses
-        // }
+        if self.mode == SpiMode::SoftwareSequencing && !self.generation.is_pch100_compatible() {
+            self.init_ich9_opcodes();
+        }
+
+        // ICH8 and Bay Trail have ICH9-like SPI engines but no documented
+        // ICH9-compatible BBAR. Do not touch ICH9_REG_BBAR on those chipsets.
+        if !self.generation.is_pch100_compatible()
+            && self.generation != IchChipset::Ich8
+            && self.generation != IchChipset::BayTrail
+        {
+            self.update_ich9_bbar_lower_bound();
+        }
 
         Ok(())
     }
 
-    /// Determine the operating mode based on hardware and user request
+    fn update_ich7_bbar_lower_bound(&mut self) {
+        let original = self.spibar.read32(ICH7_REG_BBAR);
+        log::debug!("ICH7 BBAR: {:#010x}", original);
+        if !self.locked {
+            self.spibar.write32(ICH7_REG_BBAR, original & !BBAR_MASK);
+        }
+        let effective = self.spibar.read32(ICH7_REG_BBAR) & BBAR_MASK;
+        self.swseq_bbar_lower_bound = Some(effective);
+        if effective != 0 {
+            log::warn!("ICH7 BBAR restricts swseq access below {:#x}", effective);
+        }
+    }
+
+    fn update_ich9_bbar_lower_bound(&mut self) {
+        let original = self.spibar.read32(ICH9_REG_BBAR);
+        log::debug!("BBAR: {:#010x}", original);
+        if !self.locked {
+            self.spibar.write32(ICH9_REG_BBAR, original & !BBAR_MASK);
+        }
+        let effective = self.spibar.read32(ICH9_REG_BBAR) & BBAR_MASK;
+        self.swseq_bbar_lower_bound = Some(effective);
+        if effective != 0 {
+            log::warn!("BBAR restricts swseq access below {:#x}", effective);
+        }
+    }
+
+    fn init_ich7_opcodes(&mut self) {
+        if self.locked {
+            self.read_ich7_opcodes();
+        } else {
+            self.program_ich7_opcodes();
+        }
+    }
+
+    fn init_ich9_opcodes(&mut self) {
+        if self.locked || self.swseq_locked {
+            self.read_ich9_opcodes();
+        } else {
+            self.program_ich9_opcodes();
+        }
+    }
+
+    fn read_ich7_opcodes(&mut self) {
+        self.opcodes.preop = self.spibar.read16(ICH7_REG_PREOP).to_le_bytes();
+        let opmenu = self.spibar.read32(ICH7_REG_OPMENU) as u64
+            | ((self.spibar.read32(ICH7_REG_OPMENU + 4) as u64) << 32);
+        let optype = self.spibar.read16(ICH7_REG_OPTYPE);
+        self.update_opcode_menu(opmenu, optype);
+    }
+
+    fn read_ich9_opcodes(&mut self) {
+        let preop = self.spibar.read16(ICH9_REG_PREOP);
+        self.opcodes.preop = preop.to_le_bytes();
+        let opmenu = self.spibar.read32(ICH9_REG_OPMENU) as u64
+            | ((self.spibar.read32(ICH9_REG_OPMENU + 4) as u64) << 32);
+        let optype = self.spibar.read16(ICH9_REG_OPTYPE);
+        self.update_opcode_menu(opmenu, optype);
+    }
+
+    fn update_opcode_menu(&mut self, opmenu: u64, optype: u16) {
+        for i in 0..8 {
+            let code = ((opmenu >> (i * 8)) & 0xff) as u8;
+            let kind = match (optype >> (i * 2)) & 0x3 {
+                0 => OpcodeType::Read,
+                1 => OpcodeType::Write,
+                2 => OpcodeType::AddressRead,
+                _ => OpcodeType::AddressWrite,
+            };
+            self.opcodes.table[i] = Opcode {
+                code,
+                kind,
+                atomic: Self::atomic_for_opcode(code, self.opcodes.preop),
+            };
+        }
+        log::debug!("SPI opcode menu: {:#018x}, type: {:#06x}", opmenu, optype);
+    }
+
+    fn atomic_for_opcode(code: u8, preop: [u8; 2]) -> u8 {
+        let wanted_preop = match code {
+            JEDEC_WRSR => JEDEC_EWSR,
+            JEDEC_BYTE_PROGRAM | JEDEC_SE | JEDEC_BE_52 | JEDEC_BE_D8 | JEDEC_CE_60
+            | JEDEC_CE_C7 => JEDEC_WREN,
+            _ => return 0,
+        };
+
+        if preop[0] == wanted_preop {
+            1
+        } else if preop[1] == wanted_preop {
+            2
+        } else {
+            0
+        }
+    }
+
+    fn program_ich7_opcodes(&self) {
+        self.spibar
+            .write16(ICH7_REG_PREOP, u16::from_le_bytes(self.opcodes.preop));
+        self.spibar.write16(ICH7_REG_OPTYPE, self.opcodes.optype());
+        let opmenu = self.opcodes.opmenu();
+        self.spibar.write32(ICH7_REG_OPMENU, opmenu as u32);
+        self.spibar
+            .write32(ICH7_REG_OPMENU + 4, (opmenu >> 32) as u32);
+    }
+
+    fn program_ich9_opcodes(&self) {
+        self.spibar
+            .write16(ICH9_REG_PREOP, u16::from_le_bytes(self.opcodes.preop));
+        self.spibar.write16(ICH9_REG_OPTYPE, self.opcodes.optype());
+        let opmenu = self.opcodes.opmenu();
+        self.spibar.write32(ICH9_REG_OPMENU, opmenu as u32);
+        self.spibar
+            .write32(ICH9_REG_OPMENU + 4, (opmenu >> 32) as u32);
+    }
+
+    /// Determine the operating mode based on hardware and user request.
     ///
-    /// Note: Since software sequencing (swseq) is not yet implemented, we prefer
-    /// hardware sequencing (hwseq) for any chipset that supports it when the
-    /// flash descriptor is valid. hwseq was introduced with ICH8.
+    /// ICH7 and ICH8 use software sequencing. Later descriptor-capable
+    /// chipsets default to hardware sequencing when possible.
     fn determine_mode(&mut self, requested: SpiMode) -> Result<()> {
         // Validate user's explicit request
         if requested == SpiMode::HardwareSequencing {
@@ -320,13 +522,19 @@ impl IntelSpiController {
                 log::error!("Hardware sequencing requested but flash descriptor is not valid");
                 return Err(SpiError::InvalidDescriptor);
             }
+            if self.generation == IchChipset::Ich8 {
+                log::error!("Hardware sequencing is not supported on ICH8: FPB is undocumented");
+                return Err(SpiError::NotSupported);
+            }
         } else if requested == SpiMode::SoftwareSequencing {
+            if self.generation.is_pch100_compatible() {
+                log::error!("Software sequencing is not implemented for PCH100+ register layout");
+                return Err(SpiError::NotSupported);
+            }
             if self.swseq_locked {
                 log::error!("Software sequencing requested but locked");
                 return Err(SpiError::NotSupported);
             }
-            // Warn that swseq is not implemented yet
-            log::warn!("Software sequencing requested but not yet implemented");
         }
 
         // Determine effective mode for Auto
@@ -336,21 +544,26 @@ impl IntelSpiController {
             // ICH7: swseq only (hwseq not available)
             log::debug!("Using swseq (ICH7 has no hwseq support)");
             SpiMode::SoftwareSequencing
+        } else if self.generation == IchChipset::Ich8 {
+            // ICH8 has no documented FPB at the ICH9 offset; use swseq.
+            log::debug!("Using swseq on ICH8 (hwseq FPB is undocumented)");
+            SpiMode::SoftwareSequencing
         } else if self.desc_valid {
-            // ICH8+ with valid flash descriptor: prefer hwseq
-            // This works for both locked and unlocked systems, and hwseq is
-            // currently the only implemented mode for ICH9+ chipsets.
-            // TODO: Once swseq is implemented, consider preferring swseq for
-            // non-PCH100+ chipsets when not locked (more flexible opcode support)
             if self.swseq_locked {
                 log::info!("Using hwseq (swseq is locked via DLOCK.SSEQ_LOCKDN)");
             } else {
-                log::debug!("Using hwseq (flash descriptor valid, swseq not yet implemented)");
+                log::debug!("Using hwseq (flash descriptor valid)");
             }
             SpiMode::HardwareSequencing
         } else {
-            // No valid flash descriptor - must use swseq (but it's not implemented)
-            log::warn!("Flash descriptor not valid, falling back to swseq (NOT IMPLEMENTED)");
+            if self.generation.is_pch100_compatible() {
+                log::error!(
+                    "PCH100+ auto mode requires a valid flash descriptor; swseq offsets are not implemented"
+                );
+                return Err(SpiError::InvalidDescriptor);
+            }
+            // No valid flash descriptor - must use swseq.
+            log::warn!("Flash descriptor not valid, falling back to swseq");
             SpiMode::SoftwareSequencing
         };
 
@@ -706,6 +919,300 @@ impl IntelSpiController {
         Ok(())
     }
 
+    fn swseq_addr_mask(&self) -> Result<u32> {
+        if self.generation.is_pch100_compatible() {
+            Err(SpiError::NotSupported)
+        } else {
+            // Only 3-byte address opcodes are implemented for swseq today.
+            Ok(SWSEQ_3B_ADDR_MASK)
+        }
+    }
+
+    fn validate_swseq_range(&self, addr: u32, len: usize) -> Result<()> {
+        if len > u32::MAX as usize {
+            return Err(SpiError::AddressOutOfRange);
+        }
+        let len = len as u32;
+        let end = addr.checked_add(len).ok_or(SpiError::AddressOutOfRange)?;
+        if end > self.flash_size {
+            return Err(SpiError::AddressOutOfRange);
+        }
+
+        let mask = self.swseq_addr_mask()?;
+        if len != 0 {
+            let last = end - 1;
+            if addr != (addr & mask) || last != (last & mask) {
+                return Err(SpiError::AddressOutOfRange);
+            }
+            if let Some(lower_bound) = self.swseq_bbar_lower_bound
+                && addr < lower_bound
+            {
+                log::error!(
+                    "Swseq range starts below effective BBAR lower bound: addr={:#x}, BBAR={:#x}",
+                    addr,
+                    lower_bound
+                );
+                return Err(SpiError::AddressOutOfRange);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn swseq_read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
+        self.validate_swseq_range(addr, buf.len())?;
+        let op = self
+            .opcodes
+            .find(JEDEC_READ)
+            .ok_or(SpiError::NotSupported)?;
+        let mut offset = 0;
+        while offset < buf.len() {
+            let chunk = (buf.len() - offset).min(SWSEQ_MAX_DATA);
+            self.run_swseq_opcode(op, addr + offset as u32, &mut buf[offset..offset + chunk])?;
+            offset += chunk;
+        }
+        Ok(())
+    }
+
+    fn swseq_write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
+        if !self.writes_enabled {
+            return Err(SpiError::WriteProtected);
+        }
+        self.validate_swseq_range(addr, data.len())?;
+        let op = self
+            .opcodes
+            .find(JEDEC_BYTE_PROGRAM)
+            .ok_or(SpiError::NotSupported)?;
+        let mut offset = 0;
+        while offset < data.len() {
+            let page_remaining = 256 - ((addr as usize + offset) & 0xff);
+            let chunk = (data.len() - offset)
+                .min(SWSEQ_MAX_DATA)
+                .min(page_remaining);
+            let mut scratch = [0u8; SWSEQ_MAX_DATA];
+            scratch[..chunk].copy_from_slice(&data[offset..offset + chunk]);
+            self.run_swseq_opcode(op, addr + offset as u32, &mut scratch[..chunk])?;
+            self.swseq_wait_wip(SPI_WRITE_TIMEOUT_US)?;
+            offset += chunk;
+        }
+        Ok(())
+    }
+
+    fn swseq_erase(&mut self, addr: u32, len: u32) -> Result<()> {
+        if !self.writes_enabled {
+            return Err(SpiError::WriteProtected);
+        }
+        const ERASE_SIZE: u32 = 4096;
+        if addr & (ERASE_SIZE - 1) != 0 || len & (ERASE_SIZE - 1) != 0 {
+            return Err(SpiError::InvalidArgument);
+        }
+        self.validate_swseq_range(addr, len as usize)?;
+        let op = self.opcodes.find(JEDEC_SE).ok_or(SpiError::NotSupported)?;
+        let mut current = addr;
+        let end = addr.checked_add(len).ok_or(SpiError::AddressOutOfRange)?;
+        while current < end {
+            self.run_swseq_opcode(op, current, &mut [])?;
+            self.swseq_wait_wip(SPI_WRITE_TIMEOUT_US)?;
+            current += ERASE_SIZE;
+        }
+        Ok(())
+    }
+
+    fn run_swseq_opcode(&mut self, op: Opcode, addr: u32, data: &mut [u8]) -> Result<()> {
+        if self.generation == IchChipset::Ich7 {
+            self.run_ich7_opcode(op, addr, data)
+        } else {
+            self.run_ich9_opcode(op, addr, data)
+        }
+    }
+
+    fn opcode_index(&self, op: Opcode) -> Result<u8> {
+        self.opcodes
+            .table
+            .iter()
+            .position(|candidate| candidate.code == op.code)
+            .map(|i| i as u8)
+            .ok_or(SpiError::NotSupported)
+    }
+
+    fn swseq_wait_wip(&mut self, timeout_us: u32) -> Result<()> {
+        let op = self
+            .opcodes
+            .find(JEDEC_RDSR)
+            .ok_or(SpiError::NotSupported)?;
+        let mut elapsed = 0;
+        loop {
+            let mut status = [0u8; 1];
+            self.run_swseq_opcode(op, 0, &mut status)?;
+            if status[0] & 1 == 0 {
+                return Ok(());
+            }
+            if elapsed >= timeout_us {
+                return Err(SpiError::Timeout);
+            }
+            delay_us(10);
+            elapsed += 10;
+        }
+    }
+
+    fn run_ich7_opcode(&mut self, op: Opcode, addr: u32, data: &mut [u8]) -> Result<()> {
+        let is_write = matches!(op.kind, OpcodeType::Write | OpcodeType::AddressWrite);
+        let index = self.opcode_index(op)?;
+        let mut elapsed = 0;
+        while self.spibar.read16(ICH7_REG_SPIS) & SPIS_SCIP != 0 {
+            if elapsed >= SPI_CYCLE_TIMEOUT_US {
+                return Err(SpiError::Timeout);
+            }
+            delay_us(10);
+            elapsed += 10;
+        }
+
+        let old_addr = self.spibar.read32(ICH7_REG_SPIA) & !0x00ff_ffff;
+        self.spibar
+            .write32(ICH7_REG_SPIA, old_addr | (addr & 0x00ff_ffff));
+        if is_write && !data.is_empty() {
+            self.write_ich7_data(data);
+        }
+
+        let mut spis = self.spibar.read16(ICH7_REG_SPIS) & SPIS_RESERVED_MASK;
+        spis |= SPIS_CDS | SPIS_FCERR;
+        self.spibar.write16(ICH7_REG_SPIS, spis);
+
+        let mut spic = ((index as u16) << 4) & 0x0070;
+        if !data.is_empty() {
+            spic |= SPIC_DS | (((data.len() as u16 - 1) & 0x3f) << 8);
+        }
+        if op.atomic == 2 {
+            spic |= SPIC_SPOP;
+        }
+        if op.atomic != 0 {
+            spic |= SPIC_ACS;
+        }
+        spic |= SPIC_SCGO;
+        self.spibar.write16(ICH7_REG_SPIC, spic);
+
+        self.wait_ich7_cycle(if op.atomic == 0 {
+            SPI_CYCLE_TIMEOUT_US
+        } else {
+            SPI_WRITE_TIMEOUT_US
+        })?;
+        if !is_write && !data.is_empty() {
+            self.read_ich7_data(data);
+        }
+        Ok(())
+    }
+
+    fn run_ich9_opcode(&mut self, op: Opcode, addr: u32, data: &mut [u8]) -> Result<()> {
+        let is_write = matches!(op.kind, OpcodeType::Write | OpcodeType::AddressWrite);
+        let index = self.opcode_index(op)?;
+        let mut elapsed = 0;
+        while self.spibar.read8(ICH9_REG_SSFS) as u32 & SSFS_SCIP != 0 {
+            if elapsed >= SPI_CYCLE_TIMEOUT_US {
+                return Err(SpiError::Timeout);
+            }
+            delay_us(10);
+            elapsed += 10;
+        }
+
+        let old_addr = self.spibar.read32(ICH9_REG_FADDR) & !ICH9_FADDR_FLA;
+        self.spibar
+            .write32(ICH9_REG_FADDR, old_addr | (addr & SWSEQ_3B_ADDR_MASK));
+        if is_write && !data.is_empty() {
+            self.write_fdata(data);
+        }
+
+        let mut ssfsc =
+            self.spibar.read32(ICH9_REG_SSFS) & (SSFS_RESERVED_MASK | SSFC_RESERVED_MASK);
+        ssfsc |= SSFS_FDONE | SSFS_FCERR | SSFC_SCF_20MHZ;
+        if !data.is_empty() {
+            ssfsc |= SSFC_DS | (((data.len() as u32 - 1) << SSFC_DBC_OFF) & SSFC_DBC);
+        }
+        ssfsc |= (index as u32) << SSFC_COP_OFF;
+        if op.atomic == 2 {
+            ssfsc |= SSFC_SPOP;
+        }
+        if op.atomic != 0 {
+            ssfsc |= SSFC_ACS;
+        }
+        ssfsc |= SSFC_SCGO;
+        self.spibar.write32(ICH9_REG_SSFS, ssfsc);
+
+        self.wait_ich9_cycle(if op.atomic == 0 {
+            SPI_CYCLE_TIMEOUT_US
+        } else {
+            SPI_WRITE_TIMEOUT_US
+        })?;
+        if !is_write && !data.is_empty() {
+            self.read_fdata(data);
+        }
+        Ok(())
+    }
+
+    fn wait_ich7_cycle(&self, timeout_us: u32) -> Result<()> {
+        let mut elapsed = 0;
+        loop {
+            let spis = self.spibar.read16(ICH7_REG_SPIS);
+            if spis & (SPIS_CDS | SPIS_FCERR) != 0 {
+                if spis & SPIS_FCERR != 0 {
+                    self.spibar
+                        .write16(ICH7_REG_SPIS, (spis & SPIS_RESERVED_MASK) | SPIS_FCERR);
+                    return Err(SpiError::CycleError);
+                }
+                self.spibar
+                    .write16(ICH7_REG_SPIS, (spis & SPIS_RESERVED_MASK) | SPIS_CDS);
+                return Ok(());
+            }
+            if elapsed >= timeout_us {
+                return Err(SpiError::Timeout);
+            }
+            delay_us(10);
+            elapsed += 10;
+        }
+    }
+
+    fn wait_ich9_cycle(&self, timeout_us: u32) -> Result<()> {
+        let mut elapsed = 0;
+        loop {
+            let ssfsc = self.spibar.read32(ICH9_REG_SSFS);
+            if ssfsc & (SSFS_FDONE | SSFS_FCERR) != 0 {
+                if ssfsc & SSFS_FCERR != 0 {
+                    self.spibar.write32(
+                        ICH9_REG_SSFS,
+                        (ssfsc & (SSFS_RESERVED_MASK | SSFC_RESERVED_MASK)) | SSFS_FCERR,
+                    );
+                    return Err(SpiError::CycleError);
+                }
+                self.spibar.write32(
+                    ICH9_REG_SSFS,
+                    (ssfsc & (SSFS_RESERVED_MASK | SSFC_RESERVED_MASK)) | SSFS_FDONE,
+                );
+                return Ok(());
+            }
+            if elapsed >= timeout_us {
+                return Err(SpiError::Timeout);
+            }
+            delay_us(10);
+            elapsed += 10;
+        }
+    }
+
+    fn read_ich7_data(&self, buf: &mut [u8]) {
+        for (i, byte) in buf.iter_mut().enumerate() {
+            let word = self.spibar.read32(ICH7_REG_SPID0 + (i & !3) as u64);
+            *byte = (word >> ((i & 3) * 8)) as u8;
+        }
+    }
+
+    fn write_ich7_data(&self, data: &[u8]) {
+        for (i, chunk) in data.chunks(4).enumerate() {
+            let mut word = 0u32;
+            for (j, byte) in chunk.iter().enumerate() {
+                word |= (*byte as u32) << (j * 8);
+            }
+            self.spibar.write32(ICH7_REG_SPID0 + (i * 4) as u64, word);
+        }
+    }
+
     /// Read data from FDATA registers
     #[inline(always)]
     fn read_fdata(&self, buf: &mut [u8]) {
@@ -796,22 +1303,7 @@ impl SpiController for IntelSpiController {
     fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
         match self.mode {
             SpiMode::HardwareSequencing => self.hwseq_read(addr, buf),
-            SpiMode::SoftwareSequencing => {
-                // TODO: Implement swseq_read() / ich7_swseq_read()
-                // See rflasher ichspi.rs lines 2049-2084 (ich7) and 2309-2344 (ich9+)
-                //
-                // Algorithm:
-                // 1. Find read opcode (JEDEC_READ 0x03 or JEDEC_FAST_READ 0x0B) in opcode table
-                // 2. Loop in 64-byte chunks:
-                //    a. Build write array: [opcode, addr_hi, addr_mid, addr_lo]
-                //    b. Call swseq_send_command() or ich7_swseq_send_command()
-                //    c. Copy data from response to buffer
-                //
-                // For ICH7: Uses SPIS/SPIC/SPIA/SPID0 registers
-                // For ICH9+: Uses SSFS/SSFC/FADDR/FDATA0 registers
-                log::error!("Software sequencing read not implemented");
-                Err(SpiError::NotSupported)
-            }
+            SpiMode::SoftwareSequencing => self.swseq_read(addr, buf),
             SpiMode::Auto => unreachable!("Mode should be resolved during init"),
         }
     }
@@ -819,22 +1311,7 @@ impl SpiController for IntelSpiController {
     fn write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
         match self.mode {
             SpiMode::HardwareSequencing => self.hwseq_write(addr, data),
-            SpiMode::SoftwareSequencing => {
-                // TODO: Implement swseq_write() / ich7_swseq_write()
-                // See rflasher ichspi.rs lines 2086-2122 (ich7) and 2346-2382 (ich9+)
-                //
-                // Algorithm:
-                // 1. Find JEDEC_BYTE_PROGRAM (0x02) in opcode table
-                // 2. Loop respecting 256-byte page boundaries and 64-byte max transfer:
-                //    a. Build write array: [0x02, addr_hi, addr_mid, addr_lo, data...]
-                //    b. Call swseq_send_command() with atomic=1 (sends WREN first)
-                //    c. Call swseq_wait_wip() to poll status register until WIP clears
-                //
-                // IMPORTANT: The atomic mode handles WREN automatically via preop table
-                // get_atomic_for_opcode() returns 1 for BYTE_PROGRAM to use preop[0]=WREN
-                log::error!("Software sequencing write not implemented");
-                Err(SpiError::NotSupported)
-            }
+            SpiMode::SoftwareSequencing => self.swseq_write(addr, data),
             SpiMode::Auto => unreachable!("Mode should be resolved during init"),
         }
     }
@@ -842,24 +1319,7 @@ impl SpiController for IntelSpiController {
     fn erase(&mut self, addr: u32, len: u32) -> Result<()> {
         match self.mode {
             SpiMode::HardwareSequencing => self.hwseq_erase(addr, len),
-            SpiMode::SoftwareSequencing => {
-                // TODO: Implement swseq_erase() / ich7_swseq_erase()
-                // See rflasher ichspi.rs lines 2124-2162 (ich7) and 2384-2423 (ich9+)
-                //
-                // Algorithm:
-                // 1. Find erase opcode in table - prefer JEDEC_SE (0x20, 4KB) for granularity
-                //    Fallback to JEDEC_BE_52 (0x52, 32KB) or JEDEC_BE_D8 (0xD8, 64KB)
-                // 2. Verify address/length are aligned to erase block size
-                // 3. Loop for each erase block:
-                //    a. Build erase command: [opcode, addr_hi, addr_mid, addr_lo]
-                //    b. Call swseq_send_command() with atomic=1 (sends WREN first)
-                //    c. Call swseq_wait_wip() to poll until erase completes
-                //
-                // swseq_wait_wip() polls JEDEC_RDSR (0x05) until bit 0 (WIP) clears
-                // Timeout should be ~60 seconds for chip erase operations
-                log::error!("Software sequencing erase not implemented");
-                Err(SpiError::NotSupported)
-            }
+            SpiMode::SoftwareSequencing => self.swseq_erase(addr, len),
             SpiMode::Auto => unreachable!("Mode should be resolved during init"),
         }
     }

--- a/src/drivers/spi/intel_chipsets.rs
+++ b/src/drivers/spi/intel_chipsets.rs
@@ -123,12 +123,13 @@ impl IchChipset {
         self >= Self::SPI_ENGINE_PCH100
     }
 
-    /// Returns true if this chipset supports hardware sequencing (hwseq)
+    /// Returns true if this driver supports hardware sequencing (hwseq).
     ///
-    /// Hardware sequencing was introduced with ICH8. ICH7 only supports
-    /// software sequencing.
+    /// ICH8 has an ICH9-like hardware sequencing engine, but the flash
+    /// partition boundary register is undocumented, so this driver keeps ICH8
+    /// on software sequencing.
     pub fn supports_hwseq(self) -> bool {
-        self >= Self::SPI_ENGINE_ICH9
+        self >= Self::Ich9
     }
 }
 


### PR DESCRIPTION
## Summary
- add Intel SPI software sequencing for ICH7 and ICH8/ICH9-style controllers
- add opcode table programming/reading, WIP polling, 3-byte swseq range validation, and BBAR lower-bound enforcement
- keep ICH8 on software sequencing because the hardware-sequencing FPB is undocumented, and avoid PCH100 swseq register corruption

## Validation
- cargo fmt --check
- cargo check
- cargo check --workspace --target x86_64-unknown-none
- git diff --check

## Notes
- cargo test remains blocked by the existing duplicate-core test harness issue
- PCH100+ software sequencing remains unsupported until generation-specific offsets are implemented