### PR TITLE
Fix AHCI and EHCI enumeration issues seen on Intel/X220-class hardware.

### DIFF
--- a/crabefi-core/src/boot_vars.rs
+++ b/crabefi-core/src/boot_vars.rs
@@ -434,8 +434,8 @@ pub fn read_boot_order() -> HeaplessVec<u16, MAX_BOOT_OPTIONS> {
         return order;
     }
 
-    for chunk in data.chunks_exact(2) {
-        let num = u16::from_le_bytes([chunk[0], chunk[1]]);
+    for chunk in data.as_chunks::<2>().0 {
+        let num = u16::from_le_bytes(*chunk);
         if order.push(num).is_err() {
             log::warn!(
                 "BootOrder: truncated at {} entries (max {})",
@@ -586,8 +586,8 @@ pub fn extract_file_path(load_option: &LoadOption) -> Option<heapless::String<12
             let mut path = heapless::String::<128>::new();
 
             // UCS-2 to ASCII conversion
-            for chunk in path_data.chunks_exact(2) {
-                let ch = u16::from_le_bytes([chunk[0], chunk[1]]);
+            for chunk in path_data.as_chunks::<2>().0 {
+                let ch = u16::from_le_bytes(*chunk);
                 if ch == 0 {
                     break;
                 }

--- a/crabefi-core/src/drivers/ahci/mod.rs
+++ b/crabefi-core/src/drivers/ahci/mod.rs
@@ -304,6 +304,37 @@ pub enum DeviceType {
     PortMultiplier,
 }
 
+const PCI_VENDOR_ID_INTEL: u16 = 0x8086;
+const INTEL_PCS_6: u16 = 0x92;
+
+fn needs_intel_pcs_quirk(pci_dev: &PciDevice) -> bool {
+    if pci_dev.vendor_id != PCI_VENDOR_ID_INTEL {
+        return false;
+    }
+
+    // Linux marks Cougar Point/Patsburg/Panther Point AHCI and RAID IDs with
+    // AHCI_HFLAG_INTEL_PCS_QUIRK.  X220 is CPT-M AHCI (8086:1c03).
+    matches!(
+        pci_dev.device_id,
+        0x1c02
+            | 0x1c03
+            | 0x1c04
+            | 0x1c05
+            | 0x1c06
+            | 0x1c07
+            | 0x1d02
+            | 0x1d04
+            | 0x1d06
+            | 0x1e02
+            | 0x1e03
+            | 0x1e04
+            | 0x1e05
+            | 0x1e06
+            | 0x1e07
+            | 0x1e0e
+    )
+}
+
 /// AHCI Controller
 pub struct AhciController {
     /// PCI address (bus:device.function)
@@ -354,6 +385,28 @@ impl AhciController {
     fn port_regs(&self, port: u8) -> &AhciPortRegisters {
         let port_addr = self.mmio_base + PORT_BASE + (port as u64) * PORT_SIZE;
         unsafe { &*(port_addr as *const AhciPortRegisters) }
+    }
+
+    fn apply_intel_pcs_quirk(&self, pci_dev: &PciDevice) {
+        if !needs_intel_pcs_quirk(pci_dev) {
+            return;
+        }
+
+        // Intel PCH SATA exposes a PCI PCS register which gates physical ports.
+        // Linux's ahci_intel_pcs_quirk() enables every implemented AHCI port
+        // after controller reset; without this, the X220 dock/SATAPI port can
+        // be visible in PI but fail commands.
+        let port_map = (self.ports_implemented & 0x3f) as u16;
+        let pcs = pci::read_config16(pci_dev.address, INTEL_PCS_6);
+        if (pcs & port_map) != port_map {
+            let new_pcs = pcs | port_map;
+            pci::write_config16(pci_dev.address, INTEL_PCS_6, new_pcs);
+            log::debug!(
+                "AHCI: Intel PCS quirk enabled ports ({:#06x} -> {:#06x})",
+                pcs,
+                new_pcs
+            );
+        }
     }
 
     /// Create a new AHCI controller from a PCI device
@@ -417,6 +470,8 @@ impl AhciController {
             ports_implemented,
             ports: heapless::Vec::new(),
         };
+
+        controller.apply_intel_pcs_quirk(pci_dev);
 
         // Initialize ports (pass SSS capability)
         controller.init_ports_with_sss(supports_sss)?;
@@ -485,14 +540,24 @@ impl AhciController {
                             log::warn!("AHCI: Failed to add port {} - port list full", port_num);
                         }
                     } else if port.device_type == DeviceType::Satapi {
-                        log::info!(
-                            "AHCI Port {}: SATAPI device, {} sectors (sector_size={})",
-                            port_num,
-                            port.sector_count,
-                            port.sector_size
-                        );
-                        if self.ports.push(port).is_err() {
-                            log::warn!("AHCI: Failed to add port {} - port list full", port_num);
+                        if port.sector_count == 0 {
+                            log::info!(
+                                "AHCI Port {}: SATAPI device has no readable media; skipping boot scan",
+                                port_num
+                            );
+                        } else {
+                            log::info!(
+                                "AHCI Port {}: SATAPI device, {} sectors (sector_size={})",
+                                port_num,
+                                port.sector_count,
+                                port.sector_size
+                            );
+                            if self.ports.push(port).is_err() {
+                                log::warn!(
+                                    "AHCI: Failed to add port {} - port list full",
+                                    port_num
+                                );
+                            }
                         }
                     } else {
                         log::info!("AHCI Port {}: {:?} device", port_num, port.device_type);
@@ -766,9 +831,15 @@ impl AhciController {
         let buffer = efi::allocate_pages(1).ok_or(AhciError::AllocationFailed)?;
         buffer.fill(0);
 
-        // Setup command header (set ATAPI bit)
+        // IDENTIFY PACKET DEVICE is an ATA command, not an ATA PACKET command.
+        // Do not set the AHCI command-header ATAPI bit here; that bit is only
+        // for command 0xA0 with a CDB in CommandTable::acmd.
         let header = unsafe { &mut *port.cmd_list.add(slot as usize) };
-        header.init_atapi();
+        header.dw0 = 0;
+        header.set_cfl(5);
+        header.set_write(false);
+        header.set_prdtl(1);
+        header.prdbc = 0;
 
         // Setup command table
         let table = unsafe { &mut *port.cmd_tables[slot as usize] };
@@ -784,8 +855,13 @@ impl AhciController {
         table.prdt[0].set_address(buffer_addr);
         table.prdt[0].set_byte_count(512, true)?;
 
-        // Issue command
-        self.issue_command(port, slot)?;
+        // Issue command. Match Linux's first IDENTIFY/IDENTIFY PACKET timeout
+        // budget: long enough for real devices, but not a 30s boot stall when
+        // the dock bay is empty or confused.
+        if let Err(e) = self.issue_command_on_port_with_timeout(port.port_num, slot, 5000) {
+            efi::free_pages(buffer, 1);
+            return Err(e);
+        }
 
         // Parse identify packet data
         let identify = unsafe { core::slice::from_raw_parts(buffer.as_ptr() as *const u16, 256) };
@@ -837,8 +913,9 @@ impl AhciController {
         table.prdt[0].set_address(buffer_addr);
         table.prdt[0].set_byte_count(8, true)?;
 
-        // Issue command
-        if let Err(e) = self.issue_command(port, slot) {
+        // Issue command. Empty optical drives can fail this; keep discovery
+        // responsive and mark the device as no-media below.
+        if let Err(e) = self.issue_command_on_port_with_timeout(port.port_num, slot, 5000) {
             log::warn!("READ CAPACITY failed: {:?}, using defaults", e);
             port.sector_size = 2048;
             port.sector_count = 0;
@@ -1088,6 +1165,15 @@ impl AhciController {
     /// 2. Clear error bits (PxSERR, PxIS)
     /// 3. Restart the command engine (set PxCMD.ST)
     fn issue_command_on_port(&mut self, port_num: u8, slot: u8) -> Result<(), AhciError> {
+        self.issue_command_on_port_with_timeout(port_num, slot, 30000)
+    }
+
+    fn issue_command_on_port_with_timeout(
+        &mut self,
+        port_num: u8,
+        slot: u8,
+        timeout_ms: u64,
+    ) -> Result<(), AhciError> {
         fence(Ordering::SeqCst);
 
         let port_regs = self.port_regs(port_num);
@@ -1101,8 +1187,8 @@ impl AhciController {
         // Issue command
         port_regs.ci.set(1 << slot);
 
-        // Wait for completion (up to 30 seconds)
-        let timeout = Timeout::from_ms(30000);
+        // Wait for completion
+        let timeout = Timeout::from_ms(timeout_ms);
         let mut error = None;
         while !timeout.is_expired() {
             let ci = port_regs.ci.get();

--- a/crabefi-core/src/drivers/pci/mod.rs
+++ b/crabefi-core/src/drivers/pci/mod.rs
@@ -335,6 +335,16 @@ pub fn enable_device(dev: &PciDevice) {
     });
 }
 
+/// Read a 16-bit PCI configuration-space register.
+pub fn read_config16(addr: PciAddress, offset: u16) -> u16 {
+    with_access(|access| access.read16(addr, offset))
+}
+
+/// Write a 16-bit PCI configuration-space register.
+pub fn write_config16(addr: PciAddress, offset: u16, value: u16) {
+    with_access(|access| access.write16(addr, offset, value));
+}
+
 // ============================================================================
 // Initialization
 // ============================================================================

--- a/crabefi-core/src/drivers/usb/ehci.rs
+++ b/crabefi-core/src/drivers/usb/ehci.rs
@@ -902,6 +902,25 @@ impl EhciController {
         Ok(())
     }
 
+    fn hub_port_class_request(
+        &mut self,
+        hub_device: &UsbDevice,
+        direction: u8,
+        request: u8,
+        value: u16,
+        port: u8,
+        data: Option<&mut [u8]>,
+    ) -> Result<usize, UsbError> {
+        self.control_transfer_internal(
+            hub_device,
+            direction | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+            request,
+            value,
+            port as u16,
+            data,
+        )
+    }
+
     /// Enumerate devices connected to a USB hub.
     fn enumerate_hub(&mut self, hub_slot: usize, hub_addr: u8) -> Result<(), UsbError> {
         log::info!("EHCI: Enumerating hub at address {}", hub_addr);
@@ -936,12 +955,12 @@ impl EhciController {
 
         // Power on all downstream ports (SET_FEATURE PORT_POWER).
         for port in 1..=num_ports {
-            let _ = self.control_transfer_internal(
+            let _ = self.hub_port_class_request(
                 &hub_device,
-                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                req_type::DIR_OUT,
                 request::SET_FEATURE,
                 hub_feature::PORT_POWER,
-                port as u16,
+                port,
                 None,
             );
         }
@@ -956,12 +975,12 @@ impl EhciController {
         for port in 1..=num_ports {
             let mut status_buf = [0u8; 4];
             if self
-                .control_transfer_internal(
+                .hub_port_class_request(
                     &hub_device,
-                    req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                    req_type::DIR_IN,
                     request::GET_STATUS,
                     0,
-                    port as u16,
+                    port,
                     Some(&mut status_buf),
                 )
                 .is_err()
@@ -1003,24 +1022,24 @@ impl EhciController {
     ) -> Option<UsbSpeed> {
         // Clear the connection-change bit if set.
         if initial_change & hub_port_change::C_CONNECTION != 0 {
-            let _ = self.control_transfer_internal(
+            let _ = self.hub_port_class_request(
                 hub_device,
-                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                req_type::DIR_OUT,
                 request::CLEAR_FEATURE,
                 hub_feature::C_PORT_CONNECTION,
-                port as u16,
+                port,
                 None,
             );
         }
 
         // Issue a port reset (SET_FEATURE PORT_RESET).
         if self
-            .control_transfer_internal(
+            .hub_port_class_request(
                 hub_device,
-                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                req_type::DIR_OUT,
                 request::SET_FEATURE,
                 hub_feature::PORT_RESET,
-                port as u16,
+                port,
                 None,
             )
             .is_err()
@@ -1035,12 +1054,12 @@ impl EhciController {
         while !timeout.is_expired() {
             let mut status_buf = [0u8; 4];
             if self
-                .control_transfer_internal(
+                .hub_port_class_request(
                     hub_device,
-                    req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                    req_type::DIR_IN,
                     request::GET_STATUS,
                     0,
-                    port as u16,
+                    port,
                     Some(&mut status_buf),
                 )
                 .is_err()
@@ -1053,12 +1072,12 @@ impl EhciController {
 
             if port_change & hub_port_change::C_RESET != 0 {
                 // Acknowledge the reset-complete change bit.
-                let _ = self.control_transfer_internal(
+                let _ = self.hub_port_class_request(
                     hub_device,
-                    req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                    req_type::DIR_OUT,
                     request::CLEAR_FEATURE,
                     hub_feature::C_PORT_RESET,
-                    port as u16,
+                    port,
                     None,
                 );
 

--- a/crabefi-core/src/drivers/usb/ehci.rs
+++ b/crabefi-core/src/drivers/usb/ehci.rs
@@ -19,8 +19,8 @@
 //! - libpayload ehci.c
 
 use super::controller::{
-    SetupPacket, UsbController, UsbDevice, UsbError, UsbSpeed, enumerate_device,
-    enumerate_hub_ports,
+    HUB_DESCRIPTOR_TYPE, SetupPacket, UsbController, UsbDevice, UsbError, UsbSpeed,
+    enumerate_device, hub_feature, hub_port_change, hub_port_status, req_type, request,
 };
 #[cfg(target_arch = "aarch64")]
 use crate::arch::aarch64::cache::{flush_cache_range, invalidate_cache_range};
@@ -903,9 +903,6 @@ impl EhciController {
     }
 
     /// Enumerate devices connected to a USB hub.
-    ///
-    /// Delegates to the shared [`enumerate_hub_ports`] helper in the
-    /// controller abstraction layer.
     fn enumerate_hub(&mut self, hub_slot: usize, hub_addr: u8) -> Result<(), UsbError> {
         log::info!("EHCI: Enumerating hub at address {}", hub_addr);
 
@@ -914,25 +911,179 @@ impl EhciController {
             .ok_or(UsbError::DeviceNotFound)?
             .clone();
 
-        let (num_ports, ready_ports) = enumerate_hub_ports(
+        // Fetch hub class descriptor (bmRequestType = 0xA0: D→H, Class, Device).
+        let mut hub_desc_buf = [0u8; 9];
+        self.control_transfer_internal(
             &hub_device,
-            |dev, rt, req, val, idx, data| {
-                self.control_transfer_internal(dev, rt, req, val, idx, data)
-            },
-            true, // EHCI supports high-speed devices
+            req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_DEVICE,
+            request::GET_DESCRIPTOR,
+            (HUB_DESCRIPTOR_TYPE as u16) << 8,
+            0,
+            Some(&mut hub_desc_buf),
         )?;
+
+        let num_ports = hub_desc_buf[2];
+        let power_on_delay = (hub_desc_buf[5] as u64) * 2; // 2 ms units
+        log::info!(
+            "  Hub has {} ports, power-on delay: {}ms",
+            num_ports,
+            power_on_delay
+        );
 
         if let Some(ref mut dev) = self.devices[hub_slot] {
             dev.num_hub_ports = num_ports;
         }
 
-        for (port, speed) in ready_ports {
-            if let Err(e) = self.attach_device_on_hub(port, speed, hub_addr, port) {
+        // Power on all downstream ports (SET_FEATURE PORT_POWER).
+        for port in 1..=num_ports {
+            let _ = self.control_transfer_internal(
+                &hub_device,
+                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                request::SET_FEATURE,
+                hub_feature::PORT_POWER,
+                port as u16,
+                None,
+            );
+        }
+
+        // Wait for power to stabilise (spec minimum 100 ms).
+        crate::time::delay_ms(power_on_delay.max(100));
+
+        // Reset and enumerate one port at a time.  Do not pre-reset every
+        // connected port: that leaves multiple devices simultaneously in the
+        // default address state behind the same hub, so address-0 control
+        // transfers collide.  This showed up on the X220 dock's EHCI hub chain.
+        for port in 1..=num_ports {
+            let mut status_buf = [0u8; 4];
+            if self
+                .control_transfer_internal(
+                    &hub_device,
+                    req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                    request::GET_STATUS,
+                    0,
+                    port as u16,
+                    Some(&mut status_buf),
+                )
+                .is_err()
+            {
+                continue;
+            }
+
+            let port_status = u16::from_le_bytes([status_buf[0], status_buf[1]]);
+            let port_change = u16::from_le_bytes([status_buf[2], status_buf[3]]);
+
+            log::debug!(
+                "  Hub port {} status: {:#06x}, change: {:#06x}",
+                port,
+                port_status,
+                port_change
+            );
+
+            if (port_status & hub_port_status::CONNECTION) == 0 {
+                continue;
+            }
+
+            log::info!("  Device detected on hub port {}", port);
+
+            if let Some(speed) = self.reset_hub_port(&hub_device, port, port_change)
+                && let Err(e) = self.attach_device_on_hub(port, speed, hub_addr, port)
+            {
                 log::warn!("  Failed to attach device on hub port {}: {:?}", port, e);
             }
         }
 
         Ok(())
+    }
+
+    fn reset_hub_port(
+        &mut self,
+        hub_device: &UsbDevice,
+        port: u8,
+        initial_change: u16,
+    ) -> Option<UsbSpeed> {
+        // Clear the connection-change bit if set.
+        if initial_change & hub_port_change::C_CONNECTION != 0 {
+            let _ = self.control_transfer_internal(
+                hub_device,
+                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                request::CLEAR_FEATURE,
+                hub_feature::C_PORT_CONNECTION,
+                port as u16,
+                None,
+            );
+        }
+
+        // Issue a port reset (SET_FEATURE PORT_RESET).
+        if self
+            .control_transfer_internal(
+                hub_device,
+                req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                request::SET_FEATURE,
+                hub_feature::PORT_RESET,
+                port as u16,
+                None,
+            )
+            .is_err()
+        {
+            return None;
+        }
+
+        // Wait at least 50 ms then poll for C_PORT_RESET.
+        crate::time::delay_ms(50);
+
+        let timeout = Timeout::from_ms(500);
+        while !timeout.is_expired() {
+            let mut status_buf = [0u8; 4];
+            if self
+                .control_transfer_internal(
+                    hub_device,
+                    req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                    request::GET_STATUS,
+                    0,
+                    port as u16,
+                    Some(&mut status_buf),
+                )
+                .is_err()
+            {
+                return None;
+            }
+
+            let port_status = u16::from_le_bytes([status_buf[0], status_buf[1]]);
+            let port_change = u16::from_le_bytes([status_buf[2], status_buf[3]]);
+
+            if port_change & hub_port_change::C_RESET != 0 {
+                // Acknowledge the reset-complete change bit.
+                let _ = self.control_transfer_internal(
+                    hub_device,
+                    req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_OTHER,
+                    request::CLEAR_FEATURE,
+                    hub_feature::C_PORT_RESET,
+                    port as u16,
+                    None,
+                );
+
+                if (port_status & hub_port_status::ENABLE) == 0 {
+                    break;
+                }
+
+                let speed = if (port_status & hub_port_status::HIGH_SPEED) != 0 {
+                    UsbSpeed::High
+                } else if (port_status & hub_port_status::LOW_SPEED) != 0 {
+                    UsbSpeed::Low
+                } else {
+                    UsbSpeed::Full
+                };
+
+                log::info!("  Hub port {} reset complete, speed: {:?}", port, speed);
+                crate::time::delay_ms(10); // USB spec reset-recovery time
+                return Some(speed);
+            }
+
+            crate::time::delay_ms(10);
+        }
+
+        log::warn!("  Hub port {} reset timed out", port);
+        None
     }
 
     /// Perform a control transfer

--- a/crabefi-core/src/efi/varstore/edk2.rs
+++ b/crabefi-core/src/efi/varstore/edk2.rs
@@ -650,8 +650,10 @@ where
         }
         // Convert to Vec<u16>
         let name: Vec<u16> = name_bytes
-            .chunks_exact(2)
-            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|c| u16::from_le_bytes(*c))
             .collect();
 
         // Read data

--- a/crabefi-core/src/fs/fat.rs
+++ b/crabefi-core/src/fs/fat.rs
@@ -233,10 +233,12 @@ impl LfnEntry {
     /// Returns the number of valid characters (may be less than 13 if null-terminated)
     fn extract_chars(&self, out: &mut [u16; 13]) -> usize {
         self.name1
-            .chunks_exact(2)
-            .chain(self.name2.chunks_exact(2))
-            .chain(self.name3.chunks_exact(2))
-            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .chain(self.name2.as_chunks::<2>().0.iter())
+            .chain(self.name3.as_chunks::<2>().0.iter())
+            .map(|pair| u16::from_le_bytes(*pair))
             .take_while(|&ch| ch != 0x0000 && ch != 0xFFFF)
             .zip(out.iter_mut())
             .map(|(ch, slot)| *slot = ch)

--- a/crabefi-core/src/pe/mod.rs
+++ b/crabefi-core/src/pe/mod.rs
@@ -598,15 +598,18 @@ pub fn load_image(data: &[u8]) -> Result<LoadedImage, Status> {
 
     // Parse section headers using zerocopy
     // We iterate and parse each section header individually
+    const SECTION_HEADER_SIZE: usize = core::mem::size_of::<SectionHeader>();
     let section_data = &data[sections_offset..sections_end];
 
     // Copy sections with full bounds validation
     for (i, chunk) in section_data
-        .chunks_exact(core::mem::size_of::<SectionHeader>())
+        .as_chunks::<SECTION_HEADER_SIZE>()
+        .0
+        .iter()
         .take(num_sections as usize)
         .enumerate()
     {
-        let section = match SectionHeader::ref_from_prefix(chunk) {
+        let section = match SectionHeader::ref_from_prefix(&chunk[..]) {
             Ok((s, _)) => s,
             Err(_) => break,
         };

--- a/crabefi-coreboot/src/cbmem_console.rs
+++ b/crabefi-coreboot/src/cbmem_console.rs
@@ -191,9 +191,17 @@ fn write_bytes(mut bytes: &[u8]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard};
     use std::vec::Vec;
 
     const TEST_CONSOLE_SIZE: usize = 1024;
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn test_guard() -> MutexGuard<'static, ()> {
+        TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 
     fn console_storage(size: usize) -> Vec<u8> {
         let mut storage = std::vec![0; core::mem::size_of::<CbmemConsoleHeader>() + size];
@@ -213,6 +221,7 @@ mod tests {
 
     #[test]
     fn rejects_zero_and_tiny_console_buffers() {
+        let _guard = test_guard();
         disable();
         assert!(!init(0));
 
@@ -223,6 +232,7 @@ mod tests {
 
     #[test]
     fn mirrors_newlines_as_crlf_and_advances_cursor() {
+        let _guard = test_guard();
         disable();
         let mut storage = console_storage(TEST_CONSOLE_SIZE);
         let addr = storage.as_mut_ptr() as u64;
@@ -237,6 +247,7 @@ mod tests {
 
     #[test]
     fn wraps_ring_buffer_and_sets_overflow_flag() {
+        let _guard = test_guard();
         disable();
         let mut storage = console_storage(TEST_CONSOLE_SIZE);
         let addr = storage.as_mut_ptr() as u64;
@@ -253,6 +264,7 @@ mod tests {
 
     #[test]
     fn disable_stops_later_writes() {
+        let _guard = test_guard();
         disable();
         let mut storage = console_storage(TEST_CONSOLE_SIZE);
         let addr = storage.as_mut_ptr() as u64;


### PR DESCRIPTION
- Add an Intel AHCI PCS quirk for Cougar Point/Patsburg/Panther Point controllers to enable all implemented SATA ports via PCI config space.
- Add PCI config-space 16-bit read/write helpers used by the AHCI quirk.
- Improve SATAPI handling:
  - Treat IDENTIFY PACKET DEVICE as a normal ATA command rather than an ATAPI packet command.
  - Use shorter discovery timeouts for SATAPI identify/read-capacity operations to avoid long boot stalls.
  - Skip SATAPI devices with no readable media during boot scanning.
- Rework EHCI hub enumeration to reset and enumerate hub ports one at a time, preventing multiple downstream devices from colliding at USB address 0.
- Add explicit EHCI hub descriptor parsing, port power-up, per-port status checks, reset handling, and speed detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved USB hub detection on EHCI controllers for more reliable downstream device enumeration.
  * Added broader PCI configuration-space access with new 16-bit read/write helpers.
* **Bug Fixes**
  * Fixed AHCI controller initialization for certain Intel hardware via PCS quirk handling.
  * Improved ATAPI/SATAPI device discovery with better IDENTIFY command handling, added timeout support, and skipping SATAPI ports reporting no sector count.
* **Maintenance / Tests**
  * Refined variable/path/Unicode parsing and PE section iteration internals.
  * Improved CBMEM console unit test synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->