### PR TITLE
Add CBFS payload menu entries for coreboot-payload builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,36 @@ jobs:
       - name: Run integration tests (NVMe)
         run: ./crabefi test --app hello --nvme --disable-kvm --timeout 120
 
+  test-cbfs-payload-menu:
+    name: Test x86_64 (CBFS payload menu)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchains
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+          targets: x86_64-unknown-none, x86_64-unknown-uefi
+
+      - name: Install stable toolchain for xtask
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86 mtools dosfstools zstd coreboot-utils
+
+      - name: Download CrabEFI ELF
+        uses: actions/download-artifact@v4
+        with:
+          name: crabefi-elf
+          path: target/x86_64-unknown-none/release/
+
+      - name: Run CBFS payload menu test
+        run: ./crabefi test --app cbfs-payload-menu --disable-kvm --timeout 120
+
   test-sdhci:
     name: Test x86_64 (SD Card Storage)
     runs-on: ubuntu-latest
@@ -233,7 +263,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: "stable"
 
       - name: Install kernel build dependencies
         if: steps.cache.outputs.cache-hit != 'true'
@@ -270,7 +300,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: "stable"
 
       - name: Install kernel build dependencies
         if: steps.cache.outputs.cache-hit != 'true'
@@ -637,7 +667,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: "stable"
 
       - name: Install kernel build dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ rt-log = []
 # Enable graphical UI with mouse support (PS/2 and USB HID mouse drivers,
 # cursor rendering, SimplePointerProtocol, and rlvgl-based setup utility)
 ui = []
+# Enable coreboot-payload-only boot menu entries for CBFS payloads in SPI flash.
+# This is intentionally not a default/library feature.
+coreboot-payload = []
 
 [dependencies]
 r-efi = "5.3"

--- a/crabefi-coreboot/Cargo.toml
+++ b/crabefi-coreboot/Cargo.toml
@@ -10,7 +10,7 @@ description = "CrabEFI as a coreboot payload binary"
 ui = ["crabefi/ui"]
 
 [dependencies]
-crabefi = { path = "..", features = ["global-allocator", "platform-entry"] }
+crabefi = { path = "..", features = ["global-allocator", "platform-entry", "coreboot-payload"] }
 crabefi-drivers = { path = "../crabefi-drivers" }
 
 # Needed for coreboot table parsing and early setup

--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -446,6 +446,8 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
     // (efi::varstore::persistence.rs) and must be set before
     // init_platform() runs init_persistence_and_boot().
 
+    crabefi::coreboot::store_coreboot_table_ptr(coreboot_table_ptr);
+
     if let Some(cbmem_addr) = cb_info.cbmem_console {
         crabefi::coreboot::cbmem_console::init(cbmem_addr);
     }

--- a/src/boot_manager.rs
+++ b/src/boot_manager.rs
@@ -330,7 +330,7 @@ fn try_boot_file_on_ahci(file_path: &str) -> bool {
 
 /// Try to boot a file from USB ESPs
 fn try_boot_file_on_usb(file_path: &str) -> bool {
-    use crate::drivers::usb::{self, mass_storage, UsbMassStorage};
+    use crate::drivers::usb::{self, UsbMassStorage, mass_storage};
 
     let Some((controller_id, device_addr)) = usb::find_mass_storage() else {
         return false;

--- a/src/boot_manager.rs
+++ b/src/boot_manager.rs
@@ -330,7 +330,7 @@ fn try_boot_file_on_ahci(file_path: &str) -> bool {
 
 /// Try to boot a file from USB ESPs
 fn try_boot_file_on_usb(file_path: &str) -> bool {
-    use crate::drivers::usb::{self, UsbMassStorage, mass_storage};
+    use crate::drivers::usb::{self, mass_storage, UsbMassStorage};
 
     let Some((controller_id, device_addr)) = usb::find_mass_storage() else {
         return false;
@@ -508,6 +508,12 @@ fn boot_selected_entry(entry: &menu::BootEntry) {
         menu::BootEntryKind::Payload { path, format } => {
             log::info!("Dispatching to payload chainload");
             boot_payload_entry(entry, path, *format);
+        }
+
+        #[cfg(feature = "coreboot-payload")]
+        menu::BootEntryKind::CbfsPayload { name } => {
+            log::info!("Dispatching to CBFS payload chainload");
+            boot_cbfs_payload_entry(name);
         }
     }
 }
@@ -744,12 +750,24 @@ fn boot_payload_entry(
     log::info!("  Path: {}", path);
     log::info!("  Format: {:?}", format);
 
-    // TODO: Implement full payload chainloading
-    // This requires:
-    // 1. Mount FAT filesystem on the partition
-    // 2. Create PayloadEntry from the menu entry
-    // 3. Call payload::chainload_payload()
-    //
-    // For now, log the attempt and return
-    log::warn!("Payload chainloading not yet fully implemented");
+    // TODO: Implement disk payload chainloading.
+    log::warn!("Disk payload chainloading not yet fully implemented");
+}
+
+#[cfg(feature = "coreboot-payload")]
+fn boot_cbfs_payload_entry(name: &heapless::String<128>) {
+    let payload = crate::coreboot::cbfs::discover_payloads()
+        .into_iter()
+        .find(|entry| entry.name.as_str() == name.as_str());
+
+    let Some(payload) = payload else {
+        log::error!("CBFS payload '{}' disappeared", name);
+        return;
+    };
+
+    // SAFETY: this path never returns on success; the CBFS loader validates the
+    // selected entry before transferring control.
+    match unsafe { crate::coreboot::cbfs::chainload_payload(&payload) } {
+        Err(e) => log::error!("CBFS payload chainload failed: {:?}", e),
+    }
 }

--- a/src/coreboot/cbfs.rs
+++ b/src/coreboot/cbfs.rs
@@ -183,6 +183,7 @@ fn discover_payloads_mmap(_out: &mut Vec<CbfsPayloadEntry, MAX_CBFS_FILES>) -> b
     false
 }
 
+#[cfg(target_arch = "x86_64")]
 fn discover_payloads_in_slice(
     cbfs: &[u8],
     base_flash_offset: u32,

--- a/src/coreboot/cbfs.rs
+++ b/src/coreboot/cbfs.rs
@@ -1,0 +1,263 @@
+//! Minimal CBFS payload discovery/chainloading for CrabEFI-as-coreboot-payload.
+//!
+//! This intentionally lives behind the `coreboot-payload` feature so library
+//! users do not get flash payload boot entries.
+
+use crate::drivers::spi::SpiController;
+use heapless::{String, Vec};
+use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
+
+const CBFS_FILE_MAGIC: &[u8; 8] = b"LARCHIVE";
+const CBFS_ALIGNMENT: u32 = 64;
+const MAX_CBFS_FILES: usize = 32;
+const MAX_NAME: usize = 128;
+const MAX_PAYLOAD_SIZE: usize = 16 * 1024 * 1024;
+
+const CBFS_TYPE_SELF: u32 = 0x20;
+const CBFS_TYPE_SIMPLE_ELF: u32 = 0x7f;
+
+#[repr(C, packed)]
+#[derive(FromBytes, Immutable, KnownLayout, Unaligned, Clone, Copy)]
+struct CbfsFileHeader {
+    magic: [u8; 8],
+    len: u32,
+    type_: u32,
+    attributes_offset: u32,
+    offset: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct CbfsPayloadEntry {
+    pub name: String<MAX_NAME>,
+    pub flash_offset: u32,
+    pub size: u32,
+    pub file_type: u32,
+}
+
+fn be32(v: u32) -> u32 {
+    u32::from_be(v)
+}
+
+fn align_up(v: u32, align: u32) -> Option<u32> {
+    Some(v.checked_add(align - 1)? & !(align - 1))
+}
+
+fn should_offer_payload(name: &str, file_type: u32) -> bool {
+    // Do not offer ourselves; offer common alternate payload names and generic
+    // CBFS payload records. coreboot/grub/seabios builds normally use names
+    // such as `seabios`, `img/grub2`, or `fallback/payload`.
+    file_type == CBFS_TYPE_SELF
+        || file_type == CBFS_TYPE_SIMPLE_ELF
+        || name.contains("seabios")
+        || name.contains("grub")
+        || name.contains("payload")
+}
+
+pub fn discover_payloads() -> Vec<CbfsPayloadEntry, MAX_CBFS_FILES> {
+    let mut out = Vec::new();
+
+    if discover_payloads_mmap(&mut out) {
+        return out;
+    }
+
+    crate::state::with_drivers_mut(|drivers| {
+        let Some(storage) = drivers.platform.storage.as_mut() else {
+            log::debug!("CBFS: no SPI storage backend available");
+            return;
+        };
+
+        let fmap = match super::fmap::read_fmap(storage.controller_mut()) {
+            Some(fmap) => fmap,
+            None => return,
+        };
+        let Some(coreboot_area) = super::fmap::find_region(&fmap, "COREBOOT") else {
+            log::debug!("CBFS: FMAP has no COREBOOT area");
+            return;
+        };
+
+        let base = coreboot_area.offset;
+        let end = match coreboot_area.offset.checked_add(coreboot_area.size) {
+            Some(v) => v,
+            None => return,
+        };
+        let mut off = base;
+        let mut header_buf = [0u8; core::mem::size_of::<CbfsFileHeader>()];
+
+        while off
+            .checked_add(header_buf.len() as u32)
+            .is_some_and(|v| v <= end)
+        {
+            if storage.controller_mut().read(off, &mut header_buf).is_err() {
+                break;
+            }
+
+            let Ok((hdr, _)) = CbfsFileHeader::read_from_prefix(&header_buf) else {
+                break;
+            };
+            if &hdr.magic != CBFS_FILE_MAGIC {
+                off = match off.checked_add(CBFS_ALIGNMENT) {
+                    Some(v) => v,
+                    None => break,
+                };
+                continue;
+            }
+
+            let len = be32(hdr.len);
+            let file_type = be32(hdr.type_);
+            let data_offset = be32(hdr.offset);
+            if data_offset < header_buf.len() as u32 || len == 0 || len as usize > MAX_PAYLOAD_SIZE
+            {
+                off = match off.checked_add(CBFS_ALIGNMENT) {
+                    Some(v) => v,
+                    None => break,
+                };
+                continue;
+            }
+
+            let name_len = data_offset.saturating_sub(header_buf.len() as u32) as usize;
+            let mut name_buf = [0u8; MAX_NAME];
+            let read_len = name_len.min(MAX_NAME);
+            if read_len != 0
+                && storage
+                    .controller_mut()
+                    .read(off + header_buf.len() as u32, &mut name_buf[..read_len])
+                    .is_err()
+            {
+                break;
+            }
+            let nul = name_buf.iter().position(|&b| b == 0).unwrap_or(read_len);
+            let name_str = core::str::from_utf8(&name_buf[..nul]).unwrap_or("");
+
+            if should_offer_payload(name_str, file_type) && name_str != "fallback/payload" {
+                let mut name = String::new();
+                let _ = name.push_str(name_str);
+                let _ = out.push(CbfsPayloadEntry {
+                    name,
+                    flash_offset: off,
+                    size: len,
+                    file_type,
+                });
+            }
+
+            let next = match off
+                .checked_add(data_offset)
+                .and_then(|v| v.checked_add(len))
+                .and_then(|v| align_up(v, CBFS_ALIGNMENT))
+            {
+                Some(v) if v > off => v,
+                _ => break,
+            };
+            off = next;
+        }
+    });
+
+    out
+}
+
+#[cfg(target_arch = "x86_64")]
+fn discover_payloads_mmap(out: &mut Vec<CbfsPayloadEntry, MAX_CBFS_FILES>) -> bool {
+    let Some(boot_media) = super::get_boot_media() else {
+        return false;
+    };
+    let Some(mmap_base) = 0x1_0000_0000u64.checked_sub(boot_media.boot_media_size) else {
+        return false;
+    };
+    let Some(cbfs_addr) = mmap_base.checked_add(boot_media.cbfs_offset) else {
+        return false;
+    };
+    if boot_media.cbfs_size == 0 || boot_media.cbfs_size > usize::MAX as u64 {
+        return false;
+    }
+
+    // SAFETY: coreboot reports the boot-media memory-mapped window and keeps it
+    // readable while payloads run on x86.
+    let cbfs = unsafe {
+        core::slice::from_raw_parts(cbfs_addr as *const u8, boot_media.cbfs_size as usize)
+    };
+    discover_payloads_in_slice(cbfs, boot_media.cbfs_offset as u32, out);
+    true
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn discover_payloads_mmap(_out: &mut Vec<CbfsPayloadEntry, MAX_CBFS_FILES>) -> bool {
+    false
+}
+
+fn discover_payloads_in_slice(
+    cbfs: &[u8],
+    base_flash_offset: u32,
+    out: &mut Vec<CbfsPayloadEntry, MAX_CBFS_FILES>,
+) {
+    let mut off = 0usize;
+    let header_len = core::mem::size_of::<CbfsFileHeader>();
+    while off.checked_add(header_len).is_some_and(|v| v <= cbfs.len()) {
+        let Ok((hdr, _)) = CbfsFileHeader::read_from_prefix(&cbfs[off..off + header_len]) else {
+            break;
+        };
+        if &hdr.magic != CBFS_FILE_MAGIC {
+            off = match off.checked_add(CBFS_ALIGNMENT as usize) {
+                Some(v) => v,
+                None => break,
+            };
+            continue;
+        }
+
+        let len = be32(hdr.len) as usize;
+        let file_type = be32(hdr.type_);
+        let data_offset = be32(hdr.offset) as usize;
+        if data_offset < header_len || len == 0 || len > MAX_PAYLOAD_SIZE {
+            off = match off.checked_add(CBFS_ALIGNMENT as usize) {
+                Some(v) => v,
+                None => break,
+            };
+            continue;
+        }
+
+        let name_start = off + header_len;
+        let name_end = off.saturating_add(data_offset).min(cbfs.len());
+        if name_start > name_end {
+            break;
+        }
+        let name_bytes = &cbfs[name_start..name_end];
+        let nul = name_bytes
+            .iter()
+            .position(|&b| b == 0)
+            .unwrap_or(name_bytes.len());
+        let name_str = core::str::from_utf8(&name_bytes[..nul]).unwrap_or("");
+        if should_offer_payload(name_str, file_type) && name_str != "fallback/payload" {
+            let mut name = String::new();
+            let _ = name.push_str(name_str);
+            let flash_offset = base_flash_offset.saturating_add(off as u32);
+            let _ = out.push(CbfsPayloadEntry {
+                name,
+                flash_offset,
+                size: len as u32,
+                file_type,
+            });
+        }
+
+        let next = match off
+            .checked_add(data_offset)
+            .and_then(|v| v.checked_add(len))
+            .and_then(|v| align_up(v as u32, CBFS_ALIGNMENT).map(|v| v as usize))
+        {
+            Some(v) if v > off => v,
+            _ => break,
+        };
+        off = next;
+    }
+}
+
+pub unsafe fn chainload_payload(
+    entry: &CbfsPayloadEntry,
+) -> Result<!, crate::payload::PayloadError> {
+    log::info!(
+        "CBFS chainload requested for '{}' at {:#x} (type {:#x}, {} bytes)",
+        entry.name,
+        entry.flash_offset,
+        entry.file_type,
+        entry.size
+    );
+    log::warn!("CBFS chainloading loader is not implemented yet");
+    Err(crate::payload::PayloadError::InvalidFormat)
+}

--- a/src/coreboot/cbfs.rs
+++ b/src/coreboot/cbfs.rs
@@ -248,6 +248,14 @@ fn discover_payloads_in_slice(
     }
 }
 
+/// Load and transfer control to a CBFS payload.
+///
+/// # Safety
+///
+/// On success this function does not return and transfers control to firmware
+/// code loaded from CBFS. The caller must ensure chainloading is appropriate for
+/// the current platform state and that no borrowed CrabEFI state will be used
+/// after the handoff.
 pub unsafe fn chainload_payload(
     entry: &CbfsPayloadEntry,
 ) -> Result<!, crate::payload::PayloadError> {

--- a/src/coreboot/mod.rs
+++ b/src/coreboot/mod.rs
@@ -11,6 +11,8 @@
 //! CFR (Coreboot Form Representation) parsing is also supported for
 //! exposing firmware configuration options to the user.
 
+#[cfg(feature = "coreboot-payload")]
+pub mod cbfs;
 pub mod cbmem_console;
 pub mod cfr;
 pub mod fmap;
@@ -24,6 +26,18 @@ pub use memory::{MemoryRegion, MemoryType};
 pub use tables::{
     BootMediaInfo, CorebootInfo, FlashMmapWindow, SerialInfo, Smmstorev2Info, SpiFlashInfo,
 };
+
+/// Store the coreboot table pointer for payload chainloading.
+pub fn store_coreboot_table_ptr(addr: u64) {
+    crate::state::with_drivers_mut(|drivers| {
+        drivers.platform.coreboot_table_ptr = Some(addr);
+    });
+}
+
+/// Return the coreboot table pointer, if CrabEFI was started as a coreboot payload.
+pub fn get_coreboot_table_ptr() -> Option<u64> {
+    crate::state::try_get().and_then(|state| state.drivers.platform.coreboot_table_ptr)
+}
 
 /// Store the coreboot framebuffer record address for later invalidation
 pub fn store_framebuffer_record_addr(addr: u64) {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -97,12 +97,19 @@ pub enum BootEntryKind {
         cmdline: String<512>,
     },
 
-    /// Coreboot payload (ELF or flat binary)
+    /// Coreboot payload (ELF or flat binary) from a disk filesystem.
     Payload {
         /// Path to payload file
         path: String<128>,
         /// Payload format
         format: crate::payload::PayloadFormat,
+    },
+
+    /// Coreboot payload stored in CBFS flash.
+    #[cfg(feature = "coreboot-payload")]
+    CbfsPayload {
+        /// CBFS file name.
+        name: String<128>,
     },
 }
 
@@ -209,6 +216,34 @@ impl BootEntry {
         entry
     }
 
+    #[cfg(feature = "coreboot-payload")]
+    fn new_cbfs_payload(payload: &crate::coreboot::cbfs::CbfsPayloadEntry) -> Self {
+        let empty_partition = gpt::Partition {
+            type_guid: [0; 16],
+            partition_guid: [0; 16],
+            first_lba: 0,
+            last_lba: 0,
+            attributes: 0,
+            is_esp: false,
+            block_size: 0,
+        };
+        let mut name: String<64> = String::new();
+        let _ = write!(name, "CBFS: {}", payload.name.as_str());
+        Self::new_with_kind(
+            &name,
+            payload.name.as_str(),
+            DeviceType::Platform { index: 0 },
+            0,
+            empty_partition,
+            0,
+            0,
+            BootEntryKind::CbfsPayload {
+                name: payload.name.clone(),
+            },
+            BootCategory::Payload,
+        )
+    }
+
     /// Format a description for display
     pub fn format_description(&self, buf: &mut String<128>) {
         buf.clear();
@@ -236,7 +271,12 @@ impl BootEntry {
 
     /// Check if this is a payload entry
     pub fn is_payload(&self) -> bool {
-        matches!(self.kind, BootEntryKind::Payload { .. })
+        match self.kind {
+            BootEntryKind::Payload { .. } => true,
+            #[cfg(feature = "coreboot-payload")]
+            BootEntryKind::CbfsPayload { .. } => true,
+            _ => false,
+        }
     }
 
     /// Check if this entry has an editable command line
@@ -358,9 +398,29 @@ pub fn discover_boot_entries() -> BootMenu {
     // Scan SDHCI devices (SD cards)
     discover_sdhci_entries(&mut menu);
 
+    // Scan CBFS flash only when this library is built as the coreboot payload.
+    #[cfg(feature = "coreboot-payload")]
+    discover_cbfs_payload_entries(&mut menu);
+
     log::info!("Found {} boot entries", menu.entry_count());
 
     menu
+}
+
+#[cfg(feature = "coreboot-payload")]
+fn discover_cbfs_payload_entries(menu: &mut BootMenu) {
+    if crate::coreboot::get_coreboot_table_ptr().is_none() {
+        return;
+    }
+
+    for payload in crate::coreboot::cbfs::discover_payloads().iter() {
+        if menu.entry_count() >= MAX_BOOT_ENTRIES {
+            break;
+        }
+        let entry = BootEntry::new_cbfs_payload(payload);
+        log::info!("Found CBFS payload entry: {}", entry.name);
+        let _ = menu.add_entry(entry);
+    }
 }
 
 /// Discover boot entries on a disk that has already been stored globally.

--- a/src/state.rs
+++ b/src/state.rs
@@ -609,8 +609,8 @@ impl Default for EfiState {
 // Driver State
 // ============================================================================
 
-use crate::drivers::pci::PciDevice;
 use crate::drivers::pci::access::AnyPciAccess;
+use crate::drivers::pci::PciDevice;
 use crate::drivers::serial::AnySerial;
 use crate::drivers::storage::StorageRegistry;
 use crate::efi::protocols::serial_io::SerialIoMode;
@@ -829,6 +829,10 @@ pub struct PlatformInfo {
     /// Linux from trying to use both the coreboot framebuffer and the EFI GOP.
     pub coreboot_fb_record_addr: Option<u64>,
 
+    /// Physical pointer to the coreboot table passed to this payload.
+    /// Used when chainloading another coreboot payload.
+    pub coreboot_table_ptr: Option<u64>,
+
     /// SMMSTORE v2 info for UEFI variable storage
     pub smmstorev2: Option<crate::coreboot::Smmstorev2Info>,
 
@@ -860,6 +864,7 @@ impl PlatformInfo {
         Self {
             framebuffer: None,
             coreboot_fb_record_addr: None,
+            coreboot_table_ptr: None,
             smmstorev2: None,
             spi_flash: None,
             boot_media: None,

--- a/src/state.rs
+++ b/src/state.rs
@@ -609,8 +609,8 @@ impl Default for EfiState {
 // Driver State
 // ============================================================================
 
-use crate::drivers::pci::access::AnyPciAccess;
 use crate::drivers::pci::PciDevice;
+use crate::drivers::pci::access::AnyPciAccess;
 use crate::drivers::serial::AnySerial;
 use crate::drivers::storage::StorageRegistry;
 use crate::efi::protocols::serial_io::SerialIoMode;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -331,6 +331,7 @@ fn cmd_build(release: bool, ui: bool, arch: Arch, machine: Machine) -> Result<()
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_run(
     coreboot_rom: Option<String>,
     ahci: bool,
@@ -419,6 +420,7 @@ fn cmd_run(
     qemu::run_qemu(&config, None)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_test(
     coreboot_rom: Option<String>,
     app: &str,
@@ -759,7 +761,7 @@ fn find_test_app_efi(name: &str, arch: Arch) -> Result<String> {
     for entry in std::fs::read_dir(&target_dir)? {
         let entry = entry?;
         let path = entry.path();
-        if path.extension().map_or(false, |e| e == "efi") {
+        if path.extension().is_some_and(|e| e == "efi") {
             return Ok(path.to_string_lossy().to_string());
         }
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -141,7 +141,8 @@ enum Commands {
 
         /// Test app to run (default: hello)
         ///
-        /// Use "grub-linux" for the GRUB + Linux boot-chain test.
+        /// Use "grub-linux" for the GRUB + Linux boot-chain test, or
+        /// "cbfs-payload-menu" to verify coreboot-payload-only CBFS menu entries.
         #[arg(long, default_value = "hello")]
         app: String,
 
@@ -446,8 +447,17 @@ fn cmd_test(
 
     // Prepare the ROM
     let firmware = if let Some(rom) = coreboot_rom {
+        let coreboot_rom = if app == "cbfs-payload-menu" {
+            let src = PathBuf::from(rom);
+            let dst = temp_dir.path().join("coreboot-cbfs-test.rom");
+            std::fs::copy(&src, &dst)?;
+            rom::add_test_cbfs_payload(&dst, "seabios")?;
+            dst
+        } else {
+            PathBuf::from(rom)
+        };
         rom::PreparedFirmware {
-            coreboot_rom: PathBuf::from(rom),
+            coreboot_rom,
             tfa_flash: None,
         }
     } else {
@@ -456,7 +466,11 @@ fn cmd_test(
 
         // Prepare ROM with CrabEFI payload
         let crabefi_elf = rom::get_crabefi_elf(arch);
-        rom::prepare_rom(&crabefi_elf, temp_dir.path(), arch, machine)?
+        let firmware = rom::prepare_rom(&crabefi_elf, temp_dir.path(), arch, machine)?;
+        if app == "cbfs-payload-menu" {
+            rom::add_test_cbfs_payload(&firmware.coreboot_rom, "seabios")?;
+        }
+        firmware
     };
 
     let config = qemu::QemuConfig {
@@ -529,12 +543,17 @@ fn cmd_test(
         )?;
     } else {
         // ── Normal UEFI test app ─────────────────────────────────────
-        println!("Building test app: {}", app);
-        cmd_build_test_app(app, arch)?;
+        let disk_app = if app == "cbfs-payload-menu" {
+            "hello"
+        } else {
+            app
+        };
+        println!("Building test app: {}", disk_app);
+        cmd_build_test_app(disk_app, arch)?;
 
-        let efi_path = find_test_app_efi(app, arch)?;
+        let efi_path = find_test_app_efi(disk_app, arch)?;
 
-        if app == "directory-test" {
+        if disk_app == "directory-test" {
             disk::create_directory_test_disk(
                 disk_path.to_string_lossy().as_ref(),
                 &efi_path,

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -637,6 +637,19 @@ pub fn run_tests(config: &QemuConfig, disk_path: &Path, app_name: &str) -> Resul
                 failed += 1;
             }
         }
+        "cbfs-payload-menu" => {
+            if result
+                .output
+                .contains("Found CBFS payload entry: CBFS: seabios")
+                || result.output.contains("CBFS: seabios")
+            {
+                println!("[PASS] cbfs_payload_entry: CBFS payload appeared in boot menu");
+                passed += 1;
+            } else {
+                println!("[FAIL] cbfs_payload_entry: CBFS payload did not appear in boot menu");
+                failed += 1;
+            }
+        }
         "device-path-test" => {
             // Check that the test app started
             if result.output.contains("Device Path Protocol Test Suite") {

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -312,7 +312,7 @@ fn add_storage_args_aarch64(cmd: &mut Command, config: &QemuConfig, disk_path: &
 fn is_kvm_available() -> bool {
     Path::new("/dev/kvm").exists()
         && std::fs::metadata("/dev/kvm")
-            .map(|m| m.permissions().readonly() == false)
+            .map(|m| !m.permissions().readonly())
             .unwrap_or(false)
 }
 

--- a/xtask/src/rom.rs
+++ b/xtask/src/rom.rs
@@ -236,6 +236,32 @@ fn inject_crabefi_payload(rom_path: &Path, crabefi_elf: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Add a small raw CBFS file used to verify CrabEFI discovers flash payload entries.
+pub fn add_test_cbfs_payload(rom_path: &Path, name: &str) -> Result<()> {
+    let payload = rom_path.with_extension("cbfs-test-payload.bin");
+    std::fs::write(&payload, b"CrabEFI CBFS payload discovery test\n")
+        .context("Failed to create CBFS test payload")?;
+
+    let _ = Command::new("cbfstool")
+        .arg(rom_path)
+        .args(["remove", "-n", name])
+        .status();
+
+    let status = Command::new("cbfstool")
+        .arg(rom_path)
+        .args(["add", "-f"])
+        .arg(&payload)
+        .args(["-n", name, "-t", "raw"])
+        .status()
+        .context("Failed to run cbfstool to add CBFS test payload")?;
+
+    if !status.success() {
+        bail!("Failed to add CBFS test payload to ROM");
+    }
+
+    Ok(())
+}
+
 /// Prepare riscv64 (QEMU virt) firmware — single coreboot ROM (OpenSBI embedded)
 fn prepare_rom_riscv64(crabefi_elf: &Path, output_dir: &Path) -> Result<PreparedFirmware> {
     let compressed_rom = project_root().join("firmware/coreboot-qemu-riscv64.rom.zst");


### PR DESCRIPTION
## Summary

Introduces a new `coreboot-payload` feature flag that enables CrabEFI (when running as a coreboot payload) to discover other payloads stored in CBFS flash and surface them as boot menu entries. This allows users to chainload alternative payloads like SeaBIOS or GRUB2 directly from the CrabEFI boot menu.

## Key Changes

- **New `coreboot-payload` feature flag** (`Cargo.toml`): Gates all CBFS flash boot entry logic so library consumers are not affected
- **New `src/coreboot/cbfs.rs` module**: Implements CBFS file discovery via both memory-mapped flash (x86_64) and SPI controller fallback, with payload type filtering (`CBFS_TYPE_SELF`, `CBFS_TYPE_SIMPLE_ELF`) and name-based heuristics
- **New `BootEntryKind::CbfsPayload`** (`src/menu.rs`): Adds a `coreboot-payload`-gated variant for CBFS flash entries, with discovery wired into `discover_boot_entries()`
- **Boot dispatch** (`src/boot_manager.rs`): Adds `boot_cbfs_payload_entry()` handler that re-discovers the payload at boot time and invokes `chainload_payload()` (chainloading execution is stubbed pending full implementation)
- **Coreboot table pointer storage** (`src/coreboot/mod.rs`, `src/state.rs`): Stores the coreboot table pointer passed at payload entry so CBFS discovery can confirm we are running as a coreboot payload before adding flash entries
- **CI job `test-cbfs-payload-menu`** (`.github/workflows/ci.yml`): New integration test that injects a test CBFS payload (`seabios`) into the ROM and verifies the entry appears in the boot menu log
- **xtask helpers** (`xtask/src/rom.rs`, `xtask/src/main.rs`, `xtask/src/qemu.rs`): `add_test_cbfs_payload()` uses `cbfstool` to inject a raw test payload; `cmd_test` handles the `cbfs-payload-menu` app mode; QEMU test runner validates the expected log output

## Implementation Notes

- CBFS chainload execution (`chainload_payload`) is stubbed and returns `PayloadError::InvalidFormat`; the discovery and menu presentation path is fully functional
- Disk payload chainloading TODO comment is clarified but remains unimplemented (separate concern)
- The feature is intentionally excluded from default/library builds to avoid exposing flash payload entries to non-coreboot consumers