### PR TITLE
Rebase reusable runtime variable hardening from PR #48

### DIFF
--- a/crabefi-core/src/arch/aarch64/rng.rs
+++ b/crabefi-core/src/arch/aarch64/rng.rs
@@ -89,7 +89,6 @@ fn check_smccc_trng() -> bool {
             out("x1") _,
             out("x2") _,
             out("x3") _,
-            options(nomem, nostack)
         );
     }
     // Version should be >= 1.0 (0x10000)
@@ -113,7 +112,6 @@ fn smccc_trng_rnd64() -> Option<u64> {
             val = out(reg) val,
             out("x1") _,
             out("x2") _,
-            options(nomem, nostack)
         );
     }
     // SUCCESS = 0

--- a/crabefi-core/src/arch/riscv64/sbi.rs
+++ b/crabefi-core/src/arch/riscv64/sbi.rs
@@ -66,7 +66,6 @@ pub fn sbi_call(eid: u64, fid: u64, a0: u64, a1: u64, a2: u64) -> SbiRet {
             in("a2") a2,
             in("a6") fid,
             in("a7") eid,
-            options(nostack)
         );
     }
     SbiRet { error, value }

--- a/crabefi-core/src/arch/x86_64/cache.rs
+++ b/crabefi-core/src/arch/x86_64/cache.rs
@@ -39,17 +39,19 @@ pub fn flush_cache_range(addr: u64, size: usize) {
     fence(Ordering::SeqCst);
 }
 
-/// Invalidate a memory range in CPU cache
+/// Synchronize before reading a DMA-written memory range.
 ///
-/// This ensures the CPU sees data written by DMA-capable devices.
-/// On x86, CLFLUSH both writes back and invalidates, so we use the same
-/// instruction as flush_cache_range.
+/// x86 cache coherency makes device writes visible to CPU loads without an
+/// explicit invalidation instruction. Do not use `CLFLUSH` here: it is a
+/// write-back invalidate operation, so polling code can race a device DMA
+/// update and write an older CPU cache line back over the device's completion
+/// status. A full fence is sufficient to order subsequent descriptor reads.
 ///
 /// # Arguments
 ///
-/// * `addr` - Starting address of the memory range
-/// * `size` - Size of the memory range in bytes
+/// * `_addr` - Starting address of the memory range
+/// * `_size` - Size of the memory range in bytes
 #[inline]
-pub fn invalidate_cache_range(addr: u64, size: usize) {
-    flush_cache_range(addr, size);
+pub fn invalidate_cache_range(_addr: u64, _size: usize) {
+    fence(Ordering::SeqCst);
 }

--- a/crabefi-core/src/arch/x86_64/rng.rs
+++ b/crabefi-core/src/arch/x86_64/rng.rs
@@ -18,7 +18,8 @@ const RDRAND_MIN_CHANGE: usize = 5;
 fn cpuid_has_rdrand() -> bool {
     let ecx: u32;
 
-    // rbx is reserved by LLVM, so we must save/restore it around CPUID
+    // RBX is reserved by LLVM, so save/restore it around CPUID. Do not use
+    // `options(nostack)`: the assembly intentionally uses push/pop.
     unsafe {
         core::arch::asm!(
             "push rbx",
@@ -28,7 +29,6 @@ fn cpuid_has_rdrand() -> bool {
             out("ecx") ecx,
             out("eax") _,
             out("edx") _,
-            options(nostack),
         );
     }
 

--- a/crabefi-core/src/drivers/pci/mod.rs
+++ b/crabefi-core/src/drivers/pci/mod.rs
@@ -178,7 +178,7 @@ impl PciDevice {
     /// Get the MMIO base address for the device (typically BAR0)
     pub fn mmio_base(&self) -> Option<u64> {
         for bar in &self.bars {
-            if matches!(bar.bar_type, BarType::Memory32 | BarType::Memory64) {
+            if matches!(bar.bar_type, BarType::Memory32 | BarType::Memory64) && bar.address != 0 {
                 return Some(bar.address);
             }
         }
@@ -190,7 +190,7 @@ impl PciDevice {
     /// This is used by controllers like UHCI that use I/O ports instead of MMIO.
     pub fn io_base(&self) -> Option<u64> {
         for bar in &self.bars {
-            if bar.bar_type == BarType::Io {
+            if bar.bar_type == BarType::Io && bar.address != 0 {
                 return Some(bar.address);
             }
         }
@@ -224,7 +224,7 @@ fn probe_bar(access: &AnyPciAccess, addr: PciAddress, bar_index: usize) -> PciBa
     let original = access.read32(addr, bar_offset);
 
     // Empty BAR
-    if original == 0 {
+    if original == 0 || original == 0xFFFF_FFFF {
         return PciBar::default();
     }
 

--- a/crabefi-core/src/drivers/usb/ehci.rs
+++ b/crabefi-core/src/drivers/usb/ehci.rs
@@ -1103,12 +1103,10 @@ impl EhciController {
         }
         flush_cache_range(qtd_status_addr, 64);
 
-        // Flush QH to main memory
-        flush_cache_range(qh_addr, 96);
-
         // Run one-shot control transfers on a quiet async schedule, matching
-        // libpayload/U-Boot. ICH7-era EHCI can otherwise keep stale async-list
-        // state around transient QHs.
+        // libpayload. Some ICH-era controllers do not reliably pick up a
+        // transient QH spliced into an already-programmed async ring; pointing
+        // ASYNCLISTADDR directly at the transfer QH avoids stale list state.
         if self.op().usbcmd.is_set(USBCMD::ASE) {
             self.op().usbcmd.modify(USBCMD::ASE::CLEAR);
             if !wait_for(100, || !self.op().usbsts.is_set(USBSTS::ASS)) {
@@ -1117,23 +1115,16 @@ impl EhciController {
             self.async_schedule_enabled = false;
         }
 
-        // Link QH into async schedule (insert after async head)
-        let async_qh = unsafe { &mut *(self.async_qh as *mut Qh) };
-        let old_link = async_qh.qh_link;
-        qh.qh_link = old_link;
+        // Use a single-QH circular async list for this transfer.
+        qh.qh_link = (qh_addr as u32) | Qh::TYPE_QH;
         fence(Ordering::SeqCst);
-        flush_cache_range(qh_addr, 4);
-
-        // Now link our QH into the schedule
-        async_qh.qh_link = (qh_addr as u32) | Qh::TYPE_QH;
-        fence(Ordering::SeqCst);
-        flush_cache_range(self.async_qh, 4);
+        flush_cache_range(qh_addr, 96);
+        self.op().asynclistaddr.set(qh_addr as u32);
 
         // Read back for debug
-        invalidate_cache_range(self.async_qh, 64);
         invalidate_cache_range(qh_addr, 64);
         invalidate_cache_range(qtd_setup_addr, 64);
-        let async_link = async_qh.qh_link;
+        let async_link = qh.qh_link;
         let qh_ep_chars = qh.ep_chars;
         let qh_current = qh.current_qtd;
         let qh_overlay_next = qh.overlay.next_qtd;
@@ -1168,9 +1159,7 @@ impl EhciController {
         self.op().usbcmd.modify(USBCMD::ASE::SET);
         if !wait_for(100, || self.op().usbsts.is_set(USBSTS::ASS)) {
             log::error!("EHCI: Async schedule failed to start");
-            async_qh.qh_link = old_link;
-            fence(Ordering::SeqCst);
-            flush_cache_range(self.async_qh, 4);
+            self.op().asynclistaddr.set(self.async_qh as u32);
             return Err(UsbError::Timeout);
         }
         self.async_schedule_enabled = true;
@@ -1234,17 +1223,13 @@ impl EhciController {
             crate::time::delay_us(1);
         }
 
-        // Unlink QH from schedule
-        async_qh.qh_link = old_link;
-        fence(Ordering::SeqCst);
-
-        // Stop the async schedule after the one-shot transfer. This avoids
-        // relying on IAAD for transient QHs and matches libpayload's model.
+        // Stop the one-shot async schedule before reusing transfer memory.
         self.op().usbcmd.modify(USBCMD::ASE::CLEAR);
         if !wait_for(100, || !self.op().usbsts.is_set(USBSTS::ASS)) {
             log::warn!("EHCI: Async schedule failed to stop after control transfer");
         }
         self.async_schedule_enabled = false;
+        self.op().asynclistaddr.set(self.async_qh as u32);
 
         // Invalidate caches one more time to get final state
         invalidate_cache_range(qtd_setup_addr, 64);

--- a/crabefi-core/src/efi/runtime_services.rs
+++ b/crabefi-core/src/efi/runtime_services.rs
@@ -255,6 +255,33 @@ static mut VIRTUAL_MAP_ENTRY_COUNT: usize = 0;
 /// The actual write is a one-shot during SetVirtualAddressMap.
 static VIRTUAL_MODE: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 
+fn clear_virtual_map_globals() {
+    unsafe {
+        VIRTUAL_MAP_PTR = core::ptr::null();
+        VIRTUAL_MAP_DESCRIPTOR_SIZE = 0;
+        VIRTUAL_MAP_ENTRY_COUNT = 0;
+    }
+}
+
+fn relocate_configured_deferred_buffer() -> Status {
+    let mut deferred_ptr = crate::efi::varstore::deferred::deferred_buffer_base() as *mut c_void;
+    if deferred_ptr.is_null() {
+        return Status::SUCCESS;
+    }
+
+    let status = convert_pointer_internal(0, &mut deferred_ptr);
+    if status != Status::SUCCESS {
+        log::error!(
+            "SetVirtualAddressMap: deferred buffer at {:p} is not in a runtime mapping",
+            deferred_ptr
+        );
+        return status;
+    }
+
+    crate::efi::varstore::deferred::relocate_buffer_base(deferred_ptr as u64);
+    Status::SUCCESS
+}
+
 extern "efiapi" fn set_virtual_address_map(
     memory_map_size: usize,
     descriptor_size: usize,
@@ -303,17 +330,27 @@ extern "efiapi" fn set_virtual_address_map(
         hooks.before_set_virtual_address_map();
     }
 
-    // Step 1: Commit to virtual mode
-    VIRTUAL_MODE.store(true, core::sync::atomic::Ordering::Release);
-
-    // Step 2: Set up globals so ConvertPointer can access the virtual map
+    // Step 1: Set up globals so ConvertPointer can access the virtual map.
     unsafe {
         VIRTUAL_MAP_PTR = virtual_map as *const u8;
         VIRTUAL_MAP_DESCRIPTOR_SIZE = descriptor_size;
         VIRTUAL_MAP_ENTRY_COUNT = num_entries;
     }
 
-    // Step 3: Signal EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE events
+    // Step 2: Relocate runtime-private raw pointers before committing to
+    // virtual mode. If a configured runtime pointer is not covered by an EFI
+    // runtime mapping, fail SVAM instead of leaving a stale physical pointer
+    // that a later runtime service could dereference.
+    let status = relocate_configured_deferred_buffer();
+    if status != Status::SUCCESS {
+        clear_virtual_map_globals();
+        return status;
+    }
+
+    // Step 3: Commit to virtual mode.
+    VIRTUAL_MODE.store(true, core::sync::atomic::Ordering::Release);
+
+    // Step 4: Signal EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE events
     {
         use crate::efi::boot_services::{
             EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE, signal_event_group_for_runtime,
@@ -531,11 +568,7 @@ extern "efiapi" fn set_virtual_address_map(
     }
 
     // Step 7: Clear virtual map globals
-    unsafe {
-        VIRTUAL_MAP_PTR = core::ptr::null();
-        VIRTUAL_MAP_DESCRIPTOR_SIZE = 0;
-        VIRTUAL_MAP_ENTRY_COUNT = 0;
-    }
+    clear_virtual_map_globals();
 
     log::info!("SetVirtualAddressMap: complete, disabling log crate for virtual mode");
 

--- a/crabefi-core/src/efi/varstore/deferred.rs
+++ b/crabefi-core/src/efi/varstore/deferred.rs
@@ -75,15 +75,18 @@ unsafe extern "C" {
 /// platform-configured base or 0 if no deferred buffer is configured.
 #[inline]
 pub fn deferred_buffer_base() -> u64 {
+    let ovr = BUFFER_BASE_OVERRIDE.load(core::sync::atomic::Ordering::Relaxed);
+    if ovr != 0 {
+        return ovr;
+    }
+
     #[cfg(feature = "platform-entry")]
     {
         unsafe { &_deferred_buffer_start as *const u8 as u64 }
     }
     #[cfg(not(feature = "platform-entry"))]
     {
-        // In library mode, use the override if configured, otherwise 0.
-        let ovr = BUFFER_BASE_OVERRIDE.load(core::sync::atomic::Ordering::Relaxed);
-        if ovr != 0 { ovr } else { 0 }
+        0
     }
 }
 
@@ -258,6 +261,17 @@ pub fn configure_buffer_with_size(base_addr: u64, size: usize) {
     );
 }
 
+/// Update the deferred buffer base after `SetVirtualAddressMap`.
+///
+/// The buffer itself is runtime data, but a platform-configured base is stored
+/// as a raw address in this module. Runtime `SetVariable` calls must append to
+/// the OS-provided virtual address after SVAM rather than the physical address.
+pub fn relocate_buffer_base(new_base: u64) {
+    if new_base != 0 {
+        BUFFER_BASE_OVERRIDE.store(new_base, Ordering::SeqCst);
+    }
+}
+
 /// Get the buffer base address
 ///
 /// Returns the override address if configured, otherwise the linker-allocated buffer.
@@ -275,6 +289,11 @@ fn buffer_size() -> usize {
     deferred_buffer_size()
 }
 
+/// Check whether a deferred buffer is configured and large enough for a header.
+fn buffer_available(base: *mut u8, size: usize) -> bool {
+    !base.is_null() && size >= HEADER_SIZE
+}
+
 /// Initialize the deferred buffer
 ///
 /// This clears any existing data and writes a fresh header.
@@ -284,7 +303,7 @@ pub fn init_buffer() {
 
     // No deferred buffer configured (library mode without platform-entry
     // and no explicit deferred_buffer in PlatformConfig).
-    if base.is_null() || size == 0 {
+    if !buffer_available(base, size) {
         log::debug!("No deferred variable buffer — skipping init");
         return;
     }
@@ -311,6 +330,10 @@ pub fn init_buffer() {
 /// Returns the number of pending entries, or 0 if none/invalid.
 pub fn check_pending() -> usize {
     let base = buffer_base();
+    let size = buffer_size();
+    if !buffer_available(base, size) {
+        return 0;
+    }
 
     // Read header
     let header = unsafe { core::ptr::read(base as *const DeferredHeader) };
@@ -326,7 +349,7 @@ pub fn check_pending() -> usize {
 
     // Verify data size is within buffer bounds
     let total_size = header.total_size as usize;
-    if HEADER_SIZE.saturating_add(total_size) > buffer_size() {
+    if HEADER_SIZE.saturating_add(total_size) > size {
         log::warn!(
             "Deferred buffer header total_size ({}) exceeds buffer bounds",
             total_size
@@ -357,13 +380,13 @@ pub fn check_pending() -> usize {
 
 /// Process all pending deferred writes
 ///
-/// This reads each entry from the buffer, applies it to SPI flash,
-/// then clears the buffer.
+/// This reads each entry from the buffer, applies it to persistent storage,
+/// then clears the buffer only if every entry was durably applied.
 ///
 /// For authenticated variables:
 /// - The signature is verified against the current key databases
 /// - Only if verification succeeds is the variable written to NVS
-/// - If verification fails, the entry is skipped (security policy)
+/// - If verification fails, replay stops and the buffer is preserved
 ///
 /// Returns the number of entries processed.
 pub fn process_pending() -> Result<usize, VarStoreError> {
@@ -373,17 +396,23 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
     }
 
     let base = buffer_base();
+    let size = buffer_size();
+    if !buffer_available(base, size) {
+        return Ok(0);
+    }
+
     let header = unsafe { core::ptr::read(base as *const DeferredHeader) };
 
     let mut offset = HEADER_SIZE;
     let mut processed = 0usize;
+    let mut failure = None;
     let entry_header_size = core::mem::size_of::<EntryHeader>();
 
     for i in 0..header.entry_count {
         // Bounds check: ensure we can read the entry header
         if offset
             .checked_add(entry_header_size)
-            .is_none_or(|end| end > buffer_size())
+            .is_none_or(|end| end > size)
         {
             log::warn!(
                 "Entry header at index {} would exceed buffer bounds (offset={}, header_size={})",
@@ -391,6 +420,7 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
                 offset,
                 entry_header_size
             );
+            failure = Some(VarStoreError::InvalidArgument);
             break;
         }
 
@@ -405,22 +435,21 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
 
         if record_len == 0 || record_len > MAX_ENTRY_SIZE {
             log::warn!("Invalid record length {} at index {}", record_len, i);
+            failure = Some(VarStoreError::InvalidArgument);
             break;
         }
 
         offset += entry_header_size;
 
         // Bounds check: ensure we can read the record data
-        if offset
-            .checked_add(record_len)
-            .is_none_or(|end| end > buffer_size())
-        {
+        if offset.checked_add(record_len).is_none_or(|end| end > size) {
             log::warn!(
                 "Record data at index {} would exceed buffer bounds (offset={}, record_len={})",
                 i,
                 offset,
                 record_len
             );
+            failure = Some(VarStoreError::InvalidArgument);
             break;
         }
 
@@ -436,14 +465,20 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
                 let guid = record.guid.to_guid();
 
                 if is_deletion {
-                    // Delete from storage
-                    if let Err(e) =
-                        super::persistence::write_variable_deletion_internal(&guid, &record.name)
+                    // Treat NotFound as success because the desired durable state
+                    // is already achieved; otherwise one stale deletion can block
+                    // deferred replay forever.
+                    match super::persistence::write_variable_deletion_internal(&guid, &record.name)
                     {
-                        log::warn!("Failed to apply deferred variable deletion: {:?}", e);
-                    } else {
-                        super::persistence::delete_variable_from_memory(&guid, &record.name);
-                        processed += 1;
+                        Ok(()) | Err(VarStoreError::NotFound) => {
+                            super::persistence::delete_variable_from_memory(&guid, &record.name);
+                            processed += 1;
+                        }
+                        Err(e) => {
+                            log::warn!("Failed to apply deferred variable deletion: {:?}", e);
+                            failure = Some(e);
+                            break;
+                        }
                     }
                 } else if record.is_active() {
                     // Determine the actual data to write and timestamp to preserve
@@ -464,11 +499,11 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
                             }
                             Err(e) => {
                                 log::warn!(
-                                    "Deferred authenticated variable verification failed: {:?}, skipping",
+                                    "Deferred authenticated variable verification failed: {:?}",
                                     e
                                 );
-                                offset += record_len;
-                                continue;
+                                failure = Some(VarStoreError::InvalidArgument);
+                                break;
                             }
                         }
                     } else {
@@ -495,33 +530,48 @@ pub fn process_pending() -> Result<usize, VarStoreError> {
                         )
                     };
 
-                    if let Err(e) = write_result {
-                        log::warn!("Failed to apply deferred variable write: {:?}", e);
-                    } else {
-                        // Also update in-memory (timestamp is handled by persist functions)
-                        super::persistence::update_variable_in_memory(
-                            &guid,
-                            &record.name,
-                            record.attributes,
-                            &actual_data,
-                        );
-                        processed += 1;
+                    match write_result {
+                        Ok(()) => {
+                            // Also update in-memory (timestamp is handled by persist functions)
+                            super::persistence::update_variable_in_memory(
+                                &guid,
+                                &record.name,
+                                record.attributes,
+                                &actual_data,
+                            );
+                            processed += 1;
+                        }
+                        Err(e) => {
+                            log::warn!("Failed to apply deferred variable write: {:?}", e);
+                            failure = Some(e);
+                            break;
+                        }
                     }
                 }
             }
             Err(e) => {
                 log::warn!("Failed to deserialize deferred entry {}: {:?}", i, e);
+                failure = Some(VarStoreError::SerdeError);
+                break;
             }
         }
 
         offset += record_len;
     }
 
-    // Clear the buffer
-    init_buffer();
-
-    log::info!("Processed {} deferred variable writes", processed);
-    Ok(processed)
+    if processed == pending_count && failure.is_none() {
+        init_buffer();
+        log::info!("Processed {} deferred variable writes", processed);
+        Ok(processed)
+    } else {
+        let error = failure.unwrap_or(VarStoreError::InvalidArgument);
+        log::warn!(
+            "Deferred variable replay incomplete: processed {}/{}; preserving buffer",
+            processed,
+            pending_count
+        );
+        Err(error)
+    }
 }
 
 /// Queue a variable write for deferred processing
@@ -592,6 +642,10 @@ pub fn queue_deletion(guid: &r_efi::efi::Guid, name: &[u16]) -> Result<(), VarSt
 /// Queue a variable record with flags
 fn queue_record_with_flags(record: &VariableRecord, flags: u8) -> Result<(), VarStoreError> {
     let base = buffer_base();
+    let size = buffer_size();
+    if !buffer_available(base, size) {
+        return Err(VarStoreError::NotInitialized);
+    }
 
     // Serialize the record
     let record_bytes = record.serialize()?;
@@ -633,7 +687,7 @@ fn queue_record_with_flags(record: &VariableRecord, flags: u8) -> Result<(), Var
         }
     };
 
-    if required_space > buffer_size() {
+    if required_space > size {
         log::warn!("Deferred buffer full");
         return Err(VarStoreError::StoreFull);
     }
@@ -697,14 +751,19 @@ pub fn is_initialized() -> bool {
 /// Get statistics about the deferred buffer
 pub fn get_stats() -> (usize, usize, usize) {
     let base = buffer_base();
+    let size = buffer_size();
+    if !buffer_available(base, size) {
+        return (0, 0, 0);
+    }
+
     let header = unsafe { core::ptr::read(base as *const DeferredHeader) };
 
     if !header.is_valid() {
-        return (0, 0, buffer_size() - HEADER_SIZE);
+        return (0, 0, size - HEADER_SIZE);
     }
 
     let used = header.total_size as usize;
-    let free = buffer_size() - HEADER_SIZE - used;
+    let free = size - HEADER_SIZE - used;
 
     (header.entry_count as usize, used, free)
 }

--- a/crabefi-core/src/efi/varstore/edk2_backend.rs
+++ b/crabefi-core/src/efi/varstore/edk2_backend.rs
@@ -20,10 +20,32 @@
 //! platform with direct byte-level access to a NOR flash or similar storage.
 //! Platforms using SMM or TF-A MM should implement [`VariableBackend`] directly.
 
+use alloc::vec::Vec;
+
 use crate::platform::{StorageBackend, VarBackendError, VariableBackend, VariableVisitor};
 use r_efi::efi::Guid;
 
 use super::edk2;
+
+fn guid_bytes_to_efi(bytes: &[u8; 16]) -> Guid {
+    Guid::from_fields(
+        u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+        u16::from_le_bytes([bytes[4], bytes[5]]),
+        u16::from_le_bytes([bytes[6], bytes[7]]),
+        bytes[8],
+        bytes[9],
+        &[
+            bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
+        ],
+    )
+}
+
+struct ActiveVar {
+    guid: [u8; 16],
+    name: Vec<u16>,
+    attributes: u32,
+    data: Vec<u8>,
+}
 
 /// EDK2 Firmware Volume format variable store.
 ///
@@ -82,6 +104,190 @@ impl<'a> Edk2VarStore<'a> {
     /// Check if the store has been initialized (load() called successfully).
     pub fn is_initialized(&self) -> bool {
         self.initialized
+    }
+
+    /// Read all variable records from the store.
+    fn walk_variables(&mut self) -> Vec<edk2::FvVariable> {
+        let auth_format = self.auth_format;
+        let data_size = self.data_size;
+        let storage = &mut self.storage;
+        let mut read_fn =
+            |offset: u32, buf: &mut [u8]| -> bool { storage.read(offset, buf).is_ok() };
+        edk2::walk_variables(&mut read_fn, auth_format, data_size)
+    }
+
+    /// Mark any existing active record for `guid_bytes` and `name` as deleted.
+    fn delete_existing_record(
+        &mut self,
+        guid_bytes: &[u8; 16],
+        name: &[u16],
+    ) -> Result<(), VarBackendError> {
+        let vars = self.walk_variables();
+        for var in &vars {
+            if edk2::is_var_added(var.state)
+                && var.guid == *guid_bytes
+                && edk2::name_matches(&var.name, name)
+            {
+                let _ = self.storage.enable_writes();
+                let storage = &mut self.storage;
+                let mut write_fn =
+                    |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
+                if !edk2::mark_deleted(&mut write_fn, var.state_offset) {
+                    return Err(VarBackendError::IoError);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Return the latest active variables, optionally excluding one variable.
+    fn active_variables_excluding(
+        &mut self,
+        exclude: Option<(&[u8; 16], &[u16])>,
+    ) -> Vec<ActiveVar> {
+        let vars = self.walk_variables();
+        let mut active: Vec<ActiveVar> = Vec::new();
+        for var in vars {
+            if !edk2::is_var_added(var.state) {
+                continue;
+            }
+            if exclude.is_some_and(|(guid, name)| {
+                var.guid == *guid && edk2::name_matches(&var.name, name)
+            }) {
+                continue;
+            }
+            active.retain(|existing| {
+                !(existing.guid == var.guid && edk2::name_matches(&existing.name, &var.name))
+            });
+            active.push(ActiveVar {
+                guid: var.guid,
+                name: var.name,
+                attributes: var.attributes,
+                data: var.data,
+            });
+        }
+        active
+    }
+
+    fn record_len(
+        guid: &[u8; 16],
+        name: &[u16],
+        attributes: u32,
+        data: &[u8],
+    ) -> Result<u32, VarBackendError> {
+        let len = edk2::build_variable_record(guid, name, attributes, data).len();
+        if len > u32::MAX as usize {
+            return Err(VarBackendError::DataTooLarge);
+        }
+        Ok(len as u32)
+    }
+
+    fn compacted_end(active: &[ActiveVar]) -> Result<u32, VarBackendError> {
+        let mut offset = edk2::VARIABLE_DATA_OFFSET;
+        for var in active {
+            let len = Self::record_len(&var.guid, &var.name, var.attributes, &var.data)?;
+            offset = offset.checked_add(len).ok_or(VarBackendError::StoreFull)?;
+        }
+        Ok(offset)
+    }
+
+    /// Compact the store by rewriting the provided active variables.
+    fn compact_active(&mut self, active: Vec<ActiveVar>) -> Result<(), VarBackendError> {
+        let storage_size = self.storage.size();
+        let final_offset = Self::compacted_end(&active)?;
+        if final_offset > storage_size {
+            return Err(VarBackendError::StoreFull);
+        }
+
+        let fv_headers = edk2::build_fv_headers(storage_size);
+        let _ = self.storage.enable_writes();
+        self.storage
+            .erase(0, storage_size)
+            .map_err(|_| VarBackendError::IoError)?;
+        self.storage
+            .write(0, &fv_headers)
+            .map_err(|_| VarBackendError::IoError)?;
+
+        self.auth_format = false;
+        self.data_size = storage_size - (edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32;
+        self.write_offset = edk2::VARIABLE_DATA_OFFSET;
+
+        for var in active {
+            let storage = &mut self.storage;
+            let mut write_fn =
+                |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
+            self.write_offset = edk2::write_variable(
+                &mut write_fn,
+                self.write_offset,
+                &var.guid,
+                &var.name,
+                var.attributes,
+                &var.data,
+            )
+            .ok_or(VarBackendError::IoError)?;
+        }
+
+        Ok(())
+    }
+
+    /// Append a variable record, compacting once if necessary.
+    fn append_variable(
+        &mut self,
+        name: &[u16],
+        vendor: &Guid,
+        attributes: u32,
+        data: &[u8],
+    ) -> Result<(), VarBackendError> {
+        self.ensure_initialized()?;
+
+        let guid_bytes = edk2::guid_to_bytes(vendor);
+        let record_len = Self::record_len(&guid_bytes, name, attributes, data)?;
+        let storage_size = self.storage.size();
+        let data_capacity = storage_size
+            .checked_sub(edk2::VARIABLE_DATA_OFFSET)
+            .ok_or(VarBackendError::StoreFull)?;
+        if record_len > data_capacity {
+            return Err(VarBackendError::StoreFull);
+        }
+
+        // Preflight the compacted layout before deleting the existing record or
+        // erasing flash. If the replacement cannot fit even after compaction,
+        // leave the current store untouched.
+        let compacted_active = self.active_variables_excluding(Some((&guid_bytes, name)));
+        let compacted_end = Self::compacted_end(&compacted_active)?;
+        if compacted_end
+            .checked_add(record_len)
+            .is_none_or(|end| end > storage_size)
+        {
+            return Err(VarBackendError::StoreFull);
+        }
+
+        if self
+            .write_offset
+            .checked_add(record_len)
+            .is_some_and(|end| end <= storage_size)
+        {
+            self.delete_existing_record(&guid_bytes, name)?;
+        } else {
+            log::info!("Variable store full, compacting");
+            self.compact_active(compacted_active)?;
+        }
+
+        let _ = self.storage.enable_writes();
+        let storage = &mut self.storage;
+        let mut write_fn =
+            |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
+        self.write_offset = edk2::write_variable(
+            &mut write_fn,
+            self.write_offset,
+            &guid_bytes,
+            name,
+            attributes,
+            data,
+        )
+        .ok_or(VarBackendError::IoError)?;
+
+        Ok(())
     }
 
     /// Validate or format the FV headers.
@@ -147,151 +353,26 @@ impl VariableBackend for Edk2VarStore<'_> {
     fn load(&mut self, visitor: &mut dyn VariableVisitor) -> Result<(), VarBackendError> {
         self.ensure_initialized()?;
 
-        // Read variable records from the FV and call visitor for each
-        let auth_format = self.auth_format;
-        let data_size = self.data_size;
-        let header_offset = (edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32;
-        let storage = &mut self.storage;
-
-        // Walk the variable store records
-        let mut offset = header_offset;
-        let end = header_offset + data_size;
-
-        while offset < end {
-            // Read variable header
-            let header_len = if auth_format {
-                edk2::AUTH_VAR_HEADER_SIZE
-            } else {
-                edk2::VAR_HEADER_SIZE
-            };
-
-            if offset + header_len as u32 > end {
-                break;
+        let vars = self.walk_variables();
+        let mut active: Vec<&edk2::FvVariable> = Vec::new();
+        for var in &vars {
+            if !edk2::is_var_added(var.state) {
+                continue;
             }
+            active.retain(|existing| {
+                !(existing.guid == var.guid && edk2::name_matches(&existing.name, &var.name))
+            });
+            active.push(var);
+        }
 
-            let mut header_buf = [0u8; 80]; // Large enough for auth header
-            if storage.read(offset, &mut header_buf[..header_len]).is_err() {
-                break;
-            }
-
-            // Check magic and state
-            let start_id = u16::from_le_bytes([header_buf[0], header_buf[1]]);
-            if start_id != 0xAA55 {
-                break; // End of valid records (free space)
-            }
-
-            let state = header_buf[2];
-            let attributes =
-                u32::from_le_bytes([header_buf[3], header_buf[4], header_buf[5], header_buf[6]]);
-
-            let (name_size, data_size_field) = if auth_format {
-                let ns = u32::from_le_bytes([
-                    header_buf[40],
-                    header_buf[41],
-                    header_buf[42],
-                    header_buf[43],
-                ]);
-                let ds = u32::from_le_bytes([
-                    header_buf[44],
-                    header_buf[45],
-                    header_buf[46],
-                    header_buf[47],
-                ]);
-                (ns, ds)
-            } else {
-                let ns = u32::from_le_bytes([
-                    header_buf[24],
-                    header_buf[25],
-                    header_buf[26],
-                    header_buf[27],
-                ]);
-                let ds = u32::from_le_bytes([
-                    header_buf[28],
-                    header_buf[29],
-                    header_buf[30],
-                    header_buf[31],
-                ]);
-                (ns, ds)
-            };
-
-            // Extract vendor GUID
-            let guid_offset = if auth_format { 48 } else { 32 };
-            let vendor_guid = if guid_offset + 16 <= header_len {
-                let guid_bytes = &header_buf[guid_offset..guid_offset + 16];
-                // Parse GUID from mixed-endian format (first 3 fields LE, last 2 BE)
-                let data1 = u32::from_le_bytes([
-                    guid_bytes[0],
-                    guid_bytes[1],
-                    guid_bytes[2],
-                    guid_bytes[3],
-                ]);
-                let data2 = u16::from_le_bytes([guid_bytes[4], guid_bytes[5]]);
-                let data3 = u16::from_le_bytes([guid_bytes[6], guid_bytes[7]]);
-                let data4_hi = u8::from_le_bytes([guid_bytes[8]]);
-                let data4_lo = u8::from_le_bytes([guid_bytes[9]]);
-                Guid::from_fields(
-                    data1,
-                    data2,
-                    data3,
-                    data4_hi,
-                    data4_lo,
-                    &[
-                        guid_bytes[10],
-                        guid_bytes[11],
-                        guid_bytes[12],
-                        guid_bytes[13],
-                        guid_bytes[14],
-                        guid_bytes[15],
-                    ],
-                )
-            } else {
-                break;
-            };
-
-            // Calculate total record size (header + name + data, padded to 4 bytes)
-            let record_data_start = offset + header_len as u32;
-            let total_payload = name_size + data_size_field;
-            let record_size = header_len as u32 + total_payload + ((4 - (total_payload % 4)) % 4); // 4-byte align
-
-            // Only process valid (non-deleted) records
-            if state == 0x3F || state == 0x7F {
-                // Read name and data
-                if total_payload > 0 && record_data_start + total_payload <= end {
-                    // Use a stack buffer for small records, skip huge ones
-                    const MAX_PAYLOAD: usize = 32 * 1024;
-                    if (total_payload as usize) <= MAX_PAYLOAD {
-                        let mut payload = [0u8; MAX_PAYLOAD];
-                        let payload_slice = &mut payload[..total_payload as usize];
-                        if storage.read(record_data_start, payload_slice).is_ok() {
-                            // Name is UTF-16LE, data follows
-                            let name_bytes = &payload_slice[..name_size as usize];
-                            let data_bytes =
-                                &payload_slice[name_size as usize..total_payload as usize];
-
-                            // Convert name bytes to &[u16]
-                            let name_u16_count = name_size as usize / 2;
-                            // SAFETY: name_bytes is aligned to u8, we manually convert
-                            let mut name_u16 = [0u16; 128];
-                            let name_len = name_u16_count.min(128);
-                            for i in 0..name_len {
-                                name_u16[i] =
-                                    u16::from_le_bytes([name_bytes[i * 2], name_bytes[i * 2 + 1]]);
-                            }
-                            // Strip null terminator if present
-                            let name_slice = if name_len > 0 && name_u16[name_len - 1] == 0 {
-                                &name_u16[..name_len - 1]
-                            } else {
-                                &name_u16[..name_len]
-                            };
-
-                            visitor.visit(name_slice, &vendor_guid, attributes, data_bytes);
-                        }
-                    }
-                }
-            }
-
-            // Advance to next record
-            offset += record_size;
+        for var in active {
+            let vendor = guid_bytes_to_efi(&var.guid);
+            let name_len = var
+                .name
+                .iter()
+                .position(|&c| c == 0)
+                .unwrap_or(var.name.len());
+            visitor.visit(&var.name[..name_len], &vendor, var.attributes, &var.data);
         }
 
         Ok(())
@@ -299,32 +380,18 @@ impl VariableBackend for Edk2VarStore<'_> {
 
     fn write(
         &mut self,
-        _name: &[u16],
-        _vendor: &Guid,
-        _attributes: u32,
-        _data: &[u8],
+        name: &[u16],
+        vendor: &Guid,
+        attributes: u32,
+        data: &[u8],
     ) -> Result<(), VarBackendError> {
-        if !self.initialized {
-            return Err(VarBackendError::NotAvailable);
-        }
-
-        // TODO: Delegate to the existing edk2 persistence code for writing.
-        // This requires refactoring persistence.rs to work with a borrowed
-        // StorageBackend rather than the global state accessor.
-        //
-        // For now, the legacy init() path handles writes through the existing
-        // persistence module. This stub will be completed when the full
-        // migration from init() to init_platform() happens.
-        Err(VarBackendError::Other)
+        self.append_variable(name, vendor, attributes, data)
     }
 
-    fn delete(&mut self, _name: &[u16], _vendor: &Guid) -> Result<(), VarBackendError> {
-        if !self.initialized {
-            return Err(VarBackendError::NotAvailable);
-        }
-
-        // TODO: Same as write() — pending persistence.rs refactoring.
-        Err(VarBackendError::Other)
+    fn delete(&mut self, name: &[u16], vendor: &Guid) -> Result<(), VarBackendError> {
+        self.ensure_initialized()?;
+        let guid_bytes = edk2::guid_to_bytes(vendor);
+        self.delete_existing_record(&guid_bytes, name)
     }
 
     fn runtime_capable(&self) -> bool {

--- a/crabefi-core/src/efi/varstore/edk2_backend.rs
+++ b/crabefi-core/src/efi/varstore/edk2_backend.rs
@@ -1,24 +1,12 @@
 //! EDK2 Firmware Volume Variable Backend
 //!
-//! This module provides [`Edk2VarStore`], a [`VariableBackend`] implementation
-//! that stores EFI variables in EDK2-compatible Firmware Volume (FV) format
-//! on top of a raw [`StorageBackend`].
+//! This module provides shared EDK2 Firmware Volume variable-store logic plus
+//! [`Edk2VarStore`], a [`VariableBackend`] implementation that stores EFI
+//! variables on top of a raw [`StorageBackend`].
 //!
-//! # Usage
-//!
-//! ```ignore
-//! let mut spi_backend = SpiStorageBackend::new(controller, offset, size);
-//! let mut edk2_store = crabefi::efi::varstore::Edk2VarStore::new(&mut spi_backend);
-//!
-//! let config = crabefi::PlatformConfig {
-//!     variable_backend: Some(&mut edk2_store),
-//!     // ...
-//! };
-//! ```
-//!
-//! This is the default variable backend for the coreboot target and any other
-//! platform with direct byte-level access to a NOR flash or similar storage.
-//! Platforms using SMM or TF-A MM should implement [`VariableBackend`] directly.
+//! The direct-flash persistence path and the platform [`VariableBackend`] path
+//! both use [`Edk2Store`], so EDK2 FV parsing, replacement, deletion, and
+//! compaction rules live in one place.
 
 use alloc::vec::Vec;
 
@@ -27,7 +15,39 @@ use r_efi::efi::Guid;
 
 use super::edk2;
 
-fn guid_bytes_to_efi(bytes: &[u8; 16]) -> Guid {
+/// Mutable EDK2 variable-store state tracked by a caller.
+#[derive(Clone, Copy, Debug)]
+pub struct Edk2StoreState {
+    /// Whether the FV headers have been validated/initialized.
+    pub initialized: bool,
+    /// Whether the store uses authenticated variable headers.
+    pub auth_format: bool,
+    /// Size of the variable-record area after FV + variable-store headers.
+    pub data_size: u32,
+    /// Next free byte for appending records, relative to the store start.
+    pub write_offset: u32,
+}
+
+impl Edk2StoreState {
+    /// Create an empty, uninitialized EDK2 store state.
+    pub const fn new() -> Self {
+        Self {
+            initialized: false,
+            auth_format: false,
+            data_size: 0,
+            write_offset: 0,
+        }
+    }
+}
+
+impl Default for Edk2StoreState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Convert 16-byte on-disk GUID bytes to an EFI GUID.
+pub fn guid_bytes_to_efi(bytes: &[u8; 16]) -> Guid {
     Guid::from_fields(
         u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
         u16::from_le_bytes([bytes[4], bytes[5]]),
@@ -40,6 +60,7 @@ fn guid_bytes_to_efi(bytes: &[u8; 16]) -> Guid {
     )
 }
 
+#[derive(Clone)]
 struct ActiveVar {
     guid: [u8; 16],
     name: Vec<u16>,
@@ -47,100 +68,263 @@ struct ActiveVar {
     data: Vec<u8>,
 }
 
-/// EDK2 Firmware Volume format variable store.
+/// Shared EDK2 Firmware Volume store implementation.
 ///
-/// Wraps a [`StorageBackend`] (e.g., SPI flash) and implements the
-/// [`VariableBackend`] trait using EDK2-compatible Firmware Volume format.
-///
-/// # Format
-///
-/// The storage is laid out as:
-/// ```text
-/// +-------------------------------------------+ offset 0
-/// |  EFI_FIRMWARE_VOLUME_HEADER  (72 bytes)   |
-/// +-------------------------------------------+ offset 0x48
-/// |  VARIABLE_STORE_HEADER       (28 bytes)   |
-/// +-------------------------------------------+ offset 0x64
-/// |  Variable Record #1 (header + name + data)|
-/// |  (padded to 4-byte alignment)             |
-/// +-------------------------------------------+
-/// |  Variable Record #2                       |
-/// +-------------------------------------------+
-/// |  ...                                      |
-/// +-------------------------------------------+
-/// |  Free space (0xFF)                        |
-/// +-------------------------------------------+
-/// ```
-///
-/// When a variable is updated, the old record is marked as deleted and a new
-/// record is appended. When free space runs out, compaction erases the region
-/// and rewrites only active variables.
-pub struct Edk2VarStore<'a> {
+/// `Edk2Store` borrows a storage backend and the caller-owned state for the
+/// duration of one operation. This keeps the parsing/write/compaction logic
+/// shared while allowing existing global-state and platform-backend callers to
+/// own their storage differently.
+pub struct Edk2Store<'a> {
     storage: &'a mut dyn StorageBackend,
-    /// Whether the FV headers have been validated/initialized.
-    initialized: bool,
-    /// Whether the store uses authenticated variable format.
-    auth_format: bool,
-    /// Size of the data region (total size minus headers).
-    data_size: u32,
-    /// Current write offset (next free byte in the data region).
-    write_offset: u32,
+    state: &'a mut Edk2StoreState,
 }
 
-impl<'a> Edk2VarStore<'a> {
-    /// Create a new EDK2 variable store wrapping a storage backend.
-    ///
-    /// The store is not initialized until [`VariableBackend::load()`] is called.
-    pub fn new(storage: &'a mut dyn StorageBackend) -> Self {
-        Self {
-            storage,
-            initialized: false,
-            auth_format: false,
-            data_size: 0,
-            write_offset: 0,
-        }
+impl<'a> Edk2Store<'a> {
+    /// Create a store view over `storage` and its mutable `state`.
+    pub fn new(storage: &'a mut dyn StorageBackend, state: &'a mut Edk2StoreState) -> Self {
+        Self { storage, state }
     }
 
-    /// Check if the store has been initialized (load() called successfully).
+    /// Check if the store has been initialized.
     pub fn is_initialized(&self) -> bool {
-        self.initialized
+        self.state.initialized
     }
 
-    /// Read all variable records from the store.
-    fn walk_variables(&mut self) -> Vec<edk2::FvVariable> {
-        let auth_format = self.auth_format;
-        let data_size = self.data_size;
-        let storage = &mut self.storage;
-        let mut read_fn =
-            |offset: u32, buf: &mut [u8]| -> bool { storage.read(offset, buf).is_ok() };
-        edk2::walk_variables(&mut read_fn, auth_format, data_size)
+    /// Return the current write offset.
+    pub fn write_offset(&self) -> u32 {
+        self.state.write_offset
     }
 
-    /// Mark any existing active record for `guid_bytes` and `name` as deleted.
-    fn delete_existing_record(
+    /// Return whether the current FV uses authenticated variable headers.
+    pub fn auth_format(&self) -> bool {
+        self.state.auth_format
+    }
+
+    /// Return the current EDK2 variable data size.
+    pub fn data_size(&self) -> u32 {
+        self.state.data_size
+    }
+
+    /// Validate or format the FV headers.
+    pub fn ensure_initialized(&mut self) -> Result<(), VarBackendError> {
+        if self.state.initialized {
+            return Ok(());
+        }
+
+        let storage_size = self.storage.size();
+        let header_size = edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH;
+        let mut header_bytes = [0u8; 128];
+        self.storage
+            .read(0, &mut header_bytes[..header_size])
+            .map_err(|_| VarBackendError::IoError)?;
+
+        log::debug!(
+            "Variable store header bytes: {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x}",
+            header_bytes[0],
+            header_bytes[1],
+            header_bytes[2],
+            header_bytes[3],
+            header_bytes[4],
+            header_bytes[5],
+            header_bytes[6],
+            header_bytes[7],
+            header_bytes[8],
+            header_bytes[9],
+            header_bytes[10],
+            header_bytes[11],
+            header_bytes[12],
+            header_bytes[13],
+            header_bytes[14],
+            header_bytes[15]
+        );
+
+        let validation = edk2::validate_fv(&header_bytes[..header_size], storage_size);
+        if validation.valid {
+            let mut read_fn =
+                |offset: u32, buf: &mut [u8]| -> bool { self.storage.read(offset, buf).is_ok() };
+            let write_offset =
+                edk2::find_write_offset(&mut read_fn, validation.auth_format, validation.data_size);
+
+            self.state.initialized = true;
+            self.state.auth_format = validation.auth_format;
+            self.state.data_size = validation.data_size;
+            self.state.write_offset = write_offset;
+
+            log::info!(
+                "EDK2 FV found: auth_format={}, data_size={} KB, write_offset={:#x}",
+                validation.auth_format,
+                validation.data_size / 1024,
+                write_offset
+            );
+            return Ok(());
+        }
+
+        log::info!(
+            "Formatting variable store as EDK2 FV ({} KB)...",
+            storage_size / 1024
+        );
+        let fv_headers = edk2::build_fv_headers(storage_size);
+        if let Err(e) = self.storage.enable_writes() {
+            log::warn!("Could not enable storage writes: {:?}", e);
+        }
+        self.storage
+            .erase(0, storage_size)
+            .map_err(|_| VarBackendError::IoError)?;
+        self.storage
+            .write(0, &fv_headers)
+            .map_err(|_| VarBackendError::IoError)?;
+
+        self.state.initialized = true;
+        self.state.auth_format = false;
+        self.state.data_size = storage_size
+            .checked_sub((edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32)
+            .ok_or(VarBackendError::StoreFull)?;
+        self.state.write_offset = edk2::VARIABLE_DATA_OFFSET;
+
+        log::info!("Variable store formatted as EDK2 FV successfully");
+        Ok(())
+    }
+
+    /// Load all active variables through `visitor`.
+    pub fn load(&mut self, visitor: &mut dyn VariableVisitor) -> Result<usize, VarBackendError> {
+        self.ensure_initialized()?;
+        let active = self.active_variables_excluding(None);
+        let count = active.len();
+
+        for var in active {
+            let vendor = guid_bytes_to_efi(&var.guid);
+            let name_len = var
+                .name
+                .iter()
+                .position(|&c| c == 0)
+                .unwrap_or(var.name.len());
+            visitor.visit(&var.name[..name_len], &vendor, var.attributes, &var.data);
+        }
+
+        Ok(count)
+    }
+
+    /// Persist a variable write.
+    pub fn write(
         &mut self,
-        guid_bytes: &[u8; 16],
         name: &[u16],
+        vendor: &Guid,
+        attributes: u32,
+        data: &[u8],
     ) -> Result<(), VarBackendError> {
-        let vars = self.walk_variables();
-        for var in &vars {
-            if edk2::is_var_added(var.state)
-                && var.guid == *guid_bytes
-                && edk2::name_matches(&var.name, name)
-            {
-                let _ = self.storage.enable_writes();
-                let storage = &mut self.storage;
-                let mut write_fn =
-                    |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
-                if !edk2::mark_deleted(&mut write_fn, var.state_offset) {
-                    return Err(VarBackendError::IoError);
-                }
-            }
+        self.ensure_initialized()?;
+
+        let guid_bytes = edk2::guid_to_bytes(vendor);
+        let record_len = Self::record_len(&guid_bytes, name, attributes, data)?;
+        let storage_size = self.storage.size();
+        let data_capacity = storage_size
+            .checked_sub(edk2::VARIABLE_DATA_OFFSET)
+            .ok_or(VarBackendError::StoreFull)?;
+        if record_len > data_capacity {
+            return Err(VarBackendError::StoreFull);
+        }
+
+        // Preflight the compacted layout before deleting or erasing anything.
+        let compacted_active = self.active_variables_excluding(Some((&guid_bytes, name)));
+        let compacted_end = Self::compacted_end(&compacted_active)?;
+        if compacted_end
+            .checked_add(record_len)
+            .is_none_or(|end| end > storage_size)
+        {
+            return Err(VarBackendError::StoreFull);
+        }
+
+        let mut old_state_offsets = self.matching_active_state_offsets(&guid_bytes, name);
+        if self
+            .state
+            .write_offset
+            .checked_add(record_len)
+            .is_none_or(|end| end > storage_size)
+        {
+            log::info!("Variable store full, compacting");
+            self.compact_active(compacted_active)?;
+            // Compaction rewrote the store without the replaced variable, so
+            // the pre-compaction state offsets no longer refer to old records.
+            old_state_offsets.clear();
+        }
+
+        let write_offset = self.state.write_offset;
+        if let Err(e) = self.storage.enable_writes() {
+            log::warn!("Could not enable storage writes: {:?}", e);
+        }
+        let mut write_fn =
+            |offset: u32, data: &[u8]| -> bool { self.storage.write(offset, data).is_ok() };
+        self.state.write_offset = edk2::write_variable(
+            &mut write_fn,
+            write_offset,
+            &guid_bytes,
+            name,
+            attributes,
+            data,
+        )
+        .ok_or(VarBackendError::IoError)?;
+
+        // The new record is durable now. Delete old records afterwards so an
+        // append failure cannot destroy the previous value. Deletion failures
+        // are still fatal: coreboot's SMMSTORE reader is first-match, so an old
+        // active record left before the appended replacement would keep the
+        // persistent store semantically stale.
+        for state_offset in old_state_offsets {
+            self.mark_deleted_at(state_offset)?;
+        }
+
+        log::debug!("Variable persisted at offset {:#x}", write_offset);
+        Ok(())
+    }
+
+    /// Mark active records for `name`/`vendor` deleted.
+    pub fn delete(&mut self, name: &[u16], vendor: &Guid) -> Result<(), VarBackendError> {
+        self.ensure_initialized()?;
+        let guid_bytes = edk2::guid_to_bytes(vendor);
+        let offsets = self.matching_active_state_offsets(&guid_bytes, name);
+        if offsets.is_empty() {
+            return Err(VarBackendError::NotFound);
+        }
+
+        for state_offset in offsets {
+            self.mark_deleted_at(state_offset)?;
         }
         Ok(())
     }
 
-    /// Return the latest active variables, optionally excluding one variable.
+    /// Compact the store by preserving the latest active variable records.
+    pub fn compact(&mut self) -> Result<u32, VarBackendError> {
+        self.ensure_initialized()?;
+        let old_write_offset = self.state.write_offset;
+        let active = self.active_variables_excluding(None);
+        log::info!(
+            "Found {} active variables to preserve during compaction",
+            active.len()
+        );
+        self.compact_active(active)?;
+        Ok(old_write_offset.saturating_sub(self.state.write_offset))
+    }
+
+    fn walk_variables(&mut self) -> Vec<edk2::FvVariable> {
+        let auth_format = self.state.auth_format;
+        let data_size = self.state.data_size;
+        let mut read_fn =
+            |offset: u32, buf: &mut [u8]| -> bool { self.storage.read(offset, buf).is_ok() };
+        edk2::walk_variables(&mut read_fn, auth_format, data_size)
+    }
+
+    fn matching_active_state_offsets(&mut self, guid_bytes: &[u8; 16], name: &[u16]) -> Vec<u32> {
+        self.walk_variables()
+            .into_iter()
+            .filter(|var| {
+                edk2::is_var_added(var.state)
+                    && var.guid == *guid_bytes
+                    && edk2::name_matches(&var.name, name)
+            })
+            .map(|var| var.state_offset)
+            .collect()
+    }
+
     fn active_variables_excluding(
         &mut self,
         exclude: Option<(&[u8; 16], &[u16])>,
@@ -191,7 +375,6 @@ impl<'a> Edk2VarStore<'a> {
         Ok(offset)
     }
 
-    /// Compact the store by rewriting the provided active variables.
     fn compact_active(&mut self, active: Vec<ActiveVar>) -> Result<(), VarBackendError> {
         let storage_size = self.storage.size();
         let final_offset = Self::compacted_end(&active)?;
@@ -200,7 +383,9 @@ impl<'a> Edk2VarStore<'a> {
         }
 
         let fv_headers = edk2::build_fv_headers(storage_size);
-        let _ = self.storage.enable_writes();
+        if let Err(e) = self.storage.enable_writes() {
+            log::warn!("Could not enable storage writes for compaction: {:?}", e);
+        }
         self.storage
             .erase(0, storage_size)
             .map_err(|_| VarBackendError::IoError)?;
@@ -208,17 +393,18 @@ impl<'a> Edk2VarStore<'a> {
             .write(0, &fv_headers)
             .map_err(|_| VarBackendError::IoError)?;
 
-        self.auth_format = false;
-        self.data_size = storage_size - (edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32;
-        self.write_offset = edk2::VARIABLE_DATA_OFFSET;
+        self.state.auth_format = false;
+        self.state.data_size = storage_size
+            .checked_sub((edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32)
+            .ok_or(VarBackendError::StoreFull)?;
+        self.state.write_offset = edk2::VARIABLE_DATA_OFFSET;
 
         for var in active {
-            let storage = &mut self.storage;
             let mut write_fn =
-                |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
-            self.write_offset = edk2::write_variable(
+                |offset: u32, data: &[u8]| -> bool { self.storage.write(offset, data).is_ok() };
+            self.state.write_offset = edk2::write_variable(
                 &mut write_fn,
-                self.write_offset,
+                self.state.write_offset,
                 &var.guid,
                 &var.name,
                 var.attributes,
@@ -230,152 +416,50 @@ impl<'a> Edk2VarStore<'a> {
         Ok(())
     }
 
-    /// Append a variable record, compacting once if necessary.
-    fn append_variable(
-        &mut self,
-        name: &[u16],
-        vendor: &Guid,
-        attributes: u32,
-        data: &[u8],
-    ) -> Result<(), VarBackendError> {
-        self.ensure_initialized()?;
-
-        let guid_bytes = edk2::guid_to_bytes(vendor);
-        let record_len = Self::record_len(&guid_bytes, name, attributes, data)?;
-        let storage_size = self.storage.size();
-        let data_capacity = storage_size
-            .checked_sub(edk2::VARIABLE_DATA_OFFSET)
-            .ok_or(VarBackendError::StoreFull)?;
-        if record_len > data_capacity {
-            return Err(VarBackendError::StoreFull);
+    fn mark_deleted_at(&mut self, state_offset: u32) -> Result<(), VarBackendError> {
+        if let Err(e) = self.storage.enable_writes() {
+            log::warn!("Could not enable storage writes for deletion: {:?}", e);
         }
-
-        // Preflight the compacted layout before deleting the existing record or
-        // erasing flash. If the replacement cannot fit even after compaction,
-        // leave the current store untouched.
-        let compacted_active = self.active_variables_excluding(Some((&guid_bytes, name)));
-        let compacted_end = Self::compacted_end(&compacted_active)?;
-        if compacted_end
-            .checked_add(record_len)
-            .is_none_or(|end| end > storage_size)
-        {
-            return Err(VarBackendError::StoreFull);
-        }
-
-        if self
-            .write_offset
-            .checked_add(record_len)
-            .is_some_and(|end| end <= storage_size)
-        {
-            self.delete_existing_record(&guid_bytes, name)?;
-        } else {
-            log::info!("Variable store full, compacting");
-            self.compact_active(compacted_active)?;
-        }
-
-        let _ = self.storage.enable_writes();
-        let storage = &mut self.storage;
         let mut write_fn =
-            |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
-        self.write_offset = edk2::write_variable(
-            &mut write_fn,
-            self.write_offset,
-            &guid_bytes,
-            name,
-            attributes,
-            data,
-        )
-        .ok_or(VarBackendError::IoError)?;
+            |offset: u32, data: &[u8]| -> bool { self.storage.write(offset, data).is_ok() };
+        if edk2::mark_deleted(&mut write_fn, state_offset) {
+            Ok(())
+        } else {
+            Err(VarBackendError::IoError)
+        }
+    }
+}
 
-        Ok(())
+/// EDK2 Firmware Volume format variable store.
+///
+/// Wraps a [`StorageBackend`] (e.g., SPI flash) and implements the
+/// [`VariableBackend`] trait using the same shared [`Edk2Store`] logic used by
+/// the direct persistence path.
+pub struct Edk2VarStore<'a> {
+    storage: &'a mut dyn StorageBackend,
+    state: Edk2StoreState,
+}
+
+impl<'a> Edk2VarStore<'a> {
+    /// Create a new EDK2 variable store wrapping a storage backend.
+    pub fn new(storage: &'a mut dyn StorageBackend) -> Self {
+        Self {
+            storage,
+            state: Edk2StoreState::new(),
+        }
     }
 
-    /// Validate or format the FV headers.
-    ///
-    /// Returns Ok(()) if headers are valid or were successfully written.
-    fn ensure_initialized(&mut self) -> Result<(), VarBackendError> {
-        if self.initialized {
-            return Ok(());
-        }
-
-        let storage_size = self.storage.size();
-
-        // Read FV + VS headers
-        let header_size = edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH;
-        let mut header_bytes = [0u8; 128];
-        self.storage
-            .read(0, &mut header_bytes[..header_size])
-            .map_err(|_| VarBackendError::IoError)?;
-
-        // Validate
-        let validation = edk2::validate_fv(&header_bytes[..header_size], storage_size);
-
-        if validation.valid {
-            self.auth_format = validation.auth_format;
-            self.data_size = validation.data_size;
-
-            // Find write offset
-            let auth_format = self.auth_format;
-            let data_size = self.data_size;
-            let storage = &mut self.storage;
-            let mut read_fn =
-                |offset: u32, buf: &mut [u8]| -> bool { storage.read(offset, buf).is_ok() };
-            self.write_offset = edk2::find_write_offset(&mut read_fn, auth_format, data_size);
-            self.initialized = true;
-            return Ok(());
-        }
-
-        // Format the store
-        log::info!(
-            "Formatting variable store as EDK2 FV ({} KB)...",
-            storage_size / 1024
-        );
-
-        let fv_headers = edk2::build_fv_headers(storage_size);
-        let _ = self.storage.enable_writes();
-        self.storage
-            .erase(0, storage_size)
-            .map_err(|_| VarBackendError::IoError)?;
-        self.storage
-            .write(0, &fv_headers)
-            .map_err(|_| VarBackendError::IoError)?;
-
-        self.auth_format = false;
-        self.data_size = storage_size - (edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32;
-        self.write_offset = (edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH) as u32;
-        self.initialized = true;
-
-        Ok(())
+    /// Check if the store has been initialized.
+    pub fn is_initialized(&self) -> bool {
+        self.state.initialized
     }
 }
 
 impl VariableBackend for Edk2VarStore<'_> {
     fn load(&mut self, visitor: &mut dyn VariableVisitor) -> Result<(), VarBackendError> {
-        self.ensure_initialized()?;
-
-        let vars = self.walk_variables();
-        let mut active: Vec<&edk2::FvVariable> = Vec::new();
-        for var in &vars {
-            if !edk2::is_var_added(var.state) {
-                continue;
-            }
-            active.retain(|existing| {
-                !(existing.guid == var.guid && edk2::name_matches(&existing.name, &var.name))
-            });
-            active.push(var);
-        }
-
-        for var in active {
-            let vendor = guid_bytes_to_efi(&var.guid);
-            let name_len = var
-                .name
-                .iter()
-                .position(|&c| c == 0)
-                .unwrap_or(var.name.len());
-            visitor.visit(&var.name[..name_len], &vendor, var.attributes, &var.data);
-        }
-
-        Ok(())
+        Edk2Store::new(self.storage, &mut self.state)
+            .load(visitor)
+            .map(|_| ())
     }
 
     fn write(
@@ -385,13 +469,11 @@ impl VariableBackend for Edk2VarStore<'_> {
         attributes: u32,
         data: &[u8],
     ) -> Result<(), VarBackendError> {
-        self.append_variable(name, vendor, attributes, data)
+        Edk2Store::new(self.storage, &mut self.state).write(name, vendor, attributes, data)
     }
 
     fn delete(&mut self, name: &[u16], vendor: &Guid) -> Result<(), VarBackendError> {
-        self.ensure_initialized()?;
-        let guid_bytes = edk2::guid_to_bytes(vendor);
-        self.delete_existing_record(&guid_bytes, name)
+        Edk2Store::new(self.storage, &mut self.state).delete(name, vendor)
     }
 
     fn runtime_capable(&self) -> bool {
@@ -401,7 +483,6 @@ impl VariableBackend for Edk2VarStore<'_> {
     }
 
     fn notify_exit_boot_services(&mut self) {
-        // Mark that flash is now locked — writes should go to deferred buffer.
         log::debug!("Edk2VarStore: ExitBootServices — flash writes disabled");
     }
 }

--- a/crabefi-core/src/efi/varstore/mod.rs
+++ b/crabefi-core/src/efi/varstore/mod.rs
@@ -51,7 +51,7 @@ pub use crate::platform::{StorageBackend, StorageError};
 pub use storage::SpiStorageBackend;
 
 // Re-export the EDK2 variable backend for use by platforms with raw flash
-pub use edk2_backend::Edk2VarStore;
+pub use edk2_backend::{Edk2Store, Edk2StoreState, Edk2VarStore};
 
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};

--- a/crabefi-core/src/efi/varstore/mod.rs
+++ b/crabefi-core/src/efi/varstore/mod.rs
@@ -46,8 +46,9 @@ pub mod edk2_backend;
 pub mod persistence;
 pub mod storage;
 
-// Re-export storage types
-pub use storage::{SpiStorageBackend, StorageBackend, StorageError};
+// Re-export storage types used with Edk2VarStore.
+pub use crate::platform::{StorageBackend, StorageError};
+pub use storage::SpiStorageBackend;
 
 // Re-export the EDK2 variable backend for use by platforms with raw flash
 pub use edk2_backend::Edk2VarStore;

--- a/crabefi-core/src/efi/varstore/persistence.rs
+++ b/crabefi-core/src/efi/varstore/persistence.rs
@@ -27,12 +27,14 @@
 use alloc::vec::Vec;
 
 use crate::drivers::spi::{self, SpiController};
-use crate::platform::{FirmwareStorage, FirmwareStorageRegion, VariableStoreLocator};
+use crate::platform::{
+    FirmwareStorage, FirmwareStorageRegion, StorageBackend, VarBackendError, VariableStoreLocator,
+};
 use crate::state::{self, MAX_VARIABLE_DATA_SIZE, MAX_VARIABLE_NAME_LEN};
 
-use super::VarStoreError;
 use super::edk2;
-use super::storage::{SpiStorageBackend, StorageBackend};
+use super::storage::SpiStorageBackend;
+use super::{Edk2Store, VarStoreError};
 
 /// Default variable store base address in SPI flash
 /// This is typically at the end of the flash region
@@ -42,6 +44,35 @@ pub const DEFAULT_VARSTORE_BASE: u32 = 0x00F00000; // 15MB offset (for 16MB flas
 /// Default variable store size (256KB)
 /// Used only as fallback if coreboot tables don't provide config info
 pub const DEFAULT_VARSTORE_SIZE: u32 = 256 * 1024;
+
+fn map_backend_error(error: VarBackendError) -> VarStoreError {
+    match error {
+        VarBackendError::NotAvailable => VarStoreError::NotInitialized,
+        VarBackendError::StoreFull => VarStoreError::StoreFull,
+        VarBackendError::IoError => VarStoreError::SpiError,
+        VarBackendError::Locked => VarStoreError::Locked,
+        VarBackendError::NotFound => VarStoreError::NotFound,
+        VarBackendError::DataTooLarge => VarStoreError::DataTooLarge,
+        VarBackendError::NameTooLong => VarStoreError::NameTooLong,
+        VarBackendError::Other => VarStoreError::InvalidArgument,
+    }
+}
+
+fn with_edk2_store_mut<R>(
+    f: impl FnOnce(&mut Edk2Store<'_>) -> Result<R, VarBackendError>,
+) -> Result<R, VarStoreError> {
+    state::with_mut(|state| {
+        let storage = state
+            .drivers
+            .platform
+            .storage
+            .as_mut()
+            .ok_or(VarBackendError::NotAvailable)?;
+        let mut store = Edk2Store::new(storage, &mut state.efi.varstore);
+        f(&mut store)
+    })
+    .map_err(map_backend_error)
+}
 
 /// Initialize the variable store persistence layer
 ///
@@ -187,185 +218,67 @@ fn validate_variable_store_region(
 /// Reads the FV header to validate the region, or formats it if invalid.
 /// This uses EDK2 Firmware Volume format compatible with coreboot's SMMSTORE.
 fn init_varstore() -> Result<(), VarStoreError> {
-    // Read enough bytes for FV header + VS header
-    let header_size = edk2::FV_HEADER_LENGTH + edk2::VS_HEADER_LENGTH;
-    let mut header_bytes = [0u8; 128]; // Enough for FV + VS headers (100 bytes needed)
-    let storage_size = state::with_storage_mut(|storage| {
-        storage
-            .read(0, &mut header_bytes[..header_size])
-            .map_err(|_| VarStoreError::SpiError)?;
-        Ok::<u32, VarStoreError>(storage.size())
-    })
-    .ok_or(VarStoreError::NotInitialized)??;
-
-    // Log raw header bytes for debugging
-    log::debug!(
-        "Variable store header bytes: {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x}",
-        header_bytes[0],
-        header_bytes[1],
-        header_bytes[2],
-        header_bytes[3],
-        header_bytes[4],
-        header_bytes[5],
-        header_bytes[6],
-        header_bytes[7],
-        header_bytes[8],
-        header_bytes[9],
-        header_bytes[10],
-        header_bytes[11],
-        header_bytes[12],
-        header_bytes[13],
-        header_bytes[14],
-        header_bytes[15]
-    );
-
-    // Validate EDK2 FV header
-    let validation = edk2::validate_fv(&header_bytes[..header_size], storage_size);
-
-    if validation.valid {
-        log::info!(
-            "EDK2 FV found: auth_format={}, data_size={} KB",
-            validation.auth_format,
-            validation.data_size / 1024
-        );
-
-        // Store format info in varstore state
-        state::with_varstore_mut(|vs| {
-            vs.initialized = true;
-            vs.auth_format = validation.auth_format;
-            vs.data_size = validation.data_size;
-        });
-
-        // Find the write offset (first free byte)
-        let auth_format = validation.auth_format;
-        let data_size = validation.data_size;
-        let write_offset = state::with_storage_mut(|storage| {
-            let mut read_fn =
-                |offset: u32, buf: &mut [u8]| -> bool { storage.read(offset, buf).is_ok() };
-            edk2::find_write_offset(&mut read_fn, auth_format, data_size)
-        })
-        .ok_or(VarStoreError::NotInitialized)?;
-
-        state::with_varstore_mut(|vs| {
-            vs.write_offset = write_offset;
-        });
-
-        log::info!("Variable store write offset: {:#x}", write_offset);
-        return Ok(());
-    }
-
-    // FV header invalid or missing - format the store with EDK2 FV headers
-    log::info!(
-        "Formatting variable store as EDK2 FV (size {} KB)...",
-        storage_size / 1024
-    );
-
-    // Build EDK2 FV + VS headers
-    let fv_headers = edk2::build_fv_headers(storage_size);
-
-    // Try to enable writes, erase, and write headers
-    state::with_storage_mut(|storage| {
-        if let Err(e) = storage.enable_writes() {
-            log::warn!("Could not enable storage writes: {:?}", e);
-            // Continue anyway - the erase/write will fail if truly locked
-        }
-
-        // Erase the region
-        storage
-            .erase(0, storage_size)
-            .map_err(|_| VarStoreError::SpiError)?;
-
-        // Write new FV + VS headers
-        storage
-            .write(0, &fv_headers)
-            .map_err(|_| VarStoreError::SpiError)?;
-
-        Ok::<(), VarStoreError>(())
-    })
-    .ok_or(VarStoreError::NotInitialized)??;
-
-    // Non-auth format (we always create non-auth stores)
-    let data_size = storage_size - edk2::FV_HEADER_LENGTH as u32 - edk2::VS_HEADER_LENGTH as u32;
-
-    state::with_varstore_mut(|vs| {
-        vs.initialized = true;
-        vs.auth_format = false;
-        vs.data_size = data_size;
-        vs.write_offset = edk2::VARIABLE_DATA_OFFSET;
-    });
-
-    log::info!("Variable store formatted as EDK2 FV successfully");
-    Ok(())
+    with_edk2_store_mut(|store| store.ensure_initialized())
 }
 
 /// Load variables from storage into the in-memory cache
 fn load_variables_from_storage() -> Result<(), VarStoreError> {
-    let vs = state::varstore();
-    if !vs.initialized {
-        return Err(VarStoreError::NotInitialized);
-    }
-    let auth_format = vs.auth_format;
-    let data_size = vs.data_size;
-
-    // Walk all variable records in the FV
-    let vars = state::with_storage_mut(|storage| {
-        let mut read_fn =
-            |offset: u32, buf: &mut [u8]| -> bool { storage.read(offset, buf).is_ok() };
-        edk2::walk_variables(&mut read_fn, auth_format, data_size)
-    })
-    .ok_or(VarStoreError::NotInitialized)?;
-
-    // Filter to only VAR_ADDED records and deduplicate (keep latest)
-    // Build a list of active variables
-    let mut active_vars: Vec<&edk2::FvVariable> = Vec::new();
-    for var in &vars {
-        if !edk2::is_var_added(var.state) {
-            continue;
-        }
-        // Remove any existing entry with same GUID + name
-        active_vars.retain(|existing| {
-            !(existing.guid == var.guid && edk2::name_matches(&existing.name, &var.name))
-        });
-        active_vars.push(var);
+    struct CacheVisitor<'a> {
+        variables: &'a mut [crate::state::VariableEntry],
+        count: usize,
+        full: bool,
     }
 
-    // Load active variables into in-memory cache
-    state::with_efi_mut(|efi| {
-        for var in &active_vars {
-            // Find a free slot
-            if let Some(slot) = efi.variables.iter_mut().find(|v| !v.in_use) {
-                // Copy name (UTF-16, strip trailing null for the fixed-size buffer)
-                let name_len = var.name.len().min(MAX_VARIABLE_NAME_LEN);
-                slot.name[..name_len].copy_from_slice(&var.name[..name_len]);
-                if name_len < MAX_VARIABLE_NAME_LEN {
-                    slot.name[name_len..].fill(0);
-                }
+    impl crate::platform::VariableVisitor for CacheVisitor<'_> {
+        fn visit(&mut self, name: &[u16], vendor: &r_efi::efi::Guid, attributes: u32, data: &[u8]) {
+            let Some(slot) = self.variables.iter_mut().find(|v| !v.in_use) else {
+                self.full = true;
+                return;
+            };
 
-                // Convert GUID bytes to r_efi::efi::Guid
-                slot.vendor_guid = guid_bytes_to_efi(&var.guid);
-                slot.attributes = var.attributes;
-
-                let data_len = var.data.len().min(MAX_VARIABLE_DATA_SIZE);
-                slot.data[..data_len].copy_from_slice(&var.data[..data_len]);
-                slot.data_size = data_len;
-                slot.in_use = true;
-
-                // Log the loaded variable name
-                let name_str: Vec<u8> = var
-                    .name
-                    .iter()
-                    .take_while(|&&c| c != 0)
-                    .map(|&c| c as u8)
-                    .collect();
-                log::debug!("Loaded variable: {:?}", core::str::from_utf8(&name_str));
-            } else {
-                log::warn!("No free variable slots - some variables may be lost");
-                break;
+            let name_len = name.len().min(MAX_VARIABLE_NAME_LEN);
+            slot.name[..name_len].copy_from_slice(&name[..name_len]);
+            if name_len < MAX_VARIABLE_NAME_LEN {
+                slot.name[name_len..].fill(0);
             }
-        }
-    });
 
-    log::info!("Loaded {} variables from storage", active_vars.len());
+            slot.vendor_guid = *vendor;
+            slot.attributes = attributes;
+
+            let data_len = data.len().min(MAX_VARIABLE_DATA_SIZE);
+            slot.data[..data_len].copy_from_slice(&data[..data_len]);
+            slot.data_size = data_len;
+            slot.in_use = true;
+            self.count += 1;
+
+            let name_str: Vec<u8> = name.iter().map(|&c| c as u8).collect();
+            log::debug!("Loaded variable: {:?}", core::str::from_utf8(&name_str));
+        }
+    }
+
+    let (loaded, full) = state::with_mut(|state| {
+        let storage = state
+            .drivers
+            .platform
+            .storage
+            .as_mut()
+            .ok_or(VarBackendError::NotAvailable)?;
+        let efi = &mut state.efi;
+        let mut store = Edk2Store::new(storage, &mut efi.varstore);
+        let mut visitor = CacheVisitor {
+            variables: &mut efi.variables,
+            count: 0,
+            full: false,
+        };
+        store.load(&mut visitor)?;
+        Ok::<(usize, bool), VarBackendError>((visitor.count, visitor.full))
+    })
+    .map_err(map_backend_error)?;
+
+    if full {
+        log::warn!("No free variable slots - some variables may be lost");
+    }
+    log::info!("Loaded {} variables from storage", loaded);
     Ok(())
 }
 
@@ -445,72 +358,16 @@ pub fn delete_variable(guid: &r_efi::efi::Guid, name: &[u16]) -> Result<(), VarS
 /// This is the internal function that actually writes to storage.
 /// It's exposed to the deferred module for applying queued changes.
 ///
-/// Steps:
-/// 1. Walk existing records to find and delete any old version
-/// 2. Append new record at write_offset using multi-stage protocol
-/// 3. If store is full, compact and retry
+/// Delegates to the shared EDK2 store implementation, which preflights
+/// compaction before modifying flash and appends replacements before deleting
+/// old records.
 pub(super) fn write_variable_to_storage_internal(
     guid: &r_efi::efi::Guid,
     name: &[u16],
     attributes: u32,
     data: &[u8],
 ) -> Result<(), VarStoreError> {
-    let vs = state::varstore();
-    if !vs.initialized {
-        return Err(VarStoreError::NotInitialized);
-    }
-
-    let guid_bytes = edk2::guid_to_bytes(guid);
-
-    // First, mark any existing record with same GUID+name as deleted
-    delete_existing_record(&guid_bytes, name)?;
-
-    // Check if we have space for the new record
-    let record = edk2::build_variable_record(&guid_bytes, name, attributes, data);
-    let record_len = record.len() as u32;
-
-    let vs = state::varstore();
-    let storage_size =
-        state::with_storage_mut(|s| s.size()).ok_or(VarStoreError::NotInitialized)?;
-
-    if vs.write_offset + record_len > storage_size {
-        log::info!("Variable store full, triggering compaction");
-        compact_varstore()?;
-    }
-
-    let vs = state::varstore();
-    if vs.write_offset + record_len > storage_size {
-        log::error!("Variable store still full after compaction");
-        return Err(VarStoreError::StoreFull);
-    }
-
-    let write_offset = vs.write_offset;
-
-    // Write the new record using multi-stage protocol
-    let new_offset = state::with_storage_mut(|storage| {
-        if let Err(e) = storage.enable_writes() {
-            log::warn!("Could not enable storage writes: {:?}", e);
-        }
-        let mut write_fn =
-            |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
-        edk2::write_variable(
-            &mut write_fn,
-            write_offset,
-            &guid_bytes,
-            name,
-            attributes,
-            data,
-        )
-    })
-    .ok_or(VarStoreError::NotInitialized)?
-    .ok_or(VarStoreError::SpiError)?;
-
-    state::with_varstore_mut(|vs| {
-        vs.write_offset = new_offset;
-    });
-
-    log::debug!("Variable persisted at offset {:#x}", write_offset);
-    Ok(())
+    with_edk2_store_mut(|store| store.write(name, guid, attributes, data))
 }
 
 /// Delete a variable from storage by marking its record as deleted
@@ -521,62 +378,10 @@ pub(super) fn write_variable_deletion_internal(
     guid: &r_efi::efi::Guid,
     name: &[u16],
 ) -> Result<(), VarStoreError> {
-    let vs = state::varstore();
-    if !vs.initialized {
-        return Err(VarStoreError::NotInitialized);
+    match with_edk2_store_mut(|store| store.delete(name, guid)) {
+        Ok(()) | Err(VarStoreError::NotFound) => Ok(()),
+        Err(e) => Err(e),
     }
-
-    let guid_bytes = edk2::guid_to_bytes(guid);
-    delete_existing_record(&guid_bytes, name)
-}
-
-/// Find and mark as deleted any existing record with the given GUID+name
-fn delete_existing_record(guid_bytes: &[u8; 16], name: &[u16]) -> Result<(), VarStoreError> {
-    let vs = state::varstore();
-    let auth_format = vs.auth_format;
-    let data_size = vs.data_size;
-
-    // Walk all records to find matching ones
-    let vars = state::with_storage_mut(|storage| {
-        let mut read_fn =
-            |offset: u32, buf: &mut [u8]| -> bool { storage.read(offset, buf).is_ok() };
-        edk2::walk_variables(&mut read_fn, auth_format, data_size)
-    })
-    .ok_or(VarStoreError::NotInitialized)?;
-
-    // Find and delete matching VAR_ADDED records
-    for var in &vars {
-        if edk2::is_var_added(var.state)
-            && var.guid == *guid_bytes
-            && edk2::name_matches(&var.name, name)
-        {
-            // Mark as deleted by writing to the state byte
-            let deleted = state::with_storage_mut(|storage| {
-                if let Err(e) = storage.enable_writes() {
-                    log::warn!("Could not enable storage writes: {:?}", e);
-                }
-                let mut write_fn =
-                    |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
-                edk2::mark_deleted(&mut write_fn, var.state_offset)
-            })
-            .ok_or(VarStoreError::NotInitialized)?;
-
-            if !deleted {
-                log::warn!(
-                    "Failed to mark variable as deleted at state_offset {:#x}",
-                    var.state_offset
-                );
-                return Err(VarStoreError::SpiError);
-            }
-
-            log::debug!(
-                "Marked existing variable as deleted at state_offset {:#x}",
-                var.state_offset
-            );
-        }
-    }
-
-    Ok(())
 }
 
 /// Queue a variable write for deferred processing (after ExitBootServices)
@@ -635,115 +440,11 @@ pub fn get_varstore_stats() -> Option<(u32, u32, u32)> {
 /// Returns the number of bytes reclaimed.
 pub fn compact_varstore() -> Result<u32, VarStoreError> {
     log::info!("Compacting variable store...");
-
-    let vs = state::varstore();
-    if !vs.initialized {
-        return Err(VarStoreError::NotInitialized);
-    }
-
-    let old_write_offset = vs.write_offset;
-    let auth_format = vs.auth_format;
-    let data_size = vs.data_size;
-    let size = state::with_storage_mut(|s| s.size()).ok_or(VarStoreError::NotInitialized)?;
-
-    // Step 1: Collect all active variable records
-    let vars = state::with_storage_mut(|storage| {
-        let mut read_fn =
-            |offset: u32, buf: &mut [u8]| -> bool { storage.read(offset, buf).is_ok() };
-        edk2::walk_variables(&mut read_fn, auth_format, data_size)
-    })
-    .ok_or(VarStoreError::NotInitialized)?;
-
-    // Keep only VAR_ADDED records, deduplicated (latest wins)
-    let mut active_vars: Vec<edk2::FvVariable> = Vec::new();
-    for var in vars {
-        if !edk2::is_var_added(var.state) {
-            continue;
-        }
-        active_vars.retain(|existing| {
-            !(existing.guid == var.guid && edk2::name_matches(&existing.name, &var.name))
-        });
-        active_vars.push(var);
-    }
-
+    let reclaimed = with_edk2_store_mut(|store| store.compact())?;
     log::info!(
-        "Found {} active variables to preserve during compaction",
-        active_vars.len()
+        "Variable store compaction complete: reclaimed {} bytes",
+        reclaimed
     );
-
-    // Step 2: Enable writes and erase the region
-    // Step 3: Write fresh EDK2 FV + VS headers
-    let fv_headers = edk2::build_fv_headers(size);
-
-    state::with_storage_mut(|storage| {
-        if let Err(e) = storage.enable_writes() {
-            log::warn!("Could not enable storage writes for compaction: {:?}", e);
-        }
-
-        storage
-            .erase(0, size)
-            .map_err(|_| VarStoreError::SpiError)?;
-
-        storage
-            .write(0, &fv_headers)
-            .map_err(|_| VarStoreError::SpiError)?;
-
-        Ok::<(), VarStoreError>(())
-    })
-    .ok_or(VarStoreError::NotInitialized)??;
-
-    // Step 4: Rewrite all active variables
-    let mut new_offset = edk2::VARIABLE_DATA_OFFSET;
-
-    for var in &active_vars {
-        // Check if we have space
-        let record = edk2::build_variable_record(&var.guid, &var.name, var.attributes, &var.data);
-        if new_offset + record.len() as u32 > size {
-            log::error!("Variable store full even after compaction - data loss!");
-            state::with_varstore_mut(|vs| vs.write_offset = new_offset);
-            return Err(VarStoreError::StoreFull);
-        }
-
-        let result = state::with_storage_mut(|storage| {
-            let mut write_fn =
-                |offset: u32, data: &[u8]| -> bool { storage.write(offset, data).is_ok() };
-            edk2::write_variable(
-                &mut write_fn,
-                new_offset,
-                &var.guid,
-                &var.name,
-                var.attributes,
-                &var.data,
-            )
-        })
-        .ok_or(VarStoreError::NotInitialized)?;
-
-        match result {
-            Some(next_offset) => {
-                new_offset = next_offset;
-            }
-            None => {
-                log::error!("Failed to write variable during compaction");
-                return Err(VarStoreError::SpiError);
-            }
-        }
-    }
-
-    // Update varstore state (non-auth format since we wrote fresh headers)
-    let new_data_size = size - edk2::FV_HEADER_LENGTH as u32 - edk2::VS_HEADER_LENGTH as u32;
-    state::with_varstore_mut(|vs| {
-        vs.write_offset = new_offset;
-        vs.auth_format = false;
-        vs.data_size = new_data_size;
-    });
-
-    let reclaimed = old_write_offset - new_offset;
-    log::info!(
-        "Variable store compaction complete: reclaimed {} bytes, new write offset {:#x}",
-        reclaimed,
-        new_offset
-    );
-
     Ok(reclaimed)
 }
 
@@ -812,19 +513,5 @@ pub(super) fn delete_variable_from_memory(guid: &r_efi::efi::Guid, name: &[u16])
 // ============================================================================
 // Helper functions
 // ============================================================================
-
-/// Convert 16-byte on-disk GUID to r_efi::efi::Guid
-fn guid_bytes_to_efi(bytes: &[u8; 16]) -> r_efi::efi::Guid {
-    r_efi::efi::Guid::from_fields(
-        u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
-        u16::from_le_bytes([bytes[4], bytes[5]]),
-        u16::from_le_bytes([bytes[6], bytes[7]]),
-        bytes[8],
-        bytes[9],
-        &[
-            bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
-        ],
-    )
-}
 
 // name_eq_slice consolidated into crate::efi::utils::ucs2_eq

--- a/crabefi-core/src/efi/varstore/storage.rs
+++ b/crabefi-core/src/efi/varstore/storage.rs
@@ -1,20 +1,9 @@
-//! Storage Backend Abstraction
+//! Variable Store Storage Backends
 //!
-//! This module provides a trait for abstracting storage backends,
-//! allowing the variable store to work with different storage types:
-//! - SPI flash (Intel, AMD, QEMU pflash)
-//! - Memory-backed storage (for testing)
-//! - Future backends (NVMe namespaces, etc.)
-//!
-//! # Architecture
-//!
-//! The `StorageBackend` trait provides a minimal interface for block storage:
-//! - Read/write/erase operations
-//! - Write enable control
-//! - Basic device info
-//!
-//! This abstracts away the details of how storage is accessed, allowing
-//! the variable store persistence layer to be storage-agnostic.
+//! This module provides concrete implementations of the platform
+//! [`crate::platform::StorageBackend`] trait for CrabEFI-managed variable
+//! storage. The trait itself lives in `platform.rs` so direct-flash variable
+//! storage and platform integrations use the same abstraction.
 
 // Note: alloc imports are used by MemoryBackend in tests
 #[cfg(test)]
@@ -24,96 +13,9 @@ use alloc::vec;
 #[cfg(test)]
 use alloc::vec::Vec;
 
-/// Errors that can occur during storage operations
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StorageError {
-    /// Storage device not initialized
-    NotInitialized,
-    /// Storage device is write-protected
-    WriteProtected,
-    /// Access denied (locked region)
-    AccessDenied,
-    /// Operation timed out
-    Timeout,
-    /// Invalid address or length
-    InvalidArgument,
-    /// Generic I/O error
-    IoError,
-    /// Operation not supported by this backend
-    NotSupported,
-}
+use crate::platform::{StorageBackend, StorageError};
 
-/// Result type for storage operations
-pub type Result<T> = core::result::Result<T, StorageError>;
-
-/// Storage backend trait
-///
-/// This trait abstracts storage operations, allowing different backends
-/// (SPI flash, memory, etc.) to be used interchangeably by the variable store.
-///
-/// # Implementation Notes
-///
-/// - `read` should work on any valid offset within the storage size
-/// - `write` may require the region to be erased first (flash semantics)
-/// - `erase` sets bytes to 0xFF (NOR flash erased state)
-/// - `enable_writes` may be a no-op for some backends (e.g., memory)
-pub trait StorageBackend: Send {
-    /// Get the backend name (for logging/debugging)
-    fn name(&self) -> &str;
-
-    /// Get the total storage size in bytes
-    fn size(&self) -> u32;
-
-    /// Check if the storage is write-protected
-    fn is_write_protected(&self) -> bool;
-
-    /// Enable writes to the storage
-    ///
-    /// This may need to clear write-protection bits on some hardware.
-    /// Returns Ok(()) if writes are enabled, or an error if they cannot be enabled.
-    fn enable_writes(&mut self) -> Result<()>;
-
-    /// Read data from storage
-    ///
-    /// # Arguments
-    /// - `offset`: Byte offset within the storage
-    /// - `buffer`: Buffer to read data into
-    ///
-    /// # Errors
-    /// - `InvalidArgument` if offset + buffer.len() exceeds storage size
-    /// - `IoError` if the read operation fails
-    fn read(&mut self, offset: u32, buffer: &mut [u8]) -> Result<()>;
-
-    /// Write data to storage
-    ///
-    /// # Arguments
-    /// - `offset`: Byte offset within the storage
-    /// - `data`: Data to write
-    ///
-    /// # Notes
-    /// For flash storage, the region should be erased first (bytes must be 0xFF).
-    /// Writing can only clear bits (1->0), not set them.
-    ///
-    /// # Errors
-    /// - `WriteProtected` if writes are not enabled
-    /// - `InvalidArgument` if offset + data.len() exceeds storage size
-    /// - `IoError` if the write operation fails
-    fn write(&mut self, offset: u32, data: &[u8]) -> Result<()>;
-
-    /// Erase a region of storage
-    ///
-    /// Sets all bytes in the region to 0xFF (NOR flash erased state).
-    ///
-    /// # Arguments
-    /// - `offset`: Starting byte offset (may be aligned to erase block size)
-    /// - `size`: Number of bytes to erase (may be rounded up to erase block size)
-    ///
-    /// # Errors
-    /// - `WriteProtected` if writes are not enabled
-    /// - `InvalidArgument` if offset + size exceeds storage size
-    /// - `IoError` if the erase operation fails
-    fn erase(&mut self, offset: u32, size: u32) -> Result<()>;
-}
+type Result<T> = core::result::Result<T, StorageError>;
 
 /// Wrapper to adapt SPI controllers to the StorageBackend trait
 ///
@@ -275,60 +177,6 @@ impl StorageBackend for SpiStorageBackend {
                 _ => StorageError::IoError,
             }
         })
-    }
-}
-
-fn map_storage_error(error: StorageError) -> crate::platform::StorageError {
-    match error {
-        StorageError::NotInitialized => crate::platform::StorageError::NotInitialized,
-        StorageError::WriteProtected => crate::platform::StorageError::WriteProtected,
-        StorageError::AccessDenied => crate::platform::StorageError::AccessDenied,
-        StorageError::Timeout => crate::platform::StorageError::Timeout,
-        StorageError::InvalidArgument => crate::platform::StorageError::InvalidArgument,
-        StorageError::IoError => crate::platform::StorageError::IoError,
-        StorageError::NotSupported => crate::platform::StorageError::NotSupported,
-    }
-}
-
-impl crate::platform::StorageBackend for SpiStorageBackend {
-    fn name(&self) -> &str {
-        <Self as StorageBackend>::name(self)
-    }
-
-    fn size(&self) -> u32 {
-        <Self as StorageBackend>::size(self)
-    }
-
-    fn is_write_protected(&self) -> bool {
-        <Self as StorageBackend>::is_write_protected(self)
-    }
-
-    fn enable_writes(&mut self) -> core::result::Result<(), crate::platform::StorageError> {
-        <Self as StorageBackend>::enable_writes(self).map_err(map_storage_error)
-    }
-
-    fn read(
-        &mut self,
-        offset: u32,
-        buffer: &mut [u8],
-    ) -> core::result::Result<(), crate::platform::StorageError> {
-        <Self as StorageBackend>::read(self, offset, buffer).map_err(map_storage_error)
-    }
-
-    fn write(
-        &mut self,
-        offset: u32,
-        data: &[u8],
-    ) -> core::result::Result<(), crate::platform::StorageError> {
-        <Self as StorageBackend>::write(self, offset, data).map_err(map_storage_error)
-    }
-
-    fn erase(
-        &mut self,
-        offset: u32,
-        size: u32,
-    ) -> core::result::Result<(), crate::platform::StorageError> {
-        <Self as StorageBackend>::erase(self, offset, size).map_err(map_storage_error)
     }
 }
 

--- a/crabefi-core/src/efi/varstore/storage.rs
+++ b/crabefi-core/src/efi/varstore/storage.rs
@@ -278,6 +278,60 @@ impl StorageBackend for SpiStorageBackend {
     }
 }
 
+fn map_storage_error(error: StorageError) -> crate::platform::StorageError {
+    match error {
+        StorageError::NotInitialized => crate::platform::StorageError::NotInitialized,
+        StorageError::WriteProtected => crate::platform::StorageError::WriteProtected,
+        StorageError::AccessDenied => crate::platform::StorageError::AccessDenied,
+        StorageError::Timeout => crate::platform::StorageError::Timeout,
+        StorageError::InvalidArgument => crate::platform::StorageError::InvalidArgument,
+        StorageError::IoError => crate::platform::StorageError::IoError,
+        StorageError::NotSupported => crate::platform::StorageError::NotSupported,
+    }
+}
+
+impl crate::platform::StorageBackend for SpiStorageBackend {
+    fn name(&self) -> &str {
+        <Self as StorageBackend>::name(self)
+    }
+
+    fn size(&self) -> u32 {
+        <Self as StorageBackend>::size(self)
+    }
+
+    fn is_write_protected(&self) -> bool {
+        <Self as StorageBackend>::is_write_protected(self)
+    }
+
+    fn enable_writes(&mut self) -> core::result::Result<(), crate::platform::StorageError> {
+        <Self as StorageBackend>::enable_writes(self).map_err(map_storage_error)
+    }
+
+    fn read(
+        &mut self,
+        offset: u32,
+        buffer: &mut [u8],
+    ) -> core::result::Result<(), crate::platform::StorageError> {
+        <Self as StorageBackend>::read(self, offset, buffer).map_err(map_storage_error)
+    }
+
+    fn write(
+        &mut self,
+        offset: u32,
+        data: &[u8],
+    ) -> core::result::Result<(), crate::platform::StorageError> {
+        <Self as StorageBackend>::write(self, offset, data).map_err(map_storage_error)
+    }
+
+    fn erase(
+        &mut self,
+        offset: u32,
+        size: u32,
+    ) -> core::result::Result<(), crate::platform::StorageError> {
+        <Self as StorageBackend>::erase(self, offset, size).map_err(map_storage_error)
+    }
+}
+
 /// Memory-backed storage backend for testing
 ///
 /// This backend stores data in memory, simulating flash behavior:

--- a/crabefi-core/src/lib.rs
+++ b/crabefi-core/src/lib.rs
@@ -117,6 +117,7 @@ fn init_persistence_and_boot(
     variable_store_locator: Option<&dyn platform::VariableStoreLocator>,
 ) -> ! {
     // ---- Variable persistence ----
+    let mut clear_deferred_buffer = false;
     match efi::varstore::init_persistence(variable_store_locator) {
         Ok(()) => {
             log::info!("Variable store persistence initialized");
@@ -128,9 +129,14 @@ fn init_persistence_and_boot(
                     pending_count
                 );
                 match efi::varstore::process_deferred_pending() {
-                    Ok(n) => log::info!("Applied {} deferred variable writes", n),
+                    Ok(n) => {
+                        log::info!("Applied {} deferred variable writes", n);
+                        clear_deferred_buffer = true;
+                    }
                     Err(e) => log::warn!("Failed to process deferred writes: {:?}", e),
                 }
+            } else {
+                clear_deferred_buffer = true;
             }
 
             match efi::auth::boot::init_secure_boot_default() {
@@ -144,10 +150,19 @@ fn init_persistence_and_boot(
                 Err(e) => log::warn!("Secure Boot init failed: {:?}", e),
             }
         }
-        Err(e) => log::info!("Variable persistence not available: {:?}", e),
+        Err(e) => {
+            log::info!("Variable persistence not available: {:?}", e);
+            if efi::varstore::check_deferred_pending() == 0 {
+                clear_deferred_buffer = true;
+            } else {
+                log::warn!("Preserving pending deferred variable writes");
+            }
+        }
     }
 
-    efi::varstore::init_deferred_buffer();
+    if clear_deferred_buffer {
+        efi::varstore::init_deferred_buffer();
+    }
 
     // ---- Boot manager ----
     let boot_var_state = boot_vars::read_boot_var_state();

--- a/crabefi-core/src/state.rs
+++ b/crabefi-core/src/state.rs
@@ -481,39 +481,11 @@ impl VariableEntry {
     }
 }
 
-/// Variable store persistence state
+/// Variable store persistence state.
 ///
-/// Tracks the runtime state of the persistent variable store region.
-/// The actual storage location is determined at runtime from coreboot
-/// tables (SMMSTORE v2) or FMAP (SMMSTORE region).
-#[derive(Clone, Copy)]
-pub struct VarStoreState {
-    /// Whether the store header has been validated/written
-    pub initialized: bool,
-    /// Next free location for appending records (relative to store start)
-    pub write_offset: u32,
-    /// Whether the EDK2 FV uses authenticated variable headers (60 bytes vs 32)
-    pub auth_format: bool,
-    /// Size of the variable data area (after FV + VS headers)
-    pub data_size: u32,
-}
-
-impl VarStoreState {
-    pub const fn new() -> Self {
-        Self {
-            initialized: false,
-            write_offset: 0,
-            auth_format: false,
-            data_size: 0,
-        }
-    }
-}
-
-impl Default for VarStoreState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+/// This is the shared EDK2 FV state used by both the global persistence path
+/// and the platform [`crate::platform::VariableBackend`] adapter path.
+pub type VarStoreState = crate::efi::varstore::Edk2StoreState;
 
 /// EFI subsystem state
 pub struct EfiState {


### PR DESCRIPTION
## Summary

Rebases the reusable, still-relevant parts of #48 onto the current workspace/coreboot-payload layout without reintroducing the older coreboot-specific variable backend design.

Includes:
- low-level cache/inline-asm invariant fixes
- read-only PCI BAR handling cleanup and EHCI one-shot async control transfers
- completed EDK2 `VariableBackend` write/delete support with compaction preflight
- `SpiStorageBackend` adapter for the platform storage trait
- deferred variable replay durability: preserve the buffer until every queued write/delete is durably applied, treating missing deletes as success
- deferred buffer relocation during `SetVirtualAddressMap`

Intentionally leaves the current `VariableStoreLocator`/coreboot boundary intact instead of reviving the old PR #48 `CorebootVariableBackend`.

## Testing

- `cargo fmt --check`
- `cargo check`
- `cargo clippy`
- `./crabefi build`

Note: `cargo build --release` still fails in this tree via the host linker with a duplicate `_start`; the xtask build path succeeds and produces the firmware payload.
