### PR TITLE
Carve out data for runtime variables

### DIFF
--- a/crabefi-core/src/efi/allocator.rs
+++ b/crabefi-core/src/efi/allocator.rs
@@ -1326,6 +1326,26 @@ pub fn force_add_region(
     })
 }
 
+/// Carve a physical range out of its containing map entry as `memory_type`.
+///
+/// Unlike `force_add_region`, this splits the containing Reserved/Conventional
+/// entry and never creates overlapping memory map entries (which confuse the
+/// Linux kernel's EFI mapping code).
+pub fn carve_out_region(
+    physical_start: u64,
+    num_pages: u64,
+    memory_type: MemoryType,
+) -> Result<(), efi::Status> {
+    let source_types = &[
+        MemoryType::ReservedMemoryType,
+        MemoryType::ConventionalMemory,
+        MemoryType::BootServicesData,
+    ];
+    state::with_allocator_mut(|alloc| {
+        alloc.carve_out_from(physical_start, num_pages, memory_type, source_types)
+    })
+}
+
 /// Mark a memory region as ACPI Reclaim Memory
 ///
 /// This properly splits existing regions and marks the specified range as AcpiReclaimMemory.

--- a/crabefi-core/src/efi/rtlog.rs
+++ b/crabefi-core/src/efi/rtlog.rs
@@ -259,7 +259,9 @@ pub fn register_region() {
     let buf_base = unsafe { &_rt_log_start as *const u8 as u64 };
     let buf_pages = (total_size() as u64).div_ceil(PAGE_SIZE);
 
-    if let Err(e) = crate::efi::allocator::force_add_region(
+    // carve_out_region splits the containing map entry; force_add_region
+    // would push an overlapping duplicate that breaks Linux's EFI mapping.
+    if let Err(e) = crate::efi::allocator::carve_out_region(
         buf_base,
         buf_pages,
         MemoryType::RuntimeServicesData,

--- a/crabefi-core/src/lib.rs
+++ b/crabefi-core/src/lib.rs
@@ -479,13 +479,6 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
         let buf_base = deferred::deferred_buffer_base();
         let buf_size = deferred::deferred_buffer_size();
         if buf_size > 0 {
-            // When platform-entry is active, the deferred buffer lives inside
-            // the linker's __runtime_data_start..__runtime_data_end range which
-            // reserve_runtime_region() already carved as RuntimeServicesData.
-            // Adding it again via force_add_region creates a duplicate,
-            // overlapping memory map entry that confuses the Linux kernel's
-            // efi_memattr_apply_permissions / efi_create_mapping and can leave
-            // parts of the RuntimeServicesData region unmapped in efi_mm.
             #[cfg(not(feature = "platform-entry"))]
             {
                 use efi::allocator::{MemoryType as AllocMemType, PAGE_SIZE};
@@ -511,12 +504,34 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
 
             #[cfg(feature = "platform-entry")]
             {
-                use efi::allocator::PAGE_SIZE;
-                log::info!(
-                    "Deferred buffer at {:#x} ({} pages) already in runtime data region",
+                use efi::allocator::{MemoryType as AllocMemType, PAGE_SIZE};
+                // The linker script places .deferred_buffer BELOW PAYLOAD_BASE
+                // (0x80000 on x86_64), i.e. OUTSIDE the runtime data range that
+                // reserve_runtime_region() carves. Without marking it as
+                // RuntimeServicesData the OS treats it as free RAM and the
+                // first runtime SetVariable write corrupts kernel memory or
+                // faults on an unmapped efi_mm address (hard system lockup).
+                // carve_out_region splits the containing entry instead of
+                // pushing an overlapping duplicate, which the Linux EFI
+                // mapping code cannot handle.
+                let buf_pages = (buf_size as u64).div_ceil(PAGE_SIZE);
+                match efi::allocator::carve_out_region(
                     buf_base,
-                    (buf_size as u64).div_ceil(PAGE_SIZE)
-                );
+                    buf_pages,
+                    AllocMemType::RuntimeServicesData,
+                ) {
+                    Ok(()) => log::info!(
+                        "Deferred buffer at {:#x} ({} pages) carved as RuntimeServicesData",
+                        buf_base,
+                        buf_pages
+                    ),
+                    Err(e) => log::error!(
+                        "CRITICAL: could not reserve deferred buffer at {:#x}: {:?} — \
+                         runtime SetVariable would corrupt OS memory",
+                        buf_base,
+                        e
+                    ),
+                }
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced EFI memory-map handling by carving and re-typing runtime regions to avoid overlapping entries.
  * Runtime buffers (including runtime logging and deferred variable storage) are now explicitly reserved as `RuntimeServicesData`.

* **Bug Fixes**
  * Reduced the chance of invalid EFI mappings that can disrupt Linux’s EFI memory view.
  * Improved critical error reporting when carving/reservation of runtime memory fails, preventing potential OS memory corruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->