### PR TITLE
pci: constrain ECAM enumeration

### DIFF
--- a/crabefi-core/src/drivers/pci/access.rs
+++ b/crabefi-core/src/drivers/pci/access.rs
@@ -164,7 +164,7 @@ impl EcamAccess {
 
     /// Calculate the ECAM address for a given BDF and register offset
     ///
-    /// ECAM address = base + (bus << 20) | (device << 15) | (function << 12) | offset
+    /// ECAM address = base | (bus << 20) | (device << 15) | (function << 12) | offset
     fn ecam_address(&self, addr: PciAddress, offset: u16) -> u64 {
         debug_assert!(
             offset <= 4095,

--- a/crabefi-core/src/drivers/pci/mod.rs
+++ b/crabefi-core/src/drivers/pci/mod.rs
@@ -55,6 +55,7 @@ pub const SUBCLASS_SDHCI: u8 = 0x05; // SD Host Controller
 
 /// Invalid vendor ID (no device present)
 const INVALID_VENDOR_ID: u16 = 0xFFFF;
+const ECAM_BYTES_PER_BUS: u64 = 1 << 20;
 
 /// PCI header types
 const HEADER_TYPE_NORMAL: u8 = 0x00;
@@ -358,8 +359,11 @@ pub fn init() {
     log::info!("Initializing PCI subsystem...");
 
     // Select access method based on ECAM availability
-    let ecam_base = state::drivers().pci.ecam_base;
+    let pci_state = &state::drivers().pci;
+    let ecam_base = pci_state.ecam_base;
+    let ecam_size = pci_state.ecam_size;
     let new_access = access::create_access(ecam_base);
+    let max_bus = max_bus_for_access(ecam_base, ecam_size);
 
     // Set access method and enumerate devices in one closure so we can
     // borrow both `pci.access` and `pci.devices` without aliasing issues.
@@ -369,16 +373,37 @@ pub fn init() {
         drivers.pci.access = new_access;
         let pci = &mut drivers.pci;
         pci.devices.clear();
-        enumerate_devices(&pci.access, &mut pci.devices);
+        enumerate_devices(&pci.access, &mut pci.devices, max_bus);
     });
+}
+
+fn max_bus_for_access(ecam_base: Option<u64>, ecam_size: Option<u64>) -> u8 {
+    if ecam_base.is_none() {
+        return u8::MAX;
+    }
+
+    let Some(size) = ecam_size else {
+        log::warn!("PCI ECAM size unknown; scanning all 256 buses");
+        return u8::MAX;
+    };
+
+    let bus_count = (size / ECAM_BYTES_PER_BUS).clamp(1, 256);
+    let max_bus = (bus_count - 1) as u8;
+    log::debug!(
+        "PCI ECAM window size {:#x}: scanning buses 00-{:02x}",
+        size,
+        max_bus
+    );
+    max_bus
 }
 
 /// Enumerate all PCI devices
 fn enumerate_devices(
     access: &AnyPciAccess,
     devices: &mut heapless::Vec<PciDevice, { state::MAX_PCI_DEVICES }>,
+    max_bus: u8,
 ) {
-    for bus in 0..=255u8 {
+    for bus in 0..=max_bus {
         for device in 0..32u8 {
             // First check function 0
             if let Some(dev) = scan_device(access, bus, device, 0) {
@@ -592,10 +617,19 @@ pub fn print_devices() {
 
 /// Set ECAM base address (from ACPI MCFG table)
 pub fn set_ecam_base(base: u64) {
+    set_ecam_region(base, None);
+}
+
+pub fn set_ecam_region(base: u64, size: Option<u64>) {
     state::with_drivers_mut(|drivers| {
         drivers.pci.ecam_base = Some(base);
+        drivers.pci.ecam_size = size;
     });
-    log::debug!("ECAM base set to {:#x}", base);
+    if let Some(size) = size {
+        log::debug!("ECAM region set to {:#x}+{:#x}", base, size);
+    } else {
+        log::debug!("ECAM base set to {:#x} (size unknown)", base);
+    }
 }
 
 // ============================================================================

--- a/crabefi-core/src/drivers/pci/mod.rs
+++ b/crabefi-core/src/drivers/pci/mod.rs
@@ -367,34 +367,42 @@ pub fn init() {
 
     // Set access method and enumerate devices in one closure so we can
     // borrow both `pci.access` and `pci.devices` without aliasing issues.
-    // Set access method and enumerate devices in one closure so we can
-    // borrow both `pci.access` and `pci.devices` without aliasing issues.
     state::with_drivers_mut(|drivers| {
         drivers.pci.access = new_access;
         let pci = &mut drivers.pci;
         pci.devices.clear();
-        enumerate_devices(&pci.access, &mut pci.devices, max_bus);
+        if let Some(max_bus) = max_bus {
+            enumerate_devices(&pci.access, &mut pci.devices, max_bus);
+        }
     });
 }
 
-fn max_bus_for_access(ecam_base: Option<u64>, ecam_size: Option<u64>) -> u8 {
+fn max_bus_for_access(ecam_base: Option<u64>, ecam_size: Option<u64>) -> Option<u8> {
     if ecam_base.is_none() {
-        return u8::MAX;
+        return Some(u8::MAX);
     }
 
     let Some(size) = ecam_size else {
         log::warn!("PCI ECAM size unknown; scanning all 256 buses");
-        return u8::MAX;
+        return Some(u8::MAX);
     };
 
-    let bus_count = (size / ECAM_BYTES_PER_BUS).clamp(1, 256);
-    let max_bus = (bus_count - 1) as u8;
+    let bus_count = size / ECAM_BYTES_PER_BUS;
+    if bus_count == 0 {
+        log::warn!(
+            "PCI ECAM window size {:#x} is smaller than one bus; skipping enumeration",
+            size
+        );
+        return None;
+    }
+
+    let max_bus = (bus_count.min(256) - 1) as u8;
     log::debug!(
         "PCI ECAM window size {:#x}: scanning buses 00-{:02x}",
         size,
         max_bus
     );
-    max_bus
+    Some(max_bus)
 }
 
 /// Enumerate all PCI devices

--- a/crabefi-core/src/lib.rs
+++ b/crabefi-core/src/lib.rs
@@ -467,7 +467,7 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
     // that provide ecam_base directly.
     if let Some(ecam) = config.ecam_base {
         log::info!("PCI ECAM base from platform: {:#x}", ecam);
-        drivers::pci::set_ecam_base(ecam);
+        drivers::pci::set_ecam_region(ecam, config.ecam_size);
     } else if let Some(ecam) = state::drivers().acpi_info.ecam_base {
         log::info!("PCI ECAM base from ACPI MCFG: {:#x}", ecam);
         drivers::pci::set_ecam_region(ecam, state::drivers().acpi_info.ecam_size);

--- a/crabefi-core/src/lib.rs
+++ b/crabefi-core/src/lib.rs
@@ -47,6 +47,14 @@ pub mod ui;
 
 use crate::drivers::block::{AhciDisk, NvmeDisk, SdhciDisk, UsbDisk};
 
+/// Perform a system reset using the common firmware fallback sequence.
+pub fn reset_system() -> ! {
+    log::info!("System reset requested");
+    arch::reset::keyboard_controller_reset();
+    time::delay_ms(100);
+    arch::reset::triple_fault();
+}
+
 // Re-export the public platform API at the crate root for ergonomic access.
 pub use platform::{
     BlockDevice, BlockDeviceInfo, BlockError, BootResult, CapsuleBackend, CapsuleRegion,
@@ -448,10 +456,10 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
         drivers::pci::set_ecam_base(ecam);
     } else if let Some(ecam) = state::drivers().acpi_info.ecam_base {
         log::info!("PCI ECAM base from ACPI MCFG: {:#x}", ecam);
-        drivers::pci::set_ecam_base(ecam);
+        drivers::pci::set_ecam_region(ecam, state::drivers().acpi_info.ecam_size);
     } else if let Some(ecam) = state::drivers().fdt_info.ecam_base {
         log::info!("PCI ECAM base from FDT: {:#x}", ecam);
-        drivers::pci::set_ecam_base(ecam);
+        drivers::pci::set_ecam_region(ecam, state::drivers().fdt_info.ecam_size);
     }
 
     drivers::pci::init();

--- a/crabefi-core/src/lib.rs
+++ b/crabefi-core/src/lib.rs
@@ -47,9 +47,14 @@ pub mod ui;
 
 use crate::drivers::block::{AhciDisk, NvmeDisk, SdhciDisk, UsbDisk};
 
-/// Perform a system reset using the common firmware fallback sequence.
+/// Perform a system reset using the platform handler when available.
 pub fn reset_system() -> ! {
     log::info!("System reset requested");
+
+    if let Some(reset) = state::try_get().and_then(|state| state.drivers.platform.reset) {
+        reset.reset(ResetType::Cold);
+    }
+
     arch::reset::keyboard_controller_reset();
     time::delay_ms(100);
     arch::reset::triple_fault();
@@ -364,9 +369,18 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
                 >(recorder)
             }
         });
+    let reset: &'static dyn crate::platform::ResetHandler = unsafe {
+        // SAFETY: init_platform() is -> !, so the platform reset handler
+        // reference lives for the entire firmware lifetime.
+        core::mem::transmute::<
+            &dyn crate::platform::ResetHandler,
+            &'static dyn crate::platform::ResetHandler,
+        >(config.reset)
+    };
     state::with_drivers_mut(|d| {
         d.platform.efi_fw_info = config.firmware_info;
         d.platform.hooks = hooks;
+        d.platform.reset = Some(reset);
         d.platform.timestamp_recorder = timestamp_recorder;
         d.platform.capsule_regions.clear();
         for region in config.capsule_regions {

--- a/crabefi-core/src/lib.rs
+++ b/crabefi-core/src/lib.rs
@@ -71,18 +71,6 @@ pub use platform::{
     VariableVisitor,
 };
 
-/// Perform a system reset.
-///
-/// Attempts the architecture-specific soft reset path first, waits briefly,
-/// then falls back to the architecture's non-returning hard reset path.
-pub fn reset_system() -> ! {
-    log::info!("System reset requested");
-
-    arch::reset::keyboard_controller_reset();
-    time::delay_ms(100);
-    arch::reset::triple_fault();
-}
-
 /// Display a Secure Boot violation error on screen
 ///
 /// This function displays a prominent red error message in the center of the screen

--- a/crabefi-core/src/platform.rs
+++ b/crabefi-core/src/platform.rs
@@ -1077,13 +1077,7 @@ impl FramebufferConfig {
     }
 
     /// Raw pointer to the framebuffer.
-    ///
-    /// # Safety
-    ///
-    /// The framebuffer must be identity-mapped at `physical_address`.
-    /// The caller is responsible for ensuring the pointer is not used
-    /// after the framebuffer is unmapped.
-    pub unsafe fn as_ptr(&self) -> *mut u8 {
+    pub fn as_ptr(&self) -> *mut u8 {
         core::ptr::with_exposed_provenance_mut(self.physical_address as usize)
     }
 
@@ -1118,8 +1112,7 @@ impl FramebufferConfig {
             return;
         }
         let offset = self.pixel_offset(x, y);
-        // SAFETY: caller guarantees the framebuffer is identity-mapped.
-        let fb = unsafe { self.as_ptr() };
+        let fb = self.as_ptr();
         unsafe {
             match self.bits_per_pixel {
                 32 => {
@@ -1211,8 +1204,7 @@ impl FramebufferConfig {
     ///
     /// The framebuffer must be accessible.
     pub unsafe fn clear(&self, r: u8, g: u8, b: u8) {
-        // SAFETY: caller guarantees the framebuffer is identity-mapped.
-        let fb = unsafe { self.as_ptr() };
+        let fb = self.as_ptr();
         let bpl = self.bytes_per_line() as usize;
         unsafe {
             match self.bits_per_pixel {
@@ -1415,6 +1407,9 @@ pub struct PlatformConfig<'a> {
     /// If provided, CrabEFI uses this directly for PCI config space access.
     /// Otherwise, it discovers the ECAM base from ACPI MCFG or FDT.
     pub ecam_base: Option<u64>,
+
+    /// Size of the PCI ECAM window in bytes, when `ecam_base` is provided.
+    pub ecam_size: Option<u64>,
 
     // ---- Runtime Support ----
     /// Warm-reboot persistent buffer for deferred variable writes.

--- a/crabefi-core/src/state.rs
+++ b/crabefi-core/src/state.rs
@@ -698,6 +698,8 @@ pub struct PciState {
     pub devices: HeaplessVec<PciDevice, MAX_PCI_DEVICES>,
     /// PCIe ECAM base address (from ACPI MCFG or coreboot)
     pub ecam_base: Option<u64>,
+    /// PCIe ECAM window size in bytes, when known.
+    pub ecam_size: Option<u64>,
     /// Config space access method (legacy I/O CAM or PCIe ECAM)
     pub access: AnyPciAccess,
 }
@@ -707,6 +709,7 @@ impl PciState {
         Self {
             devices: HeaplessVec::new(),
             ecam_base: None,
+            ecam_size: None,
             // x86 defaults to legacy I/O CAM (ports 0xCF8/0xCFC).
             // Non-x86 defaults to ECAM at address 0 — PCI init will
             // replace this once a real ECAM base is discovered from

--- a/crabefi-core/src/state.rs
+++ b/crabefi-core/src/state.rs
@@ -847,6 +847,9 @@ pub struct PlatformInfo {
     /// Optional platform lifecycle callbacks.
     pub hooks: Option<&'static dyn crate::platform::PlatformHooks>,
 
+    /// Platform reset handler.
+    pub reset: Option<&'static dyn crate::platform::ResetHandler>,
+
     /// Optional firmware-visible boot timestamp recorder.
     pub timestamp_recorder: Option<&'static dyn crate::platform::TimestampRecorder>,
 }
@@ -861,6 +864,7 @@ impl PlatformInfo {
             efi_fw_info: None,
             capsule_regions: HeaplessVec::new(),
             hooks: None,
+            reset: None,
             timestamp_recorder: None,
         }
     }

--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -527,6 +527,7 @@ fn riscv_fdt_only_boot(fdt_ptr: u64, fdt_size: u32) -> ! {
         hooks: Some(&hooks),
         rng: None,
         ecam_base: None,
+        ecam_size: None,
         deferred_buffer: None,
         runtime_region: None,
         heap_pre_initialized: false,
@@ -820,9 +821,10 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
         capsule_regions: &capsule_regions[..capsule_count],
         hooks: Some(&hooks),
         rng: None,
-        ecam_base: None,             // May be filled from ACPI MCFG below
-        deferred_buffer: None,       // Uses linker-symbol fallback in init_platform()
-        runtime_region: None,        // Uses linker-symbol fallback (platform-entry feature)
+        ecam_base: None, // May be filled from ACPI MCFG below
+        ecam_size: None,
+        deferred_buffer: None, // Uses linker-symbol fallback in init_platform()
+        runtime_region: None,  // Uses linker-symbol fallback (platform-entry feature)
         heap_pre_initialized: false, // Set to true after Phase 7
     };
 
@@ -883,6 +885,7 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
         {
             if let Some(ecam) = info.ecam_base {
                 config.ecam_base = Some(ecam);
+                config.ecam_size = info.ecam_size;
                 log::info!("ECAM base from FDT: {:#x}", ecam);
                 ecam_found = true;
             }
@@ -892,6 +895,7 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
         // Fallback: use coreboot's configured ECAM base for QEMU virt (0x30000000)
         if !ecam_found {
             config.ecam_base = Some(0x3000_0000);
+            config.ecam_size = Some(0x1000_0000);
             log::info!("ECAM base from coreboot config: 0x30000000");
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `reset_system()` to use an optional platform cold reset handler when available, then fall back to the keyboard-controller + triple-fault sequence.
  * Improved PCI ECAM support by introducing an optional ECAM window size for safer device enumeration (including RISC-V FDT/MCFG configuration).

* **Bug Fixes**
  * PCI enumeration now limits bus scanning to the ECAM-covered range and skips enumeration when the ECAM window is too small.
  * Corrected ECAM address calculation documentation to match the implemented formula.

* **API Changes**
  * Added `set_ecam_region(base, size: Option<u64>)` and expanded PCI/platform configuration to carry `ecam_size` (and an optional platform reset handler).
  * Made framebuffer pointer retrieval non-`unsafe` via a safe `as_ptr()` method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->