### PR TITLE
ci: add UEFI SCT smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,74 @@ jobs:
       - name: Run TCG protocol tests
         run: ./crabefi test --app tcg-test --disable-kvm --timeout 120
 
+  # ── UEFI SCT smoke subset ─────────────────────────────────────────────
+
+  build-sct-assets-x86_64:
+    name: Build SCT Assets x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore cached SCT assets
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: sct-assets/x86_64
+          key: sct-assets-x86_64-${{ hashFiles('ci/build-sct-assets.sh') }}
+
+      - name: Install SCT asset dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl p7zip-full
+
+      - name: Build SCT assets
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: ci/build-sct-assets.sh --arch x86_64
+
+      - name: Upload SCT assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: sct-assets-x86_64
+          path: sct-assets/x86_64/
+          retention-days: 7
+
+  test-uefi-sct-smoke:
+    name: Test x86_64 (UEFI SCT smoke)
+    runs-on: ubuntu-latest
+    needs: [build, build-sct-assets-x86_64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchains
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+          targets: x86_64-unknown-none
+
+      - name: Install stable toolchain for xtask
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86 mtools dosfstools zstd coreboot-utils
+
+      - name: Download CrabEFI ELF
+        uses: actions/download-artifact@v4
+        with:
+          name: crabefi-elf
+          path: target/x86_64-unknown-none/release/
+
+      - name: Download SCT assets
+        uses: actions/download-artifact@v4
+        with:
+          name: sct-assets-x86_64
+          path: sct-assets/x86_64/
+
+      - name: Run UEFI SCT smoke subset
+        run: ./crabefi test --app uefi-sct-smoke --sct-assets-dir sct-assets/x86_64 --disable-kvm --timeout 180
+
   # ── GRUB + Linux boot-chain ─────────────────────────────────────────
 
   build-boot-assets-x86_64:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,8 @@ jobs:
   build-sct-assets-x86_64:
     name: Build SCT Assets x86_64
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -339,6 +341,8 @@ jobs:
     name: Test x86_64 (UEFI SCT smoke)
     runs-on: ubuntu-latest
     needs: [build, build-sct-assets-x86_64]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ test-disk.img
 test-security-disk.img
 test/*.efi
 /boot-assets/
+/sct-assets/
 
 # IDE/Editor
 .idea/

--- a/ci/build-sct-assets.sh
+++ b/ci/build-sct-assets.sh
@@ -68,10 +68,15 @@ need_tool curl
 need_tool sha256sum
 need_tool 7z
 
+# Set to 1 by download_if_needed when a fresh copy was fetched.
+DOWNLOADED=0
+
 download_if_needed() {
   local url="$1"
   local dest="$2"
   local sha="$3"
+
+  DOWNLOADED=0
 
   if [[ -f "$dest" ]] && echo "$sha  $dest" | sha256sum -c >/dev/null 2>&1; then
     echo "Using cached $(basename "$dest")"
@@ -82,12 +87,16 @@ download_if_needed() {
   curl -L --retry 3 --fail -o "$dest.tmp" "$url"
   echo "$sha  $dest.tmp" | sha256sum -c
   mv "$dest.tmp" "$dest"
+  DOWNLOADED=1
 }
 
 download_if_needed "$SHELL_URL" "$OUT_DIR/$SHELL_FILE" "$SHELL_SHA256"
 download_if_needed "$SCT_URL" "$OUT_DIR/$SCT_ARCHIVE" "$SCT_SHA256"
+SCT_DOWNLOADED="$DOWNLOADED"
 
-if [[ ! -f "$OUT_DIR/SctPackageX64/X64/SCT.efi" ]]; then
+# Re-extract whenever the archive was (re)downloaded, otherwise a stale
+# SctPackageX64/ tree from a previous SCT_RELEASE/SHA would silently survive.
+if [[ "$SCT_DOWNLOADED" == "1" || ! -f "$OUT_DIR/SctPackageX64/X64/SCT.efi" ]]; then
   echo "Extracting $SCT_ARCHIVE"
   rm -rf "$OUT_DIR/SctPackageX64"
   7z x -y -o"$OUT_DIR" "$OUT_DIR/$SCT_ARCHIVE" >/dev/null

--- a/ci/build-sct-assets.sh
+++ b/ci/build-sct-assets.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Build/download UEFI SCT smoke-test assets for CrabEFI CI.
+#
+# This script intentionally consumes upstream prebuilt public artifacts instead
+# of building EDK2/SCT in CI:
+#   - tianocore/edk2-test UEFI SCT package
+#   - pbatard/UEFI-Shell EDK2 shell binary
+
+set -euo pipefail
+
+ARCH="x86_64"
+OUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --arch)
+      ARCH="$2"
+      shift 2
+      ;;
+    --output|--out-dir)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: ci/build-sct-assets.sh [--arch x86_64] [--output DIR]
+
+Downloads and verifies the prebuilt UEFI SCT package and EDK2 UEFI Shell used by
+`./crabefi test --app uefi-sct-smoke`.
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$ARCH" != "x86_64" ]]; then
+  echo "Only --arch x86_64 is currently supported for UEFI SCT smoke assets" >&2
+  exit 2
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/sct-assets/$ARCH}"
+mkdir -p "$OUT_DIR"
+
+SCT_RELEASE="edk2-test-stable202509"
+SCT_ARCHIVE="SctPackageX64.7z"
+SCT_URL="https://github.com/tianocore/edk2-test/releases/download/$SCT_RELEASE/$SCT_ARCHIVE"
+SCT_SHA256="0565fa59b608b7281e9d7da1c1a25713b98def85d0a8f57a31ce0b959b064d06"
+
+SHELL_RELEASE="26H1"
+SHELL_FILE="shellx64.efi"
+SHELL_URL="https://github.com/pbatard/UEFI-Shell/releases/download/$SHELL_RELEASE/$SHELL_FILE"
+SHELL_SHA256="4ea080ddd576117cd04f5c02d16712ea5d9249c0752214d8e4055e460d7b11e0"
+
+need_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required tool: $1" >&2
+    echo "Install it with nix develop, or on Ubuntu: sudo apt-get install curl p7zip-full" >&2
+    exit 1
+  fi
+}
+
+need_tool curl
+need_tool sha256sum
+need_tool 7z
+
+download_if_needed() {
+  local url="$1"
+  local dest="$2"
+  local sha="$3"
+
+  if [[ -f "$dest" ]] && echo "$sha  $dest" | sha256sum -c >/dev/null 2>&1; then
+    echo "Using cached $(basename "$dest")"
+    return
+  fi
+
+  echo "Downloading $url"
+  curl -L --retry 3 --fail -o "$dest.tmp" "$url"
+  echo "$sha  $dest.tmp" | sha256sum -c
+  mv "$dest.tmp" "$dest"
+}
+
+download_if_needed "$SHELL_URL" "$OUT_DIR/$SHELL_FILE" "$SHELL_SHA256"
+download_if_needed "$SCT_URL" "$OUT_DIR/$SCT_ARCHIVE" "$SCT_SHA256"
+
+if [[ ! -f "$OUT_DIR/SctPackageX64/X64/SCT.efi" ]]; then
+  echo "Extracting $SCT_ARCHIVE"
+  rm -rf "$OUT_DIR/SctPackageX64"
+  7z x -y -o"$OUT_DIR" "$OUT_DIR/$SCT_ARCHIVE" >/dev/null
+fi
+
+if [[ ! -f "$OUT_DIR/SctPackageX64/X64/SCT.efi" ]]; then
+  echo "SCT extraction did not produce $OUT_DIR/SctPackageX64/X64/SCT.efi" >&2
+  exit 1
+fi
+
+cat <<EOF
+UEFI SCT smoke assets ready:
+  $OUT_DIR/$SHELL_FILE
+  $OUT_DIR/SctPackageX64/X64/SCT.efi
+
+Run with:
+  ./crabefi test --app uefi-sct-smoke --sct-assets-dir ${OUT_DIR#$ROOT_DIR/} --disable-kvm --timeout 180
+EOF

--- a/crabefi-core/src/drivers/block.rs
+++ b/crabefi-core/src/drivers/block.rs
@@ -47,6 +47,8 @@ pub enum BlockError {
     NoMedia,
     /// Media has changed since last access
     MediaChanged,
+    /// Device does not support writes
+    WriteProtected,
 }
 
 impl core::fmt::Display for BlockError {
@@ -57,6 +59,7 @@ impl core::fmt::Display for BlockError {
             BlockError::OutOfRange => write!(f, "LBA out of range"),
             BlockError::NoMedia => write!(f, "no media present"),
             BlockError::MediaChanged => write!(f, "media changed"),
+            BlockError::WriteProtected => write!(f, "write protected"),
         }
     }
 }
@@ -123,11 +126,21 @@ pub trait BlockDevice {
     /// Ok(()) on success, Err(BlockError) on failure
     fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError>;
 
-    /// Validate parameters for a read operation
+    /// Write blocks to the device.
+    fn write_blocks(&mut self, _lba: u64, _count: u32, _buffer: &[u8]) -> Result<(), BlockError> {
+        Err(BlockError::WriteProtected)
+    }
+
+    /// Flush pending writes to stable media.
+    fn flush(&mut self) -> Result<(), BlockError> {
+        Ok(())
+    }
+
+    /// Validate parameters for a read or write operation
     ///
     /// Checks that the LBA range is within bounds and the buffer is large enough.
     /// Implementations should call this at the start of `read_blocks`.
-    fn validate_read(&self, lba: u64, count: u32, buffer: &[u8]) -> Result<(), BlockError> {
+    fn validate_io(&self, lba: u64, count: u32, buffer: &[u8]) -> Result<(), BlockError> {
         let info = self.info();
         if count == 0 {
             return Ok(());
@@ -148,6 +161,11 @@ pub trait BlockDevice {
     /// Read a single block (convenience method)
     fn read_block(&mut self, lba: u64, buffer: &mut [u8]) -> Result<(), BlockError> {
         self.read_blocks(lba, 1, buffer)
+    }
+
+    /// Write a single block.
+    fn write_block(&mut self, lba: u64, buffer: &[u8]) -> Result<(), BlockError> {
+        self.write_blocks(lba, 1, buffer)
     }
 }
 
@@ -189,7 +207,7 @@ impl NvmeBlockDevice {
                 block_size,
                 media_id,
                 removable: false, // NVMe is not removable
-                read_only: false,
+                read_only: true,
             },
         }
     }
@@ -211,7 +229,7 @@ impl BlockDevice for NvmeBlockDevice {
     }
 
     fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError> {
-        self.validate_read(lba, count, buffer)?;
+        self.validate_io(lba, count, buffer)?;
         // Safety: pointer valid for firmware lifetime; no overlapping &mut created
         let controller = unsafe {
             &mut *nvme::get_controller(self.controller_id).ok_or(BlockError::DeviceError)?
@@ -261,7 +279,7 @@ impl AhciBlockDevice {
                 block_size,
                 media_id,
                 removable: false, // SATA drives are generally not removable
-                read_only: false,
+                read_only: true,
             },
         }
     }
@@ -283,7 +301,7 @@ impl BlockDevice for AhciBlockDevice {
     }
 
     fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError> {
-        self.validate_read(lba, count, buffer)?;
+        self.validate_io(lba, count, buffer)?;
         // Safety: pointer valid for firmware lifetime; no overlapping &mut created
         let controller = unsafe {
             &mut *ahci::get_controller(self.controller_id).ok_or(BlockError::DeviceError)?
@@ -355,12 +373,23 @@ impl BlockDevice for UsbBlockDevice {
     }
 
     fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError> {
-        self.validate_read(lba, count, buffer)?;
+        self.validate_io(lba, count, buffer)?;
         // Read all sectors in a single call — global_read_sectors supports
         // multi-sector reads by inferring sector count from buffer size.
         let total_bytes = count as usize * self.info.block_size as usize;
         usb::mass_storage::global_read_sectors(lba, &mut buffer[..total_bytes])
             .map_err(|()| BlockError::DeviceError)
+    }
+
+    fn write_blocks(&mut self, lba: u64, count: u32, buffer: &[u8]) -> Result<(), BlockError> {
+        self.validate_io(lba, count, buffer)?;
+        let total_bytes = count as usize * self.info.block_size as usize;
+        usb::mass_storage::global_write_sectors(lba, &buffer[..total_bytes])
+            .map_err(|()| BlockError::DeviceError)
+    }
+
+    fn flush(&mut self) -> Result<(), BlockError> {
+        usb::mass_storage::global_flush().map_err(|()| BlockError::DeviceError)
     }
 }
 
@@ -403,7 +432,7 @@ impl SdhciBlockDevice {
                 block_size,
                 media_id,
                 removable,
-                read_only: false,
+                read_only: true,
             },
         }
     }
@@ -420,7 +449,7 @@ impl BlockDevice for SdhciBlockDevice {
     }
 
     fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError> {
-        self.validate_read(lba, count, buffer)?;
+        self.validate_io(lba, count, buffer)?;
         // Safety: pointer valid for firmware lifetime; no overlapping &mut created
         let controller = unsafe {
             &mut *sdhci::get_controller(self.controller_id).ok_or(BlockError::DeviceError)?
@@ -460,7 +489,7 @@ impl<'a> BlockDevice for NvmeDisk<'a> {
                 block_size: ns.block_size,
                 media_id: 0,
                 removable: false,
-                read_only: false,
+                read_only: true,
             }
         } else {
             BlockDeviceInfo {
@@ -474,7 +503,7 @@ impl<'a> BlockDevice for NvmeDisk<'a> {
     }
 
     fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError> {
-        self.validate_read(lba, count, buffer)?;
+        self.validate_io(lba, count, buffer)?;
         self.controller
             .read_sectors(self.nsid, lba, count, buffer.as_mut_ptr())
             .map_err(BlockError::from)
@@ -505,7 +534,7 @@ impl<'a> BlockDevice for AhciDisk<'a> {
                 block_size: port_info.sector_size,
                 media_id: 0,
                 removable: false,
-                read_only: false,
+                read_only: true,
             }
         } else {
             BlockDeviceInfo {
@@ -519,7 +548,7 @@ impl<'a> BlockDevice for AhciDisk<'a> {
     }
 
     fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError> {
-        self.validate_read(lba, count, buffer)?;
+        self.validate_io(lba, count, buffer)?;
         // Safety: buffer.as_mut_ptr() is valid for buffer.len() bytes
         unsafe {
             self.controller
@@ -560,7 +589,7 @@ impl<'a> BlockDevice for UsbDisk<'a> {
     }
 
     fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError> {
-        self.validate_read(lba, count, buffer)?;
+        self.validate_io(lba, count, buffer)?;
         self.device
             .read_sectors_generic(self.controller, lba, count, buffer)
             .map_err(BlockError::from)
@@ -589,12 +618,12 @@ impl<'a> BlockDevice for SdhciDisk<'a> {
             block_size: self.controller.block_size(),
             media_id: 0,
             removable: self.controller.removable(),
-            read_only: false,
+            read_only: true,
         }
     }
 
     fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError> {
-        self.validate_read(lba, count, buffer)?;
+        self.validate_io(lba, count, buffer)?;
         self.controller
             .read_sectors(lba, count, buffer.as_mut_ptr())
             .map_err(BlockError::from)
@@ -636,6 +665,22 @@ impl BlockDevice for AnyBlockDevice {
             AnyBlockDevice::Ahci(dev) => dev.read_blocks(lba, count, buffer),
             AnyBlockDevice::Usb(dev) => dev.read_blocks(lba, count, buffer),
             AnyBlockDevice::Sdhci(dev) => dev.read_blocks(lba, count, buffer),
+        }
+    }
+
+    fn write_blocks(&mut self, lba: u64, count: u32, buffer: &[u8]) -> Result<(), BlockError> {
+        match self {
+            AnyBlockDevice::Nvme(dev) => dev.write_blocks(lba, count, buffer),
+            AnyBlockDevice::Ahci(dev) => dev.write_blocks(lba, count, buffer),
+            AnyBlockDevice::Usb(dev) => dev.write_blocks(lba, count, buffer),
+            AnyBlockDevice::Sdhci(dev) => dev.write_blocks(lba, count, buffer),
+        }
+    }
+
+    fn flush(&mut self) -> Result<(), BlockError> {
+        match self {
+            AnyBlockDevice::Usb(dev) => dev.flush(),
+            _ => Ok(()),
         }
     }
 }

--- a/crabefi-core/src/drivers/usb/mass_storage.rs
+++ b/crabefi-core/src/drivers/usb/mass_storage.rs
@@ -378,6 +378,34 @@ impl UsbMassStorage {
         data: Option<&mut [u8]>,
         is_read: bool,
     ) -> Result<usize, MassStorageError> {
+        self.scsi_command_inner(controller, cdb, data, is_read, false)
+    }
+
+    /// Same as [`Self::scsi_command`], but treats a short transfer (or a
+    /// non-zero CSW residue) as a phase error.
+    ///
+    /// Only block transfer commands (READ/WRITE) may use this: commands that
+    /// carry a SCSI *allocation length* (INQUIRY, READ CAPACITY(16), SECURITY
+    /// PROTOCOL IN, ...) are allowed to return fewer bytes than requested with
+    /// a `PASSED` status.
+    fn scsi_command_exact(
+        &mut self,
+        controller: &mut dyn UsbController,
+        cdb: &[u8],
+        data: Option<&mut [u8]>,
+        is_read: bool,
+    ) -> Result<usize, MassStorageError> {
+        self.scsi_command_inner(controller, cdb, data, is_read, true)
+    }
+
+    fn scsi_command_inner(
+        &mut self,
+        controller: &mut dyn UsbController,
+        cdb: &[u8],
+        data: Option<&mut [u8]>,
+        is_read: bool,
+        require_full_transfer: bool,
+    ) -> Result<usize, MassStorageError> {
         let data_len = data.as_ref().map(|d| d.len()).unwrap_or(0);
 
         // Build CBW
@@ -539,7 +567,7 @@ impl UsbMassStorage {
 
         match csw_stat {
             csw_status::PASSED if transferred == data_len && csw_residue == 0 => Ok(transferred),
-            csw_status::PASSED => {
+            csw_status::PASSED if require_full_transfer => {
                 log::debug!(
                     "USB SCSI: Short data transfer: got {}, expected {}, residue {}",
                     transferred,
@@ -547,6 +575,20 @@ impl UsbMassStorage {
                     csw_residue
                 );
                 Err(MassStorageError::PhaseError)
+            }
+            csw_status::PASSED => {
+                // Allocation-length commands may legitimately return less data
+                // than requested; report what the device actually delivered.
+                let received = data_len
+                    .saturating_sub(csw_residue as usize)
+                    .min(transferred);
+                log::trace!(
+                    "USB SCSI: Short data transfer accepted: got {}, expected {}, residue {}",
+                    transferred,
+                    data_len,
+                    csw_residue
+                );
+                Ok(received)
             }
             csw_status::FAILED => {
                 log::debug!("USB SCSI: Command {:#04x} failed (CSW status=1)", cdb[0]);
@@ -788,7 +830,7 @@ impl UsbMassStorage {
         ];
 
         let transfer_len = count as usize * self.block_size as usize;
-        self.scsi_command(controller, &cdb, Some(&mut buffer[..transfer_len]), true)?;
+        self.scsi_command_exact(controller, &cdb, Some(&mut buffer[..transfer_len]), true)?;
 
         Ok(())
     }
@@ -824,7 +866,7 @@ impl UsbMassStorage {
         ];
 
         let transfer_len = count as usize * self.block_size as usize;
-        self.scsi_command(controller, &cdb, Some(&mut buffer[..transfer_len]), true)?;
+        self.scsi_command_exact(controller, &cdb, Some(&mut buffer[..transfer_len]), true)?;
 
         Ok(())
     }
@@ -838,8 +880,14 @@ impl UsbMassStorage {
         buffer: &[u8],
     ) -> Result<(), MassStorageError> {
         let block_size = self.block_size as usize;
+        // `scratch` below is a fixed MAX_BYTES_PER_CMD buffer and
+        // `sectors_per_cmd` is clamped to at least one sector, so a device
+        // reporting an oversized block size must be rejected up front.
+        if block_size == 0 || block_size > Self::MAX_BYTES_PER_CMD {
+            return Err(MassStorageError::InvalidParameter);
+        }
         let required = num_sectors as usize * block_size;
-        if buffer.len() < required || block_size == 0 {
+        if buffer.len() < required {
             return Err(MassStorageError::InvalidParameter);
         }
 
@@ -908,7 +956,7 @@ impl UsbMassStorage {
             count[1],
             0,
         ];
-        self.scsi_command(controller, &cdb, Some(buffer), false)?;
+        self.scsi_command_exact(controller, &cdb, Some(buffer), false)?;
         Ok(())
     }
 
@@ -925,7 +973,7 @@ impl UsbMassStorage {
             0x8a, 0, lba[0], lba[1], lba[2], lba[3], lba[4], lba[5], lba[6], lba[7], count[0],
             count[1], count[2], count[3], 0, 0,
         ];
-        self.scsi_command(controller, &cdb, Some(buffer), false)?;
+        self.scsi_command_exact(controller, &cdb, Some(buffer), false)?;
         Ok(())
     }
 

--- a/crabefi-core/src/drivers/usb/mass_storage.rs
+++ b/crabefi-core/src/drivers/usb/mass_storage.rs
@@ -892,18 +892,13 @@ impl UsbMassStorage {
         }
 
         let sectors_per_cmd = (Self::MAX_BYTES_PER_CMD / block_size).max(1) as u32;
+        let chunk_bytes = sectors_per_cmd as usize * block_size;
         let mut scratch = [0u8; Self::MAX_BYTES_PER_CMD];
-        let mut lba = start_lba;
-        let mut remaining = num_sectors;
-        let mut offset = 0;
-        while remaining > 0 {
-            let count = remaining.min(sectors_per_cmd);
-            let len = count as usize * block_size;
-            scratch[..len].copy_from_slice(&buffer[offset..offset + len]);
-            self.write_sectors_with_retry(controller, lba, count, &mut scratch[..len])?;
-            lba += count as u64;
-            remaining -= count;
-            offset += len;
+        for (index, chunk) in buffer[..required].chunks(chunk_bytes).enumerate() {
+            let count = (chunk.len() / block_size) as u32;
+            let lba = start_lba + index as u64 * sectors_per_cmd as u64;
+            scratch[..chunk.len()].copy_from_slice(chunk);
+            self.write_sectors_with_retry(controller, lba, count, &mut scratch[..chunk.len()])?;
         }
         Ok(())
     }

--- a/crabefi-core/src/drivers/usb/mass_storage.rs
+++ b/crabefi-core/src/drivers/usb/mass_storage.rs
@@ -465,12 +465,24 @@ impl UsbMassStorage {
             Err(e) => Err(e),
         };
 
-        if let Err(e) = csw_result {
-            log::debug!("USB SCSI: CSW transfer failed: {:?}", e);
-            // CSW transfer failed even after retry — perform full reset recovery
+        let csw_len = match csw_result {
+            Ok(len) => len,
+            Err(e) => {
+                log::debug!("USB SCSI: CSW transfer failed: {:?}", e);
+                // CSW transfer failed even after retry — perform full reset recovery
+                self.bot_reset_recovery(controller);
+                // Return the original data phase error if there was one
+                return Err(MassStorageError::Usb(data_phase_error.unwrap_or(e)));
+            }
+        };
+        if csw_len != csw_buf.len() {
+            log::debug!(
+                "USB SCSI: Short CSW transfer: got {} expected {}",
+                csw_len,
+                csw_buf.len()
+            );
             self.bot_reset_recovery(controller);
-            // Return the original data phase error if there was one
-            return Err(MassStorageError::Usb(data_phase_error.unwrap_or(e)));
+            return Err(MassStorageError::InvalidCsw);
         }
 
         // Parse CSW using zerocopy
@@ -526,7 +538,16 @@ impl UsbMassStorage {
         }
 
         match csw_stat {
-            csw_status::PASSED => Ok(transferred),
+            csw_status::PASSED if transferred == data_len && csw_residue == 0 => Ok(transferred),
+            csw_status::PASSED => {
+                log::debug!(
+                    "USB SCSI: Short data transfer: got {}, expected {}, residue {}",
+                    transferred,
+                    data_len,
+                    csw_residue
+                );
+                Err(MassStorageError::PhaseError)
+            }
             csw_status::FAILED => {
                 log::debug!("USB SCSI: Command {:#04x} failed (CSW status=1)", cdb[0]);
                 Err(MassStorageError::CommandFailed)
@@ -808,6 +829,115 @@ impl UsbMassStorage {
         Ok(())
     }
 
+    /// Write sectors with the same bounded transfer size and recovery used for reads.
+    pub fn write_sectors_generic(
+        &mut self,
+        controller: &mut dyn UsbController,
+        start_lba: u64,
+        num_sectors: u32,
+        buffer: &[u8],
+    ) -> Result<(), MassStorageError> {
+        let block_size = self.block_size as usize;
+        let required = num_sectors as usize * block_size;
+        if buffer.len() < required || block_size == 0 {
+            return Err(MassStorageError::InvalidParameter);
+        }
+
+        let sectors_per_cmd = (Self::MAX_BYTES_PER_CMD / block_size).max(1) as u32;
+        let mut scratch = [0u8; Self::MAX_BYTES_PER_CMD];
+        let mut lba = start_lba;
+        let mut remaining = num_sectors;
+        let mut offset = 0;
+        while remaining > 0 {
+            let count = remaining.min(sectors_per_cmd);
+            let len = count as usize * block_size;
+            scratch[..len].copy_from_slice(&buffer[offset..offset + len]);
+            self.write_sectors_with_retry(controller, lba, count, &mut scratch[..len])?;
+            lba += count as u64;
+            remaining -= count;
+            offset += len;
+        }
+        Ok(())
+    }
+
+    fn write_sectors_with_retry(
+        &mut self,
+        controller: &mut dyn UsbController,
+        lba: u64,
+        count: u32,
+        buffer: &mut [u8],
+    ) -> Result<(), MassStorageError> {
+        let mut last_error = MassStorageError::NotReady;
+        for attempt in 0..=Self::MAX_READ_RETRIES {
+            let result = if lba + count as u64 <= u32::MAX as u64 && count <= u16::MAX as u32 {
+                self.write_10(controller, lba as u32, count as u16, buffer)
+            } else {
+                self.write_16(controller, lba, count, buffer)
+            };
+            match result {
+                Ok(()) => return Ok(()),
+                Err(error) => {
+                    last_error = error;
+                    if attempt < Self::MAX_READ_RETRIES {
+                        time::delay_ms(10);
+                    }
+                }
+            }
+        }
+        Err(last_error)
+    }
+
+    fn write_10(
+        &mut self,
+        controller: &mut dyn UsbController,
+        lba: u32,
+        count: u16,
+        buffer: &mut [u8],
+    ) -> Result<(), MassStorageError> {
+        let lba = lba.to_be_bytes();
+        let count = count.to_be_bytes();
+        let cdb = [
+            scsi_cmd::WRITE_10,
+            0,
+            lba[0],
+            lba[1],
+            lba[2],
+            lba[3],
+            0,
+            count[0],
+            count[1],
+            0,
+        ];
+        self.scsi_command(controller, &cdb, Some(buffer), false)?;
+        Ok(())
+    }
+
+    fn write_16(
+        &mut self,
+        controller: &mut dyn UsbController,
+        lba: u64,
+        count: u32,
+        buffer: &mut [u8],
+    ) -> Result<(), MassStorageError> {
+        let lba = lba.to_be_bytes();
+        let count = count.to_be_bytes();
+        let cdb = [
+            0x8a, 0, lba[0], lba[1], lba[2], lba[3], lba[4], lba[5], lba[6], lba[7], count[0],
+            count[1], count[2], count[3], 0, 0,
+        ];
+        self.scsi_command(controller, &cdb, Some(buffer), false)?;
+        Ok(())
+    }
+
+    pub fn synchronize_cache(
+        &mut self,
+        controller: &mut dyn UsbController,
+    ) -> Result<(), MassStorageError> {
+        let cdb = [0x35, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        self.scsi_command(controller, &cdb, None, false)?;
+        Ok(())
+    }
+
     /// Get the device address (slot ID for xHCI, device address for others)
     pub fn device_addr(&self) -> u8 {
         self.device_addr
@@ -1067,20 +1197,21 @@ pub fn with_global_device<R>(f: impl FnOnce(&mut UsbMassStorage) -> R) -> Option
 /// This function can be used as the read callback for the SimpleFileSystem protocol.
 /// It uses the stored controller pointer directly to avoid lock contention.
 /// Supports reading multiple sectors in a single SCSI command for performance.
+fn global_device() -> Result<(*mut UsbMassStorage, *mut dyn UsbController), ()> {
+    let guard = GLOBAL_USB_STATE.lock();
+    guard
+        .as_ref()
+        .map(|state| (state.device_ptr, state.controller_ptr))
+        .ok_or(())
+}
+
 pub fn global_read_sectors(lba: u64, buffer: &mut [u8]) -> Result<(), ()> {
     log::trace!("USB mass storage: read LBA {}", lba);
 
     // Get the device and controller pointers (release lock immediately)
-    let (device_ptr, controller_ptr) = {
-        let guard = GLOBAL_USB_STATE.lock();
-        match guard.as_ref() {
-            Some(state) => (state.device_ptr, state.controller_ptr),
-            None => {
-                log::error!("USB mass storage: no device configured");
-                return Err(());
-            }
-        }
-    };
+    let (device_ptr, controller_ptr) = global_device().map_err(|()| {
+        log::error!("USB mass storage: no device configured");
+    })?;
 
     // Safety: Pointers were set up during store_global_device and remain valid
     // for the entire boot process (memory is allocated via efi::allocate_pages)
@@ -1102,4 +1233,26 @@ pub fn global_read_sectors(lba: u64, buffer: &mut [u8]) -> Result<(), ()> {
         );
     }
     result.map_err(|_| ())
+}
+
+pub fn global_write_sectors(lba: u64, buffer: &[u8]) -> Result<(), ()> {
+    let (device_ptr, controller_ptr) = global_device()?;
+    let device = unsafe { &mut *device_ptr };
+    let controller = unsafe { &mut *controller_ptr };
+    let block_size = device.block_size as usize;
+    if block_size == 0 || !buffer.len().is_multiple_of(block_size) {
+        return Err(());
+    }
+    device
+        .write_sectors_generic(controller, lba, (buffer.len() / block_size) as u32, buffer)
+        .map_err(|error| {
+            log::error!("USB mass storage write failed at LBA {}: {:?}", lba, error);
+        })
+}
+
+pub fn global_flush() -> Result<(), ()> {
+    let (device_ptr, controller_ptr) = global_device()?;
+    unsafe { (&mut *device_ptr).synchronize_cache(&mut *controller_ptr) }.map_err(|error| {
+        log::error!("USB mass storage cache flush failed: {:?}", error);
+    })
 }

--- a/crabefi-core/src/efi/allocator.rs
+++ b/crabefi-core/src/efi/allocator.rs
@@ -1702,6 +1702,12 @@ pub fn allocate_pool(memory_type: MemoryType, size: usize) -> Result<*mut u8, ef
 }
 
 /// Return a pool block to the reusable free list.
+///
+/// `buffer` must be a pointer previously returned by [`allocate_pool`]; this
+/// mirrors the `EFI_BOOT_SERVICES.FreePool` contract, so the function stays
+/// safe to call from the protocol thunk. Bogus pointers are rejected by the
+/// header magic check below whenever the memory is readable.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn free_pool(buffer: *mut u8) -> efi::Status {
     if buffer.is_null() {
         return efi::Status::INVALID_PARAMETER;
@@ -1716,6 +1722,9 @@ pub fn free_pool(buffer: *mut u8) -> efi::Status {
     }
     let block_size = unsafe { (*header).block_size };
     let memory_type = unsafe { (*header).memory_type };
+    // Invalidate the magic before the block re-enters the free list so a double
+    // free is rejected above instead of corrupting the list into a cycle.
+    unsafe { (*header).magic = 0 };
     unsafe { insert_pool_block(header.cast::<u8>(), block_size, memory_type) };
     efi::Status::SUCCESS
 }

--- a/crabefi-core/src/efi/allocator.rs
+++ b/crabefi-core/src/efi/allocator.rs
@@ -15,7 +15,13 @@ use r_efi::efi;
 
 /// Maximum number of memory map entries we can track
 /// Windows bootloader can create many small allocations, so we need a large buffer
-const MAX_MEMORY_ENTRIES: usize = 512;
+// SCT loads dozens of PE/COFF images whose code/data sections legitimately
+// create more than 1024 live descriptors. The map is compacted after each
+// mutation, so this bound covers real live regions rather than stale splits.
+const MAX_MEMORY_ENTRIES: usize = 2048;
+// AllocatePool currently uses page-granular backing, and SCT keeps several
+// thousand small pool allocations live while registering its test catalog.
+const MAX_PAGE_ALLOCATIONS: usize = 8192;
 
 /// Page size (4KB)
 pub const PAGE_SIZE: u64 = 4096;
@@ -220,10 +226,18 @@ impl MemoryDescriptor {
     }
 }
 
+#[derive(Clone, Copy)]
+struct PageAllocation {
+    physical_start: u64,
+    number_of_pages: u64,
+}
+
 /// Memory allocator state
 pub struct MemoryAllocator {
     /// Memory map entries, sorted by physical address (ascending)
     entries: Vec<MemoryDescriptor, MAX_MEMORY_ENTRIES>,
+    /// Exact page allocations, retained even when adjacent map descriptors merge.
+    allocations: Vec<PageAllocation, MAX_PAGE_ALLOCATIONS>,
     /// Memory map key (incremented on every change)
     map_key: usize,
     /// Whether boot services have exited
@@ -241,6 +255,7 @@ impl MemoryAllocator {
     pub const fn new() -> Self {
         Self {
             entries: Vec::new(),
+            allocations: Vec::new(),
             map_key: 1,
             boot_services_exited: false,
         }
@@ -262,6 +277,7 @@ impl MemoryAllocator {
         use crate::platform::MemoryType as PlatMemType;
 
         self.entries.clear();
+        self.allocations.clear();
         self.map_key = 1;
 
         log::info!("Importing platform memory map ({} regions):", regions.len());
@@ -579,6 +595,9 @@ impl MemoryAllocator {
         if self.boot_services_exited {
             return efi::Status::UNSUPPORTED;
         }
+        if self.allocations.is_full() {
+            return efi::Status::OUT_OF_RESOURCES;
+        }
 
         // Check for overflow in size calculation
         let size = match num_pages.checked_mul(PAGE_SIZE) {
@@ -592,6 +611,10 @@ impl MemoryAllocator {
                 if let Some(addr) = self.find_free_pages(num_pages, u64::MAX) {
                     match self.carve_out(addr, num_pages, memory_type) {
                         Ok(()) => {
+                            let _ = self.allocations.push(PageAllocation {
+                                physical_start: addr,
+                                number_of_pages: num_pages,
+                            });
                             *memory = addr;
                             efi::Status::SUCCESS
                         }
@@ -607,6 +630,10 @@ impl MemoryAllocator {
                 if let Some(addr) = self.find_free_pages(num_pages, max_addr) {
                     match self.carve_out(addr, num_pages, memory_type) {
                         Ok(()) => {
+                            let _ = self.allocations.push(PageAllocation {
+                                physical_start: addr,
+                                number_of_pages: num_pages,
+                            });
                             *memory = addr;
                             efi::Status::SUCCESS
                         }
@@ -626,7 +653,13 @@ impl MemoryAllocator {
                 // Check if the region is available (ConventionalMemory)
                 if self.is_region_free(addr, size) {
                     match self.carve_out(addr, num_pages, memory_type) {
-                        Ok(()) => efi::Status::SUCCESS,
+                        Ok(()) => {
+                            let _ = self.allocations.push(PageAllocation {
+                                physical_start: addr,
+                                number_of_pages: num_pages,
+                            });
+                            efi::Status::SUCCESS
+                        }
                         Err(status) => status,
                     }
                 } else {
@@ -656,35 +689,92 @@ impl MemoryAllocator {
         if self.boot_services_exited {
             return efi::Status::UNSUPPORTED;
         }
+        let Some(allocation_index) = self.allocations.iter().position(|allocation| {
+            allocation.physical_start == memory && allocation.number_of_pages == num_pages
+        }) else {
+            return efi::Status::NOT_FOUND;
+        };
 
-        // Find the entry containing this allocation
-        let found_idx = self.entries.iter().position(|entry| {
-            entry.physical_start == memory
-                && entry.number_of_pages == num_pages
-                && entry
-                    .get_memory_type()
-                    .is_some_and(|mt| mt.is_boot_services() || mt == MemoryType::ConventionalMemory)
-        });
+        let size = match num_pages.checked_mul(PAGE_SIZE) {
+            Some(size) => size,
+            None => return efi::Status::INVALID_PARAMETER,
+        };
+        let end = match memory.checked_add(size) {
+            Some(end) => end,
+            None => return efi::Status::INVALID_PARAMETER,
+        };
 
-        if let Some(idx) = found_idx {
-            // Change the type back to conventional memory
-            self.entries[idx].memory_type = MemoryType::ConventionalMemory as u32;
-            self.map_key += 1;
-            // Don't merge here - merging should only happen at ExitBootServices
-            // to keep the memory map clean for the OS. Merging during normal
-            // operation breaks subsequent free_pages calls that need exact matches.
-            efi::Status::SUCCESS
-        } else {
-            efi::Status::NOT_FOUND
+        // Allocations of the same type may have been merged to keep the map
+        // compact, so accept an exact subrange of a boot-services descriptor.
+        let Some(idx) = self.entries.iter().position(|entry| {
+            entry
+                .get_memory_type()
+                .is_some_and(|memory_type| memory_type.is_boot_services())
+                && entry.physical_start <= memory
+                && entry.end() >= end
+        }) else {
+            return efi::Status::NOT_FOUND;
+        };
+
+        let entry = self.entries[idx];
+        let need_before = entry.physical_start < memory;
+        let need_after = entry.end() > end;
+        let new_entries_needed = 1 + need_before as usize + need_after as usize;
+        if self.entries.len() + new_entries_needed - 1 > MAX_MEMORY_ENTRIES {
+            return efi::Status::OUT_OF_RESOURCES;
         }
+
+        self.entries.remove(idx);
+        let mut insert_at = idx;
+        if need_before {
+            let before_pages = (memory - entry.physical_start) / PAGE_SIZE;
+            let _ = self.entries.insert(
+                insert_at,
+                MemoryDescriptor::new(
+                    entry.get_memory_type().unwrap(),
+                    entry.physical_start,
+                    before_pages,
+                    entry.attribute,
+                ),
+            );
+            insert_at += 1;
+        }
+        let conventional_index = insert_at;
+        let _ = self.entries.insert(
+            insert_at,
+            MemoryDescriptor::new(
+                MemoryType::ConventionalMemory,
+                memory,
+                num_pages,
+                entry.attribute,
+            ),
+        );
+        insert_at += 1;
+        if need_after {
+            let after_pages = (entry.end() - end) / PAGE_SIZE;
+            let _ = self.entries.insert(
+                insert_at,
+                MemoryDescriptor::new(
+                    entry.get_memory_type().unwrap(),
+                    end,
+                    after_pages,
+                    entry.attribute,
+                ),
+            );
+        }
+
+        self.allocations.swap_remove(allocation_index);
+        self.map_key += 1;
+        self.merge_near(conventional_index);
+        efi::Status::SUCCESS
     }
 
     /// Get the current memory map
     ///
     /// Adjacent entries with the same type and attributes are merged in the
-    /// output to produce a compact map. The internal entry list is NOT modified
-    /// (free_pages needs exact entries), so merging is done on the fly when
-    /// copying into the caller's buffer.
+    /// output to produce a compact map. The internal map is also kept compact;
+    /// this output pass protects against any adjacent entries introduced by
+    /// platform map construction.
     pub fn get_memory_map(
         &self,
         memory_map_size: &mut usize,
@@ -1049,20 +1139,12 @@ impl MemoryAllocator {
             memory_type
         );
 
-        // Calculate how many new entries we need
-        let need_before = entry.physical_start < addr;
-        let need_after = entry.end() > end;
-        let new_entries_needed = 1 + need_before as usize + need_after as usize;
-
-        // Check if we have space BEFORE modifying
-        let entries_after_op = self.entries.len() + new_entries_needed - 1;
-        let idx = if entries_after_op > MAX_MEMORY_ENTRIES {
+        // Check whether a split might need more map capacity. If compaction is
+        // required, re-find and fully recompute the containing descriptor.
+        let initial_new_entries =
+            1 + (entry.physical_start < addr) as usize + (entry.end() > end) as usize;
+        let idx = if self.entries.len() + initial_new_entries - 1 > MAX_MEMORY_ENTRIES {
             self.merge_entries();
-            if self.entries.len() + new_entries_needed - 1 > MAX_MEMORY_ENTRIES {
-                log::warn!("Memory map full, cannot split loader region");
-                return false;
-            }
-            // Re-find the entry after merging since indices may have changed
             match self.entries.iter().position(|entry| {
                 let is_loader = matches!(
                     entry.get_memory_type(),
@@ -1077,36 +1159,44 @@ impl MemoryAllocator {
             idx
         };
 
-        // Re-read the entry in case merge changed the index
         let entry = self.entries[idx];
+        let Some(original_type) = entry.get_memory_type() else {
+            return false;
+        };
+        let need_before = entry.physical_start < addr;
+        let need_after = entry.end() > end;
+        let new_entries_needed = 1 + need_before as usize + need_after as usize;
+        if self.entries.len() + new_entries_needed - 1 > MAX_MEMORY_ENTRIES {
+            log::warn!("Memory map full, cannot split loader region");
+            return false;
+        }
         let attribute = entry.attribute;
 
         // Remove the old entry
         self.entries.remove(idx);
 
-        // Add region before the new allocation (keep original type)
+        let mut insert_at = idx;
         if need_before {
             let before_pages = (addr - entry.physical_start) / PAGE_SIZE;
             let before =
                 MemoryDescriptor::new(original_type, entry.physical_start, before_pages, attribute);
-            let _ = self.entries.push(before);
+            let _ = self.entries.insert(insert_at, before);
+            insert_at += 1;
         }
 
-        // Add the newly allocated region
+        let new_region_index = insert_at;
         let new_region = MemoryDescriptor::new(memory_type, addr, num_pages, attribute);
-        let _ = self.entries.push(new_region);
+        let _ = self.entries.insert(insert_at, new_region);
+        insert_at += 1;
 
-        // Add region after the new allocation (keep original type)
         if need_after {
             let after_pages = (entry.end() - end) / PAGE_SIZE;
             let after = MemoryDescriptor::new(original_type, end, after_pages, attribute);
-            let _ = self.entries.push(after);
+            let _ = self.entries.insert(insert_at, after);
         }
 
         self.map_key += 1;
-        self.sort_entries();
-        // Don't merge here - merging breaks subsequent free_pages calls
-        // that need exact matches. Merge only at ExitBootServices.
+        self.merge_near(new_region_index);
         true
     }
 
@@ -1159,30 +1249,10 @@ impl MemoryAllocator {
 
         let idx = found_idx.ok_or(efi::Status::NOT_FOUND)?;
         let entry = self.entries[idx];
-        let original_type = entry
-            .get_memory_type()
-            .unwrap_or(MemoryType::ReservedMemoryType);
-
-        // Calculate how many new entries we need (1-3: before?, carved, after?)
-        let need_before = entry.physical_start < addr;
-        let need_after = entry.end() > end;
-        let new_entries_needed = 1 + need_before as usize + need_after as usize;
-
-        // Check if we have space BEFORE modifying anything
-        // We remove 1 entry and add new_entries_needed, so net change is new_entries_needed - 1
-        let entries_after_op = self.entries.len() + new_entries_needed - 1;
-        let idx = if entries_after_op > MAX_MEMORY_ENTRIES {
-            // Try to make room by merging first
+        let initial_new_entries =
+            1 + (entry.physical_start < addr) as usize + (entry.end() > end) as usize;
+        let idx = if self.entries.len() + initial_new_entries - 1 > MAX_MEMORY_ENTRIES {
             self.merge_entries();
-            let entries_after_merge = self.entries.len() + new_entries_needed - 1;
-            if entries_after_merge > MAX_MEMORY_ENTRIES {
-                log::warn!(
-                    "Memory map full ({} entries), cannot carve out region",
-                    self.entries.len()
-                );
-                return Err(efi::Status::OUT_OF_RESOURCES);
-            }
-            // Re-find the entry after merging since indices may have changed
             self.entries
                 .iter()
                 .position(|entry| {
@@ -1196,6 +1266,21 @@ impl MemoryAllocator {
         } else {
             idx
         };
+
+        let entry = self.entries[idx];
+        let original_type = entry
+            .get_memory_type()
+            .unwrap_or(MemoryType::ReservedMemoryType);
+        let need_before = entry.physical_start < addr;
+        let need_after = entry.end() > end;
+        let new_entries_needed = 1 + need_before as usize + need_after as usize;
+        if self.entries.len() + new_entries_needed - 1 > MAX_MEMORY_ENTRIES {
+            log::warn!(
+                "Memory map full ({} entries), cannot carve out region",
+                self.entries.len()
+            );
+            return Err(efi::Status::OUT_OF_RESOURCES);
+        }
 
         // Now safe to remove the old entry
         self.entries.remove(idx);
@@ -1215,38 +1300,32 @@ impl MemoryAllocator {
             attribute |= attributes::EFI_MEMORY_XP;
         }
 
-        // Region before the carved out portion (keep original type)
+        let mut insert_at = idx;
         if need_before {
             let before_pages = (addr - entry.physical_start) / PAGE_SIZE;
             let before = MemoryDescriptor::new(
                 original_type,
                 entry.physical_start,
                 before_pages,
-                entry.attribute, // Use original attribute
+                entry.attribute,
             );
-            let _ = self.entries.push(before); // We pre-checked space
+            let _ = self.entries.insert(insert_at, before);
+            insert_at += 1;
         }
 
-        // The carved out region
+        let carved_index = insert_at;
         let carved = MemoryDescriptor::new(memory_type, addr, num_pages, attribute);
-        let _ = self.entries.push(carved); // We pre-checked space
+        let _ = self.entries.insert(insert_at, carved);
+        insert_at += 1;
 
-        // Region after the carved out portion (keep original type)
         if need_after {
             let after_pages = (entry.end() - end) / PAGE_SIZE;
-            let after = MemoryDescriptor::new(
-                original_type,
-                end,
-                after_pages,
-                entry.attribute, // Use original attribute
-            );
-            let _ = self.entries.push(after); // We pre-checked space
+            let after = MemoryDescriptor::new(original_type, end, after_pages, entry.attribute);
+            let _ = self.entries.insert(insert_at, after);
         }
 
         self.map_key += 1;
-        self.sort_entries();
-        // Don't merge here - merging breaks subsequent free_pages calls
-        // that need exact matches. Merge only at ExitBootServices.
+        self.merge_near(carved_index);
 
         Ok(())
     }
@@ -1256,6 +1335,27 @@ impl MemoryAllocator {
         self.entries
             .as_mut_slice()
             .sort_unstable_by_key(|entry| entry.physical_start);
+    }
+
+    /// Merge entries around a recently replaced descriptor while preserving sort order.
+    fn merge_near(&mut self, index: usize) {
+        if self.entries.len() < 2 {
+            return;
+        }
+        let mut current = index.saturating_sub(2);
+        let mut limit = (index + 3).min(self.entries.len() - 1);
+        while current < self.entries.len() - 1 && current <= limit {
+            if self.entries[current].end() == self.entries[current + 1].physical_start
+                && self.entries[current].memory_type == self.entries[current + 1].memory_type
+                && self.entries[current].attribute == self.entries[current + 1].attribute
+            {
+                self.entries[current].number_of_pages += self.entries[current + 1].number_of_pages;
+                self.entries.remove(current + 1);
+                limit = limit.saturating_sub(1).min(self.entries.len() - 1);
+            } else {
+                current += 1;
+            }
+        }
     }
 
     /// Merge adjacent entries of the same type and attributes
@@ -1431,79 +1531,193 @@ pub fn exit_boot_services(map_key: usize) -> efi::Status {
     state::with_allocator_mut(|alloc| alloc.exit_boot_services(map_key))
 }
 
-/// Pool allocation header (for AllocatePool/FreePool)
 #[repr(C)]
 struct PoolHeader {
-    /// Number of pages allocated
-    num_pages: u64,
-    /// Magic number for validation
+    block_size: usize,
     magic: u64,
+    memory_type: u32,
+    _reserved: u32,
 }
 
-const POOL_MAGIC: u64 = 0x504F4F4C_48445200; // "POOLHDR\0"
+#[repr(C)]
+struct FreePoolBlock {
+    block_size: usize,
+    next: *mut FreePoolBlock,
+    memory_type: u32,
+    _reserved: u32,
+}
 
-/// Allocate pool memory (arbitrary size)
+struct PoolState {
+    free_head: *mut FreePoolBlock,
+}
+
+// SAFETY: firmware allocation is single-threaded and access is serialized.
+unsafe impl Send for PoolState {}
+
+static POOL_STATE: spin::Mutex<PoolState> = spin::Mutex::new(PoolState {
+    free_head: core::ptr::null_mut(),
+});
+
+const POOL_MAGIC: u64 = 0x504F4F4C_48445200; // "POOLHDR\0"
+const POOL_ALIGNMENT: usize = 8;
+const POOL_CHUNK_PAGES: u64 = 64;
+
+fn align_pool_size(size: usize) -> Option<usize> {
+    size.checked_add(POOL_ALIGNMENT - 1)
+        .map(|size| size & !(POOL_ALIGNMENT - 1))
+}
+
+unsafe fn take_pool_block(memory_type: MemoryType, size: usize) -> Option<(*mut u8, usize)> {
+    let mut state = POOL_STATE.lock();
+    let mut previous: *mut FreePoolBlock = core::ptr::null_mut();
+    let mut current = state.free_head;
+    while !current.is_null() {
+        // SAFETY: free-list nodes are created only from page-backed pool chunks.
+        let block = unsafe { &mut *current };
+        if block.memory_type == memory_type as u32 && block.block_size >= size {
+            let remaining = block.block_size - size;
+            let allocated_size = if remaining >= core::mem::size_of::<FreePoolBlock>() {
+                let replacement = unsafe { (current as *mut u8).add(size).cast::<FreePoolBlock>() };
+                unsafe {
+                    replacement.write(FreePoolBlock {
+                        block_size: remaining,
+                        next: block.next,
+                        memory_type: block.memory_type,
+                        _reserved: 0,
+                    });
+                }
+                if previous.is_null() {
+                    state.free_head = replacement;
+                } else {
+                    unsafe { (*previous).next = replacement };
+                }
+                size
+            } else {
+                if previous.is_null() {
+                    state.free_head = block.next;
+                } else {
+                    unsafe { (*previous).next = block.next };
+                }
+                block.block_size
+            };
+            return Some((current.cast::<u8>(), allocated_size));
+        }
+        previous = current;
+        current = block.next;
+    }
+    None
+}
+
+unsafe fn insert_pool_block(address: *mut u8, size: usize, memory_type: u32) {
+    let block = address.cast::<FreePoolBlock>();
+    let mut state = POOL_STATE.lock();
+    let mut previous: *mut FreePoolBlock = core::ptr::null_mut();
+    let mut current = state.free_head;
+    while !current.is_null() && (current as usize) < address as usize {
+        previous = current;
+        current = unsafe { (*current).next };
+    }
+    unsafe {
+        block.write(FreePoolBlock {
+            block_size: size,
+            next: current,
+            memory_type,
+            _reserved: 0,
+        });
+    }
+    if previous.is_null() {
+        state.free_head = block;
+    } else {
+        unsafe { (*previous).next = block };
+    }
+
+    if !current.is_null()
+        && unsafe { (*block).memory_type == (*current).memory_type }
+        && address as usize + unsafe { (*block).block_size } == current as usize
+    {
+        unsafe {
+            (*block).block_size += (*current).block_size;
+            (*block).next = (*current).next;
+        }
+    }
+    if !previous.is_null()
+        && unsafe { (*previous).memory_type == (*block).memory_type }
+        && previous as usize + unsafe { (*previous).block_size } == block as usize
+    {
+        unsafe {
+            (*previous).block_size += (*block).block_size;
+            (*previous).next = (*block).next;
+        }
+    }
+}
+
+/// Allocate pool memory from reusable page-backed chunks.
 pub fn allocate_pool(memory_type: MemoryType, size: usize) -> Result<*mut u8, efi::Status> {
     if size == 0 {
         return Err(efi::Status::INVALID_PARAMETER);
     }
+    let total_size = align_pool_size(
+        size.checked_add(core::mem::size_of::<PoolHeader>())
+            .ok_or(efi::Status::OUT_OF_RESOURCES)?,
+    )
+    .ok_or(efi::Status::OUT_OF_RESOURCES)?;
 
-    // Calculate total size including header, with overflow check
-    let header_size = core::mem::size_of::<PoolHeader>();
-    let total_size = size
-        .checked_add(header_size)
-        .ok_or(efi::Status::OUT_OF_RESOURCES)?;
+    let (address, block_size) = match unsafe { take_pool_block(memory_type, total_size) } {
+        Some(block) => block,
+        None => {
+            let requested_pages = (total_size as u64).div_ceil(PAGE_SIZE);
+            let pages = requested_pages.max(POOL_CHUNK_PAGES);
+            let mut address = 0;
+            let status = allocate_pages(
+                AllocateType::AllocateAnyPages,
+                memory_type,
+                pages,
+                &mut address,
+            );
+            if status != efi::Status::SUCCESS {
+                return Err(status);
+            }
+            unsafe {
+                insert_pool_block(
+                    address as *mut u8,
+                    (pages * PAGE_SIZE) as usize,
+                    memory_type as u32,
+                )
+            };
+            unsafe { take_pool_block(memory_type, total_size) }
+                .ok_or(efi::Status::OUT_OF_RESOURCES)?
+        }
+    };
 
-    // Round up to pages, with overflow check
-    let total_size_u64 = total_size as u64;
-    let num_pages = total_size_u64
-        .checked_add(PAGE_SIZE - 1)
-        .ok_or(efi::Status::OUT_OF_RESOURCES)?
-        / PAGE_SIZE;
-
-    let mut addr = 0u64;
-    let status = allocate_pages(
-        AllocateType::AllocateAnyPages,
-        memory_type,
-        num_pages,
-        &mut addr,
-    );
-
-    if status != efi::Status::SUCCESS {
-        return Err(status);
-    }
-
-    // Write the header
-    let header = addr as *mut PoolHeader;
+    let header = address.cast::<PoolHeader>();
     unsafe {
-        (*header).num_pages = num_pages;
-        (*header).magic = POOL_MAGIC;
+        header.write(PoolHeader {
+            block_size,
+            magic: POOL_MAGIC,
+            memory_type: memory_type as u32,
+            _reserved: 0,
+        });
+        Ok(address.add(core::mem::size_of::<PoolHeader>()))
     }
-
-    // Return pointer to data after header
-    let data = unsafe { (header as *mut u8).add(core::mem::size_of::<PoolHeader>()) };
-    Ok(data)
 }
 
-/// Free pool memory
+/// Return a pool block to the reusable free list.
 pub fn free_pool(buffer: *mut u8) -> efi::Status {
     if buffer.is_null() {
         return efi::Status::INVALID_PARAMETER;
     }
-
-    // Get the header
-    let header = unsafe { (buffer as *mut PoolHeader).sub(1) };
-
-    // Validate magic
-    let magic = unsafe { (*header).magic };
-    if magic != POOL_MAGIC {
+    let header = unsafe {
+        buffer
+            .sub(core::mem::size_of::<PoolHeader>())
+            .cast::<PoolHeader>()
+    };
+    if unsafe { (*header).magic } != POOL_MAGIC {
         return efi::Status::INVALID_PARAMETER;
     }
-
-    let num_pages = unsafe { (*header).num_pages };
-    let addr = header as u64;
-
-    free_pages(addr, num_pages)
+    let block_size = unsafe { (*header).block_size };
+    let memory_type = unsafe { (*header).memory_type };
+    unsafe { insert_pool_block(header.cast::<u8>(), block_size, memory_type) };
+    efi::Status::SUCCESS
 }
 
 // Linker symbols for section boundaries (only when CrabEFI owns the binary layout).

--- a/crabefi-core/src/efi/boot_services.rs
+++ b/crabefi-core/src/efi/boot_services.rs
@@ -14,8 +14,8 @@ use super::protocols::loaded_image::{LOADED_IMAGE_PROTOCOL_GUID, create_loaded_i
 use super::system_table;
 use crate::pe;
 use crate::state::{
-    self, EventEntry, LoadedImageEntry, MAX_EVENTS, MAX_HANDLES, MAX_PROTOCOLS_PER_HANDLE,
-    ProtocolEntry,
+    self, EventEntry, HandleEntry, LoadedImageEntry, MAX_EVENTS, MAX_HANDLES,
+    MAX_PROTOCOLS_PER_HANDLE, ProtocolEntry,
 };
 use alloc::vec::Vec;
 use core::ffi::c_void;
@@ -875,11 +875,45 @@ extern "efiapi" fn reinstall_protocol_interface(
 }
 
 extern "efiapi" fn uninstall_protocol_interface(
-    _handle: Handle,
-    _protocol: *mut Guid,
-    _interface: *mut c_void,
+    handle: Handle,
+    protocol: *mut Guid,
+    interface: *mut c_void,
 ) -> Status {
-    Status::NOT_FOUND
+    if handle.is_null() || protocol.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+
+    let guid = unsafe { *protocol };
+    state::with_efi_mut(|efi_state| {
+        let Some(handle_index) = efi_state.handles[..efi_state.handle_count]
+            .iter()
+            .position(|entry| entry.handle == handle)
+        else {
+            return Status::NOT_FOUND;
+        };
+        let entry = &mut efi_state.handles[handle_index];
+        let Some(protocol_index) = entry.protocols[..entry.protocol_count]
+            .iter()
+            .position(|entry| entry.guid == guid && entry.interface == interface)
+        else {
+            return Status::NOT_FOUND;
+        };
+
+        entry
+            .protocols
+            .copy_within(protocol_index + 1..entry.protocol_count, protocol_index);
+        entry.protocol_count -= 1;
+        entry.protocols[entry.protocol_count] = ProtocolEntry::empty();
+
+        if entry.protocol_count == 0 {
+            efi_state
+                .handles
+                .swap(handle_index, efi_state.handle_count - 1);
+            efi_state.handle_count -= 1;
+            efi_state.handles[efi_state.handle_count] = HandleEntry::empty();
+        }
+        Status::SUCCESS
+    })
 }
 
 extern "efiapi" fn handle_protocol(
@@ -1276,8 +1310,12 @@ extern "efiapi" fn load_image(
         Some(h) => h,
         None => {
             log::error!("BS.LoadImage: Failed to create handle");
-            pe::unload_image(&loaded_image);
-            return Status::OUT_OF_RESOURCES;
+            let cleanup_status = pe::unload_image(&loaded_image);
+            return if cleanup_status == Status::SUCCESS {
+                Status::OUT_OF_RESOURCES
+            } else {
+                cleanup_status
+            };
         }
     };
 
@@ -1303,8 +1341,17 @@ extern "efiapi" fn load_image(
         if let Some(measurement) = deferred_measurement {
             let _ = allocator::free_pool(measurement.event_data);
         }
-        pe::unload_image(&loaded_image);
-        return Status::OUT_OF_RESOURCES;
+        remove_handle_entry(new_handle);
+        let cleanup_status = pe::unload_image(&loaded_image);
+        return if cleanup_status == Status::SUCCESS {
+            Status::OUT_OF_RESOURCES
+        } else {
+            cleanup_status
+        };
+    }
+
+    unsafe {
+        super::protocols::loaded_image::set_image_subsystem(loaded_image_protocol, image_subsystem);
     }
 
     // Set the device path on the loaded image if provided
@@ -1329,8 +1376,14 @@ extern "efiapi" fn load_image(
         if let Some(measurement) = deferred_measurement {
             let _ = allocator::free_pool(measurement.event_data);
         }
-        pe::unload_image(&loaded_image);
-        return status;
+        let _ = allocator::free_pool(loaded_image_protocol.cast::<u8>());
+        remove_handle_entry(new_handle);
+        let cleanup_status = pe::unload_image(&loaded_image);
+        return if cleanup_status == Status::SUCCESS {
+            status
+        } else {
+            cleanup_status
+        };
     }
 
     // Store the loaded image info so StartImage can find it
@@ -1369,8 +1422,18 @@ extern "efiapi" fn load_image(
         if let Some(measurement) = deferred_measurement {
             let _ = allocator::free_pool(measurement.event_data);
         }
-        pe::unload_image(&loaded_image);
-        return Status::OUT_OF_RESOURCES;
+        let _ = uninstall_protocol_interface(
+            new_handle,
+            &LOADED_IMAGE_PROTOCOL_GUID as *const Guid as *mut Guid,
+            loaded_image_protocol.cast(),
+        );
+        let _ = allocator::free_pool(loaded_image_protocol.cast::<u8>());
+        let cleanup_status = pe::unload_image(&loaded_image);
+        return if cleanup_status == Status::SUCCESS {
+            Status::OUT_OF_RESOURCES
+        } else {
+            cleanup_status
+        };
     }
 
     // Return the new handle
@@ -1542,56 +1605,60 @@ extern "efiapi" fn unload_image(image_handle: Handle) -> Status {
         return Status::INVALID_PARAMETER;
     }
 
-    // Find and remove the loaded image entry
-    let image_info = state::with_efi_mut(|efi_state| {
-        efi_state
+    let loaded_image_protocol =
+        get_protocol_on_handle(image_handle, &LOADED_IMAGE_PROTOCOL_GUID).cast::<u8>();
+
+    let image_info = state::efi()
+        .loaded_images
+        .iter()
+        .find(|entry| entry.handle == image_handle)
+        .map(|entry| {
+            (
+                entry.alloc_base,
+                entry.num_pages,
+                entry.measurement_event_data,
+            )
+        });
+
+    let Some((alloc_base, num_pages, measurement_event_data)) = image_info else {
+        log::warn!(
+            "BS.UnloadImage: handle {:?} not found in loaded images",
+            image_handle
+        );
+        return Status::INVALID_PARAMETER;
+    };
+
+    // Do not discard lifecycle state until the image allocation is reclaimed.
+    let status = allocator::free_pages(alloc_base, num_pages);
+    if status != Status::SUCCESS {
+        log::warn!(
+            "BS.UnloadImage: Failed to free pages at {:#x}: {:?}",
+            alloc_base,
+            status
+        );
+        return status;
+    }
+
+    state::with_efi_mut(|efi_state| {
+        if let Some(entry) = efi_state
             .loaded_images
             .iter_mut()
             .find(|entry| entry.handle == image_handle)
-            .map(|entry| {
-                let result = (
-                    entry.alloc_base,
-                    entry.num_pages,
-                    entry.measurement_event_data,
-                );
-                // Clear the entry
-                *entry = LoadedImageEntry::empty();
-                result
-            })
+        {
+            *entry = LoadedImageEntry::empty();
+        }
     });
+    remove_handle_entry(image_handle);
 
-    match image_info {
-        Some((alloc_base, num_pages, measurement_event_data)) => {
-            // Free the image memory (using alloc_base, not image_base,
-            // since the image may have been aligned within the allocation)
-            let status = allocator::free_pages(alloc_base, num_pages);
-            if status != Status::SUCCESS {
-                log::warn!(
-                    "BS.UnloadImage: Failed to free pages at {:#x}: {:?}",
-                    alloc_base,
-                    status
-                );
-            }
-
-            if !measurement_event_data.is_null() {
-                let _ = allocator::free_pool(measurement_event_data);
-            }
-
-            // Remove protocols from the handle
-            // Note: In a full implementation, we should uninstall all protocols
-            // For now, we just log success
-            log::debug!("BS.UnloadImage: SUCCESS");
-            Status::SUCCESS
-        }
-        None => {
-            log::warn!(
-                "BS.UnloadImage: handle {:?} not found in loaded images",
-                image_handle
-            );
-            // Return success anyway - the handle might have been loaded differently
-            Status::SUCCESS
-        }
+    if !measurement_event_data.is_null() {
+        let _ = allocator::free_pool(measurement_event_data);
     }
+    if !loaded_image_protocol.is_null() {
+        let _ = allocator::free_pool(loaded_image_protocol);
+    }
+
+    log::debug!("BS.UnloadImage: SUCCESS");
+    Status::SUCCESS
 }
 
 extern "efiapi" fn exit_boot_services(image_handle: Handle, map_key: usize) -> Status {
@@ -2240,26 +2307,24 @@ extern "efiapi" fn uninstall_multiple_protocol_interfaces(
     }
 
     let args = [(arg1, arg2), (arg3, arg4), (arg5, arg6), (arg7, arg8)];
+    let pair_count = args.iter().take_while(|(guid, _)| !guid.is_null()).count();
 
-    // Uninstall each protocol
-    for (guid_ptr, _) in args.iter().take_while(|(g, _)| !g.is_null()) {
-        let guid = unsafe { *(*guid_ptr as *const Guid) };
-        log::debug!("  Uninstalling protocol: {}", GuidFmt(guid));
-
-        // Find and remove the protocol from the handle
-        state::with_efi_mut(|efi_state| {
-            if let Some(entry) = efi_state.handles[..efi_state.handle_count]
-                .iter_mut()
-                .find(|e| e.handle == handle)
-                && let Some(j) = entry.protocols[..entry.protocol_count]
-                    .iter()
-                    .position(|p| p.guid == guid)
-            {
-                // Remove by shifting remaining protocols down
-                entry.protocols.copy_within(j + 1..entry.protocol_count, j);
-                entry.protocol_count -= 1;
+    for index in 0..pair_count {
+        let (guid, interface) = args[index];
+        let status = uninstall_protocol_interface(handle, guid as *mut Guid, interface);
+        if status != Status::SUCCESS {
+            for rollback_index in (0..index).rev() {
+                let (rollback_guid, rollback_interface) = args[rollback_index];
+                let mut rollback_handle = handle;
+                let _ = install_protocol_interface(
+                    &mut rollback_handle,
+                    rollback_guid as *mut Guid,
+                    efi::NATIVE_INTERFACE,
+                    rollback_interface,
+                );
             }
-        });
+            return status;
+        }
     }
 
     log::trace!("  -> SUCCESS");
@@ -2352,6 +2417,20 @@ pub fn create_handle() -> Option<Handle> {
 
         Some(handle)
     })
+}
+
+fn remove_handle_entry(handle: Handle) {
+    state::with_efi_mut(|efi_state| {
+        let Some(index) = efi_state.handles[..efi_state.handle_count]
+            .iter()
+            .position(|entry| entry.handle == handle)
+        else {
+            return;
+        };
+        efi_state.handles.swap(index, efi_state.handle_count - 1);
+        efi_state.handle_count -= 1;
+        efi_state.handles[efi_state.handle_count] = HandleEntry::empty();
+    });
 }
 
 /// Install a protocol on an existing handle

--- a/crabefi-core/src/efi/boot_services.rs
+++ b/crabefi-core/src/efi/boot_services.rs
@@ -274,8 +274,8 @@ extern "efiapi" fn allocate_pool(
     }
 
     let mem_type = match MemoryType::try_from(pool_type) {
-        Ok(t) => t,
-        Err(_) => return Status::INVALID_PARAMETER,
+        Ok(MemoryType::PersistentMemory) | Err(_) => return Status::INVALID_PARAMETER,
+        Ok(memory_type) => memory_type,
     };
 
     match allocator::allocate_pool(mem_type, size) {
@@ -1376,6 +1376,7 @@ extern "efiapi" fn load_image(
         if let Some(measurement) = deferred_measurement {
             let _ = allocator::free_pool(measurement.event_data);
         }
+        unsafe { super::protocols::loaded_image::free_file_path(loaded_image_protocol) };
         let _ = allocator::free_pool(loaded_image_protocol.cast::<u8>());
         remove_handle_entry(new_handle);
         let cleanup_status = pe::unload_image(&loaded_image);
@@ -1427,6 +1428,7 @@ extern "efiapi" fn load_image(
             &LOADED_IMAGE_PROTOCOL_GUID as *const Guid as *mut Guid,
             loaded_image_protocol.cast(),
         );
+        unsafe { super::protocols::loaded_image::free_file_path(loaded_image_protocol) };
         let _ = allocator::free_pool(loaded_image_protocol.cast::<u8>());
         let cleanup_status = pe::unload_image(&loaded_image);
         return if cleanup_status == Status::SUCCESS {
@@ -1654,6 +1656,11 @@ extern "efiapi" fn unload_image(image_handle: Handle) -> Status {
         let _ = allocator::free_pool(measurement_event_data);
     }
     if !loaded_image_protocol.is_null() {
+        unsafe {
+            super::protocols::loaded_image::free_file_path(
+                loaded_image_protocol.cast::<r_efi::protocols::loaded_image::Protocol>(),
+            )
+        };
         let _ = allocator::free_pool(loaded_image_protocol);
     }
 

--- a/crabefi-core/src/efi/boot_services.rs
+++ b/crabefi-core/src/efi/boot_services.rs
@@ -2322,13 +2322,29 @@ extern "efiapi" fn uninstall_multiple_protocol_interfaces(
         if status != Status::SUCCESS {
             for rollback_index in (0..index).rev() {
                 let (rollback_guid, rollback_interface) = args[rollback_index];
+                // Uninstalling the last protocol auto-deletes the handle, so it
+                // has to be revived before earlier protocols can be restored.
+                if !restore_handle_entry(handle) {
+                    log::error!(
+                        "  Rollback failed: cannot restore handle {:?} (handle table full)",
+                        handle
+                    );
+                    break;
+                }
                 let mut rollback_handle = handle;
-                let _ = install_protocol_interface(
+                let rollback_status = install_protocol_interface(
                     &mut rollback_handle,
                     rollback_guid as *mut Guid,
                     efi::NATIVE_INTERFACE,
                     rollback_interface,
                 );
+                if rollback_status != Status::SUCCESS {
+                    log::error!(
+                        "  Rollback failed to reinstall protocol on {:?}: {:?}",
+                        handle,
+                        rollback_status
+                    );
+                }
             }
             return status;
         }
@@ -2423,6 +2439,32 @@ pub fn create_handle() -> Option<Handle> {
         efi_state.handle_count += 1;
 
         Some(handle)
+    })
+}
+
+/// Re-create the bookkeeping entry for a handle that was auto-deleted when its
+/// last protocol went away.
+///
+/// Used by the `UninstallMultipleProtocolInterfaces` rollback path, which must
+/// be able to re-install protocols on the original handle value even though the
+/// handle was dropped in the middle of the batch.
+fn restore_handle_entry(handle: Handle) -> bool {
+    state::with_efi_mut(|efi_state| {
+        if efi_state.handles[..efi_state.handle_count]
+            .iter()
+            .any(|entry| entry.handle == handle)
+        {
+            return true;
+        }
+        if efi_state.handle_count >= MAX_HANDLES {
+            return false;
+        }
+        let idx = efi_state.handle_count;
+        efi_state.handles[idx] = HandleEntry::empty();
+        efi_state.handles[idx].handle = handle;
+        efi_state.handles[idx].protocol_count = 0;
+        efi_state.handle_count += 1;
+        true
     })
 }
 

--- a/crabefi-core/src/efi/boot_services.rs
+++ b/crabefi-core/src/efi/boot_services.rs
@@ -2316,12 +2316,10 @@ extern "efiapi" fn uninstall_multiple_protocol_interfaces(
     let args = [(arg1, arg2), (arg3, arg4), (arg5, arg6), (arg7, arg8)];
     let pair_count = args.iter().take_while(|(guid, _)| !guid.is_null()).count();
 
-    for index in 0..pair_count {
-        let (guid, interface) = args[index];
+    for (index, &(guid, interface)) in args[..pair_count].iter().enumerate() {
         let status = uninstall_protocol_interface(handle, guid as *mut Guid, interface);
         if status != Status::SUCCESS {
-            for rollback_index in (0..index).rev() {
-                let (rollback_guid, rollback_interface) = args[rollback_index];
+            for &(rollback_guid, rollback_interface) in args[..index].iter().rev() {
                 // Uninstalling the last protocol auto-deletes the handle, so it
                 // has to be revived before earlier protocols can be restored.
                 if !restore_handle_entry(handle) {

--- a/crabefi-core/src/efi/mod.rs
+++ b/crabefi-core/src/efi/mod.rs
@@ -170,6 +170,7 @@ pub fn init_from_platform(config: &mut crate::platform::PlatformConfig) {
 /// protocol installations and table finalization that are identical in both
 /// paths.
 fn install_standard_protocols_and_finalize() {
+    init_hii();
     init_unicode_collation();
     init_memory_attribute();
     init_serial_io();
@@ -485,10 +486,46 @@ fn init_console() -> Option<efi::Handle> {
     Some(console_handle)
 }
 
+/// Initialize the HII Database and String protocols required by UEFI applications.
+fn init_hii() {
+    use r_efi::protocols::{hii_database, hii_string};
+
+    let handle = match boot_services::create_handle() {
+        Some(handle) => handle,
+        None => {
+            log::error!("Failed to create HII protocol handle");
+            return;
+        }
+    };
+
+    let status = boot_services::install_protocol(
+        handle,
+        &hii_database::PROTOCOL_GUID,
+        protocols::hii::database_protocol(),
+    );
+    if status != Status::SUCCESS {
+        log::error!("Failed to install HII Database protocol: {:?}", status);
+        return;
+    }
+
+    let status = boot_services::install_protocol(
+        handle,
+        &hii_string::PROTOCOL_GUID,
+        protocols::hii::string_protocol(),
+    );
+    if status != Status::SUCCESS {
+        log::error!("Failed to install HII String protocol: {:?}", status);
+        return;
+    }
+
+    log::info!("HII Database and String protocols installed");
+}
+
 /// Initialize Unicode Collation protocol
 fn init_unicode_collation() {
     use protocols::unicode_collation::{
-        UNICODE_COLLATION_PROTOCOL_GUID, UNICODE_COLLATION_PROTOCOL2_GUID, get_protocol_void,
+        UNICODE_COLLATION_PROTOCOL_GUID, UNICODE_COLLATION_PROTOCOL2_GUID, get_v1_protocol_void,
+        get_v2_protocol_void,
     };
 
     // Create a handle for Unicode Collation
@@ -501,9 +538,11 @@ fn init_unicode_collation() {
     };
 
     // Install version 1 (legacy) protocol
-    let protocol = get_protocol_void();
-    let status =
-        boot_services::install_protocol(handle, &UNICODE_COLLATION_PROTOCOL_GUID, protocol);
+    let status = boot_services::install_protocol(
+        handle,
+        &UNICODE_COLLATION_PROTOCOL_GUID,
+        get_v1_protocol_void(),
+    );
     if status != Status::SUCCESS {
         log::error!(
             "Failed to install Unicode Collation v1 protocol: {:?}",
@@ -512,8 +551,11 @@ fn init_unicode_collation() {
     }
 
     // Install version 2 protocol
-    let status =
-        boot_services::install_protocol(handle, &UNICODE_COLLATION_PROTOCOL2_GUID, protocol);
+    let status = boot_services::install_protocol(
+        handle,
+        &UNICODE_COLLATION_PROTOCOL2_GUID,
+        get_v2_protocol_void(),
+    );
     if status != Status::SUCCESS {
         log::error!(
             "Failed to install Unicode Collation v2 protocol: {:?}",

--- a/crabefi-core/src/efi/protocols/device_path_utilities.rs
+++ b/crabefi-core/src/efi/protocols/device_path_utilities.rs
@@ -69,7 +69,7 @@ extern "efiapi" fn get_device_path_size(device_path: *const device_path::Protoco
 }
 
 /// `DuplicateDevicePath` — allocate a copy of a device path.
-extern "efiapi" fn duplicate_device_path(
+pub(crate) extern "efiapi" fn duplicate_device_path(
     device_path: *const device_path::Protocol,
 ) -> *mut device_path::Protocol {
     let size = unsafe { device_path_size(device_path) };

--- a/crabefi-core/src/efi/protocols/hii.rs
+++ b/crabefi-core/src/efi/protocols/hii.rs
@@ -1,0 +1,990 @@
+//! Minimal UEFI HII database and string protocols.
+//!
+//! The UEFI shell registers its compiled string packages at startup and reads
+//! them back through these protocols.  CrabEFI keeps the original package-list
+//! bytes and decodes strings on demand; it does not implement forms or fonts.
+
+use alloc::vec::Vec;
+use core::{ffi::c_void, ptr};
+use r_efi::{
+    efi::{Char8, Char16, Guid, Handle, Status},
+    hii,
+    protocols::{hii_database, hii_string},
+};
+
+const MAX_PACKAGE_LIST_SIZE: usize = 16 * 1024 * 1024;
+const MAX_PACKAGE_STORAGE: usize = 64 * 1024 * 1024;
+const MAX_PACKAGE_LISTS: usize = 64;
+const MAX_DYNAMIC_STRINGS: usize = 4096;
+const MAX_DYNAMIC_STRING_STORAGE: usize = 8 * 1024 * 1024;
+
+struct PackageList {
+    handle: usize,
+    driver_handle: usize,
+    bytes: Vec<u8>,
+    strings: Vec<DynamicString>,
+}
+
+struct DynamicString {
+    id: hii::StringId,
+    language: Vec<u8>,
+    value: Vec<Char16>,
+}
+
+pub struct State {
+    next_handle: usize,
+    packages: Vec<PackageList>,
+}
+
+impl State {
+    pub const fn new() -> Self {
+        Self {
+            next_handle: 1,
+            packages: Vec::new(),
+        }
+    }
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn database() -> &'static mut State {
+    // SAFETY: UEFI boot services are single-threaded and HII callbacks do not
+    // re-enter HII state while this reference is live.
+    unsafe { &mut (*crate::state::efi_mut_ptr()).hii }
+}
+
+static HII_DATABASE_PROTOCOL: hii_database::Protocol = hii_database::Protocol {
+    new_package_list,
+    remove_package_list,
+    update_package_list,
+    list_package_lists,
+    export_package_lists,
+    register_package_notify,
+    unregister_package_notify,
+    find_keyboard_layouts,
+    get_keyboard_layout,
+    set_keyboard_layout,
+    get_package_list_handle,
+};
+
+static HII_STRING_PROTOCOL: hii_string::Protocol = hii_string::Protocol {
+    new_string,
+    get_string,
+    set_string,
+    get_languages,
+    get_secondary_languages,
+};
+
+pub fn database_protocol() -> *mut c_void {
+    &HII_DATABASE_PROTOCOL as *const _ as *mut c_void
+}
+
+pub fn string_protocol() -> *mut c_void {
+    &HII_STRING_PROTOCOL as *const _ as *mut c_void
+}
+
+fn hii_handle(value: usize) -> hii::Handle {
+    value as hii::Handle
+}
+
+fn handle_value(handle: hii::Handle) -> usize {
+    handle as usize
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
+    Some(u16::from_le_bytes(
+        bytes.get(offset..offset + 2)?.try_into().ok()?,
+    ))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(
+        bytes.get(offset..offset + 4)?.try_into().ok()?,
+    ))
+}
+
+fn package_length(bytes: &[u8], offset: usize) -> Option<usize> {
+    let header = bytes.get(offset..offset + 3)?;
+    Some(header[0] as usize | ((header[1] as usize) << 8) | ((header[2] as usize) << 16))
+}
+
+fn package_type(bytes: &[u8], offset: usize) -> Option<u8> {
+    bytes.get(offset + 3).copied()
+}
+
+fn package_list_bytes(header: *const hii::PackageListHeader) -> Result<Vec<u8>, Status> {
+    if header.is_null() {
+        return Err(Status::INVALID_PARAMETER);
+    }
+
+    let length = unsafe { ptr::read_unaligned(ptr::addr_of!((*header).package_length)) } as usize;
+    if !(core::mem::size_of::<hii::PackageListHeader>()..=MAX_PACKAGE_LIST_SIZE).contains(&length) {
+        return Err(Status::INVALID_PARAMETER);
+    }
+
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(length)
+        .map_err(|_| Status::OUT_OF_RESOURCES)?;
+    bytes.extend_from_slice(unsafe { core::slice::from_raw_parts(header.cast::<u8>(), length) });
+    if !valid_package_list(&bytes) {
+        return Err(Status::INVALID_PARAMETER);
+    }
+    Ok(bytes)
+}
+
+fn valid_package_list(bytes: &[u8]) -> bool {
+    if read_u32(bytes, 16).map(|length| length as usize) != Some(bytes.len()) {
+        return false;
+    }
+
+    let mut offset = core::mem::size_of::<hii::PackageListHeader>();
+    while offset + 4 <= bytes.len() {
+        let Some(length) = package_length(bytes, offset) else {
+            return false;
+        };
+        let Some(end) = offset.checked_add(length) else {
+            return false;
+        };
+        if length < 4 || end > bytes.len() {
+            return false;
+        }
+        if package_type(bytes, offset) == Some(hii::PACKAGE_END) {
+            return length == 4 && end == bytes.len();
+        }
+        offset = end;
+    }
+    false
+}
+
+fn language_of_package(package: &[u8]) -> Option<&[u8]> {
+    // Package header + HdrSize + StringInfoOffset + LanguageWindow + LanguageName.
+    const LANGUAGE_OFFSET: usize = 4 + 4 + 4 + 32 + 2;
+    let end = package
+        .get(LANGUAGE_OFFSET..)?
+        .iter()
+        .position(|&c| c == 0)?;
+    package.get(LANGUAGE_OFFSET..LANGUAGE_OFFSET + end)
+}
+
+fn language_eq(left: &[u8], right: &[u8]) -> bool {
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right)
+            .all(|(&left, &right)| left.eq_ignore_ascii_case(&right))
+}
+
+fn primary_language(language_list: &[u8]) -> &[u8] {
+    language_list
+        .split(|&character| character == b';')
+        .next()
+        .unwrap_or_default()
+}
+
+fn language_matches(package: &[u8], language: *const Char8) -> bool {
+    let Some(requested) = language_bytes(language) else {
+        return false;
+    };
+    language_of_package(package)
+        .is_some_and(|actual| language_eq(primary_language(actual), &requested))
+}
+
+fn ucs2_string(bytes: &[u8], offset: &mut usize) -> Option<Vec<Char16>> {
+    let mut value = Vec::new();
+    loop {
+        let character = read_u16(bytes, *offset)?;
+        *offset += 2;
+        if character == 0 {
+            return Some(value);
+        }
+        value.push(character);
+    }
+}
+
+fn scsu_string(bytes: &[u8], offset: &mut usize) -> Option<Vec<Char16>> {
+    // EDK2's English shell packages only need the ASCII subset of SCSU.
+    let mut value = Vec::new();
+    loop {
+        let character = *bytes.get(*offset)?;
+        *offset += 1;
+        if character == 0 {
+            return Some(value);
+        }
+        if character >= 0x80 {
+            return None;
+        }
+        value.push(character as Char16);
+    }
+}
+
+fn find_string_in_package(package: &[u8], wanted: hii::StringId) -> Option<Vec<Char16>> {
+    find_string_in_package_inner(package, wanted, 0)
+}
+
+fn find_string_in_package_inner(
+    package: &[u8],
+    wanted: hii::StringId,
+    duplicate_depth: u8,
+) -> Option<Vec<Char16>> {
+    if duplicate_depth > 8 {
+        return None;
+    }
+
+    let mut offset = read_u32(package, 8)? as usize;
+    if offset >= package.len() {
+        return None;
+    }
+    let mut id: hii::StringId = 1;
+
+    loop {
+        let block_type = *package.get(offset)?;
+        offset += 1;
+        match block_type {
+            0x00 => return None,
+            0x10 => {
+                let value = scsu_string(package, &mut offset)?;
+                if id == wanted {
+                    return Some(value);
+                }
+                id = id.checked_add(1)?;
+            }
+            0x11 => {
+                offset += 1; // Font identifier.
+                let value = scsu_string(package, &mut offset)?;
+                if id == wanted {
+                    return Some(value);
+                }
+                id = id.checked_add(1)?;
+            }
+            0x12 | 0x13 => {
+                if block_type == 0x13 {
+                    offset += 1; // Font identifier.
+                }
+                let count = read_u16(package, offset)?;
+                offset += 2;
+                for _ in 0..count {
+                    let value = scsu_string(package, &mut offset)?;
+                    if id == wanted {
+                        return Some(value);
+                    }
+                    id = id.checked_add(1)?;
+                }
+            }
+            0x14 => {
+                let value = ucs2_string(package, &mut offset)?;
+                if id == wanted {
+                    return Some(value);
+                }
+                id = id.checked_add(1)?;
+            }
+            0x15 => {
+                offset += 1; // Font identifier.
+                let value = ucs2_string(package, &mut offset)?;
+                if id == wanted {
+                    return Some(value);
+                }
+                id = id.checked_add(1)?;
+            }
+            0x16 | 0x17 => {
+                if block_type == 0x17 {
+                    offset += 1; // Font identifier.
+                }
+                let count = read_u16(package, offset)?;
+                offset += 2;
+                for _ in 0..count {
+                    let value = ucs2_string(package, &mut offset)?;
+                    if id == wanted {
+                        return Some(value);
+                    }
+                    id = id.checked_add(1)?;
+                }
+            }
+            0x20 => {
+                let source = read_u16(package, offset)?;
+                offset += 2;
+                if id == wanted {
+                    return find_string_in_package_inner(package, source, duplicate_depth + 1);
+                }
+                id = id.checked_add(1)?;
+            }
+            0x21 => {
+                id = id.checked_add(read_u16(package, offset)?)?;
+                offset += 2;
+            }
+            0x22 => {
+                id = id.checked_add(*package.get(offset)? as u16)?;
+                offset += 1;
+            }
+            0x30 => {
+                let length = *package.get(offset + 1)? as usize;
+                if length < 3 {
+                    return None;
+                }
+                offset = offset.checked_add(length - 1)?;
+            }
+            0x31 => {
+                let length = read_u16(package, offset + 1)? as usize;
+                if length < 4 {
+                    return None;
+                }
+                offset = offset.checked_add(length - 1)?;
+            }
+            0x32 => {
+                let length = read_u32(package, offset + 1)? as usize;
+                if length < 6 {
+                    return None;
+                }
+                offset = offset.checked_add(length - 1)?;
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn string_packages(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
+    let total = read_u32(bytes, 16).unwrap_or(0) as usize;
+    let end = total.min(bytes.len());
+    let mut offset = core::mem::size_of::<hii::PackageListHeader>();
+    core::iter::from_fn(move || {
+        while offset + 4 <= end {
+            let length = package_length(bytes, offset)?;
+            if length < 4 || offset + length > end {
+                offset = end;
+                return None;
+            }
+            let start = offset;
+            offset += length;
+            if package_type(bytes, start) == Some(hii::PACKAGE_STRINGS) {
+                return bytes.get(start..start + length);
+            }
+        }
+        None
+    })
+}
+
+extern "efiapi" fn new_package_list(
+    _this: *const hii_database::Protocol,
+    package_list: *const hii::PackageListHeader,
+    driver_handle: Handle,
+    handle: *mut hii::Handle,
+) -> Status {
+    if handle.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+    let bytes = match package_list_bytes(package_list) {
+        Ok(bytes) => bytes,
+        Err(status) => return status,
+    };
+
+    let database = database();
+    if database.packages.len() >= MAX_PACKAGE_LISTS
+        || database
+            .packages
+            .iter()
+            .map(|package| package.bytes.len())
+            .sum::<usize>()
+            .checked_add(bytes.len())
+            .is_none_or(|total| total > MAX_PACKAGE_STORAGE)
+        || database.packages.try_reserve(1).is_err()
+    {
+        return Status::OUT_OF_RESOURCES;
+    }
+    let value = database.next_handle;
+    database.next_handle += 1;
+    database.packages.push(PackageList {
+        handle: value,
+        driver_handle: driver_handle as usize,
+        bytes,
+        strings: Vec::new(),
+    });
+    unsafe { *handle = hii_handle(value) };
+    Status::SUCCESS
+}
+
+extern "efiapi" fn remove_package_list(
+    _this: *const hii_database::Protocol,
+    handle: hii::Handle,
+) -> Status {
+    let database = database();
+    let Some(index) = database
+        .packages
+        .iter()
+        .position(|package| package.handle == handle_value(handle))
+    else {
+        return Status::NOT_FOUND;
+    };
+    database.packages.remove(index);
+    Status::SUCCESS
+}
+
+extern "efiapi" fn update_package_list(
+    _this: *const hii_database::Protocol,
+    _handle: hii::Handle,
+    _package_list: *const hii::PackageListHeader,
+) -> Status {
+    Status::UNSUPPORTED
+}
+
+extern "efiapi" fn list_package_lists(
+    _this: *const hii_database::Protocol,
+    _package_type: u8,
+    _package_guid: *const Guid,
+    _handle_buffer_length: *mut usize,
+    _handle_buffer: *mut hii::Handle,
+) -> Status {
+    Status::UNSUPPORTED
+}
+
+extern "efiapi" fn export_package_lists(
+    _this: *const hii_database::Protocol,
+    _handle: hii::Handle,
+    _buffer_size: *mut usize,
+    _buffer: *mut hii::PackageListHeader,
+) -> Status {
+    Status::UNSUPPORTED
+}
+
+extern "efiapi" fn register_package_notify(
+    _this: *const hii_database::Protocol,
+    _package_type: u8,
+    _package_guid: *const Guid,
+    _notify: hii_database::Notify,
+    _notify_type: hii_database::NotifyType,
+    _notify_handle: *mut Handle,
+) -> Status {
+    Status::UNSUPPORTED
+}
+
+extern "efiapi" fn unregister_package_notify(
+    _this: *const hii_database::Protocol,
+    _notification_handle: Handle,
+) -> Status {
+    Status::UNSUPPORTED
+}
+
+extern "efiapi" fn find_keyboard_layouts(
+    _this: *const hii_database::Protocol,
+    keyboard_layout_length: *mut u16,
+    _keyboard_layout: *mut Guid,
+) -> Status {
+    if keyboard_layout_length.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+    unsafe { *keyboard_layout_length = 0 };
+    Status::NOT_FOUND
+}
+
+extern "efiapi" fn get_keyboard_layout(
+    _this: *const hii_database::Protocol,
+    _key_guid: *const Guid,
+    _keyboard_layout_length: *mut u16,
+    _keyboard_layout: *mut hii_database::KeyboardLayout,
+) -> Status {
+    Status::NOT_FOUND
+}
+
+extern "efiapi" fn set_keyboard_layout(
+    _this: *const hii_database::Protocol,
+    _key_guid: *mut Guid,
+) -> Status {
+    Status::NOT_FOUND
+}
+
+extern "efiapi" fn get_package_list_handle(
+    _this: *const hii_database::Protocol,
+    handle: hii::Handle,
+    driver_handle: *mut Handle,
+) -> Status {
+    if driver_handle.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+    let database = database();
+    let Some(package) = database
+        .packages
+        .iter()
+        .find(|package| package.handle == handle_value(handle))
+    else {
+        return Status::NOT_FOUND;
+    };
+    unsafe { *driver_handle = package.driver_handle as Handle };
+    Status::SUCCESS
+}
+
+fn language_bytes(language: *const Char8) -> Option<Vec<u8>> {
+    if language.is_null() {
+        return None;
+    }
+    let mut value = Vec::new();
+    for i in 0..256 {
+        let character = unsafe { *language.add(i) };
+        if character == 0 {
+            return Some(value);
+        }
+        value.push(character);
+    }
+    None
+}
+
+fn utf16_bytes(string: *const Char16) -> Option<Vec<Char16>> {
+    if string.is_null() {
+        return None;
+    }
+    let mut value = Vec::new();
+    for i in 0..(1 << 20) {
+        let character = unsafe { *string.add(i) };
+        if character == 0 {
+            return Some(value);
+        }
+        value.push(character);
+    }
+    None
+}
+
+fn max_string_id_in_package(package: &[u8]) -> Option<hii::StringId> {
+    let mut offset = read_u32(package, 8)? as usize;
+    let mut id: hii::StringId = 1;
+    let mut max = 0;
+
+    loop {
+        let block_type = *package.get(offset)?;
+        offset += 1;
+        let count = match block_type {
+            0x00 => return Some(max),
+            0x10 => {
+                scsu_string(package, &mut offset)?;
+                1
+            }
+            0x11 => {
+                offset += 1;
+                scsu_string(package, &mut offset)?;
+                1
+            }
+            0x12 | 0x13 => {
+                if block_type == 0x13 {
+                    offset += 1;
+                }
+                let count = read_u16(package, offset)?;
+                offset += 2;
+                for _ in 0..count {
+                    scsu_string(package, &mut offset)?;
+                }
+                count
+            }
+            0x14 => {
+                ucs2_string(package, &mut offset)?;
+                1
+            }
+            0x15 => {
+                offset += 1;
+                ucs2_string(package, &mut offset)?;
+                1
+            }
+            0x16 | 0x17 => {
+                if block_type == 0x17 {
+                    offset += 1;
+                }
+                let count = read_u16(package, offset)?;
+                offset += 2;
+                for _ in 0..count {
+                    ucs2_string(package, &mut offset)?;
+                }
+                count
+            }
+            0x20 => {
+                offset += 2;
+                1
+            }
+            0x21 => {
+                let count = read_u16(package, offset)?;
+                offset += 2;
+                count
+            }
+            0x22 => {
+                let count = *package.get(offset)? as u16;
+                offset += 1;
+                count
+            }
+            0x30 => {
+                let length = *package.get(offset + 1)? as usize;
+                if length < 3 {
+                    return None;
+                }
+                offset = offset.checked_add(length - 1)?;
+                0
+            }
+            0x31 => {
+                let length = read_u16(package, offset + 1)? as usize;
+                if length < 4 {
+                    return None;
+                }
+                offset = offset.checked_add(length - 1)?;
+                0
+            }
+            0x32 => {
+                let length = read_u32(package, offset + 1)? as usize;
+                if length < 6 {
+                    return None;
+                }
+                offset = offset.checked_add(length - 1)?;
+                0
+            }
+            _ => return None,
+        };
+        if count != 0 {
+            max = id.checked_add(count - 1)?;
+            id = max.checked_add(1)?;
+        }
+    }
+}
+
+fn dynamic_string_storage(package: &PackageList) -> usize {
+    package
+        .strings
+        .iter()
+        .map(|string| string.language.len() + string.value.len() * core::mem::size_of::<Char16>())
+        .sum()
+}
+
+fn max_string_id(package: &PackageList) -> hii::StringId {
+    let dynamic = package
+        .strings
+        .iter()
+        .map(|string| string.id)
+        .max()
+        .unwrap_or(0);
+    let compiled = string_packages(&package.bytes)
+        .filter_map(max_string_id_in_package)
+        .max()
+        .unwrap_or(0);
+    dynamic.max(compiled)
+}
+
+extern "efiapi" fn new_string(
+    _this: *const hii_string::Protocol,
+    package_list: hii::Handle,
+    string_id: *mut hii::StringId,
+    language: *const Char8,
+    _language_name: *const Char16,
+    string: *mut Char16,
+    _string_font_info: *const hii_string::Info,
+) -> Status {
+    if string_id.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+    let Some(language) = language_bytes(language) else {
+        return Status::INVALID_PARAMETER;
+    };
+    let Some(value) = utf16_bytes(string) else {
+        return Status::INVALID_PARAMETER;
+    };
+    let database = database();
+    let Some(package) = database
+        .packages
+        .iter_mut()
+        .find(|package| package.handle == handle_value(package_list))
+    else {
+        return Status::NOT_FOUND;
+    };
+    let mut id = unsafe { *string_id };
+    if id == 0 {
+        let Some(next) = max_string_id(package).checked_add(1) else {
+            return Status::OUT_OF_RESOURCES;
+        };
+        id = next;
+        unsafe { *string_id = id };
+    }
+    let added = language.len() + value.len() * core::mem::size_of::<Char16>();
+    if package.strings.len() >= MAX_DYNAMIC_STRINGS
+        || dynamic_string_storage(package)
+            .checked_add(added)
+            .is_none_or(|total| total > MAX_DYNAMIC_STRING_STORAGE)
+        || package.strings.try_reserve(1).is_err()
+    {
+        return Status::OUT_OF_RESOURCES;
+    }
+    package.strings.push(DynamicString {
+        id,
+        language,
+        value,
+    });
+    Status::SUCCESS
+}
+
+extern "efiapi" fn get_string(
+    _this: *const hii_string::Protocol,
+    language: *const Char8,
+    package_list: hii::Handle,
+    string_id: hii::StringId,
+    string: *mut Char16,
+    string_size: *mut usize,
+    _string_font_info: *mut *mut hii_string::Info,
+) -> Status {
+    if language.is_null() || string_id == 0 || string_size.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+    let database = database();
+    let Some(package) = database
+        .packages
+        .iter()
+        .find(|package| package.handle == handle_value(package_list))
+    else {
+        return Status::NOT_FOUND;
+    };
+
+    let language_value = language_bytes(language).unwrap_or_default();
+    let value = package
+        .strings
+        .iter()
+        .rev()
+        .find(|entry| entry.id == string_id && language_eq(&entry.language, &language_value))
+        .map(|entry| entry.value.clone())
+        .or_else(|| {
+            string_packages(&package.bytes)
+                .find(|strings| language_matches(strings, language))
+                .and_then(|strings| find_string_in_package(strings, string_id))
+        });
+    let Some(value) = value else {
+        return Status::NOT_FOUND;
+    };
+
+    let required = (value.len() + 1) * core::mem::size_of::<Char16>();
+    let supplied = unsafe { *string_size };
+    unsafe { *string_size = required };
+    if string.is_null() {
+        return if supplied == 0 {
+            Status::BUFFER_TOO_SMALL
+        } else {
+            Status::INVALID_PARAMETER
+        };
+    }
+    if supplied < required {
+        return Status::BUFFER_TOO_SMALL;
+    }
+    unsafe {
+        ptr::copy_nonoverlapping(value.as_ptr(), string, value.len());
+        *string.add(value.len()) = 0;
+    }
+    Status::SUCCESS
+}
+
+extern "efiapi" fn set_string(
+    _this: *const hii_string::Protocol,
+    package_list: hii::Handle,
+    string_id: hii::StringId,
+    language: *const Char8,
+    string: *mut Char16,
+    _string_font_info: *const hii_string::Info,
+) -> Status {
+    if string_id == 0 {
+        return Status::INVALID_PARAMETER;
+    }
+    let Some(language) = language_bytes(language) else {
+        return Status::INVALID_PARAMETER;
+    };
+    let Some(value) = utf16_bytes(string) else {
+        return Status::INVALID_PARAMETER;
+    };
+    let database = database();
+    let Some(package) = database
+        .packages
+        .iter_mut()
+        .find(|package| package.handle == handle_value(package_list))
+    else {
+        return Status::NOT_FOUND;
+    };
+    if let Some(index) = package
+        .strings
+        .iter()
+        .position(|entry| entry.id == string_id && language_eq(&entry.language, &language))
+    {
+        let old = package.strings[index].value.len() * core::mem::size_of::<Char16>();
+        let new = value.len() * core::mem::size_of::<Char16>();
+        if dynamic_string_storage(package)
+            .checked_sub(old)
+            .and_then(|total| total.checked_add(new))
+            .is_none_or(|total| total > MAX_DYNAMIC_STRING_STORAGE)
+        {
+            return Status::OUT_OF_RESOURCES;
+        }
+        package.strings[index].value = value;
+    } else {
+        let added = language.len() + value.len() * core::mem::size_of::<Char16>();
+        if package.strings.len() >= MAX_DYNAMIC_STRINGS
+            || dynamic_string_storage(package)
+                .checked_add(added)
+                .is_none_or(|total| total > MAX_DYNAMIC_STRING_STORAGE)
+            || package.strings.try_reserve(1).is_err()
+        {
+            return Status::OUT_OF_RESOURCES;
+        }
+        package.strings.push(DynamicString {
+            id: string_id,
+            language,
+            value,
+        });
+    }
+    Status::SUCCESS
+}
+
+fn supported_languages(package: &PackageList) -> Vec<u8> {
+    let mut values: Vec<Vec<u8>> = Vec::new();
+    for strings in string_packages(&package.bytes) {
+        let Some(languages) = language_of_package(strings) else {
+            continue;
+        };
+        for language in languages
+            .split(|&character| character == b';')
+            .filter(|language| !language.is_empty())
+        {
+            if !values
+                .iter()
+                .any(|existing| language_eq(existing, language))
+            {
+                values.push(language.to_vec());
+            }
+        }
+    }
+    for string in &package.strings {
+        if !values
+            .iter()
+            .any(|existing| language_eq(existing, &string.language))
+        {
+            values.push(string.language.clone());
+        }
+    }
+
+    let mut languages = Vec::new();
+    for language in values {
+        if !languages.is_empty() {
+            languages.push(b';');
+        }
+        languages.extend_from_slice(&language);
+    }
+    languages.push(0);
+    languages
+}
+
+extern "efiapi" fn get_languages(
+    _this: *const hii_string::Protocol,
+    package_list: hii::Handle,
+    languages: *mut Char8,
+    languages_size: *mut usize,
+) -> Status {
+    if languages_size.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+    let database = database();
+    let Some(package) = database
+        .packages
+        .iter()
+        .find(|package| package.handle == handle_value(package_list))
+    else {
+        return Status::NOT_FOUND;
+    };
+    let value = supported_languages(package);
+    let supplied = unsafe { *languages_size };
+    unsafe { *languages_size = value.len() };
+    if languages.is_null() {
+        return if supplied == 0 {
+            Status::BUFFER_TOO_SMALL
+        } else {
+            Status::INVALID_PARAMETER
+        };
+    }
+    if supplied < value.len() {
+        return Status::BUFFER_TOO_SMALL;
+    }
+    unsafe { ptr::copy_nonoverlapping(value.as_ptr(), languages, value.len()) };
+    Status::SUCCESS
+}
+
+extern "efiapi" fn get_secondary_languages(
+    _this: *const hii_string::Protocol,
+    package_list: hii::Handle,
+    requested_primary: *const Char8,
+    secondary_languages: *mut Char8,
+    secondary_languages_size: *mut usize,
+) -> Status {
+    if requested_primary.is_null() || secondary_languages_size.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+    let Some(primary) = language_bytes(requested_primary) else {
+        return Status::INVALID_PARAMETER;
+    };
+    let database = database();
+    let Some(package) = database
+        .packages
+        .iter()
+        .find(|package| package.handle == handle_value(package_list))
+    else {
+        return Status::NOT_FOUND;
+    };
+
+    let Some(language_list) = string_packages(&package.bytes)
+        .filter_map(language_of_package)
+        .find(|languages| language_eq(primary_language(languages), &primary))
+    else {
+        return Status::INVALID_LANGUAGE;
+    };
+    let mut value = language_list
+        .split(|&character| character == b';')
+        .skip(1)
+        .filter(|language| !language.is_empty())
+        .fold(Vec::new(), |mut output, language| {
+            if !output.is_empty() {
+                output.push(b';');
+            }
+            output.extend_from_slice(language);
+            output
+        });
+    value.push(0);
+
+    let supplied = unsafe { *secondary_languages_size };
+    unsafe { *secondary_languages_size = value.len() };
+    if secondary_languages.is_null() {
+        return if supplied == 0 {
+            Status::BUFFER_TOO_SMALL
+        } else {
+            Status::INVALID_PARAMETER
+        };
+    }
+    if supplied < value.len() {
+        return Status::BUFFER_TOO_SMALL;
+    }
+    unsafe { ptr::copy_nonoverlapping(value.as_ptr(), secondary_languages, value.len()) };
+    Status::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_shell_style_ucs2_blocks() {
+        let mut package = vec![0; 60];
+        package[3] = hii::PACKAGE_STRINGS;
+        package[4..8].copy_from_slice(&58u32.to_le_bytes());
+        package[8..12].copy_from_slice(&60u32.to_le_bytes());
+        package[44..46].copy_from_slice(&1u16.to_le_bytes());
+        package[46..52].copy_from_slice(b"en-US\0");
+        package.extend_from_slice(&[0x14, b'O', 0, b'K', 0, 0, 0]);
+        package.extend_from_slice(&[0x22, 1]);
+        package.extend_from_slice(&[0x14, b'X', 0, 0, 0, 0]);
+        let length = package.len();
+        package[0] = length as u8;
+        package[1] = (length >> 8) as u8;
+        package[2] = (length >> 16) as u8;
+
+        assert_eq!(
+            find_string_in_package(&package, 1),
+            Some(vec![b'O' as u16, b'K' as u16])
+        );
+        assert_eq!(find_string_in_package(&package, 2), None);
+        assert_eq!(find_string_in_package(&package, 3), Some(vec![b'X' as u16]));
+    }
+}

--- a/crabefi-core/src/efi/protocols/hii.rs
+++ b/crabefi-core/src/efi/protocols/hii.rs
@@ -11,6 +11,7 @@ use r_efi::{
     hii,
     protocols::{hii_database, hii_string},
 };
+use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
 
 const MAX_PACKAGE_LIST_SIZE: usize = 16 * 1024 * 1024;
 const MAX_PACKAGE_STORAGE: usize = 64 * 1024 * 1024;
@@ -98,6 +99,56 @@ fn handle_value(handle: hii::Handle) -> usize {
     handle as usize
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, FromBytes, Immutable, KnownLayout, Unaligned)]
+struct PackageListPrefix {
+    package_list_guid: [u8; 16],
+    package_length: [u8; 4],
+}
+
+impl PackageListPrefix {
+    fn length(self) -> usize {
+        u32::from_le_bytes(self.package_length) as usize
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, FromBytes, Immutable, KnownLayout, Unaligned)]
+struct PackageHeader {
+    length: [u8; 3],
+    package_type: u8,
+}
+
+impl PackageHeader {
+    fn length(self) -> usize {
+        self.length[0] as usize
+            | ((self.length[1] as usize) << 8)
+            | ((self.length[2] as usize) << 16)
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, FromBytes, Immutable, KnownLayout, Unaligned)]
+struct StringPackagePrefix {
+    header: PackageHeader,
+    header_size: [u8; 4],
+    string_info_offset: [u8; 4],
+    language_window: [[u8; 2]; 16],
+    language_name: [u8; 2],
+}
+
+impl StringPackagePrefix {
+    fn string_info_offset(self) -> usize {
+        u32::from_le_bytes(self.string_info_offset) as usize
+    }
+}
+
+const _: () = {
+    assert!(core::mem::size_of::<PackageListPrefix>() == 20);
+    assert!(core::mem::size_of::<PackageHeader>() == 4);
+    assert!(core::mem::size_of::<StringPackagePrefix>() == 46);
+};
+
 fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
     Some(u16::from_le_bytes(
         bytes.get(offset..offset + 2)?.try_into().ok()?,
@@ -110,13 +161,22 @@ fn read_u32(bytes: &[u8], offset: usize) -> Option<u32> {
     ))
 }
 
-fn package_length(bytes: &[u8], offset: usize) -> Option<usize> {
-    let header = bytes.get(offset..offset + 3)?;
-    Some(header[0] as usize | ((header[1] as usize) << 8) | ((header[2] as usize) << 16))
+fn package_list_prefix(bytes: &[u8]) -> Option<PackageListPrefix> {
+    PackageListPrefix::read_from_prefix(bytes)
+        .ok()
+        .map(|(prefix, _)| prefix)
 }
 
-fn package_type(bytes: &[u8], offset: usize) -> Option<u8> {
-    bytes.get(offset + 3).copied()
+fn package_header(bytes: &[u8], offset: usize) -> Option<PackageHeader> {
+    PackageHeader::read_from_prefix(bytes.get(offset..)?)
+        .ok()
+        .map(|(header, _)| header)
+}
+
+fn string_package_prefix(bytes: &[u8]) -> Option<StringPackagePrefix> {
+    StringPackagePrefix::read_from_prefix(bytes)
+        .ok()
+        .map(|(prefix, _)| prefix)
 }
 
 fn package_list_bytes(header: *const hii::PackageListHeader) -> Result<Vec<u8>, Status> {
@@ -124,8 +184,11 @@ fn package_list_bytes(header: *const hii::PackageListHeader) -> Result<Vec<u8>, 
         return Err(Status::INVALID_PARAMETER);
     }
 
-    let length = unsafe { ptr::read_unaligned(ptr::addr_of!((*header).package_length)) } as usize;
-    if !(core::mem::size_of::<hii::PackageListHeader>()..=MAX_PACKAGE_LIST_SIZE).contains(&length) {
+    // SAFETY: the HII protocol requires a non-null argument to reference a
+    // complete package-list header. The wire header may be unaligned.
+    let prefix = unsafe { ptr::read_unaligned(header.cast::<PackageListPrefix>()) };
+    let length = prefix.length();
+    if !(core::mem::size_of::<PackageListPrefix>()..=MAX_PACKAGE_LIST_SIZE).contains(&length) {
         return Err(Status::INVALID_PARAMETER);
     }
 
@@ -141,22 +204,23 @@ fn package_list_bytes(header: *const hii::PackageListHeader) -> Result<Vec<u8>, 
 }
 
 fn valid_package_list(bytes: &[u8]) -> bool {
-    if read_u32(bytes, 16).map(|length| length as usize) != Some(bytes.len()) {
+    if package_list_prefix(bytes).map(PackageListPrefix::length) != Some(bytes.len()) {
         return false;
     }
 
-    let mut offset = core::mem::size_of::<hii::PackageListHeader>();
+    let mut offset = core::mem::size_of::<PackageListPrefix>();
     while offset + 4 <= bytes.len() {
-        let Some(length) = package_length(bytes, offset) else {
+        let Some(header) = package_header(bytes, offset) else {
             return false;
         };
+        let length = header.length();
         let Some(end) = offset.checked_add(length) else {
             return false;
         };
         if length < 4 || end > bytes.len() {
             return false;
         }
-        if package_type(bytes, offset) == Some(hii::PACKAGE_END) {
+        if header.package_type == hii::PACKAGE_END {
             return length == 4 && end == bytes.len();
         }
         offset = end;
@@ -165,13 +229,13 @@ fn valid_package_list(bytes: &[u8]) -> bool {
 }
 
 fn language_of_package(package: &[u8]) -> Option<&[u8]> {
-    // Package header + HdrSize + StringInfoOffset + LanguageWindow + LanguageName.
-    const LANGUAGE_OFFSET: usize = 4 + 4 + 4 + 32 + 2;
+    string_package_prefix(package)?;
+    let language_offset = core::mem::size_of::<StringPackagePrefix>();
     let end = package
-        .get(LANGUAGE_OFFSET..)?
+        .get(language_offset..)?
         .iter()
         .position(|&c| c == 0)?;
-    package.get(LANGUAGE_OFFSET..LANGUAGE_OFFSET + end)
+    package.get(language_offset..language_offset + end)
 }
 
 fn language_eq(left: &[u8], right: &[u8]) -> bool {
@@ -238,7 +302,7 @@ fn find_string_in_package_inner(
         return None;
     }
 
-    let mut offset = read_u32(package, 8)? as usize;
+    let mut offset = string_package_prefix(package)?.string_info_offset();
     if offset >= package.len() {
         return None;
     }
@@ -354,20 +418,24 @@ fn find_string_in_package_inner(
 }
 
 fn string_packages(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
-    let total = read_u32(bytes, 16).unwrap_or(0) as usize;
+    let total = package_list_prefix(bytes)
+        .map(PackageListPrefix::length)
+        .unwrap_or(0);
     let end = total.min(bytes.len());
-    let mut offset = core::mem::size_of::<hii::PackageListHeader>();
+    let mut offset = core::mem::size_of::<PackageListPrefix>();
     core::iter::from_fn(move || {
-        while offset + 4 <= end {
-            let length = package_length(bytes, offset)?;
-            if length < 4 || offset + length > end {
+        while offset + core::mem::size_of::<PackageHeader>() <= end {
+            let header = package_header(bytes, offset)?;
+            let length = header.length();
+            let package_end = offset.checked_add(length)?;
+            if length < core::mem::size_of::<PackageHeader>() || package_end > end {
                 offset = end;
                 return None;
             }
             let start = offset;
-            offset += length;
-            if package_type(bytes, start) == Some(hii::PACKAGE_STRINGS) {
-                return bytes.get(start..start + length);
+            offset = package_end;
+            if header.package_type == hii::PACKAGE_STRINGS {
+                return bytes.get(start..package_end);
             }
         }
         None
@@ -553,7 +621,7 @@ fn utf16_bytes(string: *const Char16) -> Option<Vec<Char16>> {
 }
 
 fn max_string_id_in_package(package: &[u8]) -> Option<hii::StringId> {
-    let mut offset = read_u32(package, 8)? as usize;
+    let mut offset = string_package_prefix(package)?.string_info_offset();
     let mut id: hii::StringId = 1;
     let mut max = 0;
 
@@ -973,6 +1041,7 @@ extern "efiapi" fn get_secondary_languages(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn decodes_shell_style_ucs2_blocks() {

--- a/crabefi-core/src/efi/protocols/hii.rs
+++ b/crabefi-core/src/efi/protocols/hii.rs
@@ -57,7 +57,10 @@ fn database() -> &'static mut State {
     unsafe { &mut (*crate::state::efi_mut_ptr()).hii }
 }
 
-static HII_DATABASE_PROTOCOL: hii_database::Protocol = hii_database::Protocol {
+// `static mut` (rather than a shared reference cast to `*mut`) so the protocol
+// structures live in writable memory: consumers are allowed to patch vtable
+// entries through the pointers handed out below.
+static mut HII_DATABASE_PROTOCOL: hii_database::Protocol = hii_database::Protocol {
     new_package_list,
     remove_package_list,
     update_package_list,
@@ -71,7 +74,7 @@ static HII_DATABASE_PROTOCOL: hii_database::Protocol = hii_database::Protocol {
     get_package_list_handle,
 };
 
-static HII_STRING_PROTOCOL: hii_string::Protocol = hii_string::Protocol {
+static mut HII_STRING_PROTOCOL: hii_string::Protocol = hii_string::Protocol {
     new_string,
     get_string,
     set_string,
@@ -80,11 +83,11 @@ static HII_STRING_PROTOCOL: hii_string::Protocol = hii_string::Protocol {
 };
 
 pub fn database_protocol() -> *mut c_void {
-    &HII_DATABASE_PROTOCOL as *const _ as *mut c_void
+    (&raw mut HII_DATABASE_PROTOCOL).cast()
 }
 
 pub fn string_protocol() -> *mut c_void {
-    &HII_STRING_PROTOCOL as *const _ as *mut c_void
+    (&raw mut HII_STRING_PROTOCOL).cast()
 }
 
 fn hii_handle(value: usize) -> hii::Handle {
@@ -327,7 +330,11 @@ fn find_string_in_package_inner(
                 }
                 offset = offset.checked_add(length - 1)?;
             }
-            0x31 => {
+            // EFI_HII_SIBT_EXT2 and EFI_HII_SIBT_FONT (0x40) share the
+            // EFI_HII_SIBT_EXT2_BLOCK header layout. EFI_HII_SIBT_FONT carries
+            // font metadata rather than string IDs, so skip it by its length
+            // instead of failing the whole package.
+            0x31 | 0x40 => {
                 let length = read_u16(package, offset + 1)? as usize;
                 if length < 4 {
                     return None;
@@ -617,7 +624,11 @@ fn max_string_id_in_package(package: &[u8]) -> Option<hii::StringId> {
                 offset = offset.checked_add(length - 1)?;
                 0
             }
-            0x31 => {
+            // EFI_HII_SIBT_EXT2 and EFI_HII_SIBT_FONT (0x40) share the
+            // EFI_HII_SIBT_EXT2_BLOCK header layout. EFI_HII_SIBT_FONT carries
+            // font metadata rather than string IDs, so skip it by its length
+            // instead of failing the whole package.
+            0x31 | 0x40 => {
                 let length = read_u16(package, offset + 1)? as usize;
                 if length < 4 {
                     return None;
@@ -690,14 +701,13 @@ extern "efiapi" fn new_string(
     else {
         return Status::NOT_FOUND;
     };
-    let mut id = unsafe { *string_id };
-    if id == 0 {
-        let Some(next) = max_string_id(package).checked_add(1) else {
-            return Status::OUT_OF_RESOURCES;
-        };
-        id = next;
-        unsafe { *string_id = id };
-    }
+    // StringId is an OUT parameter: the incoming value is undefined and must
+    // never be reused as a hint, otherwise an uninitialized caller value can
+    // collide with a compiled-in string.
+    let Some(id) = max_string_id(package).checked_add(1) else {
+        return Status::OUT_OF_RESOURCES;
+    };
+    unsafe { *string_id = id };
     let added = language.len() + value.len() * core::mem::size_of::<Char16>();
     if package.strings.len() >= MAX_DYNAMIC_STRINGS
         || dynamic_string_storage(package)

--- a/crabefi-core/src/efi/protocols/loaded_image.rs
+++ b/crabefi-core/src/efi/protocols/loaded_image.rs
@@ -73,6 +73,31 @@ pub fn create_loaded_image_protocol(
     ptr
 }
 
+/// Set the code/data memory types from the PE/COFF subsystem.
+///
+/// # Safety
+/// The protocol pointer must be valid.
+pub unsafe fn set_image_subsystem(protocol: *mut loaded_image::Protocol, subsystem: u16) {
+    if protocol.is_null() {
+        return;
+    }
+    let (code, data) = match subsystem {
+        11 => (
+            r_efi::efi::BOOT_SERVICES_CODE,
+            r_efi::efi::BOOT_SERVICES_DATA,
+        ),
+        12 => (
+            r_efi::efi::RUNTIME_SERVICES_CODE,
+            r_efi::efi::RUNTIME_SERVICES_DATA,
+        ),
+        _ => (r_efi::efi::LOADER_CODE, r_efi::efi::LOADER_DATA),
+    };
+    unsafe {
+        (*protocol).image_code_type = code;
+        (*protocol).image_data_type = data;
+    }
+}
+
 /// Set load options on a loaded image protocol
 ///
 /// # Safety

--- a/crabefi-core/src/efi/protocols/loaded_image.rs
+++ b/crabefi-core/src/efi/protocols/loaded_image.rs
@@ -126,10 +126,31 @@ pub unsafe fn set_file_path(
     protocol: *mut loaded_image::Protocol,
     device_path: *mut DevicePathProtocol,
 ) {
-    if !protocol.is_null() {
-        // SAFETY: Caller guarantees protocol and device_path pointers are valid.
+    if protocol.is_null() || device_path.is_null() {
+        return;
+    }
+
+    // LoadImage callers retain ownership of DevicePath, so LoadedImage must
+    // keep its own copy for the lifetime of the image.
+    let copy = super::device_path_utilities::duplicate_device_path(device_path);
+    if !copy.is_null() {
         unsafe {
-            (*protocol).file_path = device_path;
+            (*protocol).file_path = copy;
         }
+    }
+}
+
+/// Release the FilePath copy owned by a loaded-image protocol.
+///
+/// # Safety
+/// The protocol pointer must be valid and no longer externally accessible.
+pub unsafe fn free_file_path(protocol: *mut loaded_image::Protocol) {
+    if protocol.is_null() {
+        return;
+    }
+    let file_path = unsafe { (*protocol).file_path };
+    if !file_path.is_null() {
+        let _ = super::super::allocator::free_pool(file_path.cast());
+        unsafe { (*protocol).file_path = core::ptr::null_mut() };
     }
 }

--- a/crabefi-core/src/efi/protocols/mod.rs
+++ b/crabefi-core/src/efi/protocols/mod.rs
@@ -13,6 +13,7 @@ pub mod device_path_to_text;
 pub mod device_path_utilities;
 pub mod disk_io;
 pub mod graphics_output;
+pub mod hii;
 pub mod loaded_image;
 pub mod memory_attribute;
 pub mod nvme_pass_thru;

--- a/crabefi-core/src/efi/protocols/simple_file_system.rs
+++ b/crabefi-core/src/efi/protocols/simple_file_system.rs
@@ -362,18 +362,26 @@ extern "efiapi" fn file_close(this: *mut efi_file::Protocol) -> Status {
     let Some(index) = index else {
         return Status::INVALID_PARAMETER;
     };
+    // Per the UEFI spec, Close() always succeeds and always releases the
+    // handle, even when pending data could not be written. Returning early on a
+    // flush failure would leak the slot forever.
     let status = flush_write_cache(index);
     if status != Status::SUCCESS {
-        return status;
+        log::error!("File.Close: flushing pending writes failed: {:?}", status);
     }
 
+    release_handle(index);
+    Status::SUCCESS
+}
+
+/// Release a file handle slot back to the pool.
+fn release_handle(index: usize) {
     let mut handles = FILE_HANDLES.lock();
     handles[index].in_use = false;
     handles[index].path_len = 0;
     handles[index].position = 0;
     handles[index].open_mode = 0;
     handles[index].write_cache_len = 0;
-    Status::SUCCESS
 }
 
 extern "efiapi" fn file_delete(this: *mut efi_file::Protocol) -> Status {
@@ -387,13 +395,21 @@ extern "efiapi" fn file_delete(this: *mut efi_file::Protocol) -> Status {
             .copy_from_slice(&handles[index].path[..handles[index].path_len]);
         (path, handles[index].open_mode & FILE_MODE_WRITE != 0, index)
     };
+    // Per the UEFI spec, Delete() closes the handle in all cases and only uses
+    // EFI_WARN_DELETE_FAILURE to report that the file itself survived.
+    let status = delete_file_contents(&path, writable, index);
+    release_handle(index);
+    status
+}
+
+fn delete_file_contents(path: &[u8; MAX_PATH_LEN], writable: bool, index: usize) -> Status {
     if !writable || media_is_read_only() {
         return Status::WARN_DELETE_FAILURE;
     }
     if flush_write_cache(index) != Status::SUCCESS {
         return Status::WARN_DELETE_FAILURE;
     }
-    let path = core::str::from_utf8(&path)
+    let path = core::str::from_utf8(path)
         .unwrap_or("")
         .trim_end_matches('\0');
     let partition_start = match state::efi().filesystem {
@@ -404,7 +420,6 @@ extern "efiapi" fn file_delete(this: *mut efi_file::Protocol) -> Status {
         FatFilesystem::new(device, partition_start).and_then(|mut fat| fat.delete_path(path))
     });
     if matches!(deleted, Some(Ok(()))) {
-        let _ = file_close(this);
         Status::SUCCESS
     } else {
         Status::WARN_DELETE_FAILURE
@@ -536,7 +551,12 @@ extern "efiapi" fn file_write(
             index,
         )
     };
-    if mode & FILE_MODE_WRITE == 0 || is_directory {
+    // The spec distinguishes the two cases: writes to an open directory are
+    // EFI_UNSUPPORTED, while a file opened read-only is EFI_ACCESS_DENIED.
+    if is_directory {
+        return Status::UNSUPPORTED;
+    }
+    if mode & FILE_MODE_WRITE == 0 {
         return Status::ACCESS_DENIED;
     }
     if media_is_read_only() {
@@ -775,6 +795,40 @@ extern "efiapi" fn file_get_info(
     }
 }
 
+/// Check whether the `FileName` trailing an `EFI_FILE_INFO` matches the file's
+/// current name (an empty name means "no rename requested").
+fn requested_name_matches(buffer: *mut c_void, buffer_size: usize, current_name: &str) -> bool {
+    let header_size = core::mem::size_of::<efi_file::Info>();
+    let Some(name_bytes) = buffer_size.checked_sub(header_size) else {
+        return true;
+    };
+    let max_chars = name_bytes / core::mem::size_of::<u16>();
+    if max_chars == 0 {
+        return true;
+    }
+
+    // SAFETY: the caller validated `buffer` is non-null and describes at least
+    // `buffer_size` bytes.
+    let name_ptr = unsafe { buffer.cast::<u8>().add(header_size) }.cast::<u16>();
+
+    let mut expected = current_name.chars();
+    for i in 0..max_chars {
+        let unit = unsafe { name_ptr.add(i).read_unaligned() };
+        if unit == 0 {
+            // Terminated: a match only if the current name is also exhausted,
+            // and an empty request means no rename was asked for.
+            return i == 0 || expected.next().is_none();
+        }
+        match expected.next() {
+            Some(c) if c as u32 == unit as u32 => {}
+            _ => return false,
+        }
+    }
+
+    // Unterminated name: treat as no rename request rather than a mismatch.
+    true
+}
+
 extern "efiapi" fn file_set_info(
     this: *mut efi_file::Protocol,
     info_type: *mut Guid,
@@ -789,7 +843,7 @@ extern "efiapi" fn file_set_info(
     {
         return Status::UNSUPPORTED;
     }
-    let (path, path_len, mode, current_size, index) = {
+    let (path, path_len, mode, current_size, is_directory, index) = {
         let handles = FILE_HANDLES.lock();
         let Some(index) = find_handle_index_unlocked(&handles, this) else {
             return Status::INVALID_PARAMETER;
@@ -802,6 +856,7 @@ extern "efiapi" fn file_set_info(
             handles[index].path_len,
             handles[index].open_mode,
             handles[index].file_size,
+            handles[index].is_directory,
             index,
         )
     };
@@ -811,15 +866,33 @@ extern "efiapi" fn file_set_info(
     if media_is_read_only() {
         return Status::WRITE_PROTECTED;
     }
+
+    let path_str = core::str::from_utf8(&path[..path_len]).unwrap_or("");
+    let current_name = path_str.rsplit(['/', '\\']).next().unwrap_or("");
+
+    // Only truncation is implemented. Report UNSUPPORTED instead of a bogus
+    // SUCCESS for the fields this driver cannot honour: rename via FileName and
+    // attribute changes.
+    let current_attribute = if is_directory { FILE_DIRECTORY } else { 0 };
+    let requested_attribute = unsafe { (*(buffer as *const efi_file::Info)).attribute };
+    if requested_attribute != current_attribute {
+        return Status::UNSUPPORTED;
+    }
+    if !requested_name_matches(buffer, buffer_size, current_name) {
+        return Status::UNSUPPORTED;
+    }
+
     let status = flush_write_cache(index);
     if status != Status::SUCCESS {
         return status;
     }
     let size = unsafe { (*(buffer as *const efi_file::Info)).file_size };
+    // NOTE: growing a file through SetInfo is legal per the spec but not yet
+    // implemented here.
     if size > u32::MAX as u64 || size > current_size {
         return Status::UNSUPPORTED;
     }
-    let path = core::str::from_utf8(&path[..path_len]).unwrap_or("");
+    let path = path_str;
     let partition_start = match state::efi().filesystem {
         Some(state) => state.partition_start,
         None => return Status::NOT_READY,

--- a/crabefi-core/src/efi/protocols/simple_file_system.rs
+++ b/crabefi-core/src/efi/protocols/simple_file_system.rs
@@ -30,6 +30,7 @@ const MAX_PATH_LEN: usize = 256;
 
 /// Maximum number of open file handles
 const MAX_FILE_HANDLES: usize = 32;
+const WRITE_CACHE_SIZE: usize = 4096;
 
 /// File open modes
 pub const FILE_MODE_READ: u64 = efi_file::MODE_READ;
@@ -55,6 +56,12 @@ struct FileHandle {
     first_cluster: u32,
     /// Is this a directory?
     is_directory: bool,
+    /// Mode used to open this handle
+    open_mode: u64,
+    /// Bounded sequential write-back cache, persisted by Flush/Close.
+    write_cache: [u8; WRITE_CACHE_SIZE],
+    write_cache_offset: u64,
+    write_cache_len: usize,
     /// The File Protocol struct for this handle
     protocol: efi_file::Protocol,
 }
@@ -69,6 +76,10 @@ impl FileHandle {
             file_size: 0,
             first_cluster: 0,
             is_directory: false,
+            open_mode: 0,
+            write_cache: [0; WRITE_CACHE_SIZE],
+            write_cache_offset: 0,
+            write_cache_len: 0,
             protocol: efi_file::Protocol {
                 revision: efi_file::REVISION,
                 open: file_open,
@@ -200,6 +211,8 @@ extern "efiapi" fn sfs_open_volume(
     handles[handle_idx].file_size = 0;
     handles[handle_idx].first_cluster = fs_state.root_cluster;
     handles[handle_idx].is_directory = true;
+    handles[handle_idx].open_mode = FILE_MODE_READ | FILE_MODE_WRITE;
+    handles[handle_idx].write_cache_len = 0;
 
     // Return pointer to the protocol in this handle
     unsafe {
@@ -222,16 +235,19 @@ extern "efiapi" fn file_open(
     new_handle: *mut *mut efi_file::Protocol,
     file_name: *mut Char16,
     open_mode: u64,
-    _attributes: u64,
+    attributes: u64,
 ) -> Status {
     if this.is_null() || new_handle.is_null() || file_name.is_null() {
         return Status::INVALID_PARAMETER;
     }
 
-    // Only read mode is supported
-    if open_mode != FILE_MODE_READ {
-        log::debug!("File.Open: only read mode supported, got {:#x}", open_mode);
-        return Status::UNSUPPORTED;
+    let base_mode = open_mode & !FILE_MODE_CREATE;
+    if (base_mode != FILE_MODE_READ && base_mode != FILE_MODE_READ | FILE_MODE_WRITE)
+        || open_mode & !(FILE_MODE_READ | FILE_MODE_WRITE | FILE_MODE_CREATE) != 0
+        || (open_mode & FILE_MODE_CREATE != 0 && base_mode != FILE_MODE_READ | FILE_MODE_WRITE)
+        || attributes & !efi_file::VALID_ATTR != 0
+    {
+        return Status::INVALID_PARAMETER;
     }
 
     // Convert UTF-16 filename to UTF-8
@@ -245,7 +261,7 @@ extern "efiapi" fn file_open(
     log::info!("File.Open({:?})", name_str);
 
     // Get parent handle info
-    let (parent_path, parent_path_len) = {
+    let (parent_path, parent_path_len, parent_mode) = {
         let handles = FILE_HANDLES.lock();
         let parent_idx = match find_handle_index_unlocked(&handles, this) {
             Some(idx) => idx,
@@ -254,7 +270,7 @@ extern "efiapi" fn file_open(
         let mut path = [0u8; MAX_PATH_LEN];
         let len = handles[parent_idx].path_len;
         path[..len].copy_from_slice(&handles[parent_idx].path[..len]);
-        (path, len)
+        (path, len, handles[parent_idx].open_mode)
     };
 
     // Build full path
@@ -270,21 +286,31 @@ extern "efiapi" fn file_open(
         None => return Status::NOT_READY,
     };
 
-    // Find the file using FatFilesystem
-    let result = state::with_block_device_mut(|device| {
-        let mut fat = match FatFilesystem::new(device, partition_start) {
-            Ok(f) => f,
-            Err(_) => return Err(()),
-        };
+    if open_mode & FILE_MODE_WRITE != 0 && media_is_read_only() {
+        return Status::WRITE_PROTECTED;
+    }
+    if open_mode & FILE_MODE_CREATE != 0 && parent_mode & FILE_MODE_WRITE == 0 {
+        return Status::ACCESS_DENIED;
+    }
 
-        match fat.find_file(full_path_str) {
-            Ok(entry) => Ok((
-                entry.first_cluster(),
-                entry.file_size(),
-                entry.is_directory(),
-            )),
-            Err(_) => Err(()),
+    let result = state::with_block_device_mut(|device| {
+        let mut fat =
+            FatFilesystem::new(device, partition_start).map_err(|_| Status::DEVICE_ERROR)?;
+        let entry = match fat.find_file(full_path_str) {
+            Ok(entry) => entry,
+            Err(crate::fs::fat::FatError::NotFound) if open_mode & FILE_MODE_CREATE != 0 => fat
+                .create(full_path_str, attributes & FILE_DIRECTORY != 0)
+                .map_err(fat_status)?,
+            Err(error) => return Err(fat_status(error)),
+        };
+        if open_mode & FILE_MODE_WRITE != 0 && fat.fat_type() != crate::fs::fat::FatType::Fat32 {
+            return Err(Status::WRITE_PROTECTED);
         }
+        Ok((
+            entry.first_cluster(),
+            entry.file_size(),
+            entry.is_directory(),
+        ))
     });
 
     match result {
@@ -303,6 +329,8 @@ extern "efiapi" fn file_open(
             handles[handle_idx].file_size = size as u64;
             handles[handle_idx].first_cluster = cluster;
             handles[handle_idx].is_directory = is_dir;
+            handles[handle_idx].open_mode = open_mode;
+            handles[handle_idx].write_cache_len = 0;
 
             unsafe {
                 *new_handle = &raw mut handles[handle_idx].protocol;
@@ -316,10 +344,7 @@ extern "efiapi" fn file_open(
             );
             Status::SUCCESS
         }
-        Some(Err(_)) => {
-            log::debug!("File.Open: not found");
-            Status::NOT_FOUND
-        }
+        Some(Err(status)) => status,
         None => {
             log::error!("File.Open: block device not available");
             Status::NOT_READY
@@ -330,20 +355,60 @@ extern "efiapi" fn file_open(
 extern "efiapi" fn file_close(this: *mut efi_file::Protocol) -> Status {
     log::debug!("File.Close()");
 
-    let mut handles = FILE_HANDLES.lock();
-    if let Some(idx) = find_handle_index_unlocked(&handles, this) {
-        handles[idx].in_use = false;
-        handles[idx].path_len = 0;
-        handles[idx].position = 0;
-        Status::SUCCESS
-    } else {
-        Status::INVALID_PARAMETER
+    let index = {
+        let handles = FILE_HANDLES.lock();
+        find_handle_index_unlocked(&handles, this)
+    };
+    let Some(index) = index else {
+        return Status::INVALID_PARAMETER;
+    };
+    let status = flush_write_cache(index);
+    if status != Status::SUCCESS {
+        return status;
     }
+
+    let mut handles = FILE_HANDLES.lock();
+    handles[index].in_use = false;
+    handles[index].path_len = 0;
+    handles[index].position = 0;
+    handles[index].open_mode = 0;
+    handles[index].write_cache_len = 0;
+    Status::SUCCESS
 }
 
-extern "efiapi" fn file_delete(_this: *mut efi_file::Protocol) -> Status {
-    log::debug!("File.Delete() -> UNSUPPORTED");
-    Status::UNSUPPORTED
+extern "efiapi" fn file_delete(this: *mut efi_file::Protocol) -> Status {
+    let (path, writable, index) = {
+        let handles = FILE_HANDLES.lock();
+        let Some(index) = find_handle_index_unlocked(&handles, this) else {
+            return Status::INVALID_PARAMETER;
+        };
+        let mut path = [0u8; MAX_PATH_LEN];
+        path[..handles[index].path_len]
+            .copy_from_slice(&handles[index].path[..handles[index].path_len]);
+        (path, handles[index].open_mode & FILE_MODE_WRITE != 0, index)
+    };
+    if !writable || media_is_read_only() {
+        return Status::WARN_DELETE_FAILURE;
+    }
+    if flush_write_cache(index) != Status::SUCCESS {
+        return Status::WARN_DELETE_FAILURE;
+    }
+    let path = core::str::from_utf8(&path)
+        .unwrap_or("")
+        .trim_end_matches('\0');
+    let partition_start = match state::efi().filesystem {
+        Some(state) => state.partition_start,
+        None => return Status::WARN_DELETE_FAILURE,
+    };
+    let deleted = state::with_block_device_mut(|device| {
+        FatFilesystem::new(device, partition_start).and_then(|mut fat| fat.delete_path(path))
+    });
+    if matches!(deleted, Some(Ok(()))) {
+        let _ = file_close(this);
+        Status::SUCCESS
+    } else {
+        Status::WARN_DELETE_FAILURE
+    }
 }
 
 extern "efiapi" fn file_read(
@@ -376,6 +441,10 @@ extern "efiapi" fn file_read(
 
     if is_dir {
         return read_directory(buffer_size, buffer, handle_idx);
+    }
+    let flush_status = flush_write_cache(handle_idx);
+    if flush_status != Status::SUCCESS {
+        return flush_status;
     }
 
     // File read
@@ -441,12 +510,92 @@ extern "efiapi" fn file_read(
 }
 
 extern "efiapi" fn file_write(
-    _this: *mut efi_file::Protocol,
-    _buffer_size: *mut usize,
-    _buffer: *mut c_void,
+    this: *mut efi_file::Protocol,
+    buffer_size: *mut usize,
+    buffer: *mut c_void,
 ) -> Status {
-    log::debug!("File.Write() -> UNSUPPORTED");
-    Status::UNSUPPORTED
+    if this.is_null() || buffer_size.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+    let requested = unsafe { *buffer_size };
+    if requested != 0 && buffer.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+    if requested == 0 {
+        return Status::SUCCESS;
+    }
+    let (position, mode, is_directory, index) = {
+        let handles = FILE_HANDLES.lock();
+        let Some(index) = find_handle_index_unlocked(&handles, this) else {
+            return Status::INVALID_PARAMETER;
+        };
+        (
+            handles[index].position,
+            handles[index].open_mode,
+            handles[index].is_directory,
+            index,
+        )
+    };
+    if mode & FILE_MODE_WRITE == 0 || is_directory {
+        return Status::ACCESS_DENIED;
+    }
+    if media_is_read_only() {
+        return Status::WRITE_PROTECTED;
+    }
+    if position > u32::MAX as u64 || requested > u32::MAX as usize {
+        return Status::UNSUPPORTED;
+    }
+    let data = unsafe { core::slice::from_raw_parts(buffer.cast::<u8>(), requested) };
+
+    if requested <= WRITE_CACHE_SIZE {
+        let can_append = {
+            let handles = FILE_HANDLES.lock();
+            let handle = &handles[index];
+            (handle.write_cache_len == 0
+                || handle.write_cache_offset + handle.write_cache_len as u64 == position)
+                && handle.write_cache_len + requested <= WRITE_CACHE_SIZE
+        };
+        if !can_append {
+            let status = flush_write_cache(index);
+            if status != Status::SUCCESS {
+                return status;
+            }
+        }
+
+        let mut handles = FILE_HANDLES.lock();
+        let handle = &mut handles[index];
+        if handle.write_cache_len == 0 {
+            handle.write_cache_offset = position;
+        }
+        let start = handle.write_cache_len;
+        handle.write_cache[start..start + requested].copy_from_slice(data);
+        handle.write_cache_len += requested;
+        handle.position += requested as u64;
+        handle.file_size = handle.file_size.max(handle.position);
+        return Status::SUCCESS;
+    }
+
+    let status = flush_write_cache(index);
+    if status != Status::SUCCESS {
+        return status;
+    }
+    let (path, path_len) = {
+        let handles = FILE_HANDLES.lock();
+        let mut path = [0u8; MAX_PATH_LEN];
+        path[..handles[index].path_len]
+            .copy_from_slice(&handles[index].path[..handles[index].path_len]);
+        (path, handles[index].path_len)
+    };
+    match write_path_to_disk(&path[..path_len], position, data) {
+        Ok((size, cluster)) => {
+            let mut handles = FILE_HANDLES.lock();
+            handles[index].position += requested as u64;
+            handles[index].file_size = size as u64;
+            handles[index].first_cluster = cluster;
+            Status::SUCCESS
+        }
+        Err(status) => status,
+    }
 }
 
 extern "efiapi" fn file_get_position(this: *mut efi_file::Protocol, position: *mut u64) -> Status {
@@ -471,27 +620,36 @@ extern "efiapi" fn file_set_position(this: *mut efi_file::Protocol, position: u6
         return Status::INVALID_PARAMETER;
     }
 
-    let mut handles = FILE_HANDLES.lock();
-    if let Some(idx) = find_handle_index_unlocked(&handles, this) {
-        if handles[idx].is_directory {
-            // For directories, only 0 is allowed (reset enumeration)
+    let index = {
+        let handles = FILE_HANDLES.lock();
+        find_handle_index_unlocked(&handles, this)
+    };
+    let Some(index) = index else {
+        return Status::INVALID_PARAMETER;
+    };
+
+    {
+        let mut handles = FILE_HANDLES.lock();
+        if handles[index].is_directory {
             if position != 0 {
                 return Status::UNSUPPORTED;
             }
-            handles[idx].position = 0;
+            handles[index].position = 0;
             return Status::SUCCESS;
         }
-
-        // 0xFFFF_FFFF_FFFF_FFFF means seek to end
-        if position == u64::MAX {
-            handles[idx].position = handles[idx].file_size;
-        } else {
-            handles[idx].position = position;
-        }
-        Status::SUCCESS
-    } else {
-        Status::INVALID_PARAMETER
     }
+    let status = flush_write_cache(index);
+    if status != Status::SUCCESS {
+        return status;
+    }
+
+    let mut handles = FILE_HANDLES.lock();
+    if position == u64::MAX {
+        handles[index].position = handles[index].file_size;
+    } else {
+        handles[index].position = position;
+    }
+    Status::SUCCESS
 }
 
 extern "efiapi" fn file_get_info(
@@ -585,11 +743,16 @@ extern "efiapi" fn file_get_info(
             Some(s) => s,
             None => return Status::NOT_READY,
         };
+        let read_only = media_is_read_only();
 
         let info = buffer as *mut efi_file::SystemInfo;
         unsafe {
             (*info).size = required_size as u64;
-            (*info).read_only = r_efi::efi::Boolean::TRUE; // Read-only
+            (*info).read_only = if read_only {
+                r_efi::efi::Boolean::TRUE
+            } else {
+                r_efi::efi::Boolean::FALSE
+            };
             (*info).volume_size = 0; // Unknown
             (*info).free_space = 0;
             (*info).block_size = fs_state.device_block_size;
@@ -613,18 +776,97 @@ extern "efiapi" fn file_get_info(
 }
 
 extern "efiapi" fn file_set_info(
-    _this: *mut efi_file::Protocol,
-    _info_type: *mut Guid,
-    _buffer_size: usize,
-    _buffer: *mut c_void,
+    this: *mut efi_file::Protocol,
+    info_type: *mut Guid,
+    buffer_size: usize,
+    buffer: *mut c_void,
 ) -> Status {
-    log::debug!("File.SetInfo() -> UNSUPPORTED");
-    Status::UNSUPPORTED
+    if this.is_null() || info_type.is_null() || buffer.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+    if unsafe { *info_type } != FILE_INFO_GUID
+        || buffer_size < core::mem::size_of::<efi_file::Info>()
+    {
+        return Status::UNSUPPORTED;
+    }
+    let (path, path_len, mode, current_size, index) = {
+        let handles = FILE_HANDLES.lock();
+        let Some(index) = find_handle_index_unlocked(&handles, this) else {
+            return Status::INVALID_PARAMETER;
+        };
+        let mut path = [0u8; MAX_PATH_LEN];
+        path[..handles[index].path_len]
+            .copy_from_slice(&handles[index].path[..handles[index].path_len]);
+        (
+            path,
+            handles[index].path_len,
+            handles[index].open_mode,
+            handles[index].file_size,
+            index,
+        )
+    };
+    if mode & FILE_MODE_WRITE == 0 {
+        return Status::ACCESS_DENIED;
+    }
+    if media_is_read_only() {
+        return Status::WRITE_PROTECTED;
+    }
+    let status = flush_write_cache(index);
+    if status != Status::SUCCESS {
+        return status;
+    }
+    let size = unsafe { (*(buffer as *const efi_file::Info)).file_size };
+    if size > u32::MAX as u64 || size > current_size {
+        return Status::UNSUPPORTED;
+    }
+    let path = core::str::from_utf8(&path[..path_len]).unwrap_or("");
+    let partition_start = match state::efi().filesystem {
+        Some(state) => state.partition_start,
+        None => return Status::NOT_READY,
+    };
+    let result = state::with_block_device_mut(|device| {
+        FatFilesystem::new(device, partition_start)
+            .and_then(|mut fat| fat.truncate_path(path, size as u32))
+    });
+    match result {
+        Some(Ok(())) => {
+            let mut handles = FILE_HANDLES.lock();
+            handles[index].file_size = size;
+            handles[index].position = handles[index].position.min(size);
+            Status::SUCCESS
+        }
+        Some(Err(error)) => fat_status(error),
+        None => Status::NOT_READY,
+    }
 }
 
-extern "efiapi" fn file_flush(_this: *mut efi_file::Protocol) -> Status {
-    // Read-only filesystem, nothing to flush
-    Status::SUCCESS
+extern "efiapi" fn file_flush(this: *mut efi_file::Protocol) -> Status {
+    if this.is_null() {
+        return Status::INVALID_PARAMETER;
+    }
+    let index = {
+        let handles = FILE_HANDLES.lock();
+        find_handle_index_unlocked(&handles, this)
+    };
+    let Some(index) = index else {
+        return Status::INVALID_PARAMETER;
+    };
+    let status = flush_write_cache(index);
+    if status != Status::SUCCESS {
+        return status;
+    }
+
+    let partition_start = match state::efi().filesystem {
+        Some(state) => state.partition_start,
+        None => return Status::NOT_READY,
+    };
+    match state::with_block_device_mut(|device| {
+        FatFilesystem::new(device, partition_start).and_then(|mut fat| fat.flush())
+    }) {
+        Some(Ok(())) => Status::SUCCESS,
+        Some(Err(error)) => fat_status(error),
+        None => Status::NOT_READY,
+    }
 }
 
 // Async operations - not supported
@@ -663,6 +905,84 @@ extern "efiapi" fn file_flush_ex(
 // ============================================================================
 // Helper Functions
 // ============================================================================
+
+fn media_is_read_only() -> bool {
+    state::with_block_device_mut(|device| device.info().read_only).unwrap_or(true)
+}
+
+fn write_path_to_disk(path: &[u8], offset: u64, data: &[u8]) -> Result<(u32, u32), Status> {
+    if offset > u32::MAX as u64 || data.len() > u32::MAX as usize {
+        return Err(Status::UNSUPPORTED);
+    }
+    let path = core::str::from_utf8(path).unwrap_or("");
+    let partition_start = state::efi()
+        .filesystem
+        .ok_or(Status::NOT_READY)?
+        .partition_start;
+    match state::with_block_device_mut(|device| {
+        let mut fat =
+            FatFilesystem::new(device, partition_start).map_err(|_| Status::DEVICE_ERROR)?;
+        fat.write_path(path, offset as u32, data)
+            .map_err(fat_status)
+    }) {
+        Some(result) => result,
+        None => Err(Status::NOT_READY),
+    }
+}
+
+fn flush_write_cache(index: usize) -> Status {
+    let (path, path_len, offset, len, data) = {
+        let handles = FILE_HANDLES.lock();
+        if !handles[index].in_use || handles[index].write_cache_len == 0 {
+            return Status::SUCCESS;
+        }
+        let mut path = [0u8; MAX_PATH_LEN];
+        path[..handles[index].path_len]
+            .copy_from_slice(&handles[index].path[..handles[index].path_len]);
+        let mut data = [0u8; WRITE_CACHE_SIZE];
+        let len = handles[index].write_cache_len;
+        data[..len].copy_from_slice(&handles[index].write_cache[..len]);
+        (
+            path,
+            handles[index].path_len,
+            handles[index].write_cache_offset,
+            len,
+            data,
+        )
+    };
+
+    match write_path_to_disk(&path[..path_len], offset, &data[..len]) {
+        Ok((size, cluster)) => {
+            let mut handles = FILE_HANDLES.lock();
+            handles[index].write_cache_len = 0;
+            handles[index].file_size = handles[index].file_size.max(size as u64);
+            handles[index].first_cluster = cluster;
+            Status::SUCCESS
+        }
+        Err(status) => status,
+    }
+}
+
+fn fat_status(error: crate::fs::fat::FatError) -> Status {
+    use crate::fs::fat::FatError;
+    match error {
+        FatError::NotFound => Status::NOT_FOUND,
+        FatError::AlreadyExists => Status::ACCESS_DENIED,
+        FatError::ReadOnly => Status::WRITE_PROTECTED,
+        FatError::InvalidName | FatError::NotADirectory | FatError::NotAFile => {
+            Status::INVALID_PARAMETER
+        }
+        FatError::NoSpace => Status::VOLUME_FULL,
+        FatError::DirectoryNotEmpty => Status::ACCESS_DENIED,
+        FatError::InvalidBpb
+        | FatError::ReadError
+        | FatError::WriteError
+        | FatError::NotFat
+        | FatError::EndOfFile
+        | FatError::InvalidCluster
+        | FatError::BufferTooSmall => Status::DEVICE_ERROR,
+    }
+}
 
 /// Find handle index without holding the lock (for use when we already have it)
 fn find_handle_index_unlocked(

--- a/crabefi-core/src/efi/protocols/unicode_collation.rs
+++ b/crabefi-core/src/efi/protocols/unicode_collation.rs
@@ -56,31 +56,35 @@ pub struct UnicodeCollationProtocol {
     pub supported_languages: *const Char8,
 }
 
-// Static storage for supported languages string
-// Note: Unicode Collation v1 uses ISO 639-2 three-letter codes (e.g., "eng")
-// Unicode Collation v2 uses RFC 4646 codes (e.g., "en")
-// We use "eng" which works for v1, and many v2 implementations accept it too
-static SUPPORTED_LANGUAGES: [u8; 4] = *b"eng\0";
+static V1_SUPPORTED_LANGUAGES: [u8; 4] = *b"eng\0";
+static V2_SUPPORTED_LANGUAGES: [u8; 3] = *b"en\0";
 
-/// Static protocol instance
-static mut UNICODE_COLLATION: UnicodeCollationProtocol = UnicodeCollationProtocol {
+static mut UNICODE_COLLATION_V1: UnicodeCollationProtocol = UnicodeCollationProtocol {
     stri_coll,
     metai_match,
     str_lwr,
     str_upr,
     fat_to_str,
     str_to_fat,
-    supported_languages: SUPPORTED_LANGUAGES.as_ptr() as *const Char8,
+    supported_languages: V1_SUPPORTED_LANGUAGES.as_ptr() as *const Char8,
 };
 
-/// Get the Unicode Collation Protocol
-pub fn get_protocol() -> *mut UnicodeCollationProtocol {
-    &raw mut UNICODE_COLLATION
+static mut UNICODE_COLLATION_V2: UnicodeCollationProtocol = UnicodeCollationProtocol {
+    stri_coll,
+    metai_match,
+    str_lwr,
+    str_upr,
+    fat_to_str,
+    str_to_fat,
+    supported_languages: V2_SUPPORTED_LANGUAGES.as_ptr() as *const Char8,
+};
+
+pub fn get_v1_protocol_void() -> *mut c_void {
+    (&raw mut UNICODE_COLLATION_V1).cast()
 }
 
-/// Get the protocol as a void pointer
-pub fn get_protocol_void() -> *mut c_void {
-    get_protocol() as *mut c_void
+pub fn get_v2_protocol_void() -> *mut c_void {
+    (&raw mut UNICODE_COLLATION_V2).cast()
 }
 
 // Convert a UTF-16 character to uppercase (ASCII only for now)

--- a/crabefi-core/src/fs/fat.rs
+++ b/crabefi-core/src/fs/fat.rs
@@ -1317,11 +1317,9 @@ impl<'a> FatFilesystem<'a> {
         let cluster_size = self.sectors_per_cluster as usize * self.bytes_per_sector as usize;
         let base = self.cluster_byte_offset(cluster)?;
         let zero = [0u8; MAX_BLOCK_SIZE];
-        let mut done = 0;
-        while done < cluster_size {
+        for done in (0..cluster_size).step_by(MAX_BLOCK_SIZE) {
             let count = MAX_BLOCK_SIZE.min(cluster_size - done);
             self.partition_write(base + done as u64, &zero[..count])?;
-            done += count;
         }
         Ok(())
     }
@@ -1397,9 +1395,8 @@ impl<'a> FatFilesystem<'a> {
             let base = self.cluster_byte_offset(cluster)?;
             for chunk_start in (0..cluster_size).step_by(chunk) {
                 self.partition_read(base + chunk_start as u64, &mut data[..chunk])?;
-                for local in (0..chunk).step_by(32) {
-                    let position = base + (chunk_start + local) as u64;
-                    let raw = &data[local..local + 32];
+                for (entry_index, raw) in data[..chunk].as_chunks::<32>().0.iter().enumerate() {
+                    let position = base + (chunk_start + entry_index * 32) as u64;
                     let entry =
                         DirectoryEntry::read_from_bytes(raw).map_err(|_| FatError::ReadError)?;
                     if entry.is_end() {
@@ -1452,14 +1449,11 @@ impl<'a> FatFilesystem<'a> {
             let base = self.cluster_byte_offset(cluster)?;
             for chunk_start in (0..cluster_size).step_by(chunk) {
                 self.partition_read(base + chunk_start as u64, &mut data[..chunk])?;
-                for offset in (0..chunk).step_by(32) {
-                    if data[offset] == 0 {
+                for raw in data[..chunk].as_chunks::<32>().0 {
+                    if raw[0] == 0 {
                         return Ok(false);
                     }
-                    if data[offset] != 0xe5
-                        && data[offset + 11] != ATTR_LFN
-                        && data[offset..offset + 11] == short[..]
-                    {
+                    if raw[0] != 0xe5 && raw[11] != ATTR_LFN && raw[..11] == short[..] {
                         return Ok(true);
                     }
                 }
@@ -1545,11 +1539,11 @@ impl<'a> FatFilesystem<'a> {
             let mut run = 0;
             for chunk_start in (0..cluster_size).step_by(chunk) {
                 self.partition_read(base + chunk_start as u64, &mut data[..chunk])?;
-                for local in (0..chunk).step_by(32) {
-                    if data[local] == 0 || data[local] == 0xe5 {
+                for (entry_index, raw) in data[..chunk].as_chunks::<32>().0.iter().enumerate() {
+                    if raw[0] == 0 || raw[0] == 0xe5 {
                         run += 1;
                         if run == count {
-                            let end = chunk_start + local + 32;
+                            let end = chunk_start + (entry_index + 1) * 32;
                             return Ok(base + (end - count * 32) as u64);
                         }
                     } else {
@@ -1565,9 +1559,14 @@ impl<'a> FatFilesystem<'a> {
                     // stop at the old marker and never follow the new FAT link.
                     for chunk_start in (0..cluster_size).step_by(chunk) {
                         self.partition_read(base + chunk_start as u64, &mut data[..chunk])?;
-                        for local in (0..chunk).step_by(32) {
-                            if data[local] == 0 {
-                                self.partition_write(base + (chunk_start + local) as u64, &[0xe5])?;
+                        for (entry_index, raw) in
+                            data[..chunk].as_chunks::<32>().0.iter().enumerate()
+                        {
+                            if raw[0] == 0 {
+                                self.partition_write(
+                                    base + (chunk_start + entry_index * 32) as u64,
+                                    &[0xe5],
+                                )?;
                             }
                         }
                     }

--- a/crabefi-core/src/fs/fat.rs
+++ b/crabefi-core/src/fs/fat.rs
@@ -370,6 +370,18 @@ pub enum FatError {
     InvalidCluster,
     /// Buffer too small
     BufferTooSmall,
+    /// Mutation is only implemented for FAT32
+    ReadOnly,
+    /// Block-device write failed
+    WriteError,
+    /// Entry already exists
+    AlreadyExists,
+    /// Directory is not empty
+    DirectoryNotEmpty,
+    /// Invalid filename
+    InvalidName,
+    /// No free clusters or directory slots
+    NoSpace,
 }
 
 impl core::fmt::Display for FatError {
@@ -384,6 +396,12 @@ impl core::fmt::Display for FatError {
             FatError::EndOfFile => write!(f, "end of file"),
             FatError::InvalidCluster => write!(f, "invalid cluster"),
             FatError::BufferTooSmall => write!(f, "buffer too small"),
+            FatError::ReadOnly => write!(f, "read-only FAT filesystem"),
+            FatError::WriteError => write!(f, "write error"),
+            FatError::AlreadyExists => write!(f, "entry already exists"),
+            FatError::DirectoryNotEmpty => write!(f, "directory not empty"),
+            FatError::InvalidName => write!(f, "invalid filename"),
+            FatError::NoSpace => write!(f, "filesystem full"),
         }
     }
 }
@@ -404,6 +422,10 @@ pub struct FatFilesystem<'a> {
     sectors_per_cluster: u8,
     /// First FAT sector (relative to partition start)
     fat_start: u32,
+    /// Number of FAT copies
+    num_fats: u8,
+    /// Sectors occupied by one FAT copy
+    sectors_per_fat: u32,
     /// First data sector (relative to partition start)
     data_start: u32,
     /// Root directory first cluster (FAT32) or sector count (FAT12/16)
@@ -566,6 +588,8 @@ impl<'a> FatFilesystem<'a> {
             device_block_size: block_size as u32,
             sectors_per_cluster,
             fat_start,
+            num_fats: bpb_num_fats,
+            sectors_per_fat,
             data_start,
             root_cluster,
             root_dir_start,
@@ -752,9 +776,9 @@ impl<'a> FatFilesystem<'a> {
 
         let device_block_size = self.device_block_size as usize;
 
-        // Handle case where cluster is smaller than or equal to device block
-        if cluster_size <= device_block_size {
-            // Cluster fits within one or two device blocks
+        // Unaligned clusters need per-block copying so preceding bytes are skipped.
+        if cluster_size <= device_block_size || start_offset != 0 {
+            // Cluster fits within one or more device blocks
             let mut temp_buffer = [0u8; MAX_BLOCK_SIZE];
             let mut bytes_copied = 0usize;
             let mut current_block = start_device_block;
@@ -1190,6 +1214,554 @@ impl<'a> FatFilesystem<'a> {
         Ok(bytes_read)
     }
 
+    fn require_fat32(&self) -> Result<(), FatError> {
+        if self.fat_type == FatType::Fat32 {
+            Ok(())
+        } else {
+            Err(FatError::ReadOnly)
+        }
+    }
+
+    fn partition_read(&mut self, byte_offset: u64, output: &mut [u8]) -> Result<(), FatError> {
+        let block_size = self.device_block_size as usize;
+        let mut block = [0u8; MAX_BLOCK_SIZE];
+        let mut done = 0;
+        while done < output.len() {
+            let position = byte_offset + done as u64;
+            let lba = self.partition_start + position / block_size as u64;
+            let within = position as usize % block_size;
+            self.device
+                .read_block(lba, &mut block[..block_size])
+                .map_err(|_| FatError::ReadError)?;
+            let count = (block_size - within).min(output.len() - done);
+            output[done..done + count].copy_from_slice(&block[within..within + count]);
+            done += count;
+        }
+        Ok(())
+    }
+
+    fn partition_write(&mut self, byte_offset: u64, input: &[u8]) -> Result<(), FatError> {
+        self.require_fat32()?;
+        let block_size = self.device_block_size as usize;
+        let mut block = [0u8; MAX_BLOCK_SIZE];
+        let mut done = 0;
+        while done < input.len() {
+            let position = byte_offset + done as u64;
+            let lba = self.partition_start + position / block_size as u64;
+            let within = position as usize % block_size;
+            let count = (block_size - within).min(input.len() - done);
+            if within != 0 || count != block_size {
+                self.device
+                    .read_block(lba, &mut block[..block_size])
+                    .map_err(|_| FatError::ReadError)?;
+            }
+            block[within..within + count].copy_from_slice(&input[done..done + count]);
+            self.device
+                .write_block(lba, &block[..block_size])
+                .map_err(|_| FatError::WriteError)?;
+            done += count;
+        }
+        self.fat_block_cached = u64::MAX;
+        Ok(())
+    }
+
+    fn cluster_byte_offset(&self, cluster: u32) -> Result<u64, FatError> {
+        if cluster < 2 || cluster - 2 >= self.data_clusters {
+            return Err(FatError::InvalidCluster);
+        }
+        Ok(self.data_start as u64 * self.bytes_per_sector as u64
+            + (cluster - 2) as u64 * self.sectors_per_cluster as u64 * self.bytes_per_sector as u64)
+    }
+
+    fn write_cluster(&mut self, cluster: u32, data: &[u8]) -> Result<(), FatError> {
+        let cluster_size = self.sectors_per_cluster as usize * self.bytes_per_sector as usize;
+        if data.len() < cluster_size {
+            return Err(FatError::BufferTooSmall);
+        }
+        self.partition_write(self.cluster_byte_offset(cluster)?, &data[..cluster_size])
+    }
+
+    fn fat32_value(&mut self, cluster: u32) -> Result<u32, FatError> {
+        self.require_fat32()?;
+        let mut bytes = [0u8; 4];
+        let offset = self.fat_start as u64 * self.bytes_per_sector as u64 + cluster as u64 * 4;
+        self.partition_read(offset, &mut bytes)?;
+        Ok(u32::from_le_bytes(bytes) & 0x0fff_ffff)
+    }
+
+    fn set_fat32_value(&mut self, cluster: u32, value: u32) -> Result<(), FatError> {
+        self.require_fat32()?;
+        let copies = self.num_fats as usize;
+        let mut offsets = [0u64; 2];
+        let mut old_values = [0u32; 2];
+
+        for copy in 0..copies {
+            offsets[copy] = (self.fat_start + copy as u32 * self.sectors_per_fat) as u64
+                * self.bytes_per_sector as u64
+                + cluster as u64 * 4;
+            let mut bytes = [0u8; 4];
+            self.partition_read(offsets[copy], &mut bytes)?;
+            old_values[copy] = u32::from_le_bytes(bytes);
+        }
+
+        for copy in 0..copies {
+            let bytes = ((old_values[copy] & 0xf000_0000) | (value & 0x0fff_ffff)).to_le_bytes();
+            if let Err(error) = self.partition_write(offsets[copy], &bytes) {
+                for rollback in 0..copy {
+                    let _ = self
+                        .partition_write(offsets[rollback], &old_values[rollback].to_le_bytes());
+                }
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
+    fn allocate_cluster(&mut self) -> Result<u32, FatError> {
+        for cluster in 2..self.data_clusters + 2 {
+            if self.fat32_value(cluster)? == 0 {
+                let zero = [0u8; 65536];
+                self.write_cluster(cluster, &zero)?;
+                self.set_fat32_value(cluster, 0x0fff_ffff)?;
+                return Ok(cluster);
+            }
+        }
+        Err(FatError::NoSpace)
+    }
+
+    fn free_chain(&mut self, first: u32) -> Result<(), FatError> {
+        let mut cluster = first;
+        while cluster >= 2 {
+            let next = self.fat32_value(cluster)?;
+            self.set_fat32_value(cluster, 0)?;
+            if !(2..0x0fff_fff8).contains(&next) {
+                break;
+            }
+            cluster = next;
+        }
+        Ok(())
+    }
+
+    fn append_cluster(&mut self, last: u32) -> Result<u32, FatError> {
+        let new = self.allocate_cluster()?;
+        if let Err(error) = self.set_fat32_value(last, new) {
+            let _ = self.set_fat32_value(new, 0);
+            return Err(error);
+        }
+        Ok(new)
+    }
+
+    fn find_record_in_directory(
+        &mut self,
+        directory: u32,
+        name: &str,
+    ) -> Result<(DirectoryEntry, u64, u64), FatError> {
+        let cluster_size = self.sectors_per_cluster as usize * self.bytes_per_sector as usize;
+        let mut data = [0u8; 65536];
+        let mut cluster = directory;
+        let mut lfn = LfnBuffer::new();
+        let mut lfn_start = 0;
+        loop {
+            self.read_cluster(cluster, &mut data[..cluster_size])?;
+            let base = self.cluster_byte_offset(cluster)?;
+            for offset in (0..cluster_size).step_by(32) {
+                let raw = &data[offset..offset + 32];
+                let entry =
+                    DirectoryEntry::read_from_bytes(raw).map_err(|_| FatError::ReadError)?;
+                if entry.is_end() {
+                    return Err(FatError::NotFound);
+                }
+                if entry.is_free() {
+                    lfn.reset();
+                    continue;
+                }
+                if entry.is_lfn() {
+                    if !lfn.active {
+                        lfn_start = base + offset as u64;
+                    }
+                    let part = LfnEntry::read_from_bytes(raw).map_err(|_| FatError::ReadError)?;
+                    lfn.process_lfn(&part);
+                    continue;
+                }
+                let start = if lfn.active {
+                    lfn_start
+                } else {
+                    base + offset as u64
+                };
+                if (lfn.matches(name) || entry.matches_name(name)) && !entry.is_volume_id() {
+                    return Ok((entry, base + offset as u64, start));
+                }
+                lfn.reset();
+            }
+            cluster = match self.next_cluster(cluster)? {
+                Some(next) => next,
+                None => return Err(FatError::NotFound),
+            };
+        }
+    }
+
+    fn split_parent<'p>(&mut self, path: &'p str) -> Result<(u32, &'p str), FatError> {
+        let path = path.trim_matches(['/', '\\']);
+        let (parent, name) = path
+            .rsplit_once(['/', '\\'])
+            .map_or(("", path), |(parent, name)| (parent, name));
+        if name.is_empty() || name == "." || name == ".." {
+            return Err(FatError::InvalidName);
+        }
+        Ok((self.resolve_dir_cluster(parent)?, name))
+    }
+
+    fn short_name_exists(&mut self, directory: u32, short: &[u8; 11]) -> Result<bool, FatError> {
+        let cluster_size = self.sectors_per_cluster as usize * self.bytes_per_sector as usize;
+        let mut data = [0u8; 65536];
+        let mut cluster = directory;
+        loop {
+            self.read_cluster(cluster, &mut data[..cluster_size])?;
+            for offset in (0..cluster_size).step_by(32) {
+                if data[offset] == 0 {
+                    return Ok(false);
+                }
+                if data[offset] != 0xe5
+                    && data[offset + 11] != ATTR_LFN
+                    && data[offset..offset + 11] == short[..]
+                {
+                    return Ok(true);
+                }
+            }
+            cluster = match self.next_cluster(cluster)? {
+                Some(next) => next,
+                None => return Ok(false),
+            };
+        }
+    }
+
+    fn make_short_name(
+        &mut self,
+        directory: u32,
+        name: &str,
+    ) -> Result<([u8; 11], bool), FatError> {
+        let (stem, extension) = name.rsplit_once('.').unwrap_or((name, ""));
+        let valid = !stem.is_empty()
+            && stem.len() <= 8
+            && extension.len() <= 3
+            && stem
+                .bytes()
+                .chain(extension.bytes())
+                .all(is_short_name_char);
+        if valid {
+            let mut short = [b' '; 11];
+            for (slot, byte) in short[..8].iter_mut().zip(stem.bytes()) {
+                *slot = byte.to_ascii_uppercase();
+            }
+            for (slot, byte) in short[8..].iter_mut().zip(extension.bytes()) {
+                *slot = byte.to_ascii_uppercase();
+            }
+            if !self.short_name_exists(directory, &short)? {
+                let rendered_upper = extension.is_empty()
+                    && name
+                        .bytes()
+                        .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit());
+                return Ok((short, !rendered_upper));
+            }
+        }
+
+        let cleaned: heapless::Vec<u8, 64> = stem
+            .bytes()
+            .filter(|byte| byte.is_ascii_alphanumeric())
+            .map(|byte| byte.to_ascii_uppercase())
+            .collect();
+        if cleaned.is_empty() {
+            return Err(FatError::InvalidName);
+        }
+        for number in 1u16..=9999 {
+            let mut digits = [0u8; 4];
+            let digit_count = decimal(number, &mut digits);
+            let prefix_len = (7usize.saturating_sub(digit_count)).min(cleaned.len());
+            let mut short = [b' '; 11];
+            short[..prefix_len].copy_from_slice(&cleaned[..prefix_len]);
+            short[prefix_len] = b'~';
+            short[prefix_len + 1..prefix_len + 1 + digit_count]
+                .copy_from_slice(&digits[..digit_count]);
+            for (slot, byte) in short[8..].iter_mut().zip(extension.bytes().take(3)) {
+                *slot = if is_short_name_char(byte) {
+                    byte.to_ascii_uppercase()
+                } else {
+                    b'_'
+                };
+            }
+            if !self.short_name_exists(directory, &short)? {
+                return Ok((short, true));
+            }
+        }
+        Err(FatError::NoSpace)
+    }
+
+    fn find_free_slots(&mut self, directory: u32, count: usize) -> Result<u64, FatError> {
+        let cluster_size = self.sectors_per_cluster as usize * self.bytes_per_sector as usize;
+        let mut data = [0u8; 65536];
+        let mut cluster = directory;
+        loop {
+            self.read_cluster(cluster, &mut data[..cluster_size])?;
+            let mut run = 0;
+            for offset in (0..cluster_size).step_by(32) {
+                if data[offset] == 0 || data[offset] == 0xe5 {
+                    run += 1;
+                    if run == count {
+                        return Ok(
+                            self.cluster_byte_offset(cluster)? + (offset + 32 - count * 32) as u64
+                        );
+                    }
+                } else {
+                    run = 0;
+                }
+            }
+            match self.next_cluster(cluster)? {
+                Some(next) => cluster = next,
+                None => {
+                    let new = self.append_cluster(cluster)?;
+                    return self.cluster_byte_offset(new);
+                }
+            }
+        }
+    }
+
+    fn insert_entry(
+        &mut self,
+        directory: u32,
+        name: &str,
+        attributes: u8,
+        first_cluster: u32,
+    ) -> Result<DirectoryEntry, FatError> {
+        if self.find_record_in_directory(directory, name).is_ok() {
+            return Err(FatError::AlreadyExists);
+        }
+        let (short, needs_lfn) = self.make_short_name(directory, name)?;
+        let utf16: heapless::Vec<u16, 255> = name.chars().map(|ch| ch as u16).collect();
+        let lfn_count = if needs_lfn {
+            utf16.len().div_ceil(13)
+        } else {
+            0
+        };
+        let start = self.find_free_slots(directory, lfn_count + 1)?;
+        let checksum = lfn_checksum(&short);
+        for disk_index in 0..lfn_count {
+            let sequence = lfn_count - disk_index;
+            let mut raw = [0xffu8; 32];
+            raw[0] = sequence as u8 | if sequence == lfn_count { 0x40 } else { 0 };
+            raw[11] = ATTR_LFN;
+            raw[12] = 0;
+            raw[13] = checksum;
+            raw[26] = 0;
+            raw[27] = 0;
+            let first = (sequence - 1) * 13;
+            let mut chars = [0xffffu16; 13];
+            for (index, slot) in chars.iter_mut().enumerate() {
+                if let Some(character) = utf16.get(first + index) {
+                    *slot = *character;
+                } else if first + index == utf16.len() {
+                    *slot = 0;
+                }
+            }
+            write_lfn_chars(&mut raw, &chars);
+            self.partition_write(start + disk_index as u64 * 32, &raw)?;
+        }
+        let mut raw = [0u8; 32];
+        raw[..11].copy_from_slice(&short);
+        raw[11] = attributes;
+        raw[20..22].copy_from_slice(&((first_cluster >> 16) as u16).to_le_bytes());
+        raw[26..28].copy_from_slice(&(first_cluster as u16).to_le_bytes());
+        self.partition_write(start + lfn_count as u64 * 32, &raw)?;
+        DirectoryEntry::read_from_bytes(&raw).map_err(|_| FatError::WriteError)
+    }
+
+    pub fn create(&mut self, path: &str, directory: bool) -> Result<DirectoryEntry, FatError> {
+        self.require_fat32()?;
+        let (parent, name) = self.split_parent(path)?;
+        if self.find_record_in_directory(parent, name).is_ok() {
+            return Err(FatError::AlreadyExists);
+        }
+        let cluster = self.allocate_cluster()?;
+        if directory {
+            let mut block = [0u8; 65536];
+            let mut dot = [0u8; 32];
+            dot[..11].fill(b' ');
+            dot[0] = b'.';
+            dot[11] = ATTR_DIRECTORY;
+            dot[20..22].copy_from_slice(&((cluster >> 16) as u16).to_le_bytes());
+            dot[26..28].copy_from_slice(&(cluster as u16).to_le_bytes());
+            block[..32].copy_from_slice(&dot);
+            let mut dotdot = [0u8; 32];
+            dotdot[..11].fill(b' ');
+            dotdot[0] = b'.';
+            dotdot[1] = b'.';
+            dotdot[11] = ATTR_DIRECTORY;
+            let parent_value = if parent == self.root_cluster {
+                self.root_cluster
+            } else {
+                parent
+            };
+            dotdot[20..22].copy_from_slice(&((parent_value >> 16) as u16).to_le_bytes());
+            dotdot[26..28].copy_from_slice(&(parent_value as u16).to_le_bytes());
+            block[32..64].copy_from_slice(&dotdot);
+            self.write_cluster(cluster, &block)?;
+        }
+        match self.insert_entry(
+            parent,
+            name,
+            if directory { ATTR_DIRECTORY } else { 0 },
+            cluster,
+        ) {
+            Ok(entry) => Ok(entry),
+            Err(error) => {
+                let _ = self.free_chain(cluster);
+                Err(error)
+            }
+        }
+    }
+
+    fn update_record(
+        &mut self,
+        offset: u64,
+        first_cluster: u32,
+        size: u32,
+    ) -> Result<(), FatError> {
+        let mut raw = [0u8; 32];
+        self.partition_read(offset, &mut raw)?;
+        raw[20..22].copy_from_slice(&((first_cluster >> 16) as u16).to_le_bytes());
+        raw[26..28].copy_from_slice(&(first_cluster as u16).to_le_bytes());
+        raw[28..32].copy_from_slice(&size.to_le_bytes());
+        self.partition_write(offset, &raw)
+    }
+
+    pub fn write_path(
+        &mut self,
+        path: &str,
+        offset: u32,
+        input: &[u8],
+    ) -> Result<(u32, u32), FatError> {
+        self.require_fat32()?;
+        let (entry, record_offset, _) = self.find_record(path)?;
+        if entry.is_directory() {
+            return Err(FatError::NotAFile);
+        }
+        if input.is_empty() {
+            return Ok((entry.file_size(), entry.first_cluster()));
+        }
+        let end = offset
+            .checked_add(input.len() as u32)
+            .ok_or(FatError::NoSpace)?;
+        let cluster_size = self.sectors_per_cluster as u32 * self.bytes_per_sector as u32;
+        let required = end.div_ceil(cluster_size);
+        let mut first = entry.first_cluster();
+        if first < 2 {
+            first = self.allocate_cluster()?;
+        }
+        let mut cluster = first;
+        let mut existing = 1;
+        while let Some(next) = self.next_cluster(cluster)? {
+            cluster = next;
+            existing += 1;
+        }
+        while existing < required {
+            cluster = self.append_cluster(cluster)?;
+            existing += 1;
+        }
+        cluster = first;
+        for _ in 0..offset / cluster_size {
+            cluster = self
+                .next_cluster(cluster)?
+                .ok_or(FatError::InvalidCluster)?;
+        }
+        let mut within = (offset % cluster_size) as usize;
+        let mut consumed = 0;
+        let mut block = [0u8; 65536];
+        while consumed < input.len() {
+            self.read_cluster(cluster, &mut block[..cluster_size as usize])?;
+            let count = (cluster_size as usize - within).min(input.len() - consumed);
+            block[within..within + count].copy_from_slice(&input[consumed..consumed + count]);
+            self.write_cluster(cluster, &block)?;
+            consumed += count;
+            within = 0;
+            if consumed < input.len() {
+                cluster = self
+                    .next_cluster(cluster)?
+                    .ok_or(FatError::InvalidCluster)?;
+            }
+        }
+        let size = entry.file_size().max(end);
+        self.update_record(record_offset, first, size)?;
+        Ok((size, first))
+    }
+
+    fn find_record(&mut self, path: &str) -> Result<(DirectoryEntry, u64, u64), FatError> {
+        let (parent, name) = self.split_parent(path)?;
+        self.find_record_in_directory(parent, name)
+    }
+
+    pub fn truncate_path(&mut self, path: &str, size: u32) -> Result<(), FatError> {
+        self.require_fat32()?;
+        let (entry, offset, _) = self.find_record(path)?;
+        if entry.is_directory() {
+            return Err(FatError::NotAFile);
+        }
+        if size >= entry.file_size() {
+            return Ok(());
+        }
+        let first = entry.first_cluster();
+        if size == 0 {
+            if first >= 2 {
+                self.free_chain(first)?;
+            }
+            return self.update_record(offset, 0, 0);
+        }
+        let cluster_size = self.sectors_per_cluster as u32 * self.bytes_per_sector as u32;
+        let keep = size.div_ceil(cluster_size);
+        let mut last = first;
+        for _ in 1..keep {
+            last = self.next_cluster(last)?.ok_or(FatError::InvalidCluster)?;
+        }
+        let tail = self.next_cluster(last)?;
+        self.set_fat32_value(last, 0x0fff_ffff)?;
+        if let Some(tail) = tail {
+            self.free_chain(tail)?;
+        }
+        self.update_record(offset, first, size)
+    }
+
+    pub fn delete_path(&mut self, path: &str) -> Result<(), FatError> {
+        self.require_fat32()?;
+        let (entry, short_offset, first_offset) = self.find_record(path)?;
+        if entry.is_directory() {
+            let cluster = entry.first_cluster();
+            let mut nonempty = false;
+            let _ = self.for_each_dir_entry(cluster, |child, _| {
+                let name = child.short_name();
+                if name != "." && name != ".." {
+                    nonempty = true;
+                    core::ops::ControlFlow::Break(())
+                } else {
+                    core::ops::ControlFlow::Continue(())
+                }
+            })?;
+            if nonempty {
+                return Err(FatError::DirectoryNotEmpty);
+            }
+        }
+        let mut position = first_offset;
+        while position <= short_offset {
+            self.partition_write(position, &[0xe5])?;
+            position += 32;
+        }
+        if entry.first_cluster() >= 2 {
+            self.free_chain(entry.first_cluster())?;
+        }
+        Ok(())
+    }
+
+    pub fn flush(&mut self) -> Result<(), FatError> {
+        self.device.flush().map_err(|_| FatError::WriteError)
+    }
+
     /// Read entire file into a buffer (convenience method)
     pub fn read_file_all(&mut self, path: &str, buffer: &mut [u8]) -> Result<usize, FatError> {
         let entry = self.find_file(path)?;
@@ -1348,6 +1920,55 @@ impl<'a> FatFilesystem<'a> {
             ControlFlow::Break(result) => Ok(Some(result)),
             ControlFlow::Continue(()) => Ok(None),
         }
+    }
+}
+
+fn is_short_name_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric()
+        || matches!(
+            byte,
+            b'$' | b'%'
+                | b'\''
+                | b'-'
+                | b'_'
+                | b'@'
+                | b'~'
+                | b'`'
+                | b'!'
+                | b'('
+                | b')'
+                | b'{'
+                | b'}'
+                | b'^'
+                | b'#'
+                | b'&'
+        )
+}
+
+fn decimal(mut value: u16, output: &mut [u8; 4]) -> usize {
+    let mut reversed = [0u8; 4];
+    let mut length = 0;
+    while value != 0 {
+        reversed[length] = b'0' + (value % 10) as u8;
+        value /= 10;
+        length += 1;
+    }
+    for index in 0..length {
+        output[index] = reversed[length - index - 1];
+    }
+    length
+}
+
+fn lfn_checksum(short: &[u8; 11]) -> u8 {
+    short
+        .iter()
+        .fold(0u8, |sum, byte| sum.rotate_right(1).wrapping_add(*byte))
+}
+
+fn write_lfn_chars(raw: &mut [u8; 32], chars: &[u16; 13]) {
+    const OFFSETS: [usize; 13] = [1, 3, 5, 7, 9, 14, 16, 18, 20, 22, 24, 28, 30];
+    for (offset, character) in OFFSETS.into_iter().zip(chars) {
+        raw[offset..offset + 2].copy_from_slice(&character.to_le_bytes());
     }
 }
 

--- a/crabefi-core/src/fs/fat.rs
+++ b/crabefi-core/src/fs/fat.rs
@@ -1273,14 +1273,6 @@ impl<'a> FatFilesystem<'a> {
             + (cluster - 2) as u64 * self.sectors_per_cluster as u64 * self.bytes_per_sector as u64)
     }
 
-    fn write_cluster(&mut self, cluster: u32, data: &[u8]) -> Result<(), FatError> {
-        let cluster_size = self.sectors_per_cluster as usize * self.bytes_per_sector as usize;
-        if data.len() < cluster_size {
-            return Err(FatError::BufferTooSmall);
-        }
-        self.partition_write(self.cluster_byte_offset(cluster)?, &data[..cluster_size])
-    }
-
     fn fat32_value(&mut self, cluster: u32) -> Result<u32, FatError> {
         self.require_fat32()?;
         let mut bytes = [0u8; 4];
@@ -1317,6 +1309,23 @@ impl<'a> FatFilesystem<'a> {
         Ok(())
     }
 
+    /// Zero a whole cluster using a block-sized scratch buffer.
+    ///
+    /// Deliberately avoids a max-cluster-sized (64 KiB) stack buffer: this
+    /// firmware runs on a small fixed stack and these helpers nest.
+    fn zero_cluster(&mut self, cluster: u32) -> Result<(), FatError> {
+        let cluster_size = self.sectors_per_cluster as usize * self.bytes_per_sector as usize;
+        let base = self.cluster_byte_offset(cluster)?;
+        let zero = [0u8; MAX_BLOCK_SIZE];
+        let mut done = 0;
+        while done < cluster_size {
+            let count = MAX_BLOCK_SIZE.min(cluster_size - done);
+            self.partition_write(base + done as u64, &zero[..count])?;
+            done += count;
+        }
+        Ok(())
+    }
+
     fn allocate_cluster(&mut self) -> Result<u32, FatError> {
         self.require_fat32()?;
         let sector_size = self.bytes_per_sector as usize;
@@ -1342,8 +1351,7 @@ impl<'a> FatFilesystem<'a> {
                         .map_err(|_| FatError::ReadError)?,
                 ) & 0x0fff_ffff;
                 if value == 0 {
-                    let zero = [0u8; 65536];
-                    self.write_cluster(cluster, &zero)?;
+                    self.zero_cluster(cluster)?;
                     self.set_fat32_value(cluster, 0x0fff_ffff)?;
                     return Ok(cluster);
                 }
@@ -1380,41 +1388,42 @@ impl<'a> FatFilesystem<'a> {
         name: &str,
     ) -> Result<(DirectoryEntry, u64, u64), FatError> {
         let cluster_size = self.sectors_per_cluster as usize * self.bytes_per_sector as usize;
-        let mut data = [0u8; 65536];
+        let chunk = MAX_BLOCK_SIZE.min(cluster_size);
+        let mut data = [0u8; MAX_BLOCK_SIZE];
         let mut cluster = directory;
         let mut lfn = LfnBuffer::new();
         let mut lfn_start = 0;
         loop {
-            self.read_cluster(cluster, &mut data[..cluster_size])?;
             let base = self.cluster_byte_offset(cluster)?;
-            for offset in (0..cluster_size).step_by(32) {
-                let raw = &data[offset..offset + 32];
-                let entry =
-                    DirectoryEntry::read_from_bytes(raw).map_err(|_| FatError::ReadError)?;
-                if entry.is_end() {
-                    return Err(FatError::NotFound);
-                }
-                if entry.is_free() {
-                    lfn.reset();
-                    continue;
-                }
-                if entry.is_lfn() {
-                    if !lfn.active {
-                        lfn_start = base + offset as u64;
+            for chunk_start in (0..cluster_size).step_by(chunk) {
+                self.partition_read(base + chunk_start as u64, &mut data[..chunk])?;
+                for local in (0..chunk).step_by(32) {
+                    let position = base + (chunk_start + local) as u64;
+                    let raw = &data[local..local + 32];
+                    let entry =
+                        DirectoryEntry::read_from_bytes(raw).map_err(|_| FatError::ReadError)?;
+                    if entry.is_end() {
+                        return Err(FatError::NotFound);
                     }
-                    let part = LfnEntry::read_from_bytes(raw).map_err(|_| FatError::ReadError)?;
-                    lfn.process_lfn(&part);
-                    continue;
+                    if entry.is_free() {
+                        lfn.reset();
+                        continue;
+                    }
+                    if entry.is_lfn() {
+                        if !lfn.active {
+                            lfn_start = position;
+                        }
+                        let part =
+                            LfnEntry::read_from_bytes(raw).map_err(|_| FatError::ReadError)?;
+                        lfn.process_lfn(&part);
+                        continue;
+                    }
+                    let start = if lfn.active { lfn_start } else { position };
+                    if (lfn.matches(name) || entry.matches_name(name)) && !entry.is_volume_id() {
+                        return Ok((entry, position, start));
+                    }
+                    lfn.reset();
                 }
-                let start = if lfn.active {
-                    lfn_start
-                } else {
-                    base + offset as u64
-                };
-                if (lfn.matches(name) || entry.matches_name(name)) && !entry.is_volume_id() {
-                    return Ok((entry, base + offset as u64, start));
-                }
-                lfn.reset();
             }
             cluster = match self.next_cluster(cluster)? {
                 Some(next) => next,
@@ -1436,19 +1445,23 @@ impl<'a> FatFilesystem<'a> {
 
     fn short_name_exists(&mut self, directory: u32, short: &[u8; 11]) -> Result<bool, FatError> {
         let cluster_size = self.sectors_per_cluster as usize * self.bytes_per_sector as usize;
-        let mut data = [0u8; 65536];
+        let chunk = MAX_BLOCK_SIZE.min(cluster_size);
+        let mut data = [0u8; MAX_BLOCK_SIZE];
         let mut cluster = directory;
         loop {
-            self.read_cluster(cluster, &mut data[..cluster_size])?;
-            for offset in (0..cluster_size).step_by(32) {
-                if data[offset] == 0 {
-                    return Ok(false);
-                }
-                if data[offset] != 0xe5
-                    && data[offset + 11] != ATTR_LFN
-                    && data[offset..offset + 11] == short[..]
-                {
-                    return Ok(true);
+            let base = self.cluster_byte_offset(cluster)?;
+            for chunk_start in (0..cluster_size).step_by(chunk) {
+                self.partition_read(base + chunk_start as u64, &mut data[..chunk])?;
+                for offset in (0..chunk).step_by(32) {
+                    if data[offset] == 0 {
+                        return Ok(false);
+                    }
+                    if data[offset] != 0xe5
+                        && data[offset + 11] != ATTR_LFN
+                        && data[offset..offset + 11] == short[..]
+                    {
+                        return Ok(true);
+                    }
                 }
             }
             cluster = match self.next_cluster(cluster)? {
@@ -1519,21 +1532,29 @@ impl<'a> FatFilesystem<'a> {
 
     fn find_free_slots(&mut self, directory: u32, count: usize) -> Result<u64, FatError> {
         let cluster_size = self.sectors_per_cluster as usize * self.bytes_per_sector as usize;
-        let mut data = [0u8; 65536];
+        // A run of slots is written with contiguous byte offsets, so it must fit
+        // inside a single cluster: clusters are not necessarily adjacent on disk.
+        if count == 0 || count * 32 > cluster_size {
+            return Err(FatError::NoSpace);
+        }
+        let chunk = MAX_BLOCK_SIZE.min(cluster_size);
+        let mut data = [0u8; MAX_BLOCK_SIZE];
         let mut cluster = directory;
         loop {
-            self.read_cluster(cluster, &mut data[..cluster_size])?;
+            let base = self.cluster_byte_offset(cluster)?;
             let mut run = 0;
-            for offset in (0..cluster_size).step_by(32) {
-                if data[offset] == 0 || data[offset] == 0xe5 {
-                    run += 1;
-                    if run == count {
-                        return Ok(
-                            self.cluster_byte_offset(cluster)? + (offset + 32 - count * 32) as u64
-                        );
+            for chunk_start in (0..cluster_size).step_by(chunk) {
+                self.partition_read(base + chunk_start as u64, &mut data[..chunk])?;
+                for local in (0..chunk).step_by(32) {
+                    if data[local] == 0 || data[local] == 0xe5 {
+                        run += 1;
+                        if run == count {
+                            let end = chunk_start + local + 32;
+                            return Ok(base + (end - count * 32) as u64);
+                        }
+                    } else {
+                        run = 0;
                     }
-                } else {
-                    run = 0;
                 }
             }
             match self.next_cluster(cluster)? {
@@ -1542,13 +1563,17 @@ impl<'a> FatFilesystem<'a> {
                     // Once a directory is extended, zero-valued end markers in
                     // the old tail must become deleted entries. Otherwise readers
                     // stop at the old marker and never follow the new FAT link.
-                    let base = self.cluster_byte_offset(cluster)?;
-                    for offset in (0..cluster_size).step_by(32) {
-                        if data[offset] == 0 {
-                            self.partition_write(base + offset as u64, &[0xe5])?;
+                    for chunk_start in (0..cluster_size).step_by(chunk) {
+                        self.partition_read(base + chunk_start as u64, &mut data[..chunk])?;
+                        for local in (0..chunk).step_by(32) {
+                            if data[local] == 0 {
+                                self.partition_write(base + (chunk_start + local) as u64, &[0xe5])?;
+                            }
                         }
                     }
                     let new = self.append_cluster(cluster)?;
+                    // `count * 32 <= cluster_size` was checked above, so the run
+                    // fits in the freshly zeroed cluster.
                     return self.cluster_byte_offset(new);
                 }
             }
@@ -1612,28 +1637,29 @@ impl<'a> FatFilesystem<'a> {
         }
         let cluster = self.allocate_cluster()?;
         if directory {
-            let mut block = [0u8; 65536];
-            let mut dot = [0u8; 32];
-            dot[..11].fill(b' ');
-            dot[0] = b'.';
-            dot[11] = ATTR_DIRECTORY;
-            dot[20..22].copy_from_slice(&((cluster >> 16) as u16).to_le_bytes());
-            dot[26..28].copy_from_slice(&(cluster as u16).to_le_bytes());
-            block[..32].copy_from_slice(&dot);
-            let mut dotdot = [0u8; 32];
-            dotdot[..11].fill(b' ');
-            dotdot[0] = b'.';
-            dotdot[1] = b'.';
-            dotdot[11] = ATTR_DIRECTORY;
+            // `allocate_cluster` already zeroed the cluster, so only the two
+            // leading records have to be written.
+            let mut block = [0u8; 64];
+            block[..11].fill(b' ');
+            block[0] = b'.';
+            block[11] = ATTR_DIRECTORY;
+            block[20..22].copy_from_slice(&((cluster >> 16) as u16).to_le_bytes());
+            block[26..28].copy_from_slice(&(cluster as u16).to_le_bytes());
+            block[32..43].fill(b' ');
+            block[32] = b'.';
+            block[33] = b'.';
+            block[43] = ATTR_DIRECTORY;
+            // Per the FAT specification, `..` records first cluster 0 when the
+            // parent is the root directory.
             let parent_value = if parent == self.root_cluster {
-                self.root_cluster
+                0
             } else {
                 parent
             };
-            dotdot[20..22].copy_from_slice(&((parent_value >> 16) as u16).to_le_bytes());
-            dotdot[26..28].copy_from_slice(&(parent_value as u16).to_le_bytes());
-            block[32..64].copy_from_slice(&dotdot);
-            self.write_cluster(cluster, &block)?;
+            block[52..54].copy_from_slice(&((parent_value >> 16) as u16).to_le_bytes());
+            block[58..60].copy_from_slice(&(parent_value as u16).to_le_bytes());
+            let offset = self.cluster_byte_offset(cluster)?;
+            self.partition_write(offset, &block)?;
         }
         match self.insert_entry(
             parent,
@@ -1704,12 +1730,12 @@ impl<'a> FatFilesystem<'a> {
         }
         let mut within = (offset % cluster_size) as usize;
         let mut consumed = 0;
-        let mut block = [0u8; 65536];
         while consumed < input.len() {
-            self.read_cluster(cluster, &mut block[..cluster_size as usize])?;
+            // `partition_write` performs the block read-modify-write itself, so
+            // no max-cluster-sized stack buffer is needed here.
+            let base = self.cluster_byte_offset(cluster)?;
             let count = (cluster_size as usize - within).min(input.len() - consumed);
-            block[within..within + count].copy_from_slice(&input[consumed..consumed + count]);
-            self.write_cluster(cluster, &block)?;
+            self.partition_write(base + within as u64, &input[consumed..consumed + count])?;
             consumed += count;
             within = 0;
             if consumed < input.len() {
@@ -1758,9 +1784,44 @@ impl<'a> FatFilesystem<'a> {
         self.update_record(offset, first, size)
     }
 
+    /// Mark a directory record run (optional LFN chain plus its short entry) as
+    /// deleted.
+    ///
+    /// The run is walked through the directory's cluster chain rather than by
+    /// bumping raw partition offsets: clusters need not be adjacent on disk, so
+    /// an LFN chain straddling a cluster boundary would otherwise write `0xe5`
+    /// into unrelated clusters.
+    fn erase_entry_run(
+        &mut self,
+        directory: u32,
+        first_offset: u64,
+        short_offset: u64,
+    ) -> Result<(), FatError> {
+        let cluster_size = self.sectors_per_cluster as usize * self.bytes_per_sector as usize;
+        let mut cluster = directory;
+        let mut erasing = false;
+        loop {
+            let base = self.cluster_byte_offset(cluster)?;
+            for offset in (0..cluster_size).step_by(32) {
+                let position = base + offset as u64;
+                if position == first_offset {
+                    erasing = true;
+                }
+                if erasing {
+                    self.partition_write(position, &[0xe5])?;
+                    if position == short_offset {
+                        return Ok(());
+                    }
+                }
+            }
+            cluster = self.next_cluster(cluster)?.ok_or(FatError::NotFound)?;
+        }
+    }
+
     pub fn delete_path(&mut self, path: &str) -> Result<(), FatError> {
         self.require_fat32()?;
-        let (entry, short_offset, first_offset) = self.find_record(path)?;
+        let (parent, name) = self.split_parent(path)?;
+        let (entry, short_offset, first_offset) = self.find_record_in_directory(parent, name)?;
         if entry.is_directory() {
             let cluster = entry.first_cluster();
             let mut nonempty = false;
@@ -1777,11 +1838,7 @@ impl<'a> FatFilesystem<'a> {
                 return Err(FatError::DirectoryNotEmpty);
             }
         }
-        let mut position = first_offset;
-        while position <= short_offset {
-            self.partition_write(position, &[0xe5])?;
-            position += 32;
-        }
+        self.erase_entry_run(parent, first_offset, short_offset)?;
         if entry.first_cluster() >= 2 {
             self.free_chain(entry.first_cluster())?;
         }

--- a/crabefi-core/src/fs/fat.rs
+++ b/crabefi-core/src/fs/fat.rs
@@ -1318,12 +1318,35 @@ impl<'a> FatFilesystem<'a> {
     }
 
     fn allocate_cluster(&mut self) -> Result<u32, FatError> {
-        for cluster in 2..self.data_clusters + 2 {
-            if self.fat32_value(cluster)? == 0 {
-                let zero = [0u8; 65536];
-                self.write_cluster(cluster, &zero)?;
-                self.set_fat32_value(cluster, 0x0fff_ffff)?;
-                return Ok(cluster);
+        self.require_fat32()?;
+        let sector_size = self.bytes_per_sector as usize;
+        let entries_per_sector = sector_size / 4;
+        let mut sector = [0u8; MAX_BLOCK_SIZE];
+        let cluster_limit = self.data_clusters + 2;
+        let fat_offset = self.fat_start as u64 * self.bytes_per_sector as u64;
+
+        for first_cluster in (0..cluster_limit).step_by(entries_per_sector) {
+            self.partition_read(
+                fat_offset + first_cluster as u64 * 4,
+                &mut sector[..sector_size],
+            )?;
+            for index in 0..entries_per_sector {
+                let cluster = first_cluster + index as u32;
+                if cluster < 2 || cluster >= cluster_limit {
+                    continue;
+                }
+                let offset = index * 4;
+                let value = u32::from_le_bytes(
+                    sector[offset..offset + 4]
+                        .try_into()
+                        .map_err(|_| FatError::ReadError)?,
+                ) & 0x0fff_ffff;
+                if value == 0 {
+                    let zero = [0u8; 65536];
+                    self.write_cluster(cluster, &zero)?;
+                    self.set_fat32_value(cluster, 0x0fff_ffff)?;
+                    return Ok(cluster);
+                }
             }
         }
         Err(FatError::NoSpace)
@@ -1457,11 +1480,9 @@ impl<'a> FatFilesystem<'a> {
                 *slot = byte.to_ascii_uppercase();
             }
             if !self.short_name_exists(directory, &short)? {
-                let rendered_upper = extension.is_empty()
-                    && name
-                        .bytes()
-                        .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit());
-                return Ok((short, !rendered_upper));
+                // FAT short-name lookup is case-insensitive; mixed-case 8.3
+                // names do not require an LFN entry for correct resolution.
+                return Ok((short, false));
             }
         }
 
@@ -1518,6 +1539,15 @@ impl<'a> FatFilesystem<'a> {
             match self.next_cluster(cluster)? {
                 Some(next) => cluster = next,
                 None => {
+                    // Once a directory is extended, zero-valued end markers in
+                    // the old tail must become deleted entries. Otherwise readers
+                    // stop at the old marker and never follow the new FAT link.
+                    let base = self.cluster_byte_offset(cluster)?;
+                    for offset in (0..cluster_size).step_by(32) {
+                        if data[offset] == 0 {
+                            self.partition_write(base + offset as u64, &[0xe5])?;
+                        }
+                    }
                     let new = self.append_cluster(cluster)?;
                     return self.cluster_byte_offset(new);
                 }

--- a/crabefi-core/src/state.rs
+++ b/crabefi-core/src/state.rs
@@ -91,6 +91,7 @@ static IN_WITH_MUT: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicB
 /// - Must only be called once, at the start of `init()`
 /// - The `state` reference must remain valid for the entire firmware lifetime
 /// - The firmware must be single-threaded
+#[allow(unused_unsafe)]
 pub unsafe fn init(state: &mut FirmwareState) {
     // SAFETY: The caller guarantees that `state` remains valid for the
     // firmware lifetime and no other state has been installed.
@@ -112,6 +113,7 @@ pub fn is_initialized() -> bool {
 ///
 /// The new pointer must point to valid `FirmwareState` memory that has been
 /// remapped by the OS.
+#[allow(unused_unsafe)]
 pub unsafe fn relocate_state_ptr(new_ptr: *mut FirmwareState) {
     // SAFETY: The caller guarantees that `new_ptr` is the runtime-mapped
     // address of the installed firmware state.
@@ -294,7 +296,7 @@ use crate::efi::tcg::types::TaggedDigest;
 use r_efi::efi::{self, Guid, Handle};
 
 /// Maximum number of handles we can track
-pub const MAX_HANDLES: usize = 64;
+pub const MAX_HANDLES: usize = 128;
 
 /// Maximum number of protocols per handle
 pub const MAX_PROTOCOLS_PER_HANDLE: usize = 8;
@@ -303,7 +305,7 @@ pub const MAX_PROTOCOLS_PER_HANDLE: usize = 8;
 pub const MAX_EVENTS: usize = 32;
 
 /// Maximum number of loaded images we can track
-pub const MAX_LOADED_IMAGES: usize = 16;
+pub const MAX_LOADED_IMAGES: usize = 128;
 
 /// Maximum number of configuration tables
 pub const MAX_CONFIG_TABLES: usize = 24;
@@ -640,6 +642,9 @@ pub struct EfiState {
     /// Variable store persistence state (SMMSTORE tracking)
     pub varstore: VarStoreState,
 
+    /// Human Interface Infrastructure package database
+    pub hii: crate::efi::protocols::hii::State,
+
     /// Memory allocator
     pub allocator: MemoryAllocator,
 
@@ -682,6 +687,7 @@ impl EfiState {
             config_table_count: 0,
             variables: Vec::new(),
             varstore: VarStoreState::new(),
+            hii: crate::efi::protocols::hii::State::new(),
             allocator: MemoryAllocator::new(),
             monotonic_count: 0,
             ready_to_boot_signaled: false,

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -8,7 +8,7 @@
 nix develop
 ```
 
-This provides the Rust nightly toolchain, QEMU, mtools, dosfstools, cbfstool, and zstd.
+This provides the Rust nightly toolchain, QEMU, mtools, dosfstools, cbfstool, zstd, and p7zip.
 
 ### Manual Setup
 
@@ -22,7 +22,7 @@ rustup component add rust-src llvm-tools-preview
 
 **System Packages (Debian/Ubuntu):**
 ```bash
-sudo apt install qemu-system-x86 qemu-system-arm mtools dosfstools zstd coreboot-utils
+sudo apt install qemu-system-x86 qemu-system-arm mtools dosfstools zstd coreboot-utils p7zip-full
 ```
 
 ## Building
@@ -123,6 +123,29 @@ The `crabefi-coreboot` binary enables both `platform-entry` and `global-allocato
 ./crabefi run --app hello --nvme
 ./crabefi run --app hello --ahci --headless
 ```
+
+### UEFI SCT smoke subset
+
+CrabEFI can run a small public UEFI Self-Certification Test subset in QEMU. The
+test uses prebuilt public artifacts from `tianocore/edk2-test` and an EDK2 UEFI
+Shell binary from `pbatard/UEFI-Shell`; hashes are pinned in
+`ci/build-sct-assets.sh`.
+
+```bash
+# Download and verify SCT + UEFI Shell assets
+ci/build-sct-assets.sh --arch x86_64
+
+# Run the SCT smoke sequence
+./crabefi test --app uefi-sct-smoke \
+    --sct-assets-dir sct-assets/x86_64 \
+    --disable-kvm \
+    --timeout 180
+```
+
+The initial sequence intentionally exercises only a few low-risk Boot Services
+cases (`Stall`, `CopyMem`, `SetMem`, `CalculateCrc32`, pool allocation/free).
+Add more cases to the generated `smoke.seq` in `xtask/src/disk.rs` as CrabEFI's
+UEFI surface grows.
 
 ### Test Applications
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -22,7 +22,7 @@ rustup component add rust-src llvm-tools-preview
 
 **System Packages (Debian/Ubuntu):**
 ```bash
-sudo apt install qemu-system-x86 qemu-system-arm mtools dosfstools zstd coreboot-utils p7zip-full
+sudo apt install curl qemu-system-x86 qemu-system-arm mtools dosfstools zstd coreboot-utils p7zip-full
 ```
 
 ## Building

--- a/flake.nix
+++ b/flake.nix
@@ -39,8 +39,9 @@
             # (Rust has no riscv64gc-unknown-uefi target)
             pkgsCross.riscv64.buildPackages.binutils
 
-            # Compression for firmware
+            # Compression/archive tools for firmware and SCT assets
             zstd
+            p7zip
           ];
 
           # Rust is managed by rustup via rust-toolchain.toml files

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -590,6 +590,7 @@ reset -s
 
     create_mtools_dir(&disk_with_offset, "::/Sct")?;
     copy_tree_to_esp(&disk_with_offset, sct_dir, "::/Sct")?;
+    write_text_file_to_esp(&disk_with_offset, "::/Sct/.passive.mode", "\n")?;
 
     create_mtools_dir(&disk_with_offset, "::/Sct/Sequence")?;
     write_text_file_to_esp(

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -646,15 +646,37 @@ Order      = 0x00000005
 Iterations = 0x00000001
 "#;
 
+fn mtools_dir_exists(disk_with_offset: &str, path: &str) -> Result<bool> {
+    let output = Command::new("mdir")
+        .args(["-i", disk_with_offset, "-b", path])
+        .output()
+        .context("Failed to run mdir")?;
+    Ok(output.status.success())
+}
+
 fn create_mtools_dir(disk_with_offset: &str, path: &str) -> Result<()> {
+    // `mmd` fails when the directory already exists and offers no reliable way
+    // to tell that apart from a real failure, so probe first and only create
+    // when missing. Callers ensure parent directories repeatedly, so this needs
+    // to stay idempotent without swallowing genuine errors.
+    if mtools_dir_exists(disk_with_offset, path)? {
+        return Ok(());
+    }
+
     let status = Command::new("mmd")
         .args(["-i", disk_with_offset, path])
         .status()
         .context("Failed to run mmd")?;
 
-    // mmd returns an error if the directory already exists. That is harmless for
-    // our callers, which often ensure parent directories repeatedly.
-    let _ = status;
+    if !status.success() {
+        // Tolerate a lost race / mtools quirk only when the directory is
+        // actually there afterwards.
+        if mtools_dir_exists(disk_with_offset, path)? {
+            return Ok(());
+        }
+        anyhow::bail!("mmd failed to create {path} ({status})");
+    }
+
     Ok(())
 }
 

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -3,7 +3,7 @@
 //! This module provides functionality to create GPT disk images with FAT32
 //! EFI System Partitions for testing CrabEFI.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
@@ -33,6 +33,21 @@ const GPT_NUM_ENTRIES: u32 = 128;
 const ESP_TYPE_GUID: [u8; 16] = [
     0x28, 0x73, 0x2A, 0xC1, 0x1F, 0xF8, 0xD2, 0x11, 0xBA, 0x4B, 0x00, 0xA0, 0xC9, 0x3E, 0xC9, 0x3B,
 ];
+
+/// Return an mtools image specifier for the ESP inside a generated disk image.
+///
+/// # Arguments
+/// * `disk_path` - Path to the raw GPT disk image
+///
+/// # Returns
+/// An mtools `-i` argument that points at the ESP byte offset.
+pub fn mtools_esp_image(disk_path: &Path) -> String {
+    format!(
+        "{}@@{}",
+        disk_path.to_string_lossy(),
+        ESP_START_SECTOR * SECTOR_SIZE
+    )
+}
 
 /// Create a test disk image with GPT partition table and FAT32 ESP
 ///
@@ -510,6 +525,222 @@ pub fn create_grub_linux_disk(
 
     println!("Created: {}", output);
     Ok(())
+}
+
+/// Create a disk image for the UEFI SCT smoke test.
+///
+/// Disk layout:
+///   /EFI/BOOT/<BOOT_EFI>          EDK2 UEFI Shell
+///   /startup.nsh                  Shell script that launches SCT
+///   /Sct/...                      Contents of the SCT architecture directory
+///   /Sct/Sequence/smoke.seq       Minimal sequence file
+///
+/// # Arguments
+/// * `output` - Path for the output disk image
+/// * `shell_efi` - Path to a UEFI Shell binary for `arch`
+/// * `sct_dir` - Path to the SCT architecture directory, e.g. `SctPackageX64/X64`
+/// * `arch` - Target architecture
+///
+/// # Returns
+/// `Ok(())` when the disk image is created and populated.
+pub fn create_uefi_sct_smoke_disk(
+    output: &str,
+    shell_efi: &str,
+    sct_dir: &Path,
+    arch: Arch,
+) -> Result<()> {
+    if !Path::new(shell_efi).exists() {
+        bail!("UEFI Shell binary not found: {}", shell_efi);
+    }
+    if !sct_dir.join("SCT.efi").exists() {
+        bail!(
+            "SCT.efi not found in {}. Pass the architecture directory, e.g. SctPackageX64/X64",
+            sct_dir.display()
+        );
+    }
+
+    println!("Creating UEFI SCT smoke test disk: {}", output);
+    create_test_disk(output, Some(shell_efi), arch)?;
+
+    let disk_with_offset = mtools_esp_image(Path::new(output));
+
+    write_text_file_to_esp(
+        &disk_with_offset,
+        "::/startup.nsh",
+        r#"echo -off
+echo CRABEFI_SCT_SMOKE_START
+
+for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F
+  if exist FS%i:\Sct\SCT.efi then
+    FS%i:
+    cd Sct
+    Sct -s smoke.seq
+    echo CRABEFI_SCT_SMOKE_DONE
+    reset -s
+    goto Done
+  endif
+endfor
+
+echo CRABEFI_SCT_SMOKE_NOT_FOUND
+reset -s
+
+:Done
+"#,
+    )?;
+
+    create_mtools_dir(&disk_with_offset, "::/Sct")?;
+    copy_tree_to_esp(&disk_with_offset, sct_dir, "::/Sct")?;
+
+    create_mtools_dir(&disk_with_offset, "::/Sct/Sequence")?;
+    write_text_file_to_esp(
+        &disk_with_offset,
+        "::/Sct/Sequence/smoke.seq",
+        UEFI_SCT_SMOKE_SEQUENCE,
+    )?;
+
+    println!("Installed UEFI Shell and SCT smoke sequence");
+    Ok(())
+}
+
+const UEFI_SCT_SMOKE_SEQUENCE: &str = r#"[Test Case]
+Revision   = 0x00010000
+Guid       = 539675B8-D9B3-4DC7-A8D0-FF19BBA13B86
+Name       = Stall_Func
+Order      = 0x00000000
+Iterations = 0x00000001
+
+[Test Case]
+Revision   = 0x00010000
+Guid       = 4397A610-8D5D-441B-8E7D-C23377F3EB67
+Name       = CopyMem_Func
+Order      = 0x00000001
+Iterations = 0x00000001
+
+[Test Case]
+Revision   = 0x00010000
+Guid       = 315BE343-A32D-461D-A3CC-5E6895CC2CBA
+Name       = SetMem_Func
+Order      = 0x00000002
+Iterations = 0x00000001
+
+[Test Case]
+Revision   = 0x00010000
+Guid       = B510F99F-FEE9-4AF6-BB0F-3C958EF7F166
+Name       = CalculateCrc32_Func
+Order      = 0x00000003
+Iterations = 0x00000001
+
+[Test Case]
+Revision   = 0x00010000
+Guid       = 90023546-6C92-430A-B253-70110D9EFDFF
+Name       = AllocatePool_Conf
+Order      = 0x00000004
+Iterations = 0x00000001
+
+[Test Case]
+Revision   = 0x00010000
+Guid       = 49709F9F-A4D8-42D6-A684-4975EE0099DB
+Name       = FreePool_Conf
+Order      = 0x00000005
+Iterations = 0x00000001
+"#;
+
+fn create_mtools_dir(disk_with_offset: &str, path: &str) -> Result<()> {
+    let status = Command::new("mmd")
+        .args(["-i", disk_with_offset, path])
+        .status()
+        .context("Failed to run mmd")?;
+
+    // mmd returns an error if the directory already exists. That is harmless for
+    // our callers, which often ensure parent directories repeatedly.
+    let _ = status;
+    Ok(())
+}
+
+fn copy_tree_to_esp(disk_with_offset: &str, source_dir: &Path, dest_dir: &str) -> Result<()> {
+    for entry in walkdir(source_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let rel = path.strip_prefix(source_dir)?;
+        if rel.as_os_str().is_empty() {
+            continue;
+        }
+
+        let rel_mtools = rel
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+        let dest = format!("{}/{}", dest_dir, rel_mtools);
+
+        if path.is_dir() {
+            create_mtools_dir(disk_with_offset, &dest)?;
+        } else if path.is_file() {
+            if let Some(parent) = dest.rsplit_once('/') {
+                create_mtools_dir(disk_with_offset, parent.0)?;
+            }
+            let status = Command::new("mcopy")
+                .args(["-o", "-i", disk_with_offset])
+                .arg(&path)
+                .arg(&dest)
+                .status()
+                .context("Failed to run mcopy")?;
+            if !status.success() {
+                bail!("Failed to copy {} to {}", path.display(), dest);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn write_text_file_to_esp(disk_with_offset: &str, dest: &str, contents: &str) -> Result<()> {
+    let temp = tempfile::NamedTempFile::new()?;
+    {
+        let mut f = std::io::BufWriter::new(temp.as_file());
+        f.write_all(contents.as_bytes())?;
+        f.flush()?;
+    }
+
+    let status = Command::new("mcopy")
+        .args(["-o", "-i", disk_with_offset])
+        .arg(temp.path())
+        .arg(dest)
+        .status()
+        .context("Failed to run mcopy")?;
+    if !status.success() {
+        bail!("Failed to write {}", dest);
+    }
+
+    Ok(())
+}
+
+fn walkdir(root: &Path) -> Result<Vec<Result<std::fs::DirEntry, std::io::Error>>> {
+    let mut entries = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        let mut children = std::fs::read_dir(&dir)
+            .with_context(|| format!("Failed to read directory {}", dir.display()))?
+            .collect::<Vec<_>>();
+        children.sort_by_key(|entry| {
+            entry
+                .as_ref()
+                .map(|e| e.path())
+                .unwrap_or_else(|_| Path::new("").to_path_buf())
+        });
+
+        for child in children {
+            if let Ok(ref entry) = child {
+                if entry.path().is_dir() {
+                    stack.push(entry.path());
+                }
+            }
+            entries.push(child);
+        }
+    }
+
+    Ok(entries)
 }
 
 #[cfg(test)]

--- a/xtask/src/disk.rs
+++ b/xtask/src/disk.rs
@@ -574,7 +574,7 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F
   if exist FS%i:\Sct\SCT.efi then
     FS%i:
     cd Sct
-    Sct -s smoke.seq
+    Sct -s smoke.seq -v
     echo CRABEFI_SCT_SMOKE_DONE
     reset -s
     goto Done

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,7 +20,7 @@ mod disk;
 mod qemu;
 mod rom;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -142,6 +142,7 @@ enum Commands {
         /// Test app to run (default: hello)
         ///
         /// Use "grub-linux" for the GRUB + Linux boot-chain test.
+        /// Use "uefi-sct-smoke" for the UEFI SCT smoke subset.
         #[arg(long, default_value = "hello")]
         app: String,
 
@@ -173,6 +174,11 @@ enum Commands {
         /// Required when --app grub-linux is used.
         #[arg(long)]
         boot_assets_dir: Option<PathBuf>,
+
+        /// Directory containing pre-built UEFI SCT assets.
+        /// Required when --app uefi-sct-smoke is used unless sct-assets/<arch> exists.
+        #[arg(long)]
+        sct_assets_dir: Option<PathBuf>,
     },
 
     /// Take a screenshot of the graphical UI in headless QEMU
@@ -276,6 +282,7 @@ fn main() -> Result<()> {
             timeout,
             ui,
             boot_assets_dir,
+            sct_assets_dir,
         } => cmd_test(
             coreboot_rom,
             &app,
@@ -288,6 +295,7 @@ fn main() -> Result<()> {
             arch,
             machine,
             boot_assets_dir,
+            sct_assets_dir,
         ),
         Commands::Screenshot {
             out,
@@ -515,6 +523,7 @@ fn cmd_test(
     arch: Arch,
     machine: Machine,
     boot_assets_dir: Option<PathBuf>,
+    sct_assets_dir: Option<PathBuf>,
 ) -> Result<()> {
     let storage = if ahci {
         qemu::StorageType::Ahci
@@ -614,6 +623,39 @@ fn cmd_test(
             grub_cfg.to_string_lossy().as_ref(),
             arch,
         )?;
+    } else if app == "uefi-sct-smoke" {
+        if arch != Arch::X86_64 {
+            bail!("UEFI SCT smoke is currently wired for x86_64 only");
+        }
+
+        let assets_dir = sct_assets_dir
+            .as_deref()
+            .map(resolve_project_path)
+            .unwrap_or_else(|| project_root().join("sct-assets").join(arch.dir_name()));
+        let shell_efi = assets_dir.join("shellx64.efi");
+        let sct_dir = assets_dir.join("SctPackageX64").join("X64");
+
+        for (label, path) in [
+            ("shellx64.efi", &shell_efi),
+            ("SctPackageX64/X64", &sct_dir),
+        ] {
+            if !path.exists() {
+                bail!(
+                    "SCT asset not found: {} (looked in {})\n\
+                     Run ci/build-sct-assets.sh --arch x86_64 to build assets, \
+                     or pass --sct-assets-dir",
+                    label,
+                    assets_dir.display(),
+                );
+            }
+        }
+
+        disk::create_uefi_sct_smoke_disk(
+            disk_path.to_string_lossy().as_ref(),
+            shell_efi.to_string_lossy().as_ref(),
+            &sct_dir,
+            arch,
+        )?;
     } else {
         // ── Normal UEFI test app ─────────────────────────────────────
         println!("Building test app: {}", app);
@@ -633,7 +675,19 @@ fn cmd_test(
     }
 
     // Run tests
-    qemu::run_tests(&config, &disk_path, app)
+    if app == "uefi-sct-smoke" {
+        qemu::run_uefi_sct_smoke_tests(&config, &disk_path)
+    } else {
+        qemu::run_tests(&config, &disk_path, app)
+    }
+}
+
+fn resolve_project_path(path: &Path) -> PathBuf {
+    if path.is_relative() {
+        project_root().join(path)
+    } else {
+        path.to_path_buf()
+    }
 }
 
 fn cmd_build_test_app(name: &str, arch: Arch) -> Result<()> {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -635,19 +635,20 @@ fn cmd_test(
         let shell_efi = assets_dir.join("shellx64.efi");
         let sct_dir = assets_dir.join("SctPackageX64").join("X64");
 
-        for (label, path) in [
+        if let Some((label, _)) = [
             ("shellx64.efi", &shell_efi),
             ("SctPackageX64/X64", &sct_dir),
-        ] {
-            if !path.exists() {
-                bail!(
-                    "SCT asset not found: {} (looked in {})\n\
-                     Run ci/build-sct-assets.sh --arch x86_64 to build assets, \
-                     or pass --sct-assets-dir",
-                    label,
-                    assets_dir.display(),
-                );
-            }
+        ]
+        .into_iter()
+        .find(|(_, path)| !path.exists())
+        {
+            bail!(
+                "SCT asset not found: {} (looked in {})\n\
+                 Run ci/build-sct-assets.sh --arch x86_64 to build assets, \
+                 or pass --sct-assets-dir",
+                label,
+                assets_dir.display(),
+            );
         }
 
         disk::create_uefi_sct_smoke_disk(

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -3,8 +3,9 @@
 //! This module provides functionality to run CrabEFI in QEMU with various
 //! storage configurations and parse serial output for test results.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use regex::Regex;
+use std::fs;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 
@@ -1209,6 +1210,153 @@ pub fn run_tests(config: &QemuConfig, disk_path: &Path, app_name: &str) -> Resul
     }
 
     Ok(())
+}
+
+/// Run the UEFI SCT smoke subset and parse its serial/log output.
+///
+/// # Arguments
+/// * `config` - QEMU configuration
+/// * `disk_path` - Disk image containing the UEFI Shell and SCT package
+///
+/// # Returns
+/// `Ok(())` if the smoke sequence ran to completion without obvious failures.
+pub fn run_uefi_sct_smoke_tests(config: &QemuConfig, disk_path: &Path) -> Result<()> {
+    println!("=== UEFI SCT Smoke Tests ({:?}) ===\n", config.arch);
+    println!("Running SCT smoke sequence in QEMU...\n");
+
+    let result = run_qemu_with_capture(config, disk_path)?;
+    let summary_log = extract_sct_log(disk_path, "::/Sct/Overall/Summary.log")?;
+
+    println!("\n=== SCT Smoke Results ===");
+    println!("Serial output captured: {} bytes", result.output.len());
+    if let Some(ref summary) = summary_log {
+        println!("SCT Summary.log captured: {} bytes", summary.len());
+        println!("\n--- SCT Summary.log ---\n{}", summary);
+    } else {
+        println!("SCT Summary.log was not produced or could not be copied");
+    }
+
+    let mut passed = 0;
+    let mut failed = 0;
+
+    if result.output.contains("CRABEFI_SCT_SMOKE_START") {
+        println!("[PASS] sct_started: startup.nsh launched SCT smoke run");
+        passed += 1;
+    } else {
+        println!("[FAIL] sct_started: missing CRABEFI_SCT_SMOKE_START marker");
+        failed += 1;
+    }
+
+    if result.output.contains("CRABEFI_SCT_SMOKE_DONE") {
+        println!("[PASS] sct_completed: SCT command returned to startup.nsh");
+        passed += 1;
+    } else {
+        println!("[FAIL] sct_completed: missing CRABEFI_SCT_SMOKE_DONE marker");
+        failed += 1;
+    }
+
+    if result.output.contains("CRABEFI_SCT_SMOKE_NOT_FOUND") {
+        println!("[FAIL] sct_found: startup.nsh could not find \\Sct\\SCT.efi");
+        failed += 1;
+    } else {
+        println!("[PASS] sct_found: \\Sct\\SCT.efi was found");
+        passed += 1;
+    }
+
+    for test_name in [
+        "Stall_Func",
+        "CopyMem_Func",
+        "SetMem_Func",
+        "CalculateCrc32_Func",
+        "AllocatePool_Conf",
+        "FreePool_Conf",
+    ] {
+        if result.output.contains(test_name)
+            || summary_log
+                .as_ref()
+                .is_some_and(|summary| summary.contains(test_name))
+        {
+            println!("[PASS] {test_name}: SCT test appeared in output/logs");
+            passed += 1;
+        } else {
+            println!("[FAIL] {test_name}: SCT test did not appear in output/logs");
+            failed += 1;
+        }
+    }
+
+    let combined = match summary_log {
+        Some(summary) => format!("{}\n{}", result.output, summary),
+        None => result.output.clone(),
+    };
+    let failure_markers = [
+        "CRABEFI_SCT_SMOKE_NOT_FOUND",
+        "ERROR: Cannot",
+        "Invalid command line",
+        "FAILURE",
+        "Failures: 1",
+        "Failures: 2",
+        "Failures: 3",
+        "Failures: 4",
+        "Failures: 5",
+        "Failures: 6",
+        "Failures: 7",
+        "Failures: 8",
+        "Failures: 9",
+    ];
+    let found_failures = failure_markers
+        .iter()
+        .filter(|marker| combined.contains(**marker))
+        .copied()
+        .collect::<Vec<_>>();
+    if found_failures.is_empty() {
+        println!("[PASS] no_sct_failure_markers: no SCT failure markers found");
+        passed += 1;
+    } else {
+        println!(
+            "[FAIL] no_sct_failure_markers: found markers {:?}",
+            found_failures
+        );
+        failed += 1;
+    }
+
+    if combined.contains("Done!") || combined.contains("CRABEFI_SCT_SMOKE_DONE") {
+        println!("[PASS] sct_done: SCT reached a completion marker");
+        passed += 1;
+    } else {
+        println!("[FAIL] sct_done: SCT did not reach a completion marker");
+        failed += 1;
+    }
+
+    println!("\n=== Summary ===");
+    println!("Passed: {}", passed);
+    println!("Failed: {}", failed);
+
+    if failed > 0 {
+        println!("\n--- Captured Output ---");
+        println!("{}", result.output);
+        bail!("{} UEFI SCT smoke check(s) failed", failed);
+    }
+
+    Ok(())
+}
+
+fn extract_sct_log(disk_path: &Path, src: &str) -> Result<Option<String>> {
+    let temp_dir = tempfile::tempdir()?;
+    let dest = temp_dir.path().join("sct.log");
+    let image = crate::disk::mtools_esp_image(disk_path);
+    let status = Command::new("mcopy")
+        .args(["-i", &image, src])
+        .arg(&dest)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("failed to run mcopy to extract SCT log")?;
+
+    if !status.success() || !dest.exists() {
+        return Ok(None);
+    }
+
+    Ok(Some(fs::read_to_string(dest)?))
 }
 
 /// Run QEMU and capture serial output

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -1364,7 +1364,27 @@ fn extract_sct_log(disk_path: &Path, src: &str) -> Result<Option<String>> {
         return Ok(None);
     }
 
-    Ok(Some(fs::read_to_string(dest)?))
+    let bytes = fs::read(dest)?;
+    let utf16_le = bytes.starts_with(&[0xff, 0xfe])
+        || bytes
+            .iter()
+            .skip(1)
+            .step_by(2)
+            .filter(|byte| **byte == 0)
+            .count()
+            > bytes.len() / 8;
+    let text = if utf16_le {
+        let start = if bytes.starts_with(&[0xff, 0xfe]) { 2 } else { 0 };
+        String::from_utf16_lossy(
+            &bytes[start..]
+                .chunks_exact(2)
+                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+                .collect::<Vec<_>>(),
+        )
+    } else {
+        String::from_utf8_lossy(&bytes).into_owned()
+    };
+    Ok(Some(text))
 }
 
 /// Run QEMU and capture serial output

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -1239,6 +1239,14 @@ pub fn run_uefi_sct_smoke_tests(config: &QemuConfig, disk_path: &Path) -> Result
     let mut passed = 0;
     let mut failed = 0;
 
+    if summary_log.as_ref().is_some_and(|summary| !summary.trim().is_empty()) {
+        println!("[PASS] summary_log: Overall/Summary.log is non-empty");
+        passed += 1;
+    } else {
+        println!("[FAIL] summary_log: Overall/Summary.log is missing or empty");
+        failed += 1;
+    }
+
     if result.output.contains("CRABEFI_SCT_SMOKE_START") {
         println!("[PASS] sct_started: startup.nsh launched SCT smoke run");
         passed += 1;
@@ -1319,11 +1327,11 @@ pub fn run_uefi_sct_smoke_tests(config: &QemuConfig, disk_path: &Path) -> Result
         failed += 1;
     }
 
-    if combined.contains("Done!") || combined.contains("CRABEFI_SCT_SMOKE_DONE") {
-        println!("[PASS] sct_done: SCT reached a completion marker");
+    if combined.contains("Done!") {
+        println!("[PASS] sct_done: SCT printed Done!");
         passed += 1;
     } else {
-        println!("[FAIL] sct_done: SCT did not reach a completion marker");
+        println!("[FAIL] sct_done: SCT did not print Done!");
         failed += 1;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an x86_64 UEFI SCT smoke test workflow with automatic asset download, disk preparation, and QEMU execution with log-based validation.
  * Added a minimal in-memory UEFI HII database/string implementation and separated Unicode Collation into v1/v2.
  * Enabled FAT32 and Simple File System write capabilities (create/write/truncate/delete, flushing) plus writable USB/block operations.
* **Bug Fixes**
  * Hardened USB Mass Storage BOT/CSW phase validation and recovery.
  * Improved EFI boot-services protocol and image load/unload lifecycle handling.
* **Documentation**
  * Updated build/test instructions for the UEFI SCT smoke workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->