### PR TITLE
Fix Linux EFI handoff stability

### DIFF
--- a/src/drivers/pci/mod.rs
+++ b/src/drivers/pci/mod.rs
@@ -228,20 +228,16 @@ fn probe_bar(access: &AnyPciAccess, addr: PciAddress, bar_index: usize) -> PciBa
         return PciBar::default();
     }
 
-    // Check if it's I/O or memory
+    // Check if it's I/O or memory.  Do not size BARs here by writing
+    // 0xffffffff: fstart has already assigned and enabled resources, and
+    // probing live BARs can transiently break decode or bus mastering while
+    // storage/USB devices are active.  CrabEFI drivers only need the assigned
+    // base address, so keep enumeration read-only.
     if original & 1 == 1 {
-        // I/O BAR
-        access.write32(addr, bar_offset, 0xFFFFFFFF);
-        let sized = access.read32(addr, bar_offset);
-        access.write32(addr, bar_offset, original);
-
-        let io_mask = sized | 0x3;
-        let size = (!io_mask).wrapping_add(1) as u64;
-
         return PciBar {
             bar_type: BarType::Io,
             address: (original & 0xFFFFFFFC) as u64,
-            size,
+            size: 0,
             prefetchable: false,
         };
     }
@@ -251,44 +247,22 @@ fn probe_bar(access: &AnyPciAccess, addr: PciAddress, bar_index: usize) -> PciBa
     let prefetchable = (original & 0x8) != 0;
 
     match mem_type {
-        0 => {
-            // 32-bit memory
-            access.write32(addr, bar_offset, 0xFFFFFFFF);
-            let sized = access.read32(addr, bar_offset);
-            access.write32(addr, bar_offset, original);
-
-            let mem_mask = sized | 0xF;
-            let size = (!mem_mask).wrapping_add(1) as u64;
-
-            PciBar {
-                bar_type: BarType::Memory32,
-                address: (original & 0xFFFFFFF0) as u64,
-                size,
-                prefetchable,
-            }
-        }
+        0 => PciBar {
+            bar_type: BarType::Memory32,
+            address: (original & 0xFFFFFFF0) as u64,
+            size: 0,
+            prefetchable,
+        },
         2 => {
             // 64-bit memory (consumes two BARs)
             let bar_offset_hi = bar_offset + 4;
             let original_hi = access.read32(addr, bar_offset_hi);
-
-            access.write32(addr, bar_offset, 0xFFFFFFFF);
-            access.write32(addr, bar_offset_hi, 0xFFFFFFFF);
-            let sized_lo = access.read32(addr, bar_offset);
-            let sized_hi = access.read32(addr, bar_offset_hi);
-            access.write32(addr, bar_offset, original);
-            access.write32(addr, bar_offset_hi, original_hi);
-
-            let sized = ((sized_hi as u64) << 32) | (sized_lo as u64);
-            let mem_mask = sized | 0xF;
-            let size = (!mem_mask).wrapping_add(1);
-
             let address = ((original_hi as u64) << 32) | ((original & 0xFFFFFFF0) as u64);
 
             PciBar {
                 bar_type: BarType::Memory64,
                 address,
-                size,
+                size: 0,
                 prefetchable,
             }
         }
@@ -468,6 +442,43 @@ pub fn bind_drivers() {
 /// Called during ExitBootServices to cleanly quiesce hardware.
 pub fn shutdown_drivers() {
     driver::shutdown_all();
+}
+
+/// Clear PCI Bus Master Enable on all enumerated devices.
+///
+/// This is a conservative OS-handoff safety net: once ExitBootServices has
+/// succeeded, firmware-owned DMA rings and bounce buffers are no longer owned
+/// by firmware.  Any device left bus-mastering can scribble over pages Linux
+/// has already repurposed for early stacks or metadata.
+pub fn disable_all_bus_mastering_for_handoff() {
+    let devices = state::drivers().pci.devices.clone();
+    if devices.is_empty() {
+        return;
+    }
+
+    let mut changed = 0usize;
+    with_access(|access| {
+        for dev in devices.iter() {
+            let cmd = access.read16(dev.address, 0x04);
+            if cmd & 0x0004 == 0 {
+                continue;
+            }
+            let new_cmd = cmd & !0x0004;
+            access.write16(dev.address, 0x04, new_cmd);
+            changed += 1;
+            log::debug!(
+                "PCI {}: bus master disabled for OS handoff ({:#06x} -> {:#06x})",
+                dev.address,
+                cmd,
+                new_cmd
+            );
+        }
+    });
+
+    log::info!(
+        "PCI: disabled bus mastering on {} device(s) for OS handoff",
+        changed
+    );
 }
 
 // ============================================================================

--- a/src/efi/allocator.rs
+++ b/src/efi/allocator.rs
@@ -399,10 +399,15 @@ impl MemoryAllocator {
 
             let attribute = memory_type.default_attributes();
 
-            // RuntimeServices types get the RUNTIME attribute.
+            // RuntimeServices types get the RUNTIME attribute.  Runtime data
+            // should also be execute-protected, matching carve_out() and the
+            // EFI memory attributes table expectations.
             let attribute = match region.region_type {
-                PlatMemType::RuntimeServicesCode | PlatMemType::RuntimeServicesData => {
-                    attribute | attributes::EFI_MEMORY_RUNTIME
+                PlatMemType::RuntimeServicesCode => {
+                    (attribute | attributes::EFI_MEMORY_RUNTIME) & !attributes::EFI_MEMORY_XP
+                }
+                PlatMemType::RuntimeServicesData => {
+                    attribute | attributes::EFI_MEMORY_RUNTIME | attributes::EFI_MEMORY_XP
                 }
                 _ => attribute,
             };
@@ -432,6 +437,51 @@ impl MemoryAllocator {
         memory_type: MemoryType,
     ) -> Result<(), efi::Status> {
         self.carve_out(physical_start, num_pages, memory_type)
+    }
+
+    /// Reserve all ConventionalMemory fragments within a range.
+    ///
+    /// Platform-provided ACPI/SMBIOS reservations may intentionally split the
+    /// firmware's linker-described runtime data range.  Runtime data still
+    /// has to be preserved for the OS, but those pre-typed holes should keep
+    /// their more specific memory types.  This helper carves every overlapping
+    /// ConventionalMemory fragment and skips existing non-conventional holes.
+    pub fn reserve_region_fragments(
+        &mut self,
+        physical_start: u64,
+        num_pages: u64,
+        memory_type: MemoryType,
+    ) -> Result<(), efi::Status> {
+        let size = num_pages
+            .checked_mul(PAGE_SIZE)
+            .ok_or(efi::Status::INVALID_PARAMETER)?;
+        let end = physical_start
+            .checked_add(size)
+            .ok_or(efi::Status::INVALID_PARAMETER)?;
+
+        let mut fragments: heapless::Vec<(u64, u64), MAX_MEMORY_ENTRIES> = heapless::Vec::new();
+        for entry in &self.entries {
+            let Some(entry_type) = entry.get_memory_type() else {
+                continue;
+            };
+            if entry.end() <= physical_start || entry.physical_start >= end {
+                continue;
+            }
+            if entry_type == MemoryType::ConventionalMemory {
+                let start = entry.physical_start.max(physical_start);
+                let stop = entry.end().min(end);
+                if start < stop && fragments.push((start, stop)).is_err() {
+                    return Err(efi::Status::OUT_OF_RESOURCES);
+                }
+            }
+        }
+
+        for (start, stop) in fragments {
+            let pages = (stop - start).div_ceil(PAGE_SIZE);
+            self.carve_out(start, pages, memory_type)?;
+        }
+
+        Ok(())
     }
 
     /// Force-add a memory region to the map
@@ -884,7 +934,9 @@ impl MemoryAllocator {
 
         self.boot_services_exited = true;
 
-        // Log runtime services regions (these must have EFI_MEMORY_RUNTIME attribute)
+        // Log handoff-critical regions: runtime services must keep the
+        // RUNTIME attribute, and loader regions must remain reserved for the
+        // OS loader / EFI stub across ExitBootServices.
         log::debug!(
             "Memory map at ExitBootServices ({} entries):",
             self.entries.len()
@@ -896,10 +948,13 @@ impl MemoryAllocator {
             let has_runtime = (entry.attribute & attributes::EFI_MEMORY_RUNTIME) != 0;
             if matches!(
                 mem_type,
-                MemoryType::RuntimeServicesCode | MemoryType::RuntimeServicesData
+                MemoryType::RuntimeServicesCode
+                    | MemoryType::RuntimeServicesData
+                    | MemoryType::LoaderCode
+                    | MemoryType::LoaderData
             ) {
                 log::info!(
-                    "  RuntimeServices: {:#x}-{:#x} type={:?} attr={:#x} RUNTIME={}",
+                    "  Handoff: {:#x}-{:#x} type={:?} attr={:#x} RUNTIME={}",
                     entry.physical_start,
                     entry.end(),
                     mem_type,
@@ -909,11 +964,17 @@ impl MemoryAllocator {
             }
         }
 
-        // Convert boot services memory to conventional memory
+        // Convert only firmware-owned BootServicesCode/Data to conventional
+        // memory. LoaderCode/Data belongs to the OS loader and may contain the
+        // loaded kernel, initrd, command line, PE memory-map buffers, or other
+        // handoff data. If firmware reclaims LoaderData here, Linux can reuse
+        // those ranges during early boot before it has consumed/reserved them,
+        // causing corruption (e.g. NODE_DATA over initrd/handoff memory).
         for entry in self.entries.iter_mut() {
-            if let Some(mem_type) = entry.get_memory_type()
-                && mem_type.is_boot_services()
-            {
+            if matches!(
+                entry.get_memory_type(),
+                Some(MemoryType::BootServicesCode | MemoryType::BootServicesData)
+            ) {
                 entry.memory_type = MemoryType::ConventionalMemory as u32;
             }
         }
@@ -1346,6 +1407,18 @@ pub fn reserve_region(
     memory_type: MemoryType,
 ) -> Result<(), efi::Status> {
     state::with_allocator_mut(|alloc| alloc.reserve_region(physical_start, num_pages, memory_type))
+}
+
+/// Reserve all ConventionalMemory fragments in a range while preserving
+/// pre-typed holes such as ACPI reclaim and SMBIOS reserved pages.
+pub fn reserve_region_fragments(
+    physical_start: u64,
+    num_pages: u64,
+    memory_type: MemoryType,
+) -> Result<(), efi::Status> {
+    state::with_allocator_mut(|alloc| {
+        alloc.reserve_region_fragments(physical_start, num_pages, memory_type)
+    })
 }
 
 /// Force-add a memory region to the map

--- a/src/efi/boot_services.rs
+++ b/src/efi/boot_services.rs
@@ -1521,12 +1521,20 @@ extern "efiapi" fn exit_boot_services(image_handle: Handle, map_key: usize) -> S
         // After this, SPI flash is locked and variable writes go to ESP file
         crate::state::set_exit_boot_services_called();
 
-        // Clean up hardware state for OS handoff
-        // Re-enable keyboard interrupts so Linux's i8042 driver works
+        // Clean up hardware state for OS handoff.
+        // Re-enable keyboard interrupts so Linux's i8042 driver works.
         crate::drivers::keyboard_common::cleanup();
 
-        // Shutdown all PCI drivers (USB, NVMe, AHCI, SDHCI) for OS handoff
+        // Stop firmware-owned PCI drivers before returning to the OS.  USB and
+        // storage controllers may have DMA rings/bounce buffers allocated from
+        // BootServices memory; after ExitBootServices Linux may immediately
+        // reuse those pages for early stacks or metadata.
         crate::drivers::pci::shutdown_drivers();
+
+        // Final DMA safety net: regardless of per-driver shutdown coverage,
+        // clear Bus Master Enable on every enumerated PCI function.  Linux will
+        // re-enable bus mastering for drivers it owns.
+        crate::drivers::pci::disable_all_bus_mastering_for_handoff();
 
         // Invalidate the coreboot framebuffer record to prevent a race condition
         // between Linux's simplefb (coreboot) and efifb (EFI GOP) drivers.

--- a/src/efi/mod.rs
+++ b/src/efi/mod.rs
@@ -69,10 +69,12 @@ pub fn init_from_platform(config: &crate::platform::PlatformConfig) {
         {
             log::warn!("Failed to reserve runtime code region: {:?}", e);
         }
-        if let Err(e) =
-            allocator::reserve_region(rt.data_base, data_pages, MemoryType::RuntimeServicesData)
-        {
-            log::warn!("Failed to reserve runtime data region: {:?}", e);
+        if let Err(e) = allocator::reserve_region_fragments(
+            rt.data_base,
+            data_pages,
+            MemoryType::RuntimeServicesData,
+        ) {
+            log::warn!("Failed to reserve runtime data region fragments: {:?}", e);
         }
     } else {
         // Fall back to linker-symbol-based reservation. Only available when

--- a/src/efi/runtime_services.rs
+++ b/src/efi/runtime_services.rs
@@ -1044,6 +1044,89 @@ extern "efiapi" fn set_variable(
     data_size: usize,
     data: *mut c_void,
 ) -> Status {
+    if variable_name.is_null() || vendor_guid.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+
+    // Linux calls SetVariable("DUMMY", ..., size=0) during EFI runtime setup
+    // from the initial task stack.  The full SetVariable path uses 16 KiB
+    // bounded variable buffers, which is fine on firmware stacks but too large
+    // for the OS runtime-call stack.  Keep the common runtime-delete path in a
+    // tiny helper so it cannot corrupt Linux's init_task stack canary.
+    if state::is_exit_boot_services_called() && data_size == 0 {
+        return set_variable_runtime_delete(variable_name, vendor_guid, attributes);
+    }
+
+    set_variable_full(variable_name, vendor_guid, attributes, data_size, data)
+}
+
+#[inline(never)]
+fn set_variable_runtime_delete(
+    variable_name: *mut u16,
+    vendor_guid: *mut Guid,
+    attributes: u32,
+) -> Status {
+    let name_len = ucs2_strlen_ptr(variable_name);
+    if name_len == 0 || name_len >= MAX_VARIABLE_NAME_LEN {
+        return Status::INVALID_PARAMETER;
+    }
+
+    let has_runtime_access = (attributes & auth::attributes::RUNTIME_ACCESS) != 0;
+    if !has_runtime_access {
+        return Status::INVALID_PARAMETER;
+    }
+
+    let guid = unsafe { *vendor_guid };
+    let name_slice = unsafe { core::slice::from_raw_parts(variable_name, name_len + 1) };
+
+    if guid == auth::EFI_GLOBAL_VARIABLE_GUID
+        && (name_slice == auth::SECURE_BOOT_NAME || name_slice == auth::SETUP_MODE_NAME)
+    {
+        return Status::WRITE_PROTECTED;
+    }
+
+    let mut name_vec = VariableNameBuf::new();
+    if name_vec.extend_from_slice(name_slice).is_err() {
+        return Status::OUT_OF_RESOURCES;
+    }
+
+    let secure_boot_var = auth::identify_key_database(name_vec.as_slice(), &guid);
+    let (status, deleted_secure_boot_var) = state::with_efi_mut(|efi| {
+        let Some(idx) = efi.variables.iter().position(|var| {
+            var.in_use
+                && var.vendor_guid == guid
+                && crate::efi::utils::ucs2_eq(&var.name, name_vec.as_slice())
+        }) else {
+            return (Status::NOT_FOUND, None);
+        };
+
+        efi.variables[idx].in_use = false;
+        (Status::SUCCESS, secure_boot_var)
+    });
+
+    if status != Status::SUCCESS {
+        return status;
+    }
+
+    if let Some(var_type) = deleted_secure_boot_var {
+        handle_secure_boot_variable_delete(var_type);
+    }
+
+    if let Err(e) = crate::efi::varstore::delete_variable(&guid, name_vec.as_slice()) {
+        log::debug!("Variable deletion not persisted: {:?}", e);
+    }
+
+    Status::SUCCESS
+}
+
+#[inline(never)]
+fn set_variable_full(
+    variable_name: *mut u16,
+    vendor_guid: *mut Guid,
+    attributes: u32,
+    data_size: usize,
+    data: *mut c_void,
+) -> Status {
     #[cfg(feature = "rt-debug")]
     if VIRTUAL_MODE.load(core::sync::atomic::Ordering::Acquire) {
         rt_serial::str("[RT] SetVariable name=");


### PR DESCRIPTION
## Summary
- keep PCI enumeration read-only and disable bus mastering during OS handoff
- preserve loader/runtime memory map ranges needed after ExitBootServices
- use a smaller runtime SetVariable delete path to avoid Linux stack pressure

## Testing
- cargo check