### PR TITLE
ui: add graphical CFR settings and menu scrolling

### DIFF
--- a/crabefi-core/src/lib.rs
+++ b/crabefi-core/src/lib.rs
@@ -58,6 +58,18 @@ pub use platform::{
     VariableVisitor,
 };
 
+/// Perform a system reset.
+///
+/// Attempts the architecture-specific soft reset path first, waits briefly,
+/// then falls back to the architecture's non-returning hard reset path.
+pub fn reset_system() -> ! {
+    log::info!("System reset requested");
+
+    arch::reset::keyboard_controller_reset();
+    time::delay_ms(100);
+    arch::reset::triple_fault();
+}
+
 /// Display a Secure Boot violation error on screen
 ///
 /// This function displays a prominent red error message in the center of the screen

--- a/crabefi-core/src/menu.rs
+++ b/crabefi-core/src/menu.rs
@@ -1095,7 +1095,9 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
                 KeyPress::MouseClick { y, .. } => {
                     // Map screen Y pixel to menu entry index
                     // Menu entries start at row ~5 (after header + category)
-                    if let Some(idx) = row_to_entry_index(menu, y) {
+                    if let Some(idx) =
+                        row_to_entry_index(menu, y, menu_scroll_offset(menu, &fb_console))
+                    {
                         menu.selected = idx;
                         draw_menu(menu, &mut fb_console);
                     }
@@ -1123,41 +1125,100 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
 /// Returns `Some(index)` if the row corresponds to a boot entry,
 /// `None` if it's a header, separator, or out of range.
 #[cfg(feature = "ui")]
-fn row_to_entry_index(menu: &BootMenu, row: u32) -> Option<usize> {
-    // Menu layout: row 0-2 = header, row 3 = blank, row 4+ = entries with separators
-    let start_row = 4u32;
-    let mut current_row = start_row;
+fn row_to_entry_index(menu: &BootMenu, row: u32, scroll_offset: usize) -> Option<usize> {
+    // Menu layout: row 0-2 = header, row 3 = blank, row 4+ = visible menu rows.
+    let start_row = 4usize;
+    let target_row = row as usize;
+    let mut logical_row = 0usize;
     let mut current_category: Option<BootCategory> = None;
 
     for (i, entry) in menu.entries.iter().enumerate() {
         if current_category != Some(entry.category) {
             if current_category.is_some() {
-                current_row += 1; // blank line
+                logical_row += 1; // blank line
             }
-            current_row += 1; // category separator
+            logical_row += 1; // category separator
             current_category = Some(entry.category);
         }
 
-        if row == current_row {
-            return Some(i);
+        if logical_row >= scroll_offset {
+            let screen_row = start_row + logical_row - scroll_offset;
+            if target_row == screen_row {
+                return Some(i);
+            }
         }
-        current_row += 1;
+        logical_row += 1;
     }
     None
 }
 
 use crate::menu_common::{self, KeyPress, SerialWriter};
 
+fn menu_visible_rows(fb_console: &Option<FramebufferConsole>) -> usize {
+    let rows = fb_console.as_ref().map(|c| c.rows()).unwrap_or(25) as usize;
+    rows.saturating_sub(10).max(1)
+}
+
+fn menu_item_count(menu: &BootMenu) -> usize {
+    let mut count = 0usize;
+    let mut current_category: Option<BootCategory> = None;
+    for entry in &menu.entries {
+        if current_category != Some(entry.category) {
+            if current_category.is_some() {
+                count += 1;
+            }
+            count += 1;
+            current_category = Some(entry.category);
+        }
+        count += 1;
+    }
+    count
+}
+
+fn selected_menu_position(menu: &BootMenu) -> usize {
+    let mut pos = 0usize;
+    let mut current_category: Option<BootCategory> = None;
+    for (i, entry) in menu.entries.iter().enumerate() {
+        if current_category != Some(entry.category) {
+            if current_category.is_some() {
+                pos += 1;
+            }
+            pos += 1;
+            current_category = Some(entry.category);
+        }
+        if i == menu.selected {
+            return pos;
+        }
+        pos += 1;
+    }
+    0
+}
+
+fn menu_scroll_offset(menu: &BootMenu, fb_console: &Option<FramebufferConsole>) -> usize {
+    let visible_rows = menu_visible_rows(fb_console);
+    let selected_pos = selected_menu_position(menu);
+    if selected_pos >= visible_rows {
+        selected_pos - visible_rows + 1
+    } else {
+        0
+    }
+}
+
 /// Draw the menu on both outputs
 fn draw_menu(menu: &BootMenu, fb_console: &mut Option<FramebufferConsole>) {
     let cols = fb_console.as_ref().map(|c| c.cols()).unwrap_or(80) as usize;
+    let rows = fb_console.as_ref().map(|c| c.rows()).unwrap_or(25) as usize;
+    let visible_rows = menu_visible_rows(fb_console);
+    let scroll_offset = menu_scroll_offset(menu, fb_console);
+    let total_rows = menu_item_count(menu);
 
     // Draw header
     draw_header(fb_console, cols);
 
     // Draw entries with category separators
     let start_row = 4;
-    let mut current_row = start_row;
+    let mut logical_row = 0usize;
+    let mut screen_row = start_row;
     let mut current_category: Option<BootCategory> = None;
 
     for (i, entry) in menu.entries.iter().enumerate() {
@@ -1165,20 +1226,33 @@ fn draw_menu(menu: &BootMenu, fb_console: &mut Option<FramebufferConsole>) {
         if current_category != Some(entry.category) {
             // Add blank line before separator (except for first category)
             if current_category.is_some() {
-                current_row += 1;
+                logical_row += 1;
             }
-            draw_category_separator(entry.category, current_row, fb_console, cols);
-            current_row += 1;
+            if logical_row >= scroll_offset && logical_row < scroll_offset + visible_rows {
+                draw_category_separator(entry.category, screen_row, fb_console, cols);
+                screen_row += 1;
+            }
+            logical_row += 1;
             current_category = Some(entry.category);
         }
 
         let is_selected = i == menu.selected;
-        draw_entry(i, entry, is_selected, current_row, fb_console, cols);
-        current_row += 1;
+        if logical_row >= scroll_offset && logical_row < scroll_offset + visible_rows {
+            draw_entry(i, entry, is_selected, screen_row, fb_console, cols);
+            screen_row += 1;
+        }
+        logical_row += 1;
+    }
+
+    if scroll_offset > 0 {
+        draw_scroll_indicator(start_row - 1, "^", fb_console);
+    }
+    if scroll_offset + visible_rows < total_rows {
+        draw_scroll_indicator(start_row + visible_rows, "v", fb_console);
     }
 
     // Draw help text
-    let help_row = current_row + 2;
+    let help_row = rows.saturating_sub(5);
     draw_help(help_row, fb_console, cols);
 }
 
@@ -1294,6 +1368,20 @@ fn draw_entry(
             let _ = console.write_str(" ");
         }
 
+        console.reset_colors();
+    }
+}
+
+/// Draw a simple scroll indicator when the menu does not fit on screen.
+fn draw_scroll_indicator(row: usize, indicator: &str, fb_console: &mut Option<FramebufferConsole>) {
+    let ansi_row = row + 1;
+    let _ = write!(SerialWriter, "\x1b[{};40H{}", ansi_row, indicator);
+
+    if let Some(console) = fb_console {
+        let cols = console.cols();
+        console.set_position(cols / 2, row as u32);
+        console.set_fg_color(Color::new(128, 128, 128));
+        let _ = console.write_str(indicator);
         console.reset_colors();
     }
 }

--- a/crabefi-core/src/menu.rs
+++ b/crabefi-core/src/menu.rs
@@ -1049,7 +1049,7 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
                     // Reset the system
                     draw_status("Resetting system...", &mut fb_console);
                     delay_ms(500);
-                    perform_system_reset();
+                    crate::reset_system();
                 }
                 KeyPress::Char('c') | KeyPress::Char('C') => {
                     // Edit kernel command line
@@ -1095,9 +1095,13 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
                 KeyPress::MouseClick { y, .. } => {
                     // Map screen Y pixel to menu entry index
                     // Menu entries start at row ~5 (after header + category)
-                    if let Some(idx) =
-                        row_to_entry_index(menu, y, menu_scroll_offset(menu, &fb_console))
-                    {
+                    let row = y / crate::framebuffer_console::CHAR_HEIGHT;
+                    if let Some(idx) = row_to_entry_index(
+                        menu,
+                        row,
+                        menu_scroll_offset(menu, &fb_console),
+                        menu_visible_rows(&fb_console),
+                    ) {
                         menu.selected = idx;
                         draw_menu(menu, &mut fb_console);
                     }
@@ -1125,10 +1129,18 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
 /// Returns `Some(index)` if the row corresponds to a boot entry,
 /// `None` if it's a header, separator, or out of range.
 #[cfg(feature = "ui")]
-fn row_to_entry_index(menu: &BootMenu, row: u32, scroll_offset: usize) -> Option<usize> {
+fn row_to_entry_index(
+    menu: &BootMenu,
+    row: u32,
+    scroll_offset: usize,
+    visible_rows: usize,
+) -> Option<usize> {
     // Menu layout: row 0-2 = header, row 3 = blank, row 4+ = visible menu rows.
     let start_row = 4usize;
     let target_row = row as usize;
+    if target_row < start_row || target_row >= start_row + visible_rows {
+        return None;
+    }
     let mut logical_row = 0usize;
     let mut current_category: Option<BootCategory> = None;
 
@@ -1244,6 +1256,8 @@ fn draw_menu(menu: &BootMenu, fb_console: &mut Option<FramebufferConsole>) {
         logical_row += 1;
     }
 
+    clear_scroll_indicator(start_row - 1, fb_console);
+    clear_scroll_indicator(start_row + visible_rows, fb_console);
     if scroll_offset > 0 {
         draw_scroll_indicator(start_row - 1, "^", fb_console);
     }
@@ -1369,6 +1383,18 @@ fn draw_entry(
         }
 
         console.reset_colors();
+    }
+}
+
+/// Clear a possible scroll indicator row.
+fn clear_scroll_indicator(row: usize, fb_console: &mut Option<FramebufferConsole>) {
+    let ansi_row = row + 1;
+    let _ = write!(SerialWriter, "\x1b[{};40H ", ansi_row);
+
+    if let Some(console) = fb_console {
+        let cols = console.cols();
+        console.set_position(cols / 2, row as u32);
+        let _ = console.write_str(" ");
     }
 }
 
@@ -1825,23 +1851,4 @@ fn draw_cmdline_editor_line(
         let _ = console.write_str(&len_str);
         console.reset_colors();
     }
-}
-
-/// Perform a system reset
-///
-/// This attempts to reset the system using various methods:
-/// 1. Keyboard controller reset (port 0x64, command 0xFE)
-/// 2. Triple fault (if keyboard controller fails)
-fn perform_system_reset() -> ! {
-    use crate::arch::reset;
-
-    log::info!("System reset requested");
-
-    reset::keyboard_controller_reset();
-
-    // Wait a bit for reset to take effect
-    delay_ms(100);
-
-    // Triple fault if keyboard reset failed
-    reset::triple_fault();
 }

--- a/crabefi-core/src/secure_boot_menu.rs
+++ b/crabefi-core/src/secure_boot_menu.rs
@@ -253,14 +253,16 @@ pub fn show_secure_boot_menu() {
                     }
                     KeyPress::Char('f') | KeyPress::Char('F') => {
                         if let Some(hooks) = crate::state::drivers().platform.hooks {
-                            hooks.show_firmware_settings();
+                            if !hooks.show_firmware_settings() {
+                                status_message = Some(("Firmware settings not available", false));
+                            }
+                        } else {
+                            status_message = Some(("Firmware settings not available", false));
                         }
                         break;
                     }
                     KeyPress::Char('r') | KeyPress::Char('R') => {
-                        crate::arch::reset::keyboard_controller_reset();
-                        delay_ms(100);
-                        crate::arch::reset::triple_fault();
+                        crate::reset_system();
                     }
                     KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
                         return;

--- a/crabefi-core/src/secure_boot_menu.rs
+++ b/crabefi-core/src/secure_boot_menu.rs
@@ -248,7 +248,21 @@ pub fn show_secure_boot_menu() {
                         }
                         break;
                     }
-                    KeyPress::Escape | KeyPress::Char('q') => {
+                    KeyPress::Char('s') | KeyPress::Char('S') => {
+                        break;
+                    }
+                    KeyPress::Char('f') | KeyPress::Char('F') => {
+                        if let Some(hooks) = crate::state::drivers().platform.hooks {
+                            hooks.show_firmware_settings();
+                        }
+                        break;
+                    }
+                    KeyPress::Char('r') | KeyPress::Char('R') => {
+                        crate::arch::reset::keyboard_controller_reset();
+                        delay_ms(100);
+                        crate::arch::reset::triple_fault();
+                    }
+                    KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
                         return;
                     }
                     _ => {}
@@ -545,7 +559,7 @@ fn draw_options(
 fn draw_help(fb_console: &mut Option<FramebufferConsole>, row: usize, cols: usize) {
     menu_common::draw_help(
         row,
-        "Up/Down: Navigate | Enter: Select | Esc/Q: Back",
+        "Up/Down: Navigate | Enter: Select | S: Secure | F: Firmware | R: Reset | Esc/Q: Back",
         fb_console,
         cols,
     );

--- a/crabefi-core/src/ui/firmware_settings.rs
+++ b/crabefi-core/src/ui/firmware_settings.rs
@@ -2,7 +2,7 @@
 
 use super::{
     NavItem, ScreenNav, canvas, clear, draw_footer, draw_header, draw_sidebar,
-    poll_and_render_cursor, render, reset_system, theme, update_sidebar_hover,
+    poll_and_render_cursor, render, theme, update_sidebar_hover,
 };
 use crate::FramebufferConfig as FramebufferInfo;
 use crate::cursor::CursorRenderer;
@@ -19,150 +19,8 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
         return show_no_settings(fb);
     }
 
-    let mut cursor = CursorRenderer::new();
-    let mut sidebar_hov: Option<NavItem> = None;
-    let mut hovered = false;
-
-    draw_settings(fb, hovered);
-
-    loop {
-        poll_and_render_cursor(fb, &mut cursor);
-        update_sidebar_hover(fb, &mut sidebar_hov, NavItem::Firmware);
-
-        let new_hovered = card_hit(fb);
-        if new_hovered != hovered {
-            hovered = new_hovered;
-            draw_settings(fb, hovered);
-        }
-
-        if let Some(key) = menu_common::read_key() {
-            match key {
-                KeyPress::Enter | KeyPress::Char('f') | KeyPress::Char('F') => {
-                    cursor.hide(fb);
-                    hooks.show_firmware_settings();
-                    draw_settings(fb, hovered);
-                }
-                KeyPress::Char('s') | KeyPress::Char('S') => {
-                    cursor.hide(fb);
-                    return ScreenNav::Nav(NavItem::Security);
-                }
-                KeyPress::Char('r') | KeyPress::Char('R') => {
-                    reset_system();
-                }
-                KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
-                    return ScreenNav::Back;
-                }
-                #[cfg(feature = "ui")]
-                KeyPress::MouseClick { .. } => {
-                    if let Some(nav) = sidebar_hov
-                        && nav != NavItem::Firmware
-                    {
-                        cursor.hide(fb);
-                        return ScreenNav::Nav(nav);
-                    }
-                    if hovered {
-                        cursor.hide(fb);
-                        hooks.show_firmware_settings();
-                        draw_settings(fb, hovered);
-                    }
-                }
-                _ => {}
-            }
-        }
-        delay_ms(8);
-    }
-}
-
-const CARD_H: u32 = 72;
-
-fn card_base_y(fb: &FramebufferInfo) -> i32 {
-    let (_, cy, _, _) = canvas(fb);
-    let header_h =
-        render::font_height(FontSize::Small) + 4 + render::font_height(FontSize::Display) + 16;
-    cy + header_h as i32
-}
-
-fn card_hit(fb: &FramebufferInfo) -> bool {
-    let (mx, my) = crate::drivers::mouse_cursor::position();
-    let (cx, _, cw, _) = canvas(fb);
-    let y = card_base_y(fb);
-    mx >= cx && mx < cx + cw as i32 && my >= y && my < y + CARD_H as i32
-}
-
-fn draw_settings(fb: &FramebufferInfo, hovered: bool) {
-    clear(fb);
-    draw_header(fb);
-    draw_sidebar(fb, NavItem::Firmware, None);
-    draw_footer(fb, "Enter/F Open  S Security  R Reset  Esc Back");
-
-    let (cx, cy, cw, _) = canvas(fb);
-    let mut y = cy;
-
-    render::draw_text_spaced(
-        fb,
-        cx,
-        y,
-        "HARDWARE CONFIGURATION",
-        FontSize::Small,
-        2,
-        theme::PRIMARY.darken(80),
-        None,
-    );
-    y += render::font_height(FontSize::Small) as i32 + 4;
-    render::draw_text(
-        fb,
-        cx,
-        y,
-        "Firmware Settings",
-        FontSize::Display,
-        theme::TEXT,
-        None,
-    );
-
-    let card_y = card_base_y(fb);
-    let bg = if hovered {
-        theme::CONT_HIGH
-    } else {
-        theme::SURFACE_HI
-    };
-    render::fill_rounded_rect(fb, cx, card_y, cw, CARD_H, theme::RADIUS, bg);
-    render::fill_rect(
-        fb,
-        cx,
-        card_y + 2,
-        theme::ACCENT_BAR,
-        CARD_H - 4,
-        theme::PRIMARY,
-    );
-
-    let tx = cx + theme::PAD as i32 + theme::ACCENT_BAR as i32 + 4;
-    render::draw_text(
-        fb,
-        tx,
-        card_y + 8,
-        "Platform firmware settings",
-        FontSize::Normal,
-        theme::TEXT,
-        Some(bg),
-    );
-    render::draw_text(
-        fb,
-        tx,
-        card_y + 8 + render::font_height(FontSize::Normal) as i32 + 4,
-        "Open the platform-provided setup interface",
-        FontSize::Small,
-        theme::TEXT_DIM,
-        Some(bg),
-    );
-    render::draw_text(
-        fb,
-        cx + cw as i32 - 28,
-        card_y + (CARD_H as i32 - render::font_height(FontSize::Normal) as i32) / 2,
-        ">",
-        FontSize::Normal,
-        theme::PRIMARY,
-        Some(bg),
-    );
+    hooks.show_firmware_settings();
+    ScreenNav::Back
 }
 
 fn show_no_settings(fb: &FramebufferInfo) -> ScreenNav {
@@ -199,7 +57,7 @@ fn show_no_settings(fb: &FramebufferInfo) -> ScreenNav {
                 }
                 KeyPress::Char('f') | KeyPress::Char('F') => {}
                 KeyPress::Char('r') | KeyPress::Char('R') => {
-                    reset_system();
+                    crate::reset_system();
                 }
                 KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
                     return ScreenNav::Back;

--- a/crabefi-core/src/ui/firmware_settings.rs
+++ b/crabefi-core/src/ui/firmware_settings.rs
@@ -2,7 +2,7 @@
 
 use super::{
     NavItem, ScreenNav, canvas, clear, draw_footer, draw_header, draw_sidebar,
-    poll_and_render_cursor, render, theme, update_sidebar_hover,
+    poll_and_render_cursor, render, reset_system, theme, update_sidebar_hover,
 };
 use crate::FramebufferConfig as FramebufferInfo;
 use crate::cursor::CursorRenderer;
@@ -37,10 +37,17 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
 
         if let Some(key) = menu_common::read_key() {
             match key {
-                KeyPress::Enter => {
+                KeyPress::Enter | KeyPress::Char('f') | KeyPress::Char('F') => {
                     cursor.hide(fb);
                     hooks.show_firmware_settings();
                     draw_settings(fb, hovered);
+                }
+                KeyPress::Char('s') | KeyPress::Char('S') => {
+                    cursor.hide(fb);
+                    return ScreenNav::Nav(NavItem::Security);
+                }
+                KeyPress::Char('r') | KeyPress::Char('R') => {
+                    reset_system();
                 }
                 KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
                     return ScreenNav::Back;
@@ -86,7 +93,7 @@ fn draw_settings(fb: &FramebufferInfo, hovered: bool) {
     clear(fb);
     draw_header(fb);
     draw_sidebar(fb, NavItem::Firmware, None);
-    draw_footer(fb, "Enter Open   Esc Back");
+    draw_footer(fb, "Enter/F Open  S Security  R Reset  Esc Back");
 
     let (cx, cy, cw, _) = canvas(fb);
     let mut y = cy;
@@ -178,7 +185,7 @@ fn show_no_settings(fb: &FramebufferInfo) -> ScreenNav {
         theme::TEXT_DIM,
         None,
     );
-    draw_footer(fb, "Esc Back");
+    draw_footer(fb, "S Security  F Firmware  R Reset  Esc Back");
 
     loop {
         poll_and_render_cursor(fb, &mut cursor);
@@ -186,6 +193,14 @@ fn show_no_settings(fb: &FramebufferInfo) -> ScreenNav {
 
         if let Some(key) = menu_common::read_key() {
             match key {
+                KeyPress::Char('s') | KeyPress::Char('S') => {
+                    cursor.hide(fb);
+                    return ScreenNav::Nav(NavItem::Security);
+                }
+                KeyPress::Char('f') | KeyPress::Char('F') => {}
+                KeyPress::Char('r') | KeyPress::Char('R') => {
+                    reset_system();
+                }
                 KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
                     return ScreenNav::Back;
                 }

--- a/crabefi-core/src/ui/mod.rs
+++ b/crabefi-core/src/ui/mod.rs
@@ -305,6 +305,7 @@ struct BState {
     sel: usize,
     hovered: Option<usize>,
     sidebar_hov: Option<NavItem>,
+    scroll_offset: usize,
     countdown: u32,
     init_timeout: u32,
     tick: Timeout,
@@ -317,6 +318,7 @@ impl BState {
             sel,
             hovered: None,
             sidebar_hov: None,
+            scroll_offset: 0,
             countdown: timeout,
             init_timeout: timeout,
             tick: Timeout::from_ms(1000),
@@ -335,9 +337,40 @@ impl BState {
     }
 }
 
+fn reset_system() -> ! {
+    crate::arch::reset::keyboard_controller_reset();
+    delay_ms(100);
+    crate::arch::reset::triple_fault();
+}
+
+pub fn draw_scrollbar(
+    fb: &FramebufferInfo,
+    x: i32,
+    y: i32,
+    h: u32,
+    total_items: usize,
+    scroll_offset: usize,
+    visible_items: usize,
+) {
+    if total_items <= visible_items || visible_items == 0 || h == 0 {
+        return;
+    }
+
+    let track_w = 4;
+    render::fill_rounded_rect(fb, x, y, track_w, h, 2, theme::SIDE);
+
+    let thumb_h = ((h as usize * visible_items) / total_items)
+        .max(24)
+        .min(h as usize) as u32;
+    let max_offset = total_items.saturating_sub(visible_items).max(1);
+    let thumb_y = y + ((h - thumb_h) as usize * scroll_offset / max_offset) as i32;
+    render::fill_rounded_rect(fb, x, thumb_y, track_w, thumb_h, 2, theme::PRIMARY);
+}
+
 fn run_boot(fb: &FramebufferInfo, menu: &mut BootMenu) -> BootResult {
     let mut cursor = CursorRenderer::new();
     let mut st = BState::new(menu.entry_count(), menu.selected, menu.timeout_seconds);
+    keep_boot_selection_visible(fb, &mut st);
 
     paint_boot(fb, menu, &st);
 
@@ -347,7 +380,7 @@ fn run_boot(fb: &FramebufferInfo, menu: &mut BootMenu) -> BootResult {
         update_sidebar_hover(fb, &mut st.sidebar_hov, NavItem::Boot);
 
         // ── Card hover ──
-        let hov = boot_hit(fb, menu);
+        let hov = boot_hit(fb, menu, &st);
         if hov != st.hovered {
             let prev = st.hovered;
             st.hovered = hov;
@@ -367,16 +400,16 @@ fn run_boot(fb: &FramebufferInfo, menu: &mut BootMenu) -> BootResult {
 
             match key {
                 KeyPress::Up | KeyPress::Char('k') => {
-                    let p = st.sel;
                     st.sel_prev();
                     menu.selected = st.sel;
-                    repaint2(fb, menu, &st, p, st.sel);
+                    keep_boot_selection_visible(fb, &mut st);
+                    paint_boot(fb, menu, &st);
                 }
                 KeyPress::Down | KeyPress::Char('j') => {
-                    let p = st.sel;
                     st.sel_next();
                     menu.selected = st.sel;
-                    repaint2(fb, menu, &st, p, st.sel);
+                    keep_boot_selection_visible(fb, &mut st);
+                    paint_boot(fb, menu, &st);
                 }
                 KeyPress::Enter => {
                     cursor.hide(fb);
@@ -391,9 +424,7 @@ fn run_boot(fb: &FramebufferInfo, menu: &mut BootMenu) -> BootResult {
                     return BootResult::Nav(NavItem::Firmware);
                 }
                 KeyPress::Char('r') | KeyPress::Char('R') => {
-                    crate::arch::reset::keyboard_controller_reset();
-                    delay_ms(100);
-                    crate::arch::reset::triple_fault();
+                    reset_system();
                 }
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
@@ -410,22 +441,22 @@ fn run_boot(fb: &FramebufferInfo, menu: &mut BootMenu) -> BootResult {
                             cursor.hide(fb);
                             return BootResult::Selected(idx);
                         }
-                        let p = st.sel;
                         st.sel = idx;
                         menu.selected = idx;
-                        repaint2(fb, menu, &st, p, idx);
+                        keep_boot_selection_visible(fb, &mut st);
+                        paint_boot(fb, menu, &st);
                     }
                 }
                 #[cfg(feature = "ui")]
                 KeyPress::MouseScroll(dz) => {
-                    let p = st.sel;
                     if dz > 0 {
                         st.sel_next();
                     } else {
                         st.sel_prev();
                     }
                     menu.selected = st.sel;
-                    repaint2(fb, menu, &st, p, st.sel);
+                    keep_boot_selection_visible(fb, &mut st);
+                    paint_boot(fb, menu, &st);
                 }
                 _ => {}
             }
@@ -521,9 +552,7 @@ fn run_no_media(fb: &FramebufferInfo) -> ScreenNav {
         if let Some(key) = menu_common::read_key() {
             match key {
                 KeyPress::Char('r') | KeyPress::Char('R') => {
-                    crate::arch::reset::keyboard_controller_reset();
-                    delay_ms(100);
-                    crate::arch::reset::triple_fault();
+                    reset_system();
                 }
                 KeyPress::Char('s') | KeyPress::Char('S') => {
                     cursor.hide(fb);
@@ -552,24 +581,49 @@ fn run_no_media(fb: &FramebufferInfo) -> ScreenNav {
 
 // ── Boot internals ──────────────────────────────────────────────────────
 
-/// Y for the i-th boot card.
-fn card_y(fb: &FramebufferInfo, i: usize) -> i32 {
-    let (_, cy, _, _) = canvas(fb);
-    // Section header: label(16px) + 4 + title(32px) + 12 = 64px
+fn boot_list_area(fb: &FramebufferInfo) -> (i32, i32, u32, u32) {
+    let (cx, cy, cw, ch) = canvas(fb);
     let header_h =
         render::font_height(FontSize::Small) + 4 + render::font_height(FontSize::Display) + 12;
-    cy + header_h as i32 + (i as i32) * (theme::CARD_H as i32 + theme::GAP as i32)
+    let y = cy + header_h as i32;
+    (cx, y, cw, ch.saturating_sub(header_h))
 }
 
-fn card_rect(fb: &FramebufferInfo, i: usize) -> (i32, i32, u32, u32) {
-    let (cx, _, cw, _) = canvas(fb);
-    (cx, card_y(fb, i), cw, theme::CARD_H)
+fn boot_visible_slots(fb: &FramebufferInfo) -> usize {
+    let (_, _, _, h) = boot_list_area(fb);
+    if h < theme::CARD_H {
+        1
+    } else {
+        ((h + theme::GAP) / (theme::CARD_H + theme::GAP)).max(1) as usize
+    }
 }
 
-fn boot_hit(fb: &FramebufferInfo, menu: &BootMenu) -> Option<usize> {
+fn keep_boot_selection_visible(fb: &FramebufferInfo, st: &mut BState) {
+    let slots = boot_visible_slots(fb);
+    if st.sel < st.scroll_offset {
+        st.scroll_offset = st.sel;
+    } else if st.sel >= st.scroll_offset + slots {
+        st.scroll_offset = st.sel - slots + 1;
+    }
+}
+
+fn card_rect(fb: &FramebufferInfo, st: &BState, idx: usize) -> Option<(i32, i32, u32, u32)> {
+    if idx < st.scroll_offset || idx >= st.scroll_offset + boot_visible_slots(fb) {
+        return None;
+    }
+    let (cx, list_y, cw, _) = boot_list_area(fb);
+    let slot = idx - st.scroll_offset;
+    let y = list_y + (slot as i32 * (theme::CARD_H + theme::GAP) as i32);
+    Some((cx, y, cw, theme::CARD_H))
+}
+
+fn boot_hit(fb: &FramebufferInfo, menu: &BootMenu, st: &BState) -> Option<usize> {
     let (mx, my) = mouse_cursor::position();
-    for i in 0..menu.entry_count() {
-        let (cx, cy, cw, ch) = card_rect(fb, i);
+    let end = (st.scroll_offset + boot_visible_slots(fb)).min(menu.entry_count());
+    for i in st.scroll_offset..end {
+        let Some((cx, cy, cw, ch)) = card_rect(fb, st, i) else {
+            continue;
+        };
         if mx >= cx && mx < cx + cw as i32 && my >= cy && my < cy + ch as i32 {
             return Some(i);
         }
@@ -607,15 +661,29 @@ fn paint_boot(fb: &FramebufferInfo, menu: &BootMenu, st: &BState) {
         None,
     );
 
-    for i in 0..menu.entry_count() {
+    let end = (st.scroll_offset + boot_visible_slots(fb)).min(menu.entry_count());
+    for i in st.scroll_offset..end {
         paint_boot_card(fb, menu, st, i);
     }
+
+    let (list_x, list_y, list_w, list_h) = boot_list_area(fb);
+    draw_scrollbar(
+        fb,
+        list_x + list_w as i32 - 4,
+        list_y,
+        list_h,
+        menu.entry_count(),
+        st.scroll_offset,
+        boot_visible_slots(fb),
+    );
 
     paint_boot_footer(fb, st);
 }
 
 fn paint_boot_card(fb: &FramebufferInfo, menu: &BootMenu, st: &BState, idx: usize) {
-    let (cx, cy, cw, ch) = card_rect(fb, idx);
+    let Some((cx, cy, cw, ch)) = card_rect(fb, st, idx) else {
+        return;
+    };
     let is_sel = idx == st.sel;
     let is_hov = st.hovered == Some(idx);
 
@@ -760,13 +828,6 @@ fn paint_boot_footer(fb: &FramebufferInfo, st: &BState) {
             fb,
             "Up/Down Navigate  Enter Boot  S Security  F Firmware  R Reset",
         );
-    }
-}
-
-fn repaint2(fb: &FramebufferInfo, menu: &BootMenu, st: &BState, a: usize, b: usize) {
-    paint_boot_card(fb, menu, st, a);
-    if a != b {
-        paint_boot_card(fb, menu, st, b);
     }
 }
 

--- a/crabefi-core/src/ui/mod.rs
+++ b/crabefi-core/src/ui/mod.rs
@@ -337,12 +337,6 @@ impl BState {
     }
 }
 
-fn reset_system() -> ! {
-    crate::arch::reset::keyboard_controller_reset();
-    delay_ms(100);
-    crate::arch::reset::triple_fault();
-}
-
 pub fn draw_scrollbar(
     fb: &FramebufferInfo,
     x: i32,
@@ -390,6 +384,7 @@ fn run_boot(fb: &FramebufferInfo, menu: &mut BootMenu) -> BootResult {
             if let Some(i) = hov {
                 paint_boot_card(fb, menu, &st, i);
             }
+            paint_boot_scrollbar(fb, menu, &st);
         }
 
         if let Some(key) = menu_common::read_key() {
@@ -424,7 +419,7 @@ fn run_boot(fb: &FramebufferInfo, menu: &mut BootMenu) -> BootResult {
                     return BootResult::Nav(NavItem::Firmware);
                 }
                 KeyPress::Char('r') | KeyPress::Char('R') => {
-                    reset_system();
+                    crate::reset_system();
                 }
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
@@ -552,7 +547,7 @@ fn run_no_media(fb: &FramebufferInfo) -> ScreenNav {
         if let Some(key) = menu_common::read_key() {
             match key {
                 KeyPress::Char('r') | KeyPress::Char('R') => {
-                    reset_system();
+                    crate::reset_system();
                 }
                 KeyPress::Char('s') | KeyPress::Char('S') => {
                     cursor.hide(fb);
@@ -634,7 +629,7 @@ fn boot_hit(fb: &FramebufferInfo, menu: &BootMenu, st: &BState) -> Option<usize>
 fn paint_boot(fb: &FramebufferInfo, menu: &BootMenu, st: &BState) {
     clear(fb);
     draw_header(fb);
-    draw_sidebar(fb, NavItem::Boot, None);
+    draw_sidebar(fb, NavItem::Boot, st.sidebar_hov);
 
     let (cx, cy, _cw, _) = canvas(fb);
 
@@ -666,6 +661,12 @@ fn paint_boot(fb: &FramebufferInfo, menu: &BootMenu, st: &BState) {
         paint_boot_card(fb, menu, st, i);
     }
 
+    paint_boot_scrollbar(fb, menu, st);
+
+    paint_boot_footer(fb, st);
+}
+
+fn paint_boot_scrollbar(fb: &FramebufferInfo, menu: &BootMenu, st: &BState) {
     let (list_x, list_y, list_w, list_h) = boot_list_area(fb);
     draw_scrollbar(
         fb,
@@ -676,8 +677,6 @@ fn paint_boot(fb: &FramebufferInfo, menu: &BootMenu, st: &BState) {
         st.scroll_offset,
         boot_visible_slots(fb),
     );
-
-    paint_boot_footer(fb, st);
 }
 
 fn paint_boot_card(fb: &FramebufferInfo, menu: &BootMenu, st: &BState, idx: usize) {

--- a/crabefi-core/src/ui/secure_boot.rs
+++ b/crabefi-core/src/ui/secure_boot.rs
@@ -1,8 +1,8 @@
 //! Graphical Secure Boot screen — Kinetic Command design.
 
 use super::{
-    NavItem, ScreenNav, canvas, clear, draw_footer, draw_header, draw_sidebar,
-    poll_and_render_cursor, render, theme, update_sidebar_hover,
+    NavItem, ScreenNav, canvas, clear, draw_footer, draw_header, draw_scrollbar, draw_sidebar,
+    poll_and_render_cursor, render, reset_system, theme, update_sidebar_hover,
 };
 use crate::FramebufferConfig as FramebufferInfo;
 use crate::cursor::CursorRenderer;
@@ -19,9 +19,10 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
     let mut selected: usize = 0;
     let mut hovered: Option<usize> = None;
     let mut sidebar_hov: Option<NavItem> = None;
+    let mut scroll_offset: usize = 0;
     let mut status: Option<(&str, bool)> = None;
 
-    draw_screen(fb, selected, hovered, status);
+    draw_screen(fb, selected, hovered, scroll_offset, status);
 
     loop {
         poll_and_render_cursor(fb, &mut cursor);
@@ -29,17 +30,10 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
         update_sidebar_hover(fb, &mut sidebar_hov, NavItem::Security);
 
         // ── Card hover ──
-        let new_hov = action_hit(fb);
+        let new_hov = action_hit(fb, scroll_offset);
         if new_hov != hovered {
-            let old = hovered;
             hovered = new_hov;
-            // Repaint only the changed cards (not the whole screen)
-            if let Some(i) = old {
-                paint_action_card(fb, i, selected, hovered);
-            }
-            if let Some(i) = new_hov {
-                paint_action_card(fb, i, selected, hovered);
-            }
+            draw_screen(fb, selected, hovered, scroll_offset, status);
         }
 
         if let Some(key) = menu_common::read_key() {
@@ -47,13 +41,23 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
             match key {
                 KeyPress::Up | KeyPress::Char('k') => {
                     selected = selected.saturating_sub(1);
-                    draw_screen(fb, selected, hovered, status);
+                    keep_action_visible(fb, selected, &mut scroll_offset);
+                    draw_screen(fb, selected, hovered, scroll_offset, status);
                 }
                 KeyPress::Down | KeyPress::Char('j') => {
                     if selected < ACTION_COUNT - 1 {
                         selected += 1;
                     }
-                    draw_screen(fb, selected, hovered, status);
+                    keep_action_visible(fb, selected, &mut scroll_offset);
+                    draw_screen(fb, selected, hovered, scroll_offset, status);
+                }
+                KeyPress::Char('s') | KeyPress::Char('S') => {}
+                KeyPress::Char('f') | KeyPress::Char('F') => {
+                    cursor.hide(fb);
+                    return ScreenNav::Nav(NavItem::Firmware);
+                }
+                KeyPress::Char('r') | KeyPress::Char('R') => {
+                    reset_system();
                 }
                 KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
                     return ScreenNav::Back;
@@ -63,7 +67,7 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
                     if selected == ACTION_BACK {
                         return ScreenNav::Back;
                     }
-                    draw_screen(fb, selected, hovered, status);
+                    draw_screen(fb, selected, hovered, scroll_offset, status);
                 }
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
@@ -83,8 +87,9 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
                             }
                         } else {
                             selected = idx;
+                            keep_action_visible(fb, selected, &mut scroll_offset);
                         }
-                        draw_screen(fb, selected, hovered, status);
+                        draw_screen(fb, selected, hovered, scroll_offset, status);
                     }
                 }
                 #[cfg(feature = "ui")]
@@ -94,7 +99,8 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
                     } else if dz < 0 && selected > 0 {
                         selected -= 1;
                     }
-                    draw_screen(fb, selected, hovered, status);
+                    keep_action_visible(fb, selected, &mut scroll_offset);
+                    draw_screen(fb, selected, hovered, scroll_offset, status);
                 }
                 _ => {}
             }
@@ -133,10 +139,13 @@ fn handle_action(idx: usize) -> Option<(&'static str, bool)> {
 }
 
 /// Hit-test action cards.
-fn action_hit(fb: &FramebufferInfo) -> Option<usize> {
+fn action_hit(fb: &FramebufferInfo, scroll_offset: usize) -> Option<usize> {
     let (mx, my) = crate::drivers::mouse_cursor::position();
-    for i in 0..ACTION_COUNT {
-        let (ax, ay, aw, ah) = action_card_rect(fb, i);
+    let end = (scroll_offset + action_visible_slots(fb)).min(ACTION_COUNT);
+    for i in scroll_offset..end {
+        let Some((ax, ay, aw, ah)) = action_card_rect(fb, scroll_offset, i) else {
+            continue;
+        };
         if mx >= ax && mx < ax + aw as i32 && my >= ay && my < ay + ah as i32 {
             return Some(i);
         }
@@ -159,22 +168,63 @@ const ACTION_ITEMS: [(&str, &str); ACTION_COUNT] = [
     ("Back to Boot Menu", "Return to boot entry selection"),
 ];
 
-/// Rect for the i-th action card.
-fn action_card_rect(fb: &FramebufferInfo, i: usize) -> (i32, i32, u32, u32) {
-    let (cx, cy, cw, _) = canvas(fb);
-    let card_h = 44u32;
+fn action_list_area(fb: &FramebufferInfo) -> (i32, i32, u32, u32) {
+    let (cx, cy, cw, ch) = canvas(fb);
     // Section header + hero card + gap
     let hero_h = 56u32;
     let header_h =
         render::font_height(FontSize::Small) + 4 + render::font_height(FontSize::Display) + 16;
-    let base_y = cy + header_h as i32 + hero_h as i32 + 16;
-    let y = base_y + (i as i32 * (card_h as i32 + theme::GAP as i32));
-    (cx, y, cw, card_h)
+    let used_h = header_h + hero_h + 16;
+    let base_y = cy + used_h as i32;
+    (cx, base_y, cw, ch.saturating_sub(used_h))
+}
+
+fn action_visible_slots(fb: &FramebufferInfo) -> usize {
+    let (_, _, _, h) = action_list_area(fb);
+    let card_h = 44u32;
+    if h < card_h {
+        1
+    } else {
+        ((h + theme::GAP) / (card_h + theme::GAP)).max(1) as usize
+    }
+}
+
+fn keep_action_visible(fb: &FramebufferInfo, selected: usize, scroll_offset: &mut usize) {
+    let slots = action_visible_slots(fb);
+    if selected < *scroll_offset {
+        *scroll_offset = selected;
+    } else if selected >= *scroll_offset + slots {
+        *scroll_offset = selected - slots + 1;
+    }
+}
+
+/// Rect for the i-th action card.
+fn action_card_rect(
+    fb: &FramebufferInfo,
+    scroll_offset: usize,
+    i: usize,
+) -> Option<(i32, i32, u32, u32)> {
+    if i < scroll_offset || i >= scroll_offset + action_visible_slots(fb) {
+        return None;
+    }
+    let (cx, base_y, cw, _) = action_list_area(fb);
+    let card_h = 44u32;
+    let slot = i - scroll_offset;
+    let y = base_y + (slot as i32 * (card_h as i32 + theme::GAP as i32));
+    Some((cx, y, cw, card_h))
 }
 
 /// Repaint a single action card (avoids full-screen redraw on hover changes).
-fn paint_action_card(fb: &FramebufferInfo, i: usize, selected: usize, hovered: Option<usize>) {
-    let (cx, y, cw, card_h) = action_card_rect(fb, i);
+fn paint_action_card(
+    fb: &FramebufferInfo,
+    i: usize,
+    selected: usize,
+    hovered: Option<usize>,
+    scroll_offset: usize,
+) {
+    let Some((cx, y, cw, card_h)) = action_card_rect(fb, scroll_offset, i) else {
+        return;
+    };
     let (title, desc) = ACTION_ITEMS[i];
     let is_sel = i == selected;
     let is_hov = hovered == Some(i) && !is_sel;
@@ -235,12 +285,16 @@ fn draw_screen(
     fb: &FramebufferInfo,
     selected: usize,
     hovered: Option<usize>,
+    scroll_offset: usize,
     status: Option<(&str, bool)>,
 ) {
     clear(fb);
     draw_header(fb);
     draw_sidebar(fb, NavItem::Security, None);
-    draw_footer(fb, "Up/Down Navigate   Enter Select   Esc Back");
+    draw_footer(
+        fb,
+        "Up/Down Navigate  Enter Select  S Security  F Firmware  R Reset  Esc Back",
+    );
 
     let (cx, cy, cw, _ch) = canvas(fb);
     let mut y = cy;
@@ -349,9 +403,21 @@ fn draw_screen(
     let _ = y; // y was used to position hero card; action cards use action_card_rect()
 
     // ── Action cards ──
-    for i in 0..ACTION_COUNT {
-        paint_action_card(fb, i, selected, hovered);
+    let end = (scroll_offset + action_visible_slots(fb)).min(ACTION_COUNT);
+    for i in scroll_offset..end {
+        paint_action_card(fb, i, selected, hovered, scroll_offset);
     }
+
+    let (list_x, list_y, list_w, list_h) = action_list_area(fb);
+    draw_scrollbar(
+        fb,
+        list_x + list_w as i32 - 4,
+        list_y,
+        list_h,
+        ACTION_COUNT,
+        scroll_offset,
+        action_visible_slots(fb),
+    );
 
     // Status toast
     if let Some((msg, ok)) = status {

--- a/crabefi-core/src/ui/secure_boot.rs
+++ b/crabefi-core/src/ui/secure_boot.rs
@@ -2,7 +2,7 @@
 
 use super::{
     NavItem, ScreenNav, canvas, clear, draw_footer, draw_header, draw_scrollbar, draw_sidebar,
-    poll_and_render_cursor, render, reset_system, theme, update_sidebar_hover,
+    poll_and_render_cursor, render, theme, update_sidebar_hover,
 };
 use crate::FramebufferConfig as FramebufferInfo;
 use crate::cursor::CursorRenderer;
@@ -22,7 +22,7 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
     let mut scroll_offset: usize = 0;
     let mut status: Option<(&str, bool)> = None;
 
-    draw_screen(fb, selected, hovered, scroll_offset, status);
+    draw_screen(fb, selected, hovered, sidebar_hov, scroll_offset, status);
 
     loop {
         poll_and_render_cursor(fb, &mut cursor);
@@ -33,7 +33,7 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
         let new_hov = action_hit(fb, scroll_offset);
         if new_hov != hovered {
             hovered = new_hov;
-            draw_screen(fb, selected, hovered, scroll_offset, status);
+            draw_screen(fb, selected, hovered, sidebar_hov, scroll_offset, status);
         }
 
         if let Some(key) = menu_common::read_key() {
@@ -42,14 +42,14 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
                 KeyPress::Up | KeyPress::Char('k') => {
                     selected = selected.saturating_sub(1);
                     keep_action_visible(fb, selected, &mut scroll_offset);
-                    draw_screen(fb, selected, hovered, scroll_offset, status);
+                    draw_screen(fb, selected, hovered, sidebar_hov, scroll_offset, status);
                 }
                 KeyPress::Down | KeyPress::Char('j') => {
                     if selected < ACTION_COUNT - 1 {
                         selected += 1;
                     }
                     keep_action_visible(fb, selected, &mut scroll_offset);
-                    draw_screen(fb, selected, hovered, scroll_offset, status);
+                    draw_screen(fb, selected, hovered, sidebar_hov, scroll_offset, status);
                 }
                 KeyPress::Char('s') | KeyPress::Char('S') => {}
                 KeyPress::Char('f') | KeyPress::Char('F') => {
@@ -57,7 +57,7 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
                     return ScreenNav::Nav(NavItem::Firmware);
                 }
                 KeyPress::Char('r') | KeyPress::Char('R') => {
-                    reset_system();
+                    crate::reset_system();
                 }
                 KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
                     return ScreenNav::Back;
@@ -67,7 +67,7 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
                     if selected == ACTION_BACK {
                         return ScreenNav::Back;
                     }
-                    draw_screen(fb, selected, hovered, scroll_offset, status);
+                    draw_screen(fb, selected, hovered, sidebar_hov, scroll_offset, status);
                 }
                 #[cfg(feature = "ui")]
                 KeyPress::MouseClick { .. } => {
@@ -89,7 +89,7 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
                             selected = idx;
                             keep_action_visible(fb, selected, &mut scroll_offset);
                         }
-                        draw_screen(fb, selected, hovered, scroll_offset, status);
+                        draw_screen(fb, selected, hovered, sidebar_hov, scroll_offset, status);
                     }
                 }
                 #[cfg(feature = "ui")]
@@ -100,7 +100,7 @@ pub fn show(fb: &FramebufferInfo) -> ScreenNav {
                         selected -= 1;
                     }
                     keep_action_visible(fb, selected, &mut scroll_offset);
-                    draw_screen(fb, selected, hovered, scroll_offset, status);
+                    draw_screen(fb, selected, hovered, sidebar_hov, scroll_offset, status);
                 }
                 _ => {}
             }
@@ -285,12 +285,13 @@ fn draw_screen(
     fb: &FramebufferInfo,
     selected: usize,
     hovered: Option<usize>,
+    sidebar_hov: Option<NavItem>,
     scroll_offset: usize,
     status: Option<(&str, bool)>,
 ) {
     clear(fb);
     draw_header(fb);
-    draw_sidebar(fb, NavItem::Security, None);
+    draw_sidebar(fb, NavItem::Security, sidebar_hov);
     draw_footer(
         fb,
         "Up/Down Navigate  Enter Select  S Security  F Firmware  R Reset  Esc Back",

--- a/crabefi-coreboot/src/cfr_menu.rs
+++ b/crabefi-coreboot/src/cfr_menu.rs
@@ -80,6 +80,25 @@ fn has_changes(items: &[MenuItem]) -> bool {
     })
 }
 
+/// Treat the current in-menu values as saved after a successful explicit save.
+#[cfg(feature = "ui")]
+fn mark_changes_saved(items: &mut [MenuItem]) {
+    for item in items {
+        match item {
+            MenuItem::CrabLogLevel {
+                current_level,
+                original_level,
+            } => *original_level = *current_level,
+            MenuItem::Option {
+                current_value,
+                original_value,
+                ..
+            } => *original_value = current_value.clone(),
+            _ => {}
+        }
+    }
+}
+
 /// Show the CFR firmware settings menu
 ///
 /// Displays the menu and handles user interaction.
@@ -125,6 +144,8 @@ pub fn show_cfr_menu() {
         } else if sel_vis_pos >= scroll_offset + screen_rows {
             scroll_offset = sel_vis_pos - screen_rows + 1;
         }
+        scroll_offset =
+            scroll_offset.min(visible_count(cfr_info, &items).saturating_sub(screen_rows));
         draw_menu(
             cfr_info,
             &items,
@@ -611,11 +632,12 @@ fn save_all_changes(cfr: &CfrInfo, items: &[MenuItem]) -> (usize, usize) {
                 current_level,
                 original_level,
             } if current_level != original_level => {
-                if crabefi::logger::set_configured_level(*current_level).is_ok() {
-                    saved += 1;
-                } else {
-                    log::warn!("Failed to save CrabEFI log level");
-                    failed += 1;
+                match crabefi::logger::set_configured_level(*current_level) {
+                    Ok(()) => saved += 1,
+                    Err(e) => {
+                        log::warn!("Failed to save CrabEFI log level: {:?}", e);
+                        failed += 1;
+                    }
                 }
             }
             MenuItem::Option {
@@ -878,6 +900,24 @@ fn show_cfr_menu_graphical(cfr_info: &CfrInfo, fb: &FramebufferInfo) {
                         state.status_message = Some(("Option cannot be decreased", false));
                     }
                 }
+                KeyPress::Char('s') | KeyPress::Char('S') => {
+                    if has_changes(&items) {
+                        cursor.hide(fb);
+                        let (saved, failed) = save_all_changes(cfr_info, &items);
+                        show_save_result_graphical(fb, saved, failed);
+                        if failed == 0 {
+                            mark_changes_saved(&mut items);
+                        }
+                    } else {
+                        state.status_message = Some(("No changes to save", true));
+                    }
+                }
+                KeyPress::Char('f') | KeyPress::Char('F') => {
+                    state.status_message = Some(("Already in firmware settings", true));
+                }
+                KeyPress::Char('r') | KeyPress::Char('R') => {
+                    crabefi::reset_system();
+                }
                 KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
                     cursor.hide(fb);
                     if has_changes(&items) && confirm_save_graphical(fb) {
@@ -986,6 +1026,9 @@ fn keep_graphical_selection_visible(
     } else if sel_vis_pos >= state.scroll_offset + slots {
         state.scroll_offset = sel_vis_pos - slots + 1;
     }
+    state.scroll_offset = state
+        .scroll_offset
+        .min(visible_count(cfr, items).saturating_sub(slots));
 }
 
 #[cfg(feature = "ui")]
@@ -1000,9 +1043,9 @@ fn draw_graphical_menu(
     ui::draw_sidebar(fb, NavItem::Firmware, None);
 
     let footer = if has_changes(items) {
-        "Up/Down Navigate  Enter Edit  +/- Adjust  ? Help  Esc Save/Exit"
+        "Up/Down Navigate  Enter Edit  +/- Adjust  ? Help  S Save  F Firmware  R Reset  Esc Save/Exit"
     } else {
-        "Up/Down Navigate  Enter Edit  +/- Adjust  ? Help  Esc Back"
+        "Up/Down Navigate  Enter Edit  +/- Adjust  ? Help  S Save  F Firmware  R Reset  Esc Back"
     };
     ui::draw_footer(fb, footer);
 
@@ -1310,6 +1353,27 @@ fn graphical_item_hit(
     visible_index_at(cfr, items, state.scroll_offset + slot)
 }
 
+fn push_truncated<const N: usize>(out: &mut StackString<N>, text: &str, max_chars: usize) {
+    if max_chars == 0 {
+        return;
+    }
+
+    let mut chars = text.chars();
+    for idx in 0..max_chars {
+        let Some(ch) = chars.next() else {
+            return;
+        };
+        if idx + 1 == max_chars && chars.next().is_some() {
+            let _ = out.push('~');
+            return;
+        }
+        if out.push(ch).is_err() {
+            let _ = out.push('~');
+            return;
+        }
+    }
+}
+
 #[cfg(feature = "ui")]
 fn format_value(option: &CfrOption, value: &CfrValue) -> StackString<96> {
     let mut out = StackString::new();
@@ -1319,7 +1383,7 @@ fn format_value(option: &CfrOption, value: &CfrValue) -> StackString<96> {
         }
         (CfrOptionType::Enum { choices, .. }, CfrValue::Number(n)) => {
             if let Some(choice) = choices.iter().find(|c| c.value == *n) {
-                let _ = out.push_str(&choice.ui_name);
+                push_truncated(&mut out, &choice.ui_name, 95);
             } else {
                 let _ = write!(out, "{}", n);
             }
@@ -1332,7 +1396,7 @@ fn format_value(option: &CfrOption, value: &CfrValue) -> StackString<96> {
             }
         }
         (CfrOptionType::Varchar { .. }, CfrValue::Varchar(s)) => {
-            let _ = out.push_str(s);
+            push_truncated(&mut out, s, 95);
         }
         _ => {
             let _ = out.push('-');
@@ -1931,7 +1995,7 @@ fn draw_option_item(
         (CfrOptionType::Enum { choices, .. }, CfrValue::Number(n)) => {
             if let Some(choice) = choices.iter().find(|c| c.value == *n) {
                 let _ = value_str.push('[');
-                let _ = value_str.push_str(&choice.ui_name);
+                push_truncated(&mut value_str, &choice.ui_name, 120);
                 let _ = value_str.push(']');
             } else {
                 let _ = write!(value_str, "[{}]", n);
@@ -1946,13 +2010,7 @@ fn draw_option_item(
         }
         (CfrOptionType::Varchar { .. }, CfrValue::Varchar(s)) => {
             let _ = value_str.push('[');
-            let max_len = 20;
-            if s.len() > max_len {
-                let _ = value_str.push_str(&s[..max_len]);
-                let _ = value_str.push_str("...");
-            } else {
-                let _ = value_str.push_str(s);
-            }
+            push_truncated(&mut value_str, s, 20);
             let _ = value_str.push(']');
         }
         _ => {

--- a/crabefi-coreboot/src/cfr_menu.rs
+++ b/crabefi-coreboot/src/cfr_menu.rs
@@ -13,12 +13,20 @@ use crate::cfr::{self, CfrInfo, CfrOption, CfrOptionType, CfrValue};
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::Write;
+#[cfg(feature = "ui")]
+use crabefi::FramebufferConfig as FramebufferInfo;
 use crabefi::drivers::serial as serial_driver;
 use crabefi::framebuffer_console::{
     Color, DEFAULT_BG, DEFAULT_FG, FramebufferConsole, HIGHLIGHT_BG, HIGHLIGHT_FG,
 };
 use crabefi::menu_common::{self, KeyPress, SerialWriter};
 use crabefi::time::delay_ms;
+#[cfg(feature = "ui")]
+use crabefi::ui::{self, NavItem, render, theme};
+
+use heapless::String as StackString;
+#[cfg(feature = "ui")]
+use render::{FontSize, Rgb};
 
 /// Menu title
 const MENU_TITLE: &str = "Firmware Settings";
@@ -86,6 +94,12 @@ pub fn show_cfr_menu() {
         }
     };
 
+    #[cfg(feature = "ui")]
+    if let Some(fb) = crabefi::state::get_framebuffer() {
+        show_cfr_menu_graphical(cfr_info, &fb);
+        return;
+    }
+
     let fb_info = crabefi::state::get_framebuffer();
     let mut fb_console = fb_info.as_ref().map(FramebufferConsole::new);
 
@@ -103,9 +117,8 @@ pub fn show_cfr_menu() {
     loop {
         menu_common::clear_screen(&mut fb_console);
         let modified = has_changes(&items);
-        // Ensure scroll keeps selected item visible
-        let vis = visible_indices(cfr_info, &items);
-        let sel_vis_pos = vis.iter().position(|&i| i == selected).unwrap_or(0);
+        // Ensure scroll keeps selected item visible without allocating.
+        let sel_vis_pos = visible_position_of(cfr_info, &items, selected).unwrap_or(0);
         let screen_rows = get_visible_rows(&fb_console);
         if sel_vis_pos < scroll_offset {
             scroll_offset = sel_vis_pos;
@@ -771,17 +784,946 @@ fn show_no_options_message(fb_console: &mut Option<FramebufferConsole>) {
 }
 
 // ============================================================================
+// Graphical UI (feature = "ui")
+// ============================================================================
+
+#[cfg(feature = "ui")]
+const GFX_ITEM_H: u32 = 50;
+#[cfg(feature = "ui")]
+const GFX_ITEM_GAP: u32 = 6;
+#[cfg(feature = "ui")]
+const GFX_ITEM_STRIDE: u32 = GFX_ITEM_H + GFX_ITEM_GAP;
+#[cfg(feature = "ui")]
+const GFX_TITLE_H: u32 = 68;
+
+#[cfg(feature = "ui")]
+struct GraphicalState {
+    selected: usize,
+    hovered: Option<usize>,
+    scroll_offset: usize,
+    status_message: Option<(&'static str, bool)>,
+}
+
+#[cfg(feature = "ui")]
+impl GraphicalState {
+    fn new(selected: usize) -> Self {
+        Self {
+            selected,
+            hovered: None,
+            scroll_offset: 0,
+            status_message: None,
+        }
+    }
+}
+
+/// Show the CFR settings menu using the graphical CrabEFI UI.
+#[cfg(feature = "ui")]
+fn show_cfr_menu_graphical(cfr_info: &CfrInfo, fb: &FramebufferInfo) {
+    let mut items = build_menu_items(cfr_info);
+
+    if items.is_empty() {
+        show_no_options_graphical(fb);
+        return;
+    }
+
+    let mut cursor = crabefi::cursor::CursorRenderer::new();
+    let mut state = GraphicalState::new(find_first_selectable(cfr_info, &items, 0));
+
+    draw_graphical_menu(cfr_info, &items, &state, fb);
+
+    loop {
+        ui::poll_and_render_cursor(fb, &mut cursor);
+
+        let hovered = graphical_item_hit(cfr_info, &items, &state, fb);
+        if hovered != state.hovered {
+            state.hovered = hovered;
+            draw_graphical_menu(cfr_info, &items, &state, fb);
+        }
+
+        if let Some(key) = menu_common::read_key() {
+            state.status_message = None;
+            match key {
+                KeyPress::Up | KeyPress::Char('k') => {
+                    state.selected = find_prev_selectable(cfr_info, &items, state.selected);
+                }
+                KeyPress::Down | KeyPress::Char('j') => {
+                    state.selected = find_next_selectable(cfr_info, &items, state.selected);
+                }
+                KeyPress::Enter | KeyPress::Char(' ') => {
+                    if can_edit_item(cfr_info, &items, state.selected) {
+                        if let Some(MenuItem::Option {
+                            form_idx,
+                            option_idx,
+                            current_value,
+                            ..
+                        }) = items.get_mut(state.selected)
+                        {
+                            if let Some(option) = get_option(cfr_info, *form_idx, *option_idx) {
+                                toggle_value(option, current_value);
+                            }
+                        } else {
+                            increment_option(cfr_info, &mut items, state.selected);
+                        }
+                    } else if is_selectable_item(items.get(state.selected)) {
+                        state.status_message = Some(("Option is read-only", false));
+                    }
+                }
+                KeyPress::Char('+') | KeyPress::Char('=') => {
+                    if !increment_option(cfr_info, &mut items, state.selected) {
+                        state.status_message = Some(("Option cannot be increased", false));
+                    }
+                }
+                KeyPress::Char('-') => {
+                    if !decrement_option(cfr_info, &mut items, state.selected) {
+                        state.status_message = Some(("Option cannot be decreased", false));
+                    }
+                }
+                KeyPress::Escape | KeyPress::Char('q') | KeyPress::Char('Q') => {
+                    cursor.hide(fb);
+                    if has_changes(&items) && confirm_save_graphical(fb) {
+                        let (saved, failed) = save_all_changes(cfr_info, &items);
+                        show_save_result_graphical(fb, saved, failed);
+                    }
+                    return;
+                }
+                KeyPress::Char('?') => {
+                    if let Some(MenuItem::Option {
+                        form_idx,
+                        option_idx,
+                        ..
+                    }) = items.get(state.selected)
+                        && let Some(option) = get_option(cfr_info, *form_idx, *option_idx)
+                    {
+                        cursor.hide(fb);
+                        show_help_graphical(fb, option);
+                    } else if matches!(
+                        items.get(state.selected),
+                        Some(MenuItem::CrabLogLevel { .. })
+                    ) {
+                        state.status_message =
+                            Some(("Controls CrabEFI serial log verbosity", true));
+                    }
+                }
+                KeyPress::MouseClick { .. } => {
+                    if let Some(item_idx) = state.hovered {
+                        if is_selectable(&items[item_idx]) {
+                            state.selected = item_idx;
+                            if can_edit_item(cfr_info, &items, item_idx) {
+                                if let Some(MenuItem::Option {
+                                    form_idx,
+                                    option_idx,
+                                    current_value,
+                                    ..
+                                }) = items.get_mut(item_idx)
+                                {
+                                    if let Some(option) =
+                                        get_option(cfr_info, *form_idx, *option_idx)
+                                    {
+                                        toggle_value(option, current_value);
+                                    }
+                                } else {
+                                    increment_option(cfr_info, &mut items, item_idx);
+                                }
+                            }
+                        }
+                    }
+                }
+                KeyPress::MouseScroll(dz) => {
+                    if dz > 0 {
+                        state.selected = find_next_selectable(cfr_info, &items, state.selected);
+                    } else {
+                        state.selected = find_prev_selectable(cfr_info, &items, state.selected);
+                    }
+                }
+                _ => {}
+            }
+
+            keep_graphical_selection_visible(cfr_info, &items, &mut state, fb);
+            draw_graphical_menu(cfr_info, &items, &state, fb);
+        }
+
+        delay_ms(8);
+    }
+}
+
+#[cfg(feature = "ui")]
+fn graphical_canvas(fb: &FramebufferInfo) -> (i32, i32, u32, u32) {
+    let x = theme::SIDEBAR_W as i32 + theme::PAD as i32;
+    let y = (theme::HEADER_H + theme::PAD) as i32;
+    let w = fb.width - theme::SIDEBAR_W - theme::PAD * 2;
+    let h = fb.height - theme::HEADER_H - theme::FOOTER_H - theme::PAD * 2;
+    (x, y, w, h)
+}
+
+#[cfg(feature = "ui")]
+fn graphical_list_area(fb: &FramebufferInfo) -> (i32, i32, u32, u32) {
+    let (cx, cy, cw, ch) = graphical_canvas(fb);
+    let y = cy + GFX_TITLE_H as i32;
+    (cx, y, cw, ch.saturating_sub(GFX_TITLE_H))
+}
+
+#[cfg(feature = "ui")]
+fn graphical_visible_slots(fb: &FramebufferInfo) -> usize {
+    let (_, _, _, h) = graphical_list_area(fb);
+    (h / GFX_ITEM_STRIDE).max(1) as usize
+}
+
+#[cfg(feature = "ui")]
+fn keep_graphical_selection_visible(
+    cfr: &CfrInfo,
+    items: &[MenuItem],
+    state: &mut GraphicalState,
+    fb: &FramebufferInfo,
+) {
+    let Some(sel_vis_pos) = visible_position_of(cfr, items, state.selected) else {
+        state.selected = find_first_selectable(cfr, items, 0);
+        state.scroll_offset = 0;
+        return;
+    };
+    let slots = graphical_visible_slots(fb);
+    if sel_vis_pos < state.scroll_offset {
+        state.scroll_offset = sel_vis_pos;
+    } else if sel_vis_pos >= state.scroll_offset + slots {
+        state.scroll_offset = sel_vis_pos - slots + 1;
+    }
+}
+
+#[cfg(feature = "ui")]
+fn draw_graphical_menu(
+    cfr: &CfrInfo,
+    items: &[MenuItem],
+    state: &GraphicalState,
+    fb: &FramebufferInfo,
+) {
+    ui::clear(fb);
+    ui::draw_header(fb);
+    ui::draw_sidebar(fb, NavItem::Firmware, None);
+
+    let footer = if has_changes(items) {
+        "Up/Down Navigate  Enter Edit  +/- Adjust  ? Help  Esc Save/Exit"
+    } else {
+        "Up/Down Navigate  Enter Edit  +/- Adjust  ? Help  Esc Back"
+    };
+    ui::draw_footer(fb, footer);
+
+    let (cx, cy, cw, _) = graphical_canvas(fb);
+    draw_graphical_title(fb, cx, cy, cw, has_changes(items));
+
+    let slots = graphical_visible_slots(fb);
+    let visible_len = visible_count(cfr, items);
+    let (_, list_y, _, _) = graphical_list_area(fb);
+
+    for screen_idx in 0..slots {
+        let Some(item_idx) = visible_index_at(cfr, items, state.scroll_offset + screen_idx) else {
+            break;
+        };
+        let y = list_y + (screen_idx as u32 * GFX_ITEM_STRIDE) as i32;
+        draw_graphical_item(
+            cfr,
+            &items[item_idx],
+            item_idx == state.selected,
+            state.hovered == Some(item_idx),
+            fb,
+            cx,
+            y,
+            cw,
+        );
+    }
+
+    draw_graphical_scroll(fb, visible_len, state.scroll_offset, slots);
+
+    if let Some((msg, ok)) = state.status_message {
+        let color = if ok { theme::GREEN } else { theme::ERROR };
+        render::draw_text_centered(
+            fb,
+            cx,
+            (fb.height - theme::FOOTER_H - 24) as i32,
+            cw,
+            msg,
+            FontSize::Small,
+            color,
+            None,
+        );
+    }
+}
+
+#[cfg(feature = "ui")]
+fn draw_graphical_title(fb: &FramebufferInfo, cx: i32, cy: i32, cw: u32, modified: bool) {
+    render::draw_text_spaced(
+        fb,
+        cx,
+        cy,
+        "HARDWARE CONFIGURATION",
+        FontSize::Small,
+        2,
+        theme::PRIMARY.darken(80),
+        None,
+    );
+    let title_y = cy + render::font_height(FontSize::Small) as i32 + 4;
+    render::draw_text(
+        fb,
+        cx,
+        title_y,
+        if modified {
+            "Firmware Settings *"
+        } else {
+            "Firmware Settings"
+        },
+        FontSize::Display,
+        theme::TEXT,
+        None,
+    );
+    render::draw_text_right(
+        fb,
+        cx,
+        title_y + 10,
+        cw,
+        "COREBOOT CFR",
+        FontSize::Small,
+        theme::OUTLINE,
+        None,
+    );
+}
+
+#[cfg(feature = "ui")]
+fn draw_graphical_item(
+    cfr: &CfrInfo,
+    item: &MenuItem,
+    selected: bool,
+    hovered: bool,
+    fb: &FramebufferInfo,
+    x: i32,
+    y: i32,
+    w: u32,
+) {
+    match item {
+        MenuItem::FormHeader { name } => {
+            render::draw_text_spaced(
+                fb,
+                x,
+                y + 16,
+                &truncate_for_width(name, w.saturating_sub(24), FontSize::Small),
+                FontSize::Small,
+                2,
+                theme::PRIMARY,
+                None,
+            );
+            render::draw_separator(fb, x, y + GFX_ITEM_H as i32 - 8, w, theme::GHOST, theme::BG);
+        }
+        MenuItem::SubformHeader { name } => {
+            render::draw_text(
+                fb,
+                x + 12,
+                y + 15,
+                &truncate_for_width(name, w.saturating_sub(24), FontSize::Normal),
+                FontSize::Normal,
+                theme::TERTIARY,
+                None,
+            );
+        }
+        MenuItem::Comment { text } => {
+            render::draw_text(
+                fb,
+                x + 12,
+                y + 17,
+                &truncate_for_width(text, w.saturating_sub(24), FontSize::Small),
+                FontSize::Small,
+                theme::TEXT_DIM,
+                None,
+            );
+        }
+        MenuItem::Option {
+            form_idx,
+            option_idx,
+            current_value,
+            ..
+        } => {
+            if let Some(option) = get_option(cfr, *form_idx, *option_idx) {
+                draw_graphical_option(fb, option, current_value, selected, hovered, x, y, w);
+            }
+        }
+        MenuItem::CrabLogLevel { current_level, .. } => {
+            draw_graphical_log_level(fb, *current_level, selected, hovered, x, y, w);
+        }
+    }
+}
+
+#[cfg(feature = "ui")]
+fn draw_graphical_log_level(
+    fb: &FramebufferInfo,
+    level: log::LevelFilter,
+    selected: bool,
+    hovered: bool,
+    x: i32,
+    y: i32,
+    w: u32,
+) {
+    let bg = if selected {
+        theme::BRIGHT
+    } else if hovered {
+        theme::CONT_HIGH
+    } else {
+        theme::CONTAINER
+    };
+    render::fill_rounded_rect(fb, x, y, w, GFX_ITEM_H, theme::RADIUS, bg);
+    render::fill_rect(
+        fb,
+        x,
+        y + 3,
+        theme::ACCENT_BAR,
+        GFX_ITEM_H - 6,
+        theme::PRIMARY,
+    );
+
+    let label = crabefi::logger::level_name(level);
+    let value_w = value_width(label).min(w / 2);
+    let value_x = x + w as i32 - value_w as i32 - 14;
+    let name_max_w = (value_x - x - 34).max(32) as u32;
+
+    render::draw_text(
+        fb,
+        x + 18,
+        y + 8,
+        &truncate_for_width("CrabEFI log level", name_max_w, FontSize::Normal),
+        FontSize::Normal,
+        theme::TEXT,
+        Some(bg),
+    );
+    render::draw_text(
+        fb,
+        x + 18,
+        y + 31,
+        "serial verbosity",
+        FontSize::Small,
+        theme::OUTLINE,
+        Some(bg),
+    );
+    draw_value_pill(fb, value_x, y + 12, value_w, label, true);
+}
+
+#[cfg(feature = "ui")]
+fn draw_graphical_option(
+    fb: &FramebufferInfo,
+    option: &CfrOption,
+    value: &CfrValue,
+    selected: bool,
+    hovered: bool,
+    x: i32,
+    y: i32,
+    w: u32,
+) {
+    let editable = option.is_editable();
+    let bg = if selected {
+        theme::BRIGHT
+    } else if hovered {
+        theme::CONT_HIGH
+    } else {
+        theme::CONTAINER
+    };
+    render::fill_rounded_rect(fb, x, y, w, GFX_ITEM_H, theme::RADIUS, bg);
+
+    let accent = if selected {
+        theme::PRIMARY
+    } else if editable {
+        theme::GHOST
+    } else {
+        theme::CONT_LOW
+    };
+    render::fill_rect(fb, x, y + 3, theme::ACCENT_BAR, GFX_ITEM_H - 6, accent);
+
+    let value_label = format_value(option, value);
+    let value_w = value_width(&value_label).min(w / 2);
+    let value_x = x + w as i32 - value_w as i32 - 14;
+    let name_max_w = (value_x - x - 34).max(32) as u32;
+    let name_color = if editable {
+        theme::TEXT
+    } else {
+        theme::TEXT_DIM
+    };
+
+    render::draw_text(
+        fb,
+        x + 18,
+        y + 8,
+        &truncate_for_width(&option.ui_name, name_max_w, FontSize::Normal),
+        FontSize::Normal,
+        name_color,
+        Some(bg),
+    );
+
+    if !option.ui_helptext.is_empty() {
+        render::draw_text(
+            fb,
+            x + 18,
+            y + 31,
+            "? help available",
+            FontSize::Small,
+            theme::OUTLINE,
+            Some(bg),
+        );
+    }
+
+    match (&option.option_type, value) {
+        (CfrOptionType::Bool { .. }, CfrValue::Bool(on)) => {
+            render::draw_toggle(fb, value_x, y + 16, *on, theme::PRIMARY);
+        }
+        _ => draw_value_pill(fb, value_x, y + 12, value_w, &value_label, editable),
+    }
+}
+
+#[cfg(feature = "ui")]
+fn draw_graphical_scroll(
+    fb: &FramebufferInfo,
+    visible_len: usize,
+    scroll_offset: usize,
+    visible_slots: usize,
+) {
+    if visible_len <= visible_slots {
+        return;
+    }
+    let (cx, list_y, cw, list_h) = graphical_list_area(fb);
+    let track_x = cx + cw as i32 - 4;
+    render::fill_rounded_rect(fb, track_x, list_y, 4, list_h, 2, theme::SIDE);
+    let fraction = visible_slots as u32 * 255 / visible_len as u32;
+    let thumb_h = (list_h * fraction / 255).max(24).min(list_h);
+    let max_off = visible_len.saturating_sub(visible_slots).max(1);
+    let thumb_y = list_y + ((list_h - thumb_h) as usize * scroll_offset / max_off) as i32;
+    render::fill_rounded_rect(fb, track_x, thumb_y, 4, thumb_h, 2, theme::PRIMARY);
+}
+
+#[cfg(feature = "ui")]
+fn graphical_item_hit(
+    cfr: &CfrInfo,
+    items: &[MenuItem],
+    state: &GraphicalState,
+    fb: &FramebufferInfo,
+) -> Option<usize> {
+    let (mx, my) = crabefi::drivers::mouse_cursor::position();
+    let (x, y, w, _) = graphical_list_area(fb);
+    if mx < x || mx >= x + w as i32 || my < y {
+        return None;
+    }
+    let slot = ((my - y) as u32 / GFX_ITEM_STRIDE) as usize;
+    if slot >= graphical_visible_slots(fb) {
+        return None;
+    }
+    visible_index_at(cfr, items, state.scroll_offset + slot)
+}
+
+#[cfg(feature = "ui")]
+fn format_value(option: &CfrOption, value: &CfrValue) -> StackString<96> {
+    let mut out = StackString::new();
+    match (&option.option_type, value) {
+        (CfrOptionType::Bool { .. }, CfrValue::Bool(b)) => {
+            let _ = out.push_str(if *b { "Enabled" } else { "Disabled" });
+        }
+        (CfrOptionType::Enum { choices, .. }, CfrValue::Number(n)) => {
+            if let Some(choice) = choices.iter().find(|c| c.value == *n) {
+                let _ = out.push_str(&choice.ui_name);
+            } else {
+                let _ = write!(out, "{}", n);
+            }
+        }
+        (CfrOptionType::Number { hex_display, .. }, CfrValue::Number(n)) => {
+            if *hex_display {
+                let _ = write!(out, "0x{:X}", n);
+            } else {
+                let _ = write!(out, "{}", n);
+            }
+        }
+        (CfrOptionType::Varchar { .. }, CfrValue::Varchar(s)) => {
+            let _ = out.push_str(s);
+        }
+        _ => {
+            let _ = out.push('-');
+        }
+    }
+    out
+}
+
+#[cfg(feature = "ui")]
+fn value_width(label: &str) -> u32 {
+    render::text_width(label, FontSize::Small) + 18
+}
+
+#[cfg(feature = "ui")]
+fn draw_value_pill(fb: &FramebufferInfo, x: i32, y: i32, w: u32, label: &str, editable: bool) {
+    let bg = if editable {
+        theme::CONT_LOW
+    } else {
+        theme::SIDE
+    };
+    let fg = if editable {
+        theme::PRIMARY
+    } else {
+        theme::TEXT_DIM
+    };
+    render::fill_rounded_rect(fb, x, y, w, 26, 13, bg);
+    render::draw_text_centered(
+        fb,
+        x,
+        y + 5,
+        w,
+        &truncate_for_width(label, w.saturating_sub(16), FontSize::Small),
+        FontSize::Small,
+        fg,
+        Some(bg),
+    );
+}
+
+#[cfg(feature = "ui")]
+fn truncate_for_width(text: &str, max_width: u32, size: FontSize) -> StackString<128> {
+    let max_chars = (max_width / render::font_width(size)).max(1) as usize;
+    let char_count = text.chars().count();
+    if char_count <= max_chars {
+        let mut out = StackString::new();
+        let _ = out.push_str(text);
+        return out;
+    }
+
+    let mut out = StackString::new();
+    for (idx, ch) in text.chars().enumerate() {
+        if idx + 1 >= max_chars {
+            let _ = out.push('~');
+            break;
+        }
+        let _ = out.push(ch);
+    }
+    out
+}
+
+#[cfg(feature = "ui")]
+fn show_help_graphical(fb: &FramebufferInfo, option: &CfrOption) {
+    let mut cursor = crabefi::cursor::CursorRenderer::new();
+    draw_help_graphical(fb, option);
+    loop {
+        ui::poll_and_render_cursor(fb, &mut cursor);
+        if menu_common::read_key().is_some() {
+            cursor.hide(fb);
+            return;
+        }
+        delay_ms(8);
+    }
+}
+
+#[cfg(feature = "ui")]
+fn draw_help_graphical(fb: &FramebufferInfo, option: &CfrOption) {
+    ui::clear(fb);
+    ui::draw_header(fb);
+    ui::draw_sidebar(fb, NavItem::Firmware, None);
+    ui::draw_footer(fb, "Any key Back");
+
+    let (cx, cy, cw, _) = graphical_canvas(fb);
+    render::draw_text_spaced(
+        fb,
+        cx,
+        cy,
+        "SETTING HELP",
+        FontSize::Small,
+        2,
+        theme::PRIMARY.darken(80),
+        None,
+    );
+    render::draw_text(
+        fb,
+        cx,
+        cy + render::font_height(FontSize::Small) as i32 + 4,
+        &truncate_for_width(&option.ui_name, cw, FontSize::Display),
+        FontSize::Display,
+        theme::TEXT,
+        None,
+    );
+
+    let card_y = cy + GFX_TITLE_H as i32;
+    render::fill_rounded_rect(fb, cx, card_y, cw, 180, theme::RADIUS, theme::CONTAINER);
+    render::fill_rect(fb, cx, card_y + 3, theme::ACCENT_BAR, 174, theme::PRIMARY);
+
+    let text = if option.ui_helptext.is_empty() {
+        "No help available for this option."
+    } else {
+        &option.ui_helptext
+    };
+    draw_wrapped_text(
+        fb,
+        cx + 18,
+        card_y + 18,
+        cw.saturating_sub(36),
+        text,
+        FontSize::Normal,
+        theme::TEXT_DIM,
+        Some(theme::CONTAINER),
+        6,
+    );
+}
+
+#[cfg(feature = "ui")]
+fn draw_wrapped_text(
+    fb: &FramebufferInfo,
+    x: i32,
+    mut y: i32,
+    w: u32,
+    text: &str,
+    size: FontSize,
+    fg: Rgb,
+    bg: Option<Rgb>,
+    max_lines: usize,
+) {
+    let max_chars = (w / render::font_width(size)).max(1) as usize;
+    let mut line: StackString<160> = StackString::new();
+    let mut lines = 0usize;
+
+    for word in text.split(' ') {
+        if lines >= max_lines {
+            break;
+        }
+        let add_len = if line.is_empty() {
+            word.len()
+        } else {
+            word.len() + 1
+        };
+        if !line.is_empty() && line.len() + add_len > max_chars {
+            render::draw_text(fb, x, y, &line, size, fg, bg);
+            y += render::font_height(size) as i32 + 4;
+            line.clear();
+            lines += 1;
+        }
+        if !line.is_empty() {
+            let _ = line.push(' ');
+        }
+        let _ = line.push_str(word);
+    }
+
+    if !line.is_empty() && lines < max_lines {
+        render::draw_text(fb, x, y, &line, size, fg, bg);
+    }
+}
+
+#[cfg(feature = "ui")]
+fn confirm_save_graphical(fb: &FramebufferInfo) -> bool {
+    let mut cursor = crabefi::cursor::CursorRenderer::new();
+    draw_confirm_save_graphical(fb);
+    loop {
+        ui::poll_and_render_cursor(fb, &mut cursor);
+        if let Some(key) = menu_common::read_key() {
+            match key {
+                KeyPress::Char('y') | KeyPress::Char('Y') | KeyPress::Enter => {
+                    cursor.hide(fb);
+                    return true;
+                }
+                KeyPress::Char('n') | KeyPress::Char('N') | KeyPress::Escape => {
+                    cursor.hide(fb);
+                    return false;
+                }
+                KeyPress::MouseClick { x, y } => {
+                    let (yes, no) = confirm_button_rects(fb);
+                    if point_in_rect(x as i32, y as i32, yes) {
+                        cursor.hide(fb);
+                        return true;
+                    }
+                    if point_in_rect(x as i32, y as i32, no) {
+                        cursor.hide(fb);
+                        return false;
+                    }
+                }
+                _ => {}
+            }
+        }
+        delay_ms(8);
+    }
+}
+
+#[cfg(feature = "ui")]
+fn draw_confirm_save_graphical(fb: &FramebufferInfo) {
+    ui::clear(fb);
+    ui::draw_header(fb);
+    ui::draw_sidebar(fb, NavItem::Firmware, None);
+    ui::draw_footer(fb, "Y/Enter Save   N/Esc Discard");
+
+    let (cx, cy, cw, ch) = graphical_canvas(fb);
+    let modal_w = cw.min(520);
+    let modal_h = 180;
+    let x = cx + (cw - modal_w) as i32 / 2;
+    let y = cy + (ch - modal_h) as i32 / 2;
+
+    render::fill_rounded_rect(fb, x, y, modal_w, modal_h, theme::RADIUS, theme::CONTAINER);
+    render::draw_glow(
+        fb,
+        x,
+        y,
+        modal_w,
+        modal_h,
+        theme::RADIUS,
+        3,
+        theme::PRIMARY,
+        theme::BG,
+    );
+    render::draw_text_centered(
+        fb,
+        x,
+        y + 24,
+        modal_w,
+        "Save firmware setting changes?",
+        FontSize::Heading,
+        theme::TEXT,
+        Some(theme::CONTAINER),
+    );
+    render::draw_text_centered(
+        fb,
+        x,
+        y + 62,
+        modal_w,
+        "Changes take effect after reset.",
+        FontSize::Small,
+        theme::TEXT_DIM,
+        Some(theme::CONTAINER),
+    );
+
+    let (yes, no) = confirm_button_rects(fb);
+    draw_button(fb, yes, "SAVE", true);
+    draw_button(fb, no, "DISCARD", false);
+}
+
+#[cfg(feature = "ui")]
+fn confirm_button_rects(fb: &FramebufferInfo) -> ((i32, i32, u32, u32), (i32, i32, u32, u32)) {
+    let (cx, cy, cw, ch) = graphical_canvas(fb);
+    let modal_w = cw.min(520);
+    let modal_h = 180;
+    let x = cx + (cw - modal_w) as i32 / 2;
+    let y = cy + (ch - modal_h) as i32 / 2;
+    let bw = 132;
+    let bh = 38;
+    let gap = 16;
+    let by = y + 118;
+    let bx = x + (modal_w as i32 - (bw * 2 + gap)) / 2;
+    (
+        (bx, by, bw as u32, bh as u32),
+        (bx + bw + gap, by, bw as u32, bh as u32),
+    )
+}
+
+#[cfg(feature = "ui")]
+fn draw_button(fb: &FramebufferInfo, rect: (i32, i32, u32, u32), label: &str, primary: bool) {
+    let (x, y, w, h) = rect;
+    let bg = if primary {
+        theme::PRIMARY
+    } else {
+        theme::CONT_HIGH
+    };
+    let fg = if primary {
+        theme::ON_PRIMARY
+    } else {
+        theme::TEXT
+    };
+    render::fill_rounded_rect(fb, x, y, w, h, theme::RADIUS, bg);
+    render::draw_text_centered(fb, x, y + 9, w, label, FontSize::Small, fg, Some(bg));
+}
+
+#[cfg(feature = "ui")]
+fn point_in_rect(px: i32, py: i32, rect: (i32, i32, u32, u32)) -> bool {
+    let (x, y, w, h) = rect;
+    px >= x && px < x + w as i32 && py >= y && py < y + h as i32
+}
+
+#[cfg(feature = "ui")]
+fn show_save_result_graphical(fb: &FramebufferInfo, saved: usize, failed: usize) {
+    ui::clear(fb);
+    ui::draw_header(fb);
+    ui::draw_sidebar(fb, NavItem::Firmware, None);
+    ui::draw_footer(fb, "Returning to firmware menu");
+
+    let (cx, cy, cw, ch) = graphical_canvas(fb);
+    let mut msg: StackString<80> = StackString::new();
+    let ok = failed == 0;
+    if ok {
+        let _ = write!(msg, "Saved {} option(s).", saved);
+    } else {
+        let _ = write!(msg, "Saved {}, {} failed to write.", saved, failed);
+    }
+    render::draw_text_centered(
+        fb,
+        cx,
+        cy + ch as i32 / 2 - 18,
+        cw,
+        &msg,
+        FontSize::Heading,
+        if ok { theme::GREEN } else { theme::ERROR },
+        None,
+    );
+    delay_ms(1500);
+}
+
+#[cfg(feature = "ui")]
+fn show_no_options_graphical(fb: &FramebufferInfo) {
+    let mut cursor = crabefi::cursor::CursorRenderer::new();
+    ui::clear(fb);
+    ui::draw_header(fb);
+    ui::draw_sidebar(fb, NavItem::Firmware, None);
+    ui::draw_footer(fb, "Esc Back");
+
+    let (cx, cy, cw, ch) = graphical_canvas(fb);
+    render::draw_text_centered(
+        fb,
+        cx,
+        cy + ch as i32 / 2 - 12,
+        cw,
+        "No configurable options found",
+        FontSize::Normal,
+        theme::TEXT_DIM,
+        None,
+    );
+
+    loop {
+        ui::poll_and_render_cursor(fb, &mut cursor);
+        if let Some(key) = menu_common::read_key()
+            && matches!(key, KeyPress::Escape | KeyPress::Enter | KeyPress::Char(_))
+        {
+            cursor.hide(fb);
+            return;
+        }
+        delay_ms(8);
+    }
+}
+
+// ============================================================================
 // Drawing
 // ============================================================================
 
-/// Collect the indices of items that are currently visible (dependency-aware).
-fn visible_indices(cfr: &CfrInfo, items: &[MenuItem]) -> Vec<usize> {
+/// Count menu items that are currently visible (dependency-aware).
+fn visible_count(cfr: &CfrInfo, items: &[MenuItem]) -> usize {
     items
         .iter()
-        .enumerate()
-        .filter(|(_, item)| is_item_visible(cfr, items, item))
-        .map(|(i, _)| i)
-        .collect()
+        .filter(|item| is_item_visible(cfr, items, item))
+        .count()
+}
+
+/// Return the visible-list position of an item index without allocating.
+fn visible_position_of(cfr: &CfrInfo, items: &[MenuItem], target: usize) -> Option<usize> {
+    let mut pos = 0usize;
+    for (idx, item) in items.iter().enumerate() {
+        if !is_item_visible(cfr, items, item) {
+            continue;
+        }
+        if idx == target {
+            return Some(pos);
+        }
+        pos += 1;
+    }
+    None
+}
+
+/// Return the item index at a visible-list position without allocating.
+fn visible_index_at(cfr: &CfrInfo, items: &[MenuItem], target_pos: usize) -> Option<usize> {
+    let mut pos = 0usize;
+    for (idx, item) in items.iter().enumerate() {
+        if !is_item_visible(cfr, items, item) {
+            continue;
+        }
+        if pos == target_pos {
+            return Some(idx);
+        }
+        pos += 1;
+    }
+    None
 }
 
 /// Draw the complete menu
@@ -805,21 +1747,17 @@ fn draw_menu(
     };
     menu_common::draw_header(title, fb_console, cols);
 
-    // Build list of visible item indices (dependency-aware)
-    let vis = visible_indices(cfr, items);
-
     // Calculate visible area
     let start_row = 4;
     let visible_rows = rows.saturating_sub(8);
+    let vis_len = visible_count(cfr, items);
 
-    // Draw items — only the visible ones, respecting scroll_offset
-    for (screen_idx, &item_idx) in vis
-        .iter()
-        .enumerate()
-        .skip(scroll_offset)
-        .take(visible_rows)
-    {
-        let row = start_row + (screen_idx - scroll_offset);
+    // Draw items — only the visible ones, respecting scroll_offset.
+    for screen_idx in 0..visible_rows {
+        let Some(item_idx) = visible_index_at(cfr, items, scroll_offset + screen_idx) else {
+            break;
+        };
+        let row = start_row + screen_idx;
         let is_selected = item_idx == selected;
         draw_item(cfr, &items[item_idx], is_selected, row, fb_console, cols);
     }
@@ -828,7 +1766,7 @@ fn draw_menu(
     if scroll_offset > 0 {
         draw_scroll_indicator(start_row - 1, "^", fb_console);
     }
-    if scroll_offset + visible_rows < vis.len() {
+    if scroll_offset + visible_rows < vis_len {
         draw_scroll_indicator(start_row + visible_rows, "v", fb_console);
     }
 
@@ -985,16 +1923,16 @@ fn draw_option_item(
     let is_editable = option.is_editable();
 
     // Format the value for display
-    let mut value_str = String::new();
+    let mut value_str: StackString<128> = StackString::new();
     match (&option.option_type, value) {
         (CfrOptionType::Bool { .. }, CfrValue::Bool(b)) => {
-            value_str.push_str(if *b { "[Enabled]" } else { "[Disabled]" });
+            let _ = value_str.push_str(if *b { "[Enabled]" } else { "[Disabled]" });
         }
         (CfrOptionType::Enum { choices, .. }, CfrValue::Number(n)) => {
             if let Some(choice) = choices.iter().find(|c| c.value == *n) {
-                value_str.push('[');
-                value_str.push_str(&choice.ui_name);
-                value_str.push(']');
+                let _ = value_str.push('[');
+                let _ = value_str.push_str(&choice.ui_name);
+                let _ = value_str.push(']');
             } else {
                 let _ = write!(value_str, "[{}]", n);
             }
@@ -1007,18 +1945,18 @@ fn draw_option_item(
             }
         }
         (CfrOptionType::Varchar { .. }, CfrValue::Varchar(s)) => {
-            value_str.push('[');
+            let _ = value_str.push('[');
             let max_len = 20;
             if s.len() > max_len {
-                value_str.push_str(&s[..max_len]);
-                value_str.push_str("...");
+                let _ = value_str.push_str(&s[..max_len]);
+                let _ = value_str.push_str("...");
             } else {
-                value_str.push_str(s);
+                let _ = value_str.push_str(s);
             }
-            value_str.push(']');
+            let _ = value_str.push(']');
         }
         _ => {
-            value_str.push_str("[-]");
+            let _ = value_str.push_str("[-]");
         }
     }
 

--- a/crabefi-coreboot/src/fmap.rs
+++ b/crabefi-coreboot/src/fmap.rs
@@ -310,16 +310,30 @@ pub fn find_smmstore_region(fmap: &FmapInfo) -> Option<&FmapAreaInfo> {
     // Note: RW_ELOG is the event log region and must NOT be used as variable storage
     const SMMSTORE_NAMES: &[&str] = &["SMMSTORE", "RW_NVRAM", "NVRAM"];
 
-    SMMSTORE_NAMES.iter().find_map(|name| {
-        find_region(fmap, name).inspect(|area| {
+    for name in SMMSTORE_NAMES {
+        if let Some(area) = find_region(fmap, name) {
             log::info!(
                 "Found SMMSTORE region '{}' at {:#x}, size {} KB",
                 area.name.as_str(),
                 area.offset,
                 area.size / 1024
             );
-        })
-    })
+            return Some(area);
+        }
+    }
+
+    log::warn!(
+        "No SMMSTORE/RW_NVRAM/NVRAM region in FMAP; UEFI/CFR variable persistence is unavailable"
+    );
+    for area in fmap.areas.iter() {
+        log::warn!(
+            "  FMAP area '{}' at {:#x}, size {} KB",
+            area.name.as_str(),
+            area.offset,
+            area.size / 1024
+        );
+    }
+    None
 }
 
 /// SMMSTORE information derived from FMAP


### PR DESCRIPTION
## Summary

This PR adds the graphical CFR firmware settings menu and tightens the surrounding menu UX so every graphical menu behaves consistently when content exceeds the available screen space.

### CFR firmware settings

- Renders coreboot CFR forms with the same graphical CrabEFI chrome as the other menus.
- Shows the CrabEFI-owned serial log-level setting alongside CFR options.
- Supports editing the log level from the graphical CFR menu with Enter/Space, `+`, `-`, and mouse click.
- Preserves CFR dependency-aware visibility and save-on-exit behavior.
- Shows a scrollbar only when the visible CFR item list does not fit the screen.

### Scrolling / long menus

- Adds selected-item scrolling to the graphical boot entry list.
- Adds selected-item scrolling to the graphical Secure Boot action list.
- Adds scroll indicators to the text boot menu when boot entries/categories exceed the available rows.
- Keeps scrollbars/indicators hidden when content fits.

### Navigation consistency

- Adds main-menu-style shortcuts from non-boot menus:
  - `S` for Secure Boot / Security
  - `F` for Firmware Settings
  - `R` for Reset
- Applies these to graphical Secure Boot, graphical Firmware Settings, and the text Secure Boot menu.

## Commit structure

1. `ui: add graphical CFR firmware settings menu`
2. `ui: add scrolling to boot and secure menus`
3. `ui: align secure and firmware menu shortcuts`

## Validation

- `cargo fmt`
- `cargo check --features ui`
- `cargo check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Boot and Secure Boot action/menu lists now support scrolling with on-screen indicators, including click/hover selection that stays visible.
  * Added reset, firmware, and security shortcuts across the menu flows.
  * Secure Boot and CFR menus can switch to a graphical UI when a framebuffer is available.
* **Bug Fixes**
  * Mouse selection mapping is now correct when menus are scrolled.
  * Firmware settings now exits cleanly after launching external settings.
  * Reset behavior is consistent across boot and related screens.
* **Chores**
  * Improved FMAP logging when SMMSTORE lookup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->