### PR TITLE
Boot Timestamps, CBMEM Console Tee, Persistent Log Level, and Variable Store Hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,18 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
+  coreboot-feature-tests:
+    name: Coreboot feature regression tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run coreboot feature regression tests
+        run: ci/run-coreboot-feature-tests.sh
+
   # ── x86_64 ────────────────────────────────────────────────────────────
 
   clippy:

--- a/ci/run-coreboot-feature-tests.sh
+++ b/ci/run-coreboot-feature-tests.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Run fast host-side regression tests for coreboot payload features that are
+# otherwise only exercised inside firmware/QEMU runs.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+rustc --edition=2024 --test \
+    "$ROOT/crabefi-coreboot/src/cbmem_console.rs" \
+    -o "$TMPDIR/cbmem_console_tests"
+"$TMPDIR/cbmem_console_tests"
+
+rustc --edition=2024 --test \
+    "$ROOT/crabefi-coreboot/src/timestamps.rs" \
+    -o "$TMPDIR/timestamp_tests"
+"$TMPDIR/timestamp_tests"
+
+python3 - "$ROOT/crabefi-coreboot/src/cfr.rs" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+src = Path(sys.argv[1]).read_text()
+
+write_match = re.search(
+    r"pub fn write_option_value\(.*?\n}\n\n/// Delete a CFR option",
+    src,
+    re.S,
+)
+assert write_match, "write_option_value block not found"
+write_block = write_match.group(0)
+assert "varstore::persist_variable(&COREBOOT_CFR_GUID, &name, attrs, &data)" in write_block, (
+    "CFR writes must persist to the backend"
+)
+assert "varstore::update_variable_in_memory(&COREBOOT_CFR_GUID, &name, attrs, &data);" in write_block, (
+    "CFR writes must refresh CrabEFI's in-memory variable cache"
+)
+assert write_block.index("varstore::persist_variable") < write_block.index("varstore::update_variable_in_memory"), (
+    "CFR cache update must happen after successful backend persistence"
+)
+
+delete_match = re.search(
+    r"pub fn delete_option_value\(.*?\n}\n\nfn delete_option_from_memory",
+    src,
+    re.S,
+)
+assert delete_match, "delete_option_value block not found"
+delete_block = delete_match.group(0)
+assert "varstore::delete_variable(&COREBOOT_CFR_GUID, &name)" in delete_block, (
+    "CFR deletes must remove the persisted backend variable"
+)
+assert "delete_option_from_memory(&name);" in delete_block, (
+    "CFR deletes must invalidate CrabEFI's in-memory variable cache"
+)
+assert delete_block.index("varstore::delete_variable") < delete_block.index("delete_option_from_memory"), (
+    "CFR cache invalidation must happen after successful backend delete"
+)
+
+memory_delete_match = re.search(r"fn delete_option_from_memory\(.*?\n}\n\Z", src, re.S)
+assert memory_delete_match, "delete_option_from_memory helper not found"
+memory_delete_block = memory_delete_match.group(0)
+assert "var.in_use = false;" in memory_delete_block, "CFR memory delete must mark cache entry unused"
+assert "crabefi::efi::utils::ucs2_eq(&var.name, name)" in memory_delete_block, (
+    "CFR memory delete must match UCS-2 variable names exactly"
+)
+
+print("CFR variable-cache regression checks passed")
+PY

--- a/crabefi-core/src/drivers/serial.rs
+++ b/crabefi-core/src/drivers/serial.rs
@@ -427,6 +427,16 @@ pub(crate) struct PlatformSerial {
 }
 
 impl PlatformSerial {
+    /// Create a platform serial adapter from a raw `DebugOutput` pointer.
+    ///
+    /// # Safety
+    ///
+    /// `inner` must point to a valid debug output object that lives for the
+    /// entire firmware lifetime.
+    unsafe fn new(inner: *mut dyn crate::platform::DebugOutput) -> Self {
+        Self { inner }
+    }
+
     /// Write a single byte to the platform debug output.
     fn write_byte(&mut self, byte: u8) {
         // SAFETY: Single-threaded firmware. Pointer is valid for firmware lifetime.
@@ -464,6 +474,57 @@ pub(crate) enum AnySerial {
     Pl011(Pl011Port),
     /// Platform-provided debug output (used by `init_platform()` path).
     Platform(PlatformSerial),
+}
+
+impl AnySerial {
+    /// Write a string to the active serial backend.
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        match self {
+            Self::Uart16550(serial) => serial.write_str(s),
+            #[cfg(target_arch = "aarch64")]
+            Self::Pl011(serial) => serial.write_str(s),
+            Self::Platform(serial) => serial.write_str(s),
+        }
+    }
+
+    /// Write one byte to the active serial backend.
+    fn write_byte(&mut self, byte: u8) {
+        match self {
+            Self::Uart16550(serial) => serial.write_byte(byte),
+            #[cfg(target_arch = "aarch64")]
+            Self::Pl011(serial) => serial.write_byte(byte),
+            Self::Platform(serial) => serial.write_byte(byte),
+        }
+    }
+
+    /// Check whether the active serial backend has pending input.
+    fn has_input(&self) -> bool {
+        match self {
+            Self::Uart16550(serial) => serial.can_receive(),
+            #[cfg(target_arch = "aarch64")]
+            Self::Pl011(serial) => serial.can_receive(),
+            Self::Platform(serial) => serial.has_input(),
+        }
+    }
+
+    /// Try to read one byte from the active serial backend.
+    fn try_read_byte(&mut self) -> Option<u8> {
+        match self {
+            Self::Uart16550(serial) => serial.try_read_byte(),
+            #[cfg(target_arch = "aarch64")]
+            Self::Pl011(serial) => serial.try_read_byte(),
+            Self::Platform(serial) => serial.try_read_byte(),
+        }
+    }
+}
+
+struct SerialFormatter;
+
+impl Write for SerialFormatter {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        write_str(s);
+        Ok(())
+    }
 }
 
 // ============================================================================
@@ -570,7 +631,8 @@ pub fn init_from_config(info: &SerialConfig) {
 /// `raw` must point to a valid `DebugOutput` that lives for the entire
 /// firmware lifetime (i.e., at least until `init_platform()` returns).
 pub unsafe fn init_from_platform_raw(raw: *mut dyn crate::platform::DebugOutput) {
-    let plat = PlatformSerial { inner: raw };
+    // SAFETY: The caller guarantees `raw` lives for the firmware lifetime.
+    let plat = unsafe { PlatformSerial::new(raw) };
     // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
     // issues since serial is called from log macros inside other state closures.
     unsafe {
@@ -578,93 +640,75 @@ pub unsafe fn init_from_platform_raw(raw: *mut dyn crate::platform::DebugOutput)
     }
 }
 
-/// Write a string to the serial port
+/// Add a platform-provided mirror for all serial/console output.
+///
+/// Unlike [`init_from_platform_raw()`], this does not replace the active UART.
+/// It tees every subsequent byte/string written through the serial subsystem to
+/// `raw` as well as to the primary serial driver. Platform payloads use this for
+/// firmware memory consoles such as coreboot's CBMEM console.
+///
+/// # Safety
+///
+/// `raw` must point to a valid `DebugOutput` that lives for the entire firmware
+/// lifetime (i.e., at least until `init_platform()` returns).
+pub unsafe fn add_platform_debug_sink_raw(raw: *mut dyn crate::platform::DebugOutput) {
+    // SAFETY: The caller guarantees `raw` lives for the firmware lifetime.
+    let sink = unsafe { PlatformSerial::new(raw) };
+    // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
+    // issues since serial is called from log macros inside other state closures.
+    unsafe {
+        (*crate::state::drivers_mut_ptr()).serial.debug_sink = Some(sink);
+    }
+}
+
+/// Write a string to the serial port and optional debug mirror.
 pub fn write_str(s: &str) {
     // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
     // issues since serial is called from log macros inside other state closures.
-    let driver = unsafe { &mut (*crate::state::drivers_mut_ptr()).serial.driver };
-    if let Some(serial) = driver {
-        match serial {
-            AnySerial::Uart16550(uart) => {
-                let _ = uart.write_str(s);
-            }
-            #[cfg(target_arch = "aarch64")]
-            AnySerial::Pl011(pl011) => {
-                let _ = pl011.write_str(s);
-            }
-            AnySerial::Platform(plat) => {
-                let _ = plat.write_str(s);
-            }
-        }
+    let serial_state = unsafe { &mut (*crate::state::drivers_mut_ptr()).serial };
+    if let Some(serial) = &mut serial_state.driver {
+        let _ = serial.write_str(s);
+    }
+    if let Some(sink) = &mut serial_state.debug_sink {
+        let _ = sink.write_str(s);
     }
 }
 
-/// Write formatted output to the serial port
+/// Write formatted output to the serial port and optional debug mirror.
 pub fn write_fmt(args: fmt::Arguments) {
-    // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
-    // issues since serial is called from log macros inside other state closures.
-    let driver = unsafe { &mut (*crate::state::drivers_mut_ptr()).serial.driver };
-    if let Some(serial) = driver {
-        match serial {
-            AnySerial::Uart16550(uart) => {
-                let _ = uart.write_fmt(args);
-            }
-            #[cfg(target_arch = "aarch64")]
-            AnySerial::Pl011(pl011) => {
-                let _ = pl011.write_fmt(args);
-            }
-            AnySerial::Platform(plat) => {
-                let _ = plat.write_fmt(args);
-            }
-        }
-    }
+    let _ = SerialFormatter.write_fmt(args);
 }
 
-/// Write a single byte to the serial port
+/// Write a single byte to the serial port and optional debug mirror.
 pub fn write_byte(byte: u8) {
     // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
     // issues since serial is called from log macros inside other state closures.
-    let driver = unsafe { &mut (*crate::state::drivers_mut_ptr()).serial.driver };
-    if let Some(serial) = driver {
-        match serial {
-            AnySerial::Uart16550(uart) => uart.write_byte(byte),
-            #[cfg(target_arch = "aarch64")]
-            AnySerial::Pl011(pl011) => pl011.write_byte(byte),
-            AnySerial::Platform(plat) => plat.write_byte(byte),
-        }
+    let serial_state = unsafe { &mut (*crate::state::drivers_mut_ptr()).serial };
+    if let Some(serial) = &mut serial_state.driver {
+        serial.write_byte(byte);
+    }
+    if let Some(sink) = &mut serial_state.debug_sink {
+        sink.write_byte(byte);
     }
 }
 
-/// Check if there is input available on the serial port
+/// Check if there is input available on the serial port.
 pub fn has_input() -> bool {
-    // Read-only check -- use immutable access (no raw pointer needed).
-    if let Some(serial) = &crate::state::drivers().serial.driver {
-        match serial {
-            AnySerial::Uart16550(uart) => uart.can_receive(),
-            #[cfg(target_arch = "aarch64")]
-            AnySerial::Pl011(pl011) => pl011.can_receive(),
-            AnySerial::Platform(plat) => plat.has_input(),
-        }
-    } else {
-        false
-    }
+    // Read-only check -- use immutable access (no raw pointer needed). The debug
+    // mirror is output-only, so it is intentionally ignored for input.
+    crate::state::drivers()
+        .serial
+        .driver
+        .as_ref()
+        .is_some_and(AnySerial::has_input)
 }
 
-/// Try to read a byte from the serial port (non-blocking)
+/// Try to read a byte from the serial port (non-blocking).
 pub fn try_read() -> Option<u8> {
     // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
     // issues since serial is called from log macros inside other state closures.
     let driver = unsafe { &mut (*crate::state::drivers_mut_ptr()).serial.driver };
-    if let Some(serial) = driver {
-        match serial {
-            AnySerial::Uart16550(uart) => uart.try_read_byte(),
-            #[cfg(target_arch = "aarch64")]
-            AnySerial::Pl011(pl011) => pl011.try_read_byte(),
-            AnySerial::Platform(plat) => plat.try_read_byte(),
-        }
-    } else {
-        None
-    }
+    driver.as_mut().and_then(AnySerial::try_read_byte)
 }
 
 /// Macro for printing to serial

--- a/crabefi-core/src/drivers/usb/ehci.rs
+++ b/crabefi-core/src/drivers/usb/ehci.rs
@@ -1174,10 +1174,6 @@ impl EhciController {
             return Err(UsbError::Timeout);
         }
         self.async_schedule_enabled = true;
-        log::debug!(
-            "EHCI: Async schedule enabled, ASS={}",
-            self.op().usbsts.is_set(USBSTS::ASS)
-        );
 
         // Wait for transfer completion
         let timeout = Timeout::from_ms(5000);

--- a/crabefi-core/src/efi/runtime_services.rs
+++ b/crabefi-core/src/efi/runtime_services.rs
@@ -1265,6 +1265,13 @@ fn set_variable_full(
     }
 
     let final_data_size = final_data_vec.len();
+    if final_data_size > 0
+        && crate::logger::is_log_level_variable(&guid, name_vec.as_slice())
+        && crate::logger::level_from_data(final_data_vec.as_slice()).is_none()
+    {
+        return Status::INVALID_PARAMETER;
+    }
+
     let secure_boot_var = auth::identify_key_database(name_vec.as_slice(), &guid);
 
     let (status, persist_action, secure_boot_action) = state::with_efi_mut(|efi| {
@@ -1496,6 +1503,14 @@ fn set_variable_full(
                     }
                 }
             }
+        }
+    }
+
+    if crate::logger::is_log_level_variable(&guid, name_vec.as_slice()) {
+        if final_data_size == 0 {
+            crate::logger::apply_variable_delete();
+        } else {
+            crate::logger::apply_variable_write(final_data_vec.as_slice());
         }
     }
 

--- a/crabefi-core/src/efi/varstore/edk2.rs
+++ b/crabefi-core/src/efi/varstore/edk2.rs
@@ -327,7 +327,8 @@ pub struct FvVariable {
 /// # Arguments
 /// * `region` - Full EDK2 FV variable-store region bytes.
 /// * `guid_bytes` - EFI variable GUID in mixed-endian UEFI byte order.
-/// * `name` - UTF-16 variable name, with or without a trailing NUL.
+/// * `name` - UTF-16 variable name, with or without a trailing NUL. Stored
+///   EDK2 names are matched with their required trailing NUL.
 /// * `data_out` - Buffer that receives the variable data.
 ///
 /// # Returns
@@ -445,21 +446,25 @@ where
         VAR_HEADER_SIZE
     } as u32;
 
-    let target_name_len = name
-        .iter()
-        .position(|&ch| ch == 0)
-        .map(|len| len + 1)
-        .unwrap_or(name.len());
-    if target_name_len == 0 {
+    let target_name_chars = name.iter().position(|&ch| ch == 0).unwrap_or(name.len());
+    if target_name_chars == 0 {
         return None;
     }
+    let stored_name_size = target_name_chars
+        .checked_add(1)?
+        .checked_mul(2)
+        .and_then(|len| u32::try_from(len).ok())?;
 
     let mut found_len = None;
     let mut offset = VARIABLE_DATA_OFFSET;
-    let end = VARIABLE_DATA_OFFSET + data_area_size;
+    let end = VARIABLE_DATA_OFFSET.checked_add(data_area_size)?;
+    let end_with_header = end.checked_add(hdr_size)?;
     let mut hdr_buf = [0u8; AUTH_VAR_HEADER_SIZE];
 
-    while offset + hdr_size <= end {
+    while offset
+        .checked_add(hdr_size)
+        .is_some_and(|header_end| header_end <= end)
+    {
         let hdr = &mut hdr_buf[..hdr_size as usize];
         if !read_fn(offset, hdr) {
             break;
@@ -489,20 +494,18 @@ where
             (name_size, data_size, 0x10usize)
         };
 
-        let name_offset = offset + hdr_size;
+        let name_offset = offset.checked_add(hdr_size)?;
         let data_offset = name_offset.checked_add(name_size)?;
-        let next_offset = offset.checked_add(align_up(
-            hdr_size.checked_add(name_size)?.checked_add(data_size)?,
-            HEADER_ALIGNMENT,
-        ))?;
-        if data_offset.checked_add(data_size)? > end || next_offset > end + hdr_size {
+        let record_size = hdr_size.checked_add(name_size)?.checked_add(data_size)?;
+        let next_offset = offset.checked_add(checked_align_up(record_size, HEADER_ALIGNMENT)?)?;
+        if data_offset.checked_add(data_size)? > end || next_offset > end_with_header {
             break;
         }
 
         if state == VAR_ADDED
             && hdr[guid_offset..guid_offset + 16] == *guid_bytes
-            && name_size == (target_name_len * 2) as u32
-            && variable_name_matches(read_fn, name_offset, name, target_name_len)
+            && name_size == stored_name_size
+            && variable_name_matches(read_fn, name_offset, name, target_name_chars)
         {
             if data_size as usize > data_out.len() {
                 return None;
@@ -523,21 +526,41 @@ fn variable_name_matches<F>(
     read_fn: &mut F,
     name_offset: u32,
     name: &[u16],
-    target_name_len: usize,
+    target_name_chars: usize,
 ) -> bool
 where
     F: FnMut(u32, &mut [u8]) -> bool,
 {
     let mut buf = [0u8; 2];
-    for (idx, &expected) in name.iter().take(target_name_len).enumerate() {
-        if !read_fn(name_offset + (idx * 2) as u32, &mut buf) {
+    for (idx, &expected) in name.iter().take(target_name_chars).enumerate() {
+        let Some(offset) = idx
+            .checked_mul(2)
+            .and_then(|offset| u32::try_from(offset).ok())
+            .and_then(|offset| name_offset.checked_add(offset))
+        else {
+            return false;
+        };
+
+        if !read_fn(offset, &mut buf) {
             return false;
         }
         if u16::from_le_bytes(buf) != expected {
             return false;
         }
     }
-    true
+
+    let Some(terminator_offset) = target_name_chars
+        .checked_mul(2)
+        .and_then(|offset| u32::try_from(offset).ok())
+        .and_then(|offset| name_offset.checked_add(offset))
+    else {
+        return false;
+    };
+
+    if !read_fn(terminator_offset, &mut buf) {
+        return false;
+    }
+    u16::from_le_bytes(buf) == 0
 }
 
 /// Walk all variable records in the FV data area.
@@ -855,6 +878,13 @@ pub fn is_var_added(state: u8) -> bool {
 /// Align a value up to the given alignment (must be a power of 2).
 fn align_up(value: u32, alignment: u32) -> u32 {
     (value + alignment - 1) & !(alignment - 1)
+}
+
+/// Checked variant of [`align_up`] for parsing untrusted variable records.
+fn checked_align_up(value: u32, alignment: u32) -> Option<u32> {
+    value
+        .checked_add(alignment.checked_sub(1)?)
+        .map(|value| value & !(alignment - 1))
 }
 
 /// Convert an `r_efi::efi::Guid` to the 16-byte mixed-endian representation

--- a/crabefi-core/src/efi/varstore/edk2.rs
+++ b/crabefi-core/src/efi/varstore/edk2.rs
@@ -318,6 +318,228 @@ pub struct FvVariable {
     pub state_offset: u32,
 }
 
+/// Read one variable's data from an EDK2-compatible variable-store region.
+///
+/// This helper is intentionally allocation-free and silent so platforms can use
+/// it during early boot before the heap and normal logging policy are ready.
+/// If multiple active records match, the last one wins.
+///
+/// # Arguments
+/// * `region` - Full EDK2 FV variable-store region bytes.
+/// * `guid_bytes` - EFI variable GUID in mixed-endian UEFI byte order.
+/// * `name` - UTF-16 variable name, with or without a trailing NUL.
+/// * `data_out` - Buffer that receives the variable data.
+///
+/// # Returns
+/// The number of bytes copied into `data_out`, or `None` if the store is
+/// invalid, the variable was not found, or the output buffer is too small.
+pub fn read_variable_data_from_region(
+    region: &[u8],
+    guid_bytes: &[u8; 16],
+    name: &[u16],
+    data_out: &mut [u8],
+) -> Option<usize> {
+    if region.len() > u32::MAX as usize {
+        return None;
+    }
+
+    let validation = validate_fv_silent(region, region.len() as u32)?;
+    let mut read_fn = |offset: u32, buf: &mut [u8]| -> bool {
+        let offset = offset as usize;
+        let Some(end) = offset.checked_add(buf.len()) else {
+            return false;
+        };
+        let Some(src) = region.get(offset..end) else {
+            return false;
+        };
+        buf.copy_from_slice(src);
+        true
+    };
+
+    read_variable_data(
+        &mut read_fn,
+        validation.auth_format,
+        validation.data_size,
+        guid_bytes,
+        name,
+        data_out,
+    )
+}
+
+fn validate_fv_silent(header_bytes: &[u8], region_size: u32) -> Option<FvValidation> {
+    if header_bytes.len() < FV_HEADER_LENGTH + VS_HEADER_LENGTH {
+        return None;
+    }
+
+    let sig = u32::from_le_bytes([
+        header_bytes[0x28],
+        header_bytes[0x29],
+        header_bytes[0x2A],
+        header_bytes[0x2B],
+    ]);
+    if sig != FV_SIGNATURE || header_bytes[0x37] != FV_REVISION {
+        return None;
+    }
+
+    if header_bytes[0x10..0x20] != EFI_SYSTEM_NV_DATA_FV_GUID {
+        return None;
+    }
+
+    let header_length = u16::from_le_bytes([header_bytes[0x30], header_bytes[0x31]]) as usize;
+    if header_length > header_bytes.len()
+        || header_length < 0x38
+        || !header_length.is_multiple_of(2)
+    {
+        return None;
+    }
+
+    let mut checksum: u16 = 0;
+    for i in (0..header_length).step_by(2) {
+        let lo = header_bytes[i] as u16;
+        let hi = header_bytes[i + 1] as u16;
+        checksum = checksum.wrapping_add(lo | (hi << 8));
+    }
+    if checksum != 0 {
+        return None;
+    }
+
+    let vs = &header_bytes[FV_HEADER_LENGTH..];
+    let auth_format = if vs[..16] == EFI_VARIABLE_GUID {
+        false
+    } else if vs[..16] == EFI_AUTH_VARIABLE_GUID {
+        true
+    } else {
+        return None;
+    };
+
+    if vs[0x14] != VARIABLE_STORE_FORMATTED || vs[0x15] != VARIABLE_STORE_HEALTHY {
+        return None;
+    }
+
+    let data_size = u32::from_le_bytes([vs[0x10], vs[0x11], vs[0x12], vs[0x13]]);
+    if data_size > region_size - FV_HEADER_LENGTH as u32 {
+        return None;
+    }
+
+    Some(FvValidation {
+        valid: true,
+        auth_format,
+        data_size,
+    })
+}
+
+fn read_variable_data<F>(
+    read_fn: &mut F,
+    auth_format: bool,
+    data_area_size: u32,
+    guid_bytes: &[u8; 16],
+    name: &[u16],
+    data_out: &mut [u8],
+) -> Option<usize>
+where
+    F: FnMut(u32, &mut [u8]) -> bool,
+{
+    let hdr_size = if auth_format {
+        AUTH_VAR_HEADER_SIZE
+    } else {
+        VAR_HEADER_SIZE
+    } as u32;
+
+    let target_name_len = name
+        .iter()
+        .position(|&ch| ch == 0)
+        .map(|len| len + 1)
+        .unwrap_or(name.len());
+    if target_name_len == 0 {
+        return None;
+    }
+
+    let mut found_len = None;
+    let mut offset = VARIABLE_DATA_OFFSET;
+    let end = VARIABLE_DATA_OFFSET + data_area_size;
+    let mut hdr_buf = [0u8; AUTH_VAR_HEADER_SIZE];
+
+    while offset + hdr_size <= end {
+        let hdr = &mut hdr_buf[..hdr_size as usize];
+        if !read_fn(offset, hdr) {
+            break;
+        }
+
+        let start_id = u16::from_le_bytes([hdr[0], hdr[1]]);
+        let state = hdr[2];
+        if start_id != VARIABLE_DATA || state == 0xFF {
+            break;
+        }
+
+        let (name_size, data_size, guid_offset) = if auth_format {
+            let attributes = u32::from_le_bytes([hdr[0x04], hdr[0x05], hdr[0x06], hdr[0x07]]);
+            let name_size = u32::from_le_bytes([hdr[0x24], hdr[0x25], hdr[0x26], hdr[0x27]]);
+            let data_size = u32::from_le_bytes([hdr[0x28], hdr[0x29], hdr[0x2A], hdr[0x2B]]);
+            if attributes == 0xFFFF_FFFF || name_size == 0xFFFF_FFFF || data_size == 0xFFFF_FFFF {
+                break;
+            }
+            (name_size, data_size, 0x2Cusize)
+        } else {
+            let attributes = u32::from_le_bytes([hdr[0x04], hdr[0x05], hdr[0x06], hdr[0x07]]);
+            let name_size = u32::from_le_bytes([hdr[0x08], hdr[0x09], hdr[0x0A], hdr[0x0B]]);
+            let data_size = u32::from_le_bytes([hdr[0x0C], hdr[0x0D], hdr[0x0E], hdr[0x0F]]);
+            if attributes == 0xFFFF_FFFF || name_size == 0xFFFF_FFFF || data_size == 0xFFFF_FFFF {
+                break;
+            }
+            (name_size, data_size, 0x10usize)
+        };
+
+        let name_offset = offset + hdr_size;
+        let data_offset = name_offset.checked_add(name_size)?;
+        let next_offset = offset.checked_add(align_up(
+            hdr_size.checked_add(name_size)?.checked_add(data_size)?,
+            HEADER_ALIGNMENT,
+        ))?;
+        if data_offset.checked_add(data_size)? > end || next_offset > end + hdr_size {
+            break;
+        }
+
+        if state == VAR_ADDED
+            && hdr[guid_offset..guid_offset + 16] == *guid_bytes
+            && name_size == (target_name_len * 2) as u32
+            && variable_name_matches(read_fn, name_offset, name, target_name_len)
+        {
+            if data_size as usize > data_out.len() {
+                return None;
+            }
+            if !read_fn(data_offset, &mut data_out[..data_size as usize]) {
+                return None;
+            }
+            found_len = Some(data_size as usize);
+        }
+
+        offset = next_offset;
+    }
+
+    found_len
+}
+
+fn variable_name_matches<F>(
+    read_fn: &mut F,
+    name_offset: u32,
+    name: &[u16],
+    target_name_len: usize,
+) -> bool
+where
+    F: FnMut(u32, &mut [u8]) -> bool,
+{
+    let mut buf = [0u8; 2];
+    for (idx, &expected) in name.iter().take(target_name_len).enumerate() {
+        if !read_fn(name_offset + (idx * 2) as u32, &mut buf) {
+            return false;
+        }
+        if u16::from_le_bytes(buf) != expected {
+            return false;
+        }
+    }
+    true
+}
+
 /// Walk all variable records in the FV data area.
 ///
 /// `read_fn` reads bytes from the storage region at the given offset.

--- a/crabefi-core/src/efi/varstore/persistence.rs
+++ b/crabefi-core/src/efi/varstore/persistence.rs
@@ -480,22 +480,42 @@ pub(super) fn write_variable_to_storage_internal(
     let record = edk2::build_variable_record(&guid_bytes, name, attributes, data);
     let record_len = record.len() as u32;
 
-    let vs = state::varstore();
     let storage_size =
         state::with_storage_mut(|s| s.size()).ok_or(VarStoreError::NotInitialized)?;
 
-    if vs.write_offset + record_len > storage_size {
+    let mut write_offset = state::varstore().write_offset;
+    if write_offset + record_len > storage_size {
         log::info!("Variable store full, triggering compaction");
         compact_varstore()?;
+        write_offset = state::varstore().write_offset;
     }
 
-    let vs = state::varstore();
-    if vs.write_offset + record_len > storage_size {
+    if write_offset + record_len > storage_size {
         log::error!("Variable store still full after compaction");
         return Err(VarStoreError::StoreFull);
     }
 
-    let write_offset = vs.write_offset;
+    if !is_erased_for_write(write_offset, record_len)? {
+        log::warn!(
+            "Variable store append area at {:#x} is not erased; compacting before write",
+            write_offset
+        );
+        compact_varstore()?;
+        write_offset = state::varstore().write_offset;
+    }
+
+    if write_offset + record_len > storage_size {
+        log::error!("Variable store full after compaction");
+        return Err(VarStoreError::StoreFull);
+    }
+
+    if !is_erased_for_write(write_offset, record_len)? {
+        log::error!(
+            "Variable store append area at {:#x} is still not erased after compaction",
+            write_offset
+        );
+        return Err(VarStoreError::SpiError);
+    }
 
     // Write the new record using multi-stage protocol
     let new_offset = state::with_storage_mut(|storage| {
@@ -516,12 +536,113 @@ pub(super) fn write_variable_to_storage_internal(
     .ok_or(VarStoreError::NotInitialized)?
     .ok_or(VarStoreError::SpiError)?;
 
+    let mut expected_record = record;
+    if let Some(state) = expected_record.get_mut(2) {
+        *state = edk2::VAR_ADDED;
+    }
+    verify_written_record(write_offset, &expected_record)?;
+
     state::with_varstore_mut(|vs| {
         vs.write_offset = new_offset;
     });
 
-    log::debug!("Variable persisted at offset {:#x}", write_offset);
+    log::debug!(
+        "Variable persisted at offset {:#x}: {}",
+        write_offset,
+        variable_name_for_log(name).as_str()
+    );
     Ok(())
+}
+
+/// Check that a flash range is erased before programming it.
+fn is_erased_for_write(offset: u32, len: u32) -> Result<bool, VarStoreError> {
+    const CHUNK_SIZE: usize = 256;
+
+    state::with_storage_mut(|storage| {
+        let mut remaining = len as usize;
+        let mut current = offset;
+        let mut buffer = [0u8; CHUNK_SIZE];
+
+        while remaining > 0 {
+            let chunk_len = remaining.min(CHUNK_SIZE);
+            storage
+                .read_controller(current, &mut buffer[..chunk_len])
+                .map_err(|_| VarStoreError::SpiError)?;
+
+            if buffer[..chunk_len].iter().any(|&byte| byte != 0xFF) {
+                return Ok(false);
+            }
+
+            remaining -= chunk_len;
+            current += chunk_len as u32;
+        }
+
+        Ok::<bool, VarStoreError>(true)
+    })
+    .ok_or(VarStoreError::NotInitialized)?
+}
+
+/// Verify that a just-written record is readable through the SPI controller.
+fn verify_written_record(offset: u32, expected: &[u8]) -> Result<(), VarStoreError> {
+    state::with_storage_mut(|storage| {
+        let mut controller_bytes = Vec::new();
+        controller_bytes.resize(expected.len(), 0);
+        storage
+            .read_controller(offset, &mut controller_bytes)
+            .map_err(|_| VarStoreError::SpiError)?;
+
+        if controller_bytes.as_slice() != expected {
+            log_record_mismatch("controller", offset, expected, &controller_bytes);
+            return Err(VarStoreError::SpiError);
+        }
+
+        if storage.has_mapped_read_base() {
+            let mut mapped_bytes = Vec::new();
+            mapped_bytes.resize(expected.len(), 0);
+            match storage.read(offset, &mut mapped_bytes) {
+                Ok(()) if mapped_bytes.as_slice() != expected => {
+                    log_record_mismatch("mapped", offset, expected, &mapped_bytes);
+                    log::warn!(
+                        "Variable store mapped readback differs from controller readback; \
+                         subsequent reads may use stale or incorrectly resolved mapped flash"
+                    );
+                }
+                Ok(()) => {}
+                Err(e) => log::warn!("Variable store mapped readback failed: {:?}", e),
+            }
+        }
+
+        Ok::<(), VarStoreError>(())
+    })
+    .ok_or(VarStoreError::NotInitialized)??;
+
+    Ok(())
+}
+
+fn log_record_mismatch(kind: &str, offset: u32, expected: &[u8], actual: &[u8]) {
+    let mismatch = expected
+        .iter()
+        .zip(actual.iter())
+        .position(|(expected, actual)| expected != actual)
+        .unwrap_or(0);
+    let expected_byte = expected.get(mismatch).copied().unwrap_or(0);
+    let actual_byte = actual.get(mismatch).copied().unwrap_or(0);
+
+    log::error!(
+        "Variable store {} readback mismatch at offset {:#x}+{:#x}: expected {:#04x}, got {:#04x}",
+        kind,
+        offset,
+        mismatch,
+        expected_byte,
+        actual_byte
+    );
+}
+
+fn variable_name_for_log(name: &[u16]) -> alloc::string::String {
+    name.iter()
+        .take_while(|&&ch| ch != 0)
+        .map(|&ch| char::from_u32(ch as u32).unwrap_or('?'))
+        .collect()
 }
 
 /// Delete a variable from storage by marking its record as deleted

--- a/crabefi-core/src/efi/varstore/persistence.rs
+++ b/crabefi-core/src/efi/varstore/persistence.rs
@@ -585,8 +585,7 @@ fn is_erased_for_write(offset: u32, len: u32) -> Result<bool, VarStoreError> {
 /// Verify that a just-written record is readable through the SPI controller.
 fn verify_written_record(offset: u32, expected: &[u8]) -> Result<(), VarStoreError> {
     state::with_storage_mut(|storage| {
-        let mut controller_bytes = Vec::new();
-        controller_bytes.resize(expected.len(), 0);
+        let mut controller_bytes = alloc::vec![0; expected.len()];
         storage
             .read_controller(offset, &mut controller_bytes)
             .map_err(|_| VarStoreError::SpiError)?;
@@ -597,8 +596,7 @@ fn verify_written_record(offset: u32, expected: &[u8]) -> Result<(), VarStoreErr
         }
 
         if storage.has_mapped_read_base() {
-            let mut mapped_bytes = Vec::new();
-            mapped_bytes.resize(expected.len(), 0);
+            let mut mapped_bytes = alloc::vec![0; expected.len()];
             match storage.read(offset, &mut mapped_bytes) {
                 Ok(()) if mapped_bytes.as_slice() != expected => {
                     log_record_mismatch("mapped", offset, expected, &mapped_bytes);

--- a/crabefi-core/src/efi/varstore/storage.rs
+++ b/crabefi-core/src/efi/varstore/storage.rs
@@ -179,6 +179,38 @@ impl SpiStorageBackend {
     pub fn set_mapped_read_base(&mut self, phys_base: u64) {
         self.mapped_read_base = Some(phys_base);
     }
+
+    /// Return whether reads normally use a CPU-visible flash mapping.
+    pub fn has_mapped_read_base(&self) -> bool {
+        self.mapped_read_base.is_some()
+    }
+
+    /// Read from the underlying SPI controller, bypassing any mapped-read window.
+    ///
+    /// This is useful after programming flash: a CPU-visible mapping can be
+    /// stale, cached, or incorrectly resolved, while the controller path reads
+    /// the same address space used for writes.
+    pub fn read_controller(&mut self, offset: u32, buffer: &mut [u8]) -> Result<()> {
+        use crate::drivers::spi::SpiController;
+
+        if offset as u64 + buffer.len() as u64 > self.storage_size as u64 {
+            return Err(StorageError::InvalidArgument);
+        }
+
+        let flash_addr = self
+            .base_offset
+            .checked_add(offset)
+            .ok_or(StorageError::InvalidArgument)?;
+
+        self.controller.read(flash_addr, buffer).map_err(|e| {
+            log::warn!("SPI controller read failed at {:#x}: {:?}", flash_addr, e);
+            match e {
+                crate::drivers::spi::SpiError::InvalidArgument => StorageError::InvalidArgument,
+                crate::drivers::spi::SpiError::Timeout => StorageError::Timeout,
+                _ => StorageError::IoError,
+            }
+        })
+    }
 }
 
 fn read_mapped_flash(phys_base: u64, offset: u32, buffer: &mut [u8]) -> Result<()> {

--- a/crabefi-core/src/lib.rs
+++ b/crabefi-core/src/lib.rs
@@ -135,6 +135,8 @@ fn init_persistence_and_boot(
                 }
             }
 
+            logger::apply_persisted_level();
+
             match efi::auth::boot::init_secure_boot_default() {
                 Ok(status) => {
                     log::info!(

--- a/crabefi-core/src/logger.rs
+++ b/crabefi-core/src/logger.rs
@@ -11,6 +11,56 @@
 
 use crate::time::read_counter;
 use log::{Level, LevelFilter, Metadata, Record};
+use r_efi::efi::Guid;
+
+/// Default log level when no persistent CrabEFI log-level variable exists.
+pub const DEFAULT_LEVEL: LevelFilter = LevelFilter::Debug;
+
+/// Log levels shown in the CrabEFI settings menu.
+pub const LEVEL_CHOICES: [LevelFilter; 6] = [
+    LevelFilter::Off,
+    LevelFilter::Error,
+    LevelFilter::Warn,
+    LevelFilter::Info,
+    LevelFilter::Debug,
+    LevelFilter::Trace,
+];
+
+/// CrabEFI settings variable GUID.
+///
+/// {9e80634c-cdc7-41d5-a345-4a297f9c7d1a}
+pub const CRABEFI_SETTINGS_GUID: Guid = Guid::from_fields(
+    0x9e80634c,
+    0xcdc7,
+    0x41d5,
+    0xa3,
+    0x45,
+    &[0x4a, 0x29, 0x7f, 0x9c, 0x7d, 0x1a],
+);
+
+/// UEFI variable name used to persist CrabEFI's maximum log level.
+pub const LOG_LEVEL_VARIABLE_NAME: &[u16] = &[
+    b'C' as u16,
+    b'r' as u16,
+    b'a' as u16,
+    b'b' as u16,
+    b'E' as u16,
+    b'F' as u16,
+    b'I' as u16,
+    b'L' as u16,
+    b'o' as u16,
+    b'g' as u16,
+    b'L' as u16,
+    b'e' as u16,
+    b'v' as u16,
+    b'e' as u16,
+    b'l' as u16,
+    0,
+];
+
+const LOG_LEVEL_VARIABLE_ATTRS: u32 = crate::efi::auth::attributes::NON_VOLATILE
+    | crate::efi::auth::attributes::BOOTSERVICE_ACCESS
+    | crate::efi::auth::attributes::RUNTIME_ACCESS;
 
 /// Get microseconds elapsed since boot.
 ///
@@ -80,7 +130,7 @@ pub fn init() {
         unsafe {
             (*crate::state::drivers_mut_ptr()).timing.boot_counter = read_counter();
         }
-        log::set_max_level(LevelFilter::Debug);
+        log::set_max_level(DEFAULT_LEVEL);
     }
 }
 
@@ -104,4 +154,113 @@ pub fn set_framebuffer(_fb: crate::platform::FramebufferConfig) {
 /// Set the maximum log level
 pub fn set_level(level: LevelFilter) {
     log::set_max_level(level);
+}
+
+/// Return the display name for a log level.
+pub fn level_name(level: LevelFilter) -> &'static str {
+    match level {
+        LevelFilter::Off => "Off",
+        LevelFilter::Error => "Error",
+        LevelFilter::Warn => "Warn",
+        LevelFilter::Info => "Info",
+        LevelFilter::Debug => "Debug",
+        LevelFilter::Trace => "Trace",
+    }
+}
+
+/// Return the menu index for a log level.
+pub fn level_index(level: LevelFilter) -> usize {
+    LEVEL_CHOICES.iter().position(|&l| l == level).unwrap_or(4)
+}
+
+/// Parse a persisted log-level variable payload.
+pub fn level_from_data(data: &[u8]) -> Option<LevelFilter> {
+    match data.first().copied() {
+        Some(0) => Some(LevelFilter::Off),
+        Some(1) => Some(LevelFilter::Error),
+        Some(2) => Some(LevelFilter::Warn),
+        Some(3) => Some(LevelFilter::Info),
+        Some(4) => Some(LevelFilter::Debug),
+        Some(5) => Some(LevelFilter::Trace),
+        _ => None,
+    }
+}
+
+fn level_to_data(level: LevelFilter) -> [u8; 1] {
+    [match level {
+        LevelFilter::Off => 0,
+        LevelFilter::Error => 1,
+        LevelFilter::Warn => 2,
+        LevelFilter::Info => 3,
+        LevelFilter::Debug => 4,
+        LevelFilter::Trace => 5,
+    }]
+}
+
+/// Check whether a variable name/GUID pair is the CrabEFI log-level variable.
+pub fn is_log_level_variable(guid: &Guid, name: &[u16]) -> bool {
+    *guid == CRABEFI_SETTINGS_GUID && crate::efi::utils::ucs2_eq(name, LOG_LEVEL_VARIABLE_NAME)
+}
+
+/// Read the configured log level from the in-memory EFI variable cache.
+pub fn configured_level() -> LevelFilter {
+    read_persisted_level().unwrap_or_else(log::max_level)
+}
+
+/// Apply the persisted log level from the in-memory EFI variable cache.
+pub fn apply_persisted_level() {
+    if let Some(level) = read_persisted_level() {
+        set_level(level);
+        log::info!("CrabEFI log level set to {}", level_name(level));
+    }
+}
+
+/// Apply a just-written log-level variable payload.
+pub fn apply_variable_write(data: &[u8]) {
+    if crate::state::is_exit_boot_services_called() {
+        return;
+    }
+
+    if let Some(level) = level_from_data(data) {
+        set_level(level);
+    }
+}
+
+/// Apply deletion of the log-level variable by reverting to the default level.
+pub fn apply_variable_delete() {
+    if crate::state::is_exit_boot_services_called() {
+        return;
+    }
+
+    set_level(DEFAULT_LEVEL);
+}
+
+/// Persist and apply a new CrabEFI log level.
+pub fn set_configured_level(level: LevelFilter) -> Result<(), crate::efi::varstore::VarStoreError> {
+    let data = level_to_data(level);
+
+    crate::efi::varstore::persist_variable(
+        &CRABEFI_SETTINGS_GUID,
+        LOG_LEVEL_VARIABLE_NAME,
+        LOG_LEVEL_VARIABLE_ATTRS,
+        &data,
+    )?;
+
+    crate::efi::varstore::update_variable_in_memory(
+        &CRABEFI_SETTINGS_GUID,
+        LOG_LEVEL_VARIABLE_NAME,
+        LOG_LEVEL_VARIABLE_ATTRS,
+        &data,
+    );
+    set_level(level);
+
+    Ok(())
+}
+
+fn read_persisted_level() -> Option<LevelFilter> {
+    crate::state::efi()
+        .variables
+        .iter()
+        .find(|var| var.in_use && is_log_level_variable(&var.vendor_guid, &var.name))
+        .and_then(|var| level_from_data(&var.data[..var.data_size]))
 }

--- a/crabefi-core/src/logger.rs
+++ b/crabefi-core/src/logger.rs
@@ -215,6 +215,32 @@ pub fn apply_persisted_level() {
     }
 }
 
+/// Apply the persisted log level from an EDK2-compatible variable-store region.
+///
+/// This is a read-only, allocation-free early-boot helper. Platforms that can
+/// already see an EDK2 variable store as a byte slice may use it before the
+/// full variable backend is initialized. Platform-specific discovery remains in
+/// the platform crate; this helper only understands the generic EDK2 variable
+/// store format.
+pub fn apply_from_edk2_varstore_region(region: &[u8]) -> bool {
+    let mut data = [0u8; 1];
+    let Some(data_len) = crate::efi::varstore::edk2::read_variable_data_from_region(
+        region,
+        CRABEFI_SETTINGS_GUID.as_bytes(),
+        LOG_LEVEL_VARIABLE_NAME,
+        &mut data,
+    ) else {
+        return false;
+    };
+
+    if let Some(level) = level_from_data(&data[..data_len]) {
+        set_level(level);
+        true
+    } else {
+        false
+    }
+}
+
 /// Apply a just-written log-level variable payload.
 pub fn apply_variable_write(data: &[u8]) {
     if crate::state::is_exit_boot_services_called() {

--- a/crabefi-core/src/logger.rs
+++ b/crabefi-core/src/logger.rs
@@ -175,13 +175,13 @@ pub fn level_index(level: LevelFilter) -> usize {
 
 /// Parse a persisted log-level variable payload.
 pub fn level_from_data(data: &[u8]) -> Option<LevelFilter> {
-    match data.first().copied() {
-        Some(0) => Some(LevelFilter::Off),
-        Some(1) => Some(LevelFilter::Error),
-        Some(2) => Some(LevelFilter::Warn),
-        Some(3) => Some(LevelFilter::Info),
-        Some(4) => Some(LevelFilter::Debug),
-        Some(5) => Some(LevelFilter::Trace),
+    match data {
+        [0] => Some(LevelFilter::Off),
+        [1] => Some(LevelFilter::Error),
+        [2] => Some(LevelFilter::Warn),
+        [3] => Some(LevelFilter::Info),
+        [4] => Some(LevelFilter::Debug),
+        [5] => Some(LevelFilter::Trace),
         _ => None,
     }
 }

--- a/crabefi-core/src/menu.rs
+++ b/crabefi-core/src/menu.rs
@@ -61,8 +61,7 @@ pub const EFI_BOOT_PATH: &str = "EFI\\BOOT\\BOOTRISCV64.EFI";
 const MENU_TITLE: &str = "CrabEFI Boot Menu";
 
 /// Help text
-const HELP_TEXT: &str =
-    "Arrows: Select | Enter: Boot | F: Firmware | C: Cmdline | S: Secure Boot | R: Reset";
+const HELP_TEXT: &str = "Enter: Boot | F: Firmware | C: Cmdline | S: Secure Boot | R: Reset";
 
 /// Re-export storage device type for backward compatibility
 pub type DeviceType = StorageType;

--- a/crabefi-core/src/state.rs
+++ b/crabefi-core/src/state.rs
@@ -609,7 +609,7 @@ impl Default for EfiState {
 
 use crate::drivers::pci::PciDevice;
 use crate::drivers::pci::access::AnyPciAccess;
-use crate::drivers::serial::AnySerial;
+use crate::drivers::serial::{AnySerial, PlatformSerial};
 use crate::drivers::storage::StorageRegistry;
 use crate::efi::protocols::serial_io::SerialIoMode;
 use crate::platform::FramebufferConfig;
@@ -735,6 +735,8 @@ impl Default for PciState {
 pub struct SerialState {
     /// Active serial port driver (16550 UART, PL011, or platform-provided primary output).
     pub(crate) driver: Option<AnySerial>,
+    /// Optional mirror for debug output such as a firmware memory console.
+    pub(crate) debug_sink: Option<PlatformSerial>,
     /// EFI Serial IO protocol mode (current port settings).
     ///
     /// The Protocol.mode pointer is set to point here during init.
@@ -751,6 +753,7 @@ impl SerialState {
 
         Self {
             driver: None,
+            debug_sink: None,
             io_mode: SerialIoMode {
                 control_mask: EFI_SERIAL_CLEAR_TO_SEND
                     | EFI_SERIAL_DATA_SET_READY

--- a/crabefi-coreboot/src/cbmem_console.rs
+++ b/crabefi-coreboot/src/cbmem_console.rs
@@ -8,8 +8,6 @@
 use core::fmt::{self, Write};
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
-
 /// Mask for the cursor offset bits in coreboot's CBMEM console header.
 const CURSOR_MASK: u32 = (1 << 28) - 1;
 /// Cursor flag indicating that the ring buffer has wrapped.
@@ -21,7 +19,6 @@ const MAX_CONSOLE_SIZE: u32 = CURSOR_MASK;
 ///
 /// The actual console buffer follows immediately after this header.
 #[repr(C, packed)]
-#[derive(FromBytes, Immutable, KnownLayout, Unaligned)]
 struct CbmemConsoleHeader {
     /// Size of the console buffer, not including this header.
     size: u32,
@@ -57,6 +54,7 @@ impl Write for CbmemConsole {
     }
 }
 
+#[cfg(not(test))]
 impl crabefi::DebugOutput for CbmemConsole {
     fn write_byte(&mut self, byte: u8) {
         self.write_raw_byte(byte);
@@ -78,6 +76,7 @@ pub fn init(addr: u64) -> bool {
     match read_size(addr) {
         Some(size) if (1024..=MAX_CONSOLE_SIZE).contains(&size) => {
             CBMEM_CONSOLE_ADDR.store(addr, Ordering::Release);
+            #[cfg(not(test))]
             log::debug!(
                 "CBMEM console initialized: addr={:#x}, size={} bytes",
                 addr,
@@ -86,11 +85,14 @@ pub fn init(addr: u64) -> bool {
             true
         }
         Some(size) => {
+            #[cfg(not(test))]
             log::warn!(
                 "CBMEM console has invalid size: {} bytes at {:#x}",
                 size,
                 addr
             );
+            #[cfg(test)]
+            let _ = size;
             false
         }
         None => false,
@@ -183,5 +185,83 @@ fn write_bytes(mut bytes: &[u8]) {
             write_cursor(addr, cursor.wrapping_add(bytes.len() as u32));
             break;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::vec::Vec;
+
+    const TEST_CONSOLE_SIZE: usize = 1024;
+
+    fn console_storage(size: usize) -> Vec<u8> {
+        let mut storage = std::vec![0; core::mem::size_of::<CbmemConsoleHeader>() + size];
+        let addr = storage.as_mut_ptr() as u64;
+        let header = addr as *mut CbmemConsoleHeader;
+        // SAFETY: `storage` is large enough for the packed header.
+        unsafe {
+            core::ptr::addr_of_mut!((*header).size).write_unaligned(size as u32);
+            core::ptr::addr_of_mut!((*header).cursor).write_unaligned(0);
+        }
+        storage
+    }
+
+    fn console_body(storage: &[u8]) -> &[u8] {
+        &storage[core::mem::size_of::<CbmemConsoleHeader>()..]
+    }
+
+    #[test]
+    fn rejects_zero_and_tiny_console_buffers() {
+        disable();
+        assert!(!init(0));
+
+        let mut storage = console_storage(512);
+        assert!(!init(storage.as_mut_ptr() as u64));
+        assert_eq!(console_addr(), None);
+    }
+
+    #[test]
+    fn mirrors_newlines_as_crlf_and_advances_cursor() {
+        disable();
+        let mut storage = console_storage(TEST_CONSOLE_SIZE);
+        let addr = storage.as_mut_ptr() as u64;
+        assert!(init(addr));
+
+        let mut console = CbmemConsole::new();
+        console.write_str("A\nB").unwrap();
+
+        assert_eq!(&console_body(&storage)[..4], b"A\r\nB");
+        assert_eq!(read_cursor(addr), 4);
+    }
+
+    #[test]
+    fn wraps_ring_buffer_and_sets_overflow_flag() {
+        disable();
+        let mut storage = console_storage(TEST_CONSOLE_SIZE);
+        let addr = storage.as_mut_ptr() as u64;
+        assert!(init(addr));
+        write_cursor(addr, (TEST_CONSOLE_SIZE - 2) as u32);
+
+        write_bytes(b"abcd");
+
+        let body = console_body(&storage);
+        assert_eq!(&body[TEST_CONSOLE_SIZE - 2..], b"ab");
+        assert_eq!(&body[..2], b"cd");
+        assert_eq!(read_cursor(addr), OVERFLOW | 2);
+    }
+
+    #[test]
+    fn disable_stops_later_writes() {
+        disable();
+        let mut storage = console_storage(TEST_CONSOLE_SIZE);
+        let addr = storage.as_mut_ptr() as u64;
+        assert!(init(addr));
+        disable();
+
+        write_bytes(b"ignored");
+
+        assert_eq!(read_cursor(addr), 0);
+        assert!(console_body(&storage).iter().all(|byte| *byte == 0));
     }
 }

--- a/crabefi-coreboot/src/cbmem_console.rs
+++ b/crabefi-coreboot/src/cbmem_console.rs
@@ -1,12 +1,21 @@
-//! Coreboot CBMEM Console Handoff
+//! Coreboot CBMEM console output
 //!
-//! This module tracks the coreboot in-memory console (CBMEM console) only so
-//! the payload can disable it before handing control to the OS. The generic
-//! CrabEFI logger is intentionally unaware of CBMEM.
+//! This module exposes coreboot's in-memory CBMEM console as a CrabEFI
+//! [`DebugOutput`](crabefi::DebugOutput) sink. The coreboot payload injects this
+//! sink into CrabEFI's serial subsystem so log output and EFI console bytes are
+//! mirrored into CBMEM while the physical buffer is valid.
 
+use core::fmt::{self, Write};
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
+
+/// Mask for the cursor offset bits in coreboot's CBMEM console header.
+const CURSOR_MASK: u32 = (1 << 28) - 1;
+/// Cursor flag indicating that the ring buffer has wrapped.
+const OVERFLOW: u32 = 1 << 31;
+/// Largest buffer representable by the cursor offset bits.
+const MAX_CONSOLE_SIZE: u32 = CURSOR_MASK;
 
 /// CBMEM console structure header.
 ///
@@ -22,33 +31,69 @@ struct CbmemConsoleHeader {
 
 static CBMEM_CONSOLE_ADDR: AtomicU64 = AtomicU64::new(0);
 
+/// Debug output sink for the coreboot CBMEM console.
+pub struct CbmemConsole;
+
+impl CbmemConsole {
+    /// Create a CBMEM console debug-output sink.
+    pub const fn new() -> Self {
+        Self
+    }
+
+    fn write_raw_byte(&mut self, byte: u8) {
+        write_bytes(&[byte]);
+    }
+}
+
+impl Write for CbmemConsole {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for byte in s.bytes() {
+            if byte == b'\n' {
+                self.write_raw_byte(b'\r');
+            }
+            self.write_raw_byte(byte);
+        }
+        Ok(())
+    }
+}
+
+impl crabefi::DebugOutput for CbmemConsole {
+    fn write_byte(&mut self, byte: u8) {
+        self.write_raw_byte(byte);
+    }
+}
+
 /// Initialize the CBMEM console with the given physical address.
 ///
 /// # Arguments
 /// * `addr` - Physical address of the CBMEM console structure
-pub fn init(addr: u64) {
+///
+/// # Returns
+/// `true` when the console header is valid and output was enabled.
+pub fn init(addr: u64) -> bool {
     if addr == 0 {
-        return;
+        return false;
     }
 
-    // Verify the console looks valid before enabling.
-    unsafe {
-        let header = &*(addr as *const CbmemConsoleHeader);
-        let size = header.size;
-        if (1024..=1024 * 1024).contains(&size) {
+    match read_size(addr) {
+        Some(size) if (1024..=MAX_CONSOLE_SIZE).contains(&size) => {
             CBMEM_CONSOLE_ADDR.store(addr, Ordering::Release);
             log::debug!(
                 "CBMEM console initialized: addr={:#x}, size={} bytes",
                 addr,
                 size
             );
-        } else {
+            true
+        }
+        Some(size) => {
             log::warn!(
                 "CBMEM console has invalid size: {} bytes at {:#x}",
                 size,
                 addr
             );
+            false
         }
+        None => false,
     }
 }
 
@@ -58,4 +103,85 @@ pub fn init(addr: u64) {
 /// from accessing the physical-only CBMEM buffer.
 pub fn disable() {
     CBMEM_CONSOLE_ADDR.store(0, Ordering::Release);
+}
+
+fn console_addr() -> Option<u64> {
+    let addr = CBMEM_CONSOLE_ADDR.load(Ordering::Acquire);
+    (addr != 0).then_some(addr)
+}
+
+fn read_size(addr: u64) -> Option<u32> {
+    let header = addr as *const CbmemConsoleHeader;
+    if header.is_null() {
+        return None;
+    }
+
+    // SAFETY: `addr` comes from the validated coreboot table. The structure is
+    // packed, so use unaligned raw-field access instead of taking references to
+    // fields.
+    Some(unsafe { core::ptr::addr_of!((*header).size).read_unaligned() })
+}
+
+fn read_cursor(addr: u64) -> u32 {
+    let header = addr as *const CbmemConsoleHeader;
+    // SAFETY: `addr` is the enabled CBMEM console address. The header is packed.
+    unsafe { core::ptr::addr_of!((*header).cursor).read_unaligned() }
+}
+
+fn write_cursor(addr: u64, cursor: u32) {
+    let header = addr as *mut CbmemConsoleHeader;
+    // SAFETY: `addr` is the enabled CBMEM console address. The header is packed.
+    unsafe { core::ptr::addr_of_mut!((*header).cursor).write_unaligned(cursor) };
+}
+
+fn body_ptr(addr: u64) -> *mut u8 {
+    // SAFETY: Pointer arithmetic only constructs the body pointer immediately
+    // after the fixed-size header.
+    unsafe { (addr as *mut u8).add(core::mem::size_of::<CbmemConsoleHeader>()) }
+}
+
+fn write_chunk(addr: u64, offset: usize, bytes: &[u8]) {
+    let body = body_ptr(addr);
+    for (i, byte) in bytes.iter().copied().enumerate() {
+        // SAFETY: Callers ensure `offset + bytes.len()` is within the console
+        // body. Volatile writes keep the firmware-visible log side effect.
+        unsafe { body.add(offset + i).write_volatile(byte) };
+    }
+}
+
+fn write_bytes(mut bytes: &[u8]) {
+    let Some(addr) = console_addr() else {
+        return;
+    };
+    let Some(size) = read_size(addr) else {
+        disable();
+        return;
+    };
+    if !(1024..=MAX_CONSOLE_SIZE).contains(&size) {
+        disable();
+        return;
+    }
+
+    let size = size as usize;
+    while !bytes.is_empty() {
+        let cursor = read_cursor(addr);
+        let offset = (cursor & CURSOR_MASK) as usize;
+        if offset >= size {
+            write_cursor(addr, (cursor & !CURSOR_MASK) | OVERFLOW);
+            continue;
+        }
+
+        let remaining = size - offset;
+        if bytes.len() >= remaining {
+            let (chunk, rest) = bytes.split_at(remaining);
+            write_chunk(addr, offset, chunk);
+            let new_cursor = cursor.wrapping_add(remaining as u32);
+            write_cursor(addr, (new_cursor & !CURSOR_MASK) | OVERFLOW);
+            bytes = rest;
+        } else {
+            write_chunk(addr, offset, bytes);
+            write_cursor(addr, cursor.wrapping_add(bytes.len() as u32));
+            break;
+        }
+    }
 }

--- a/crabefi-coreboot/src/cfr.rs
+++ b/crabefi-coreboot/src/cfr.rs
@@ -1063,7 +1063,15 @@ pub fn write_option_value(option: &CfrOption, value: &CfrValue) -> Result<(), &'
             e
         );
         "Failed to persist CFR variable"
-    })
+    })?;
+
+    // `persist_variable()` writes the EDK2/SMMSTORE backend but does not update
+    // CrabEFI's in-memory variable cache. Keep the cache in sync so reopening
+    // the firmware-settings menu during this same payload run shows the saved
+    // values instead of the values loaded when the payload started.
+    varstore::update_variable_in_memory(&COREBOOT_CFR_GUID, &name, attrs, &data);
+
+    Ok(())
 }
 
 /// Delete a CFR option from storage (revert to default)
@@ -1079,5 +1087,23 @@ pub fn delete_option_value(option: &CfrOption) -> Result<(), &'static str> {
             e
         );
         "Failed to delete CFR variable"
-    })
+    })?;
+
+    delete_option_from_memory(&name);
+
+    Ok(())
+}
+
+fn delete_option_from_memory(name: &[u16]) {
+    use crabefi::state;
+
+    state::with_efi_mut(|efi| {
+        if let Some(var) = efi.variables.iter_mut().find(|var| {
+            var.in_use
+                && var.vendor_guid == COREBOOT_CFR_GUID
+                && crabefi::efi::utils::ucs2_eq(&var.name, name)
+        }) {
+            var.in_use = false;
+        }
+    });
 }

--- a/crabefi-coreboot/src/cfr.rs
+++ b/crabefi-coreboot/src/cfr.rs
@@ -355,11 +355,27 @@ pub fn get_cfr() -> Option<&'static CfrInfo> {
 // CRC32 computation (matching coreboot's CRC32 used in lb_cfr.checksum)
 // ============================================================================
 
-/// Compute CRC32 matching coreboot's crc_byte implementation.
-/// This is the standard CRC-32 (ISO 3309, ITU-T V.42, Ethernet, PKZIP, etc.)
+/// Compute CRC32 matching coreboot's `crc32_byte` implementation.
+///
+/// Coreboot's CFR checksum is not the UEFI/IEEE reflected CRC32 used for EFI
+/// table headers. It starts from zero, shifts MSB-first with polynomial
+/// `0x04c11db7`, and does not apply a final XOR.
 fn compute_crc32(data: &[u8]) -> u32 {
-    // Use the same CRC32 as the rest of CrabEFI
-    crabefi::efi::boot_services::compute_crc32(data)
+    let mut crc = 0u32;
+
+    for &byte in data {
+        crc ^= (byte as u32) << 24;
+
+        for _ in 0..8 {
+            if (crc & 0x8000_0000) != 0 {
+                crc = (crc << 1) ^ 0x04c1_1db7;
+            } else {
+                crc <<= 1;
+            }
+        }
+    }
+
+    crc
 }
 
 // ============================================================================

--- a/crabefi-coreboot/src/cfr_menu.rs
+++ b/crabefi-coreboot/src/cfr_menu.rs
@@ -631,7 +631,7 @@ fn save_all_changes(cfr: &CfrInfo, items: &[MenuItem]) -> (usize, usize) {
 fn confirm_save(fb_console: &mut Option<FramebufferConsole>) -> bool {
     menu_common::confirm_dialog(
         fb_console,
-        "Save changes? (takes effect after reset)",
+        "Save changes? (CFR changes may require reset)",
         "Press Y to save, N to discard",
     )
 }

--- a/crabefi-coreboot/src/cfr_menu.rs
+++ b/crabefi-coreboot/src/cfr_menu.rs
@@ -32,6 +32,12 @@ const HELP_TEXT: &str =
 enum MenuItem {
     /// Form header (category separator)
     FormHeader { name: String },
+    /// CrabEFI-owned log-level setting.
+    CrabLogLevel {
+        current_level: log::LevelFilter,
+        /// Snapshot of the value when the menu was opened, used to detect changes.
+        original_level: log::LevelFilter,
+    },
     /// Editable option
     Option {
         form_idx: usize,
@@ -56,6 +62,12 @@ fn has_changes(items: &[MenuItem]) -> bool {
                 original_value,
                 ..
             } if current_value != original_value
+        ) || matches!(
+            item,
+            MenuItem::CrabLogLevel {
+                current_level,
+                original_level,
+            } if current_level != original_level
         )
     })
 }
@@ -65,11 +77,12 @@ fn has_changes(items: &[MenuItem]) -> bool {
 /// Displays the menu and handles user interaction.
 /// Returns when the user exits the menu.
 pub fn show_cfr_menu() {
+    let empty_cfr;
     let cfr_info = match cfr::get_cfr() {
         Some(cfr) => cfr,
         None => {
-            show_no_cfr_message();
-            return;
+            empty_cfr = CfrInfo::new();
+            &empty_cfr
         }
     };
 
@@ -123,22 +136,7 @@ pub fn show_cfr_menu() {
                         break;
                     }
                     KeyPress::Enter | KeyPress::Char(' ') => {
-                        // Check visibility/editability before taking a mutable borrow
-                        let can_edit = if let Some(
-                            item @ MenuItem::Option {
-                                form_idx,
-                                option_idx,
-                                ..
-                            },
-                        ) = items.get(selected)
-                        {
-                            is_item_visible(cfr_info, &items, item)
-                                && get_option(cfr_info, *form_idx, *option_idx)
-                                    .is_some_and(|o| o.is_editable())
-                        } else {
-                            false
-                        };
-                        if can_edit {
+                        if can_edit_item(cfr_info, &items, selected) {
                             if let Some(MenuItem::Option {
                                 form_idx,
                                 option_idx,
@@ -150,8 +148,10 @@ pub fn show_cfr_menu() {
                                 if let Some(option) = get_option(cfr_info, fi, oi) {
                                     toggle_value(option, current_value);
                                 }
+                            } else {
+                                increment_option(cfr_info, &mut items, selected);
                             }
-                        } else if matches!(items.get(selected), Some(MenuItem::Option { .. })) {
+                        } else if is_selectable_item(items.get(selected)) {
                             status_message = Some(("Option is read-only", false));
                         }
                         break;
@@ -180,6 +180,9 @@ pub fn show_cfr_menu() {
                             && let Some(option) = get_option(cfr_info, *form_idx, *option_idx)
                         {
                             show_help(option, &mut fb_console);
+                        } else if matches!(items.get(selected), Some(MenuItem::CrabLogLevel { .. }))
+                        {
+                            status_message = Some(("Controls CrabEFI serial log verbosity", true));
                         }
                         break;
                     }
@@ -198,6 +201,15 @@ pub fn show_cfr_menu() {
 /// toggling a "parent" option immediately shows or hides dependent items.
 fn build_menu_items(cfr: &CfrInfo) -> Vec<MenuItem> {
     let mut items = Vec::new();
+
+    let mut crabefi_name = String::new();
+    crabefi_name.push_str("CrabEFI");
+    items.push(MenuItem::FormHeader { name: crabefi_name });
+    let current_level = crabefi::logger::configured_level();
+    items.push(MenuItem::CrabLogLevel {
+        current_level,
+        original_level: current_level,
+    });
 
     for (form_idx, form) in cfr.forms.iter().enumerate() {
         if !form.is_visible() {
@@ -323,6 +335,7 @@ fn is_item_visible(cfr: &CfrInfo, items: &[MenuItem], item: &MenuItem) -> bool {
                 .is_none_or(|opt| is_dep_met_live(cfr, items, opt.dependency_id, &opt.dep_values));
             form_ok && opt_ok
         }
+        MenuItem::CrabLogLevel { .. } => true,
         // Comments and subform headers don't carry their own indices, so
         // they stay visible (their parent form header hides the section).
         MenuItem::Comment { .. } | MenuItem::SubformHeader { .. } => true,
@@ -370,11 +383,22 @@ fn find_next_selectable(cfr: &CfrInfo, items: &[MenuItem], current: usize) -> us
 }
 
 fn is_selectable(item: &MenuItem) -> bool {
-    matches!(item, MenuItem::Option { .. })
+    matches!(
+        item,
+        MenuItem::Option { .. } | MenuItem::CrabLogLevel { .. }
+    )
+}
+
+fn is_selectable_item(item: Option<&MenuItem>) -> bool {
+    item.is_some_and(is_selectable)
 }
 
 /// Check if the item at `index` is an editable, visible option (immutable borrow).
 fn can_edit_item(cfr: &CfrInfo, items: &[MenuItem], index: usize) -> bool {
+    if matches!(items.get(index), Some(MenuItem::CrabLogLevel { .. })) {
+        return true;
+    }
+
     if let Some(
         item @ MenuItem::Option {
             form_idx,
@@ -436,6 +460,14 @@ fn increment_option(cfr: &CfrInfo, items: &mut [MenuItem], index: usize) -> bool
     if !can_edit_item(cfr, items, index) {
         return false;
     }
+
+    if let Some(MenuItem::CrabLogLevel { current_level, .. }) = items.get_mut(index) {
+        let current_idx = crabefi::logger::level_index(*current_level);
+        let next_idx = (current_idx + 1) % crabefi::logger::LEVEL_CHOICES.len();
+        *current_level = crabefi::logger::LEVEL_CHOICES[next_idx];
+        return true;
+    }
+
     let Some(MenuItem::Option {
         form_idx,
         option_idx,
@@ -490,6 +522,18 @@ fn decrement_option(cfr: &CfrInfo, items: &mut [MenuItem], index: usize) -> bool
     if !can_edit_item(cfr, items, index) {
         return false;
     }
+
+    if let Some(MenuItem::CrabLogLevel { current_level, .. }) = items.get_mut(index) {
+        let current_idx = crabefi::logger::level_index(*current_level);
+        let prev_idx = if current_idx == 0 {
+            crabefi::logger::LEVEL_CHOICES.len().saturating_sub(1)
+        } else {
+            current_idx - 1
+        };
+        *current_level = crabefi::logger::LEVEL_CHOICES[prev_idx];
+        return true;
+    }
+
     let Some(MenuItem::Option {
         form_idx,
         option_idx,
@@ -549,22 +593,35 @@ fn save_all_changes(cfr: &CfrInfo, items: &[MenuItem]) -> (usize, usize) {
     let mut saved = 0usize;
     let mut failed = 0usize;
     for item in items {
-        if let MenuItem::Option {
-            form_idx,
-            option_idx,
-            current_value,
-            original_value,
-        } = item
-            && current_value != original_value
-            && let Some(option) = get_option(cfr, *form_idx, *option_idx)
-        {
-            match cfr::write_option_value(option, current_value) {
-                Ok(()) => saved += 1,
-                Err(e) => {
-                    log::warn!("Failed to save '{}': {}", option.opt_name, e);
+        match item {
+            MenuItem::CrabLogLevel {
+                current_level,
+                original_level,
+            } if current_level != original_level => {
+                if crabefi::logger::set_configured_level(*current_level).is_ok() {
+                    saved += 1;
+                } else {
+                    log::warn!("Failed to save CrabEFI log level");
                     failed += 1;
                 }
             }
+            MenuItem::Option {
+                form_idx,
+                option_idx,
+                current_value,
+                original_value,
+            } if current_value != original_value => {
+                if let Some(option) = get_option(cfr, *form_idx, *option_idx) {
+                    match cfr::write_option_value(option, current_value) {
+                        Ok(()) => saved += 1,
+                        Err(e) => {
+                            log::warn!("Failed to save '{}': {}", option.opt_name, e);
+                            failed += 1;
+                        }
+                    }
+                }
+            }
+            _ => {}
         }
     }
     (saved, failed)
@@ -678,39 +735,6 @@ fn show_help(option: &CfrOption, fb_console: &mut Option<FramebufferConsole>) {
         }
 
         console.write_centered(rows - 3, "Press any key to continue...");
-    }
-
-    loop {
-        if menu_common::read_key().is_some() {
-            break;
-        }
-        delay_ms(10);
-    }
-}
-
-/// Show message that CFR is not available
-fn show_no_cfr_message() {
-    let fb_info = crabefi::state::get_framebuffer();
-    let mut fb_console = fb_info.as_ref().map(FramebufferConsole::new);
-
-    serial_driver::write_str("\r\n");
-    serial_driver::write_str("\x1b[1;33m");
-    serial_driver::write_str("  Firmware settings not available\r\n");
-    serial_driver::write_str("\x1b[0m");
-    serial_driver::write_str("  This firmware does not expose CFR configuration options.\r\n");
-    serial_driver::write_str("\r\n  Press any key to continue...\r\n");
-
-    if let Some(console) = &mut fb_console {
-        console.clear();
-        let rows = console.rows();
-        console.set_fg_color(Color::new(255, 255, 0));
-        console.write_centered(rows / 2 - 1, "Firmware settings not available");
-        console.reset_colors();
-        console.write_centered(
-            rows / 2 + 1,
-            "This firmware does not expose CFR configuration options.",
-        );
-        console.write_centered(rows / 2 + 3, "Press any key to continue...");
     }
 
     loop {
@@ -844,6 +868,9 @@ fn draw_item(
                 draw_option_item(option, current_value, is_selected, row, fb_console, cols);
             }
         }
+        MenuItem::CrabLogLevel { current_level, .. } => {
+            draw_log_level_item(*current_level, is_selected, row, fb_console, cols);
+        }
         MenuItem::Comment { text } => {
             draw_comment(text, row, fb_console);
         }
@@ -885,6 +912,62 @@ fn draw_subform_header(name: &str, row: usize, fb_console: &mut Option<Framebuff
         console.set_fg_color(Color::new(192, 0, 192)); // Magenta
         let _ = console.write_str("     ");
         let _ = console.write_str(name);
+        clear_line_remainder(console);
+        console.reset_colors();
+    }
+}
+
+/// Draw the CrabEFI log-level item.
+fn draw_log_level_item(
+    level: log::LevelFilter,
+    is_selected: bool,
+    row: usize,
+    fb_console: &mut Option<FramebufferConsole>,
+    cols: usize,
+) {
+    let name = "CrabEFI log level";
+    let mut value_str = String::new();
+    value_str.push('[');
+    value_str.push_str(crabefi::logger::level_name(level));
+    value_str.push(']');
+
+    let ansi_row = row + 1;
+    let _ = write!(SerialWriter, "\x1b[{};1H", ansi_row);
+
+    if is_selected {
+        serial_driver::write_str("\x1b[7m");
+    }
+
+    serial_driver::write_str("   ");
+    serial_driver::write_str(name);
+
+    let name_len = name.len();
+    let pad_to = 40.min(cols.saturating_sub(value_str.len() + 5));
+    for _ in name_len + 3..pad_to {
+        serial_driver::write_str(" ");
+    }
+    serial_driver::write_str(&value_str);
+    serial_driver::write_str("\x1b[0m\x1b[K\r\n");
+
+    if let Some(console) = fb_console {
+        console.set_position(0, row as u32);
+
+        if is_selected {
+            console.set_colors(HIGHLIGHT_FG, HIGHLIGHT_BG);
+        } else {
+            console.set_colors(DEFAULT_FG, DEFAULT_BG);
+        }
+
+        let _ = console.write_str("   ");
+        let _ = console.write_str(name);
+
+        let term_cols = console.cols() as usize;
+        let pad_to = 40.min(term_cols.saturating_sub(value_str.len() + 5));
+        for _ in name_len + 3..pad_to {
+            let _ = console.write_str(" ");
+        }
+        let _ = console.write_str(&value_str);
+
         clear_line_remainder(console);
         console.reset_colors();
     }

--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -83,16 +83,12 @@ impl crabefi::PlatformHooks for CorebootHooks {
     }
 
     fn firmware_settings_available(&self) -> bool {
-        cfr::get_cfr().is_some()
+        true
     }
 
     fn show_firmware_settings(&self) -> bool {
-        if cfr::get_cfr().is_some() {
-            cfr_menu::show_cfr_menu();
-            true
-        } else {
-            false
-        }
+        cfr_menu::show_cfr_menu();
+        true
     }
 }
 

--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -713,6 +713,7 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
 
     // Initialize logging (idempotent — init_platform() will call it again).
     crabefi::logger::init();
+    apply_early_log_level(&cb_info);
 
     if let Some(fb) = cb_info.framebuffer {
         crabefi::logger::set_framebuffer(crabefi::FramebufferConfig::from(fb));
@@ -922,6 +923,36 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
 // ============================================================================
 // Logging helpers
 // ============================================================================
+
+/// Apply CrabEFI's persisted log level before normal platform initialization.
+///
+/// Keep this path read-only and silent: at this point the heap, SPI drivers, and
+/// full EFI variable services are not initialized yet. Coreboot-specific code is
+/// limited to discovering the memory-mapped SMMSTORE region; parsing the EDK2
+/// variable-store format is handled by the generic CrabEFI logger helper.
+fn apply_early_log_level(cb_info: &tables::CorebootInfo) {
+    let Some(smmstore) = cb_info.smmstorev2 else {
+        return;
+    };
+
+    let Some(size) = smmstore
+        .num_blocks
+        .checked_mul(smmstore.block_size)
+        .map(usize::try_from)
+        .and_then(Result::ok)
+    else {
+        return;
+    };
+
+    if size == 0 || smmstore.mmap_addr == 0 {
+        return;
+    }
+
+    // SAFETY: coreboot reports SMMSTORE as a memory-mapped region. We only read
+    // the bounded region while still in identity-mapped physical mode.
+    let region = unsafe { core::slice::from_raw_parts(smmstore.mmap_addr as *const u8, size) };
+    let _ = crabefi::logger::apply_from_edk2_varstore_region(region);
+}
 
 fn log_coreboot_info(cb_info: &tables::CorebootInfo) {
     log::info!("Parsed coreboot tables:");

--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -609,6 +609,8 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
     #[cfg(target_arch = "x86_64")]
     let entry_counter = crabefi::time::read_counter();
 
+    let mut cbmem_output = cbmem_console::CbmemConsole::new();
+
     // ================================================================
     // Phase 1: Initialize firmware state (needed for all state access)
     // ================================================================
@@ -644,9 +646,7 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
     // (efi::varstore::persistence.rs) and must be set before
     // init_platform() runs init_persistence_and_boot().
 
-    if let Some(cbmem_addr) = cb_info.cbmem_console {
-        cbmem_console::init(cbmem_addr);
-    }
+    let cbmem_console_available = cb_info.cbmem_console.is_some_and(cbmem_console::init);
 
     #[cfg(target_arch = "x86_64")]
     let timestamp_recorder = cb_info.timestamps.and_then(|table_addr| {
@@ -696,6 +696,23 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
             regwidth: serial.regwidth,
             input_hertz: serial.input_hertz,
         });
+    }
+
+    if cbmem_console_available {
+        let debug_output: &mut dyn crabefi::DebugOutput = &mut cbmem_output;
+        // SAFETY: `rust_main()` never returns, so `cbmem_output` remains alive
+        // for the entire firmware lifetime. The CBMEM module disables itself
+        // before runtime when the physical-only buffer is no longer safe.
+        let raw = unsafe {
+            core::mem::transmute::<&mut dyn crabefi::DebugOutput, *mut dyn crabefi::DebugOutput>(
+                debug_output,
+            )
+        };
+        // SAFETY: `raw` points to `cbmem_output`, whose stack frame never
+        // unwinds because this entry point is `-> !`.
+        unsafe {
+            crabefi::drivers::serial::add_platform_debug_sink_raw(raw);
+        }
     }
 
     // Initialize logging (idempotent — init_platform() will call it again).

--- a/crabefi-coreboot/src/timestamps.rs
+++ b/crabefi-coreboot/src/timestamps.rs
@@ -56,12 +56,15 @@ impl CorebootTimestampRecorder {
         };
 
         if !(16..=1024).contains(&max_entries) || num_entries > max_entries as u32 {
+            #[cfg(not(test))]
             log::warn!(
                 "Ignoring suspicious coreboot timestamp table at {:#x}: entries={}/{}",
                 table_addr,
                 num_entries,
                 max_entries
             );
+            #[cfg(test)]
+            let _ = (num_entries, max_entries);
             return None;
         }
 
@@ -69,6 +72,7 @@ impl CorebootTimestampRecorder {
     }
 
     /// Append a milestone using the current architecture counter.
+    #[cfg(not(test))]
     pub(crate) fn record_now(&self, id: u32) {
         self.record_counter(id, crabefi::time::read_counter());
     }
@@ -86,12 +90,15 @@ impl CorebootTimestampRecorder {
             let num_entries = num_ptr.read_unaligned();
 
             if num_entries >= max_entries as u32 {
+                #[cfg(not(test))]
                 log::warn!(
                     "Coreboot timestamp table full ({}/{}), dropping id={}",
                     num_entries,
                     max_entries,
                     id
                 );
+                #[cfg(test)]
+                let _ = (num_entries, max_entries, id);
                 return;
             }
 
@@ -108,8 +115,97 @@ impl CorebootTimestampRecorder {
     }
 }
 
+#[cfg(not(test))]
 impl crabefi::TimestampRecorder for CorebootTimestampRecorder {
     fn record(&self, id: u32) {
         self.record_now(id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::vec::Vec;
+
+    const ENTRIES: usize = 16;
+
+    fn timestamp_storage(base_time: u64, max_entries: u16, num_entries: u32) -> Vec<u8> {
+        let mut storage = std::vec![
+            0;
+            core::mem::size_of::<TimestampTable>()
+                + ENTRIES * core::mem::size_of::<TimestampEntry>()
+        ];
+        let table = storage.as_mut_ptr() as *mut TimestampTable;
+        // SAFETY: `storage` is large enough for the packed table header.
+        unsafe {
+            core::ptr::addr_of_mut!((*table).base_time).write_unaligned(base_time);
+            core::ptr::addr_of_mut!((*table).max_entries).write_unaligned(max_entries);
+            core::ptr::addr_of_mut!((*table).tick_freq_mhz).write_unaligned(1000);
+            core::ptr::addr_of_mut!((*table).num_entries).write_unaligned(num_entries);
+        }
+        storage
+    }
+
+    fn entry(storage: &[u8], index: usize) -> (u32, i64) {
+        let entries_base = unsafe {
+            storage.as_ptr().add(core::mem::size_of::<TimestampTable>()) as *const TimestampEntry
+        };
+        let entry = unsafe { entries_base.add(index) };
+        // SAFETY: Tests only read entries within the allocated storage.
+        unsafe {
+            (
+                core::ptr::addr_of!((*entry).entry_id).read_unaligned(),
+                core::ptr::addr_of!((*entry).entry_stamp).read_unaligned(),
+            )
+        }
+    }
+
+    fn num_entries(storage: &[u8]) -> u32 {
+        let table = storage.as_ptr() as *const TimestampTable;
+        // SAFETY: `storage` begins with a packed timestamp table header.
+        unsafe { core::ptr::addr_of!((*table).num_entries).read_unaligned() }
+    }
+
+    #[test]
+    fn rejects_null_and_suspicious_tables() {
+        assert!(CorebootTimestampRecorder::new(0).is_none());
+
+        let mut too_small = timestamp_storage(0, 15, 0);
+        assert!(CorebootTimestampRecorder::new(too_small.as_mut_ptr() as u64).is_none());
+
+        let mut inconsistent = timestamp_storage(0, 16, 17);
+        assert!(CorebootTimestampRecorder::new(inconsistent.as_mut_ptr() as u64).is_none());
+    }
+
+    #[test]
+    fn appends_entries_relative_to_base_time() {
+        let mut storage = timestamp_storage(1_000_000, ENTRIES as u16, 2);
+        let recorder = CorebootTimestampRecorder::new(storage.as_mut_ptr() as u64).unwrap();
+
+        recorder.record_counter(1500, 1_000_123);
+
+        assert_eq!(num_entries(&storage), 3);
+        assert_eq!(entry(&storage, 2), (1500, 123));
+    }
+
+    #[test]
+    fn full_table_drops_new_entries() {
+        let mut storage = timestamp_storage(42, ENTRIES as u16, ENTRIES as u32);
+        let recorder = CorebootTimestampRecorder::new(storage.as_mut_ptr() as u64).unwrap();
+
+        recorder.record_counter(1501, 1000);
+
+        assert_eq!(num_entries(&storage), ENTRIES as u32);
+        assert_eq!(entry(&storage, ENTRIES - 1), (0, 0));
+    }
+
+    #[test]
+    fn counter_before_base_wraps_like_coreboot_stamps() {
+        let mut storage = timestamp_storage(10, ENTRIES as u16, 0);
+        let recorder = CorebootTimestampRecorder::new(storage.as_mut_ptr() as u64).unwrap();
+
+        recorder.record_counter(1502, 8);
+
+        assert_eq!(entry(&storage, 0), (1502, -2));
     }
 }


### PR DESCRIPTION
## Summary

This PR adds four major features: a boot timestamp recording framework (with coreboot CBMEM timestamp table integration), a CBMEM console output mirror, a persistent log level UEFI variable, and variable store write hardening (erase verification + readback verification).

## Key Changes


### CBMEM Console Output Tee
- Transformed the CBMEM console module from a handoff-only tracker into a full `DebugOutput` sink
- Added `add_platform_debug_sink_raw()` to the serial subsystem to tee output to a secondary debug sink without replacing the primary UART
- Added `SerialState::debug_sink` field; all write paths (`write_str`, `write_byte`, `write_fmt`) now forward to both the primary driver and the optional sink
- Refactored `AnySerial` to expose unified `write_str`, `write_byte`, `has_input`, and `try_read_byte` methods to reduce match boilerplate in public API functions

### Persistent Log Level Variable
- Added `CrabEFILogLevel` UEFI variable under a new `CRABEFI_SETTINGS_GUID` to persist the maximum log level across boots
- Validation in `set_variable_full` rejects invalid data payloads before write; `apply_variable_write`/`apply_variable_delete` keep the runtime log level in sync
- Added `apply_from_edk2_varstore_region()` as an allocation-free early-boot helper to apply the log level before heap/EFI services are ready (used in coreboot path via SMMSTORE mmap)
- Changed logger timestamp from k-ticks to microseconds since boot using the calibrated counter frequency
- Firmware settings menu (`cfr_menu`) now always available (even without CFR options) and includes a "CrabEFI log level" entry in the settings UI
- CFR in-memory variable cache is now kept in sync after `write_option_value`/`delete_option_value`

### Variable Store Write Hardening
- `write_variable_to_storage_internal` now checks the target flash range is erased (`0xFF`) before writing, triggering compaction if not; after compaction it verifies erasure again before giving up
- Added `verify_written_record` which reads back via the SPI controller (bypassing cached mapped reads) and optionally cross-checks against the mapped window, logging detailed mismatch information
- Added `SpiStorageBackend::read_controller()` and `has_mapped_read_base()` to support controller-path readback
- Added `checked_align_up` for safe overflow-free alignment in untrusted variable record parsing

### EDK2 Variable Store Reader
- Added `read_variable_data_from_region()`: allocation-free, allocation-silent helper to read a single variable from a raw EDK2 FV variable store byte slice, used by the early log level path

### Other
- Coreboot CFR CRC32 corrected to use coreboot's MSB-first polynomial (`0x04c11db7`) instead of the UEFI reflected CRC32
- Removed a noisy EHCI async-schedule debug log line
- Updated docs and doc examples to include `timestamp_recorder: None`