### PR TITLE
Heap-backed state tables, linked-list allocator, and memory reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
       - name: Build release
         run: cargo build -p crabefi-coreboot --release --target x86_64-unknown-none
 
+      - name: Report reserved stack
+        run: |
+          stack_hex=$(readelf -SW target/x86_64-unknown-none/release/crabefi | awk '$2 == ".stack" { print $6 }')
+          printf '## x86_64 memory report\n\n- Reserved stack: %d KiB\n' "$((16#$stack_hex / 1024))" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload CrabEFI ELF
         uses: actions/upload-artifact@v4
         with:
@@ -109,7 +114,13 @@ jobs:
           path: target/x86_64-unknown-none/release/
 
       - name: Run integration tests (USB)
-        run: ./crabefi test --app hello --disable-kvm --timeout 120
+        run: |
+          set -o pipefail
+          ./crabefi test --app hello --disable-kvm --timeout 120 | tee qemu.log
+          {
+            echo '## Q35 runtime memory report'
+            grep -F 'MEMORY_REPORT' qemu.log || true
+          } >> "$GITHUB_STEP_SUMMARY"
 
   test-ahci:
     name: Test x86_64 (AHCI Storage)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
  "byteorder",
  "log",
  "pci_types",
- "spinning_top",
+ "spinning_top 0.3.0",
 ]
 
 [[package]]
@@ -135,6 +135,7 @@ dependencies = [
  "der",
  "fdt",
  "heapless",
+ "linked_list_allocator",
  "log",
  "mem-barrier",
  "noto-sans-mono-bitmap",
@@ -322,6 +323,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linked_list_allocator"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b23ac50abb8261cb38c6e2a7192d3302e0836dac1628f6a93b82b4fad185897"
+dependencies = [
+ "spinning_top 0.2.5",
+]
 
 [[package]]
 name = "lock_api"
@@ -694,6 +704,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9eb1a2f4c41445a3a0ff9abc5221c5fcd28e1f13cd7c0397706f9ac938ddb0"
 dependencies = [
  "lock_api",
 ]

--- a/crabefi-core/Cargo.toml
+++ b/crabefi-core/Cargo.toml
@@ -32,6 +32,7 @@ ui = []
 r-efi = { workspace = true }
 log = { workspace = true }
 heapless = { workspace = true }
+linked_list_allocator = { version = "0.10.6", default-features = false, features = ["use_spin"] }
 mem-barrier = { workspace = true }
 pci_types = { workspace = true }
 xhci = { workspace = true }

--- a/crabefi-core/src/boot_vars.rs
+++ b/crabefi-core/src/boot_vars.rs
@@ -324,7 +324,7 @@ fn write_variable(name: &[u16], attrs: u32, data: &[u8]) -> bool {
         if data.is_empty() && attrs == 0 {
             for var in efi.variables.iter_mut() {
                 if var.in_use && var.vendor_guid == guid && ucs2_eq(&var.name, name) {
-                    var.in_use = false;
+                    var.clear();
                     return true;
                 }
             }
@@ -340,9 +340,7 @@ fn write_variable(name: &[u16], attrs: u32, data: &[u8]) -> bool {
         for var in efi.variables.iter_mut() {
             if var.in_use && var.vendor_guid == guid && ucs2_eq(&var.name, name) {
                 var.attributes = attrs;
-                var.data[..data.len()].copy_from_slice(data);
-                var.data_size = data.len();
-                return true;
+                return var.set_data(data).is_ok();
             }
         }
 
@@ -361,11 +359,7 @@ fn write_variable(name: &[u16], attrs: u32, data: &[u8]) -> bool {
                 for c in &mut var.name[copy_len + 1..] {
                     *c = 0;
                 }
-                // Copy data and zero the tail (defense-in-depth for variable isolation)
-                var.data[..data.len()].copy_from_slice(data);
-                var.data[data.len()..].fill(0);
-                var.data_size = data.len();
-                return true;
+                return var.set_data(data).is_ok();
             }
         }
 

--- a/crabefi-core/src/efi/mod.rs
+++ b/crabefi-core/src/efi/mod.rs
@@ -88,6 +88,28 @@ pub fn init_from_platform(config: &mut crate::platform::PlatformConfig) {
         );
     }
 
+    // The EFI state tables are heap-backed, so initialize the heap after the
+    // page allocator and runtime regions are ready but before system-table and
+    // protocol setup starts using them.
+    if !config.heap_pre_initialized && !crate::heap::init() {
+        panic!("Failed to initialize heap allocator");
+    }
+    if !crate::heap::is_initialized() {
+        panic!("Failed to initialize heap allocator");
+    }
+    let (heap_before, heap_total) = crate::heap::stats();
+    if !crate::state::init_efi_caches() {
+        panic!("Failed to initialize EFI state tables");
+    }
+    let (heap_after, _) = crate::heap::stats();
+    log::info!(
+        "MEMORY_REPORT heap_before_efi_tables={} heap_after_efi_tables={} heap_delta={} heap_total={}",
+        heap_before,
+        heap_after,
+        heap_after.saturating_sub(heap_before),
+        heap_total,
+    );
+
     // Initialize system table with boot and runtime services
     unsafe {
         system_table::init(

--- a/crabefi-core/src/efi/runtime_services.rs
+++ b/crabefi-core/src/efi/runtime_services.rs
@@ -1102,7 +1102,7 @@ fn set_variable_runtime_delete(
             return (Status::NOT_FOUND, None);
         };
 
-        efi.variables[idx].in_use = false;
+        efi.variables[idx].clear();
         (Status::SUCCESS, secure_boot_var)
     });
 
@@ -1287,7 +1287,7 @@ fn set_variable_full(
         // Delete variable if data_size is 0 (for authenticated vars, this means empty after header).
         if final_data_size == 0 {
             if let Some(idx) = existing_idx {
-                variables[idx].in_use = false;
+                variables[idx].clear();
                 let secure_action = secure_boot_var
                     .map(SecureBootDbAction::Delete)
                     .unwrap_or(SecureBootDbAction::None);
@@ -1325,8 +1325,13 @@ fn set_variable_full(
                         );
                     }
 
-                    variables[idx].data[..combined.len()].copy_from_slice(combined.as_slice());
-                    variables[idx].data_size = combined.len();
+                    if variables[idx].set_data(combined.as_slice()).is_err() {
+                        return (
+                            Status::OUT_OF_RESOURCES,
+                            VariablePersistAction::None,
+                            SecureBootDbAction::None,
+                        );
+                    }
 
                     let mut combined_buf = VariableDataBuf::new();
                     if combined_buf.extend_from_slice(combined.as_slice()).is_err() {
@@ -1410,10 +1415,15 @@ fn set_variable_full(
 
         variables[idx].name[..name_vec.len()].copy_from_slice(&name_vec);
         variables[idx].name[name_vec.len()..].fill(0);
-        variables[idx].data[..final_data_size].copy_from_slice(&final_data_vec);
+        if variables[idx].set_data(final_data_vec.as_slice()).is_err() {
+            return (
+                Status::OUT_OF_RESOURCES,
+                VariablePersistAction::None,
+                SecureBootDbAction::None,
+            );
+        }
         variables[idx].vendor_guid = guid;
         variables[idx].attributes = attributes;
-        variables[idx].data_size = final_data_size;
         variables[idx].in_use = true;
 
         let secure_action = secure_boot_var

--- a/crabefi-core/src/efi/varstore/persistence.rs
+++ b/crabefi-core/src/efi/varstore/persistence.rs
@@ -357,8 +357,10 @@ fn load_variables_from_storage() -> Result<(), VarStoreError> {
                 slot.attributes = var.attributes;
 
                 let data_len = var.data.len().min(MAX_VARIABLE_DATA_SIZE);
-                slot.data[..data_len].copy_from_slice(&var.data[..data_len]);
-                slot.data_size = data_len;
+                if slot.set_data(&var.data[..data_len]).is_err() {
+                    log::warn!("No heap space for variable payload");
+                    continue;
+                }
                 slot.in_use = true;
 
                 // Log the loaded variable name
@@ -913,13 +915,14 @@ pub fn update_variable_in_memory(
             efi.variables[idx].name[name_len..].fill(0);
         }
 
-        // Copy data
         let data_len = data.len().min(MAX_VARIABLE_DATA_SIZE);
-        efi.variables[idx].data[..data_len].copy_from_slice(&data[..data_len]);
+        if efi.variables[idx].set_data(&data[..data_len]).is_err() {
+            log::warn!("No heap space for variable payload");
+            return;
+        }
 
         efi.variables[idx].vendor_guid = *guid;
         efi.variables[idx].attributes = attributes;
-        efi.variables[idx].data_size = data_len;
         efi.variables[idx].in_use = true;
     });
 }
@@ -934,7 +937,7 @@ pub(super) fn delete_variable_from_memory(guid: &r_efi::efi::Guid, name: &[u16])
         if let Some(var) = efi.variables.iter_mut().find(|var| {
             var.in_use && var.vendor_guid == *guid && crate::efi::utils::ucs2_eq(&var.name, name)
         }) {
-            var.in_use = false;
+            var.clear();
         }
     });
 }

--- a/crabefi-core/src/heap.rs
+++ b/crabefi-core/src/heap.rs
@@ -1,168 +1,37 @@
 //! Global Allocator for CrabEFI
 //!
-//! This module provides a global allocator implementation that enables the use of
-//! the `alloc` crate for heap allocations. This is required for cryptographic
-//! operations in the RustCrypto crates (RSA, X.509, etc.).
-//!
-//! # Design
-//!
-//! We use a simple bump allocator backed by a pre-allocated heap region. The heap
-//! is allocated from the EFI memory allocator during initialization.
-//!
-//! # Memory Management
-//!
-//! - Heap is allocated as `RuntimeServicesData` with EFI_MEMORY_RUNTIME attribute
-//! - This ensures the OS preserves the heap after ExitBootServices, so runtime
-//!   services (SetVariable, etc.) can continue to use heap allocations for
-//!   authenticated variable verification, varstore persistence, etc.
-//! - Allocations are bump-pointer style (fast allocation)
-//! - Deallocation is a no-op (bump allocator never frees)
+//! This module provides the global allocator used by `alloc`. Its backing pages
+//! are RuntimeServicesData, so allocations remain available to EFI runtime
+//! services after ExitBootServices.
 
-use core::alloc::{GlobalAlloc, Layout};
-use core::cell::UnsafeCell;
-use core::ptr::null_mut;
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, Ordering};
 
-/// Heap size (2 MB should be sufficient for crypto operations)
+use linked_list_allocator::LockedHeap;
+
+/// Heap size (2 MB should be sufficient for crypto operations and EFI state).
 const HEAP_SIZE: usize = 2 * 1024 * 1024;
 
-/// Page size (4KB)
+/// Page size (4KB).
 const PAGE_SIZE: usize = 4096;
 
-/// Number of pages for the heap
+/// Number of pages for the heap.
 const HEAP_PAGES: u64 = (HEAP_SIZE / PAGE_SIZE) as u64;
 
-/// Global heap state.
-///
-/// Binary crates must wire this up as `#[global_allocator]`. The library
-/// provides [`ALLOCATOR`] as the singleton instance; the binary just
-/// re-exports it with the attribute.
-pub struct BumpAllocator {
-    /// Start of the heap
-    heap_start: UnsafeCell<usize>,
-    /// Current allocation pointer (offset from heap_start)
-    offset: AtomicUsize,
-    /// Heap size (written once during init)
-    heap_size: UnsafeCell<usize>,
-    /// Whether the allocator has been initialized
-    initialized: AtomicBool,
-}
-
-// SAFETY: BumpAllocator is thread-safe because:
-// 1. CrabEFI is single-threaded firmware
-// 2. We use atomic operations for offset updates
-// 3. heap_start is only written once during initialization
-unsafe impl Sync for BumpAllocator {}
-
-impl BumpAllocator {
-    const fn new() -> Self {
-        Self {
-            heap_start: UnsafeCell::new(0),
-            offset: AtomicUsize::new(0),
-            heap_size: UnsafeCell::new(0),
-            initialized: AtomicBool::new(false),
-        }
-    }
-
-    /// Initialize the allocator with a heap region
-    ///
-    /// # Safety
-    ///
-    /// Must be called only once, before any allocations.
-    unsafe fn init(&self, heap_start: usize, heap_size: usize) {
-        // SAFETY: Must be called only once, before any allocations.
-        // UnsafeCell access is safe because this is single-threaded initialization.
-        unsafe {
-            // Store the heap start address
-            *self.heap_start.get() = heap_start;
-
-            *self.heap_size.get() = heap_size;
-        }
-
-        // Reset the offset
-        self.offset.store(0, Ordering::Release);
-        self.initialized.store(true, Ordering::Release);
-
-        log::info!(
-            "Global allocator initialized: heap at {:#x}, size {} KB",
-            heap_start,
-            heap_size / 1024
-        );
-    }
-
-    /// Check if the allocator is initialized
-    fn is_initialized(&self) -> bool {
-        self.initialized.load(Ordering::Acquire)
-    }
-}
-
-unsafe impl GlobalAlloc for BumpAllocator {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        if !self.is_initialized() {
-            // Allocator not initialized yet - this shouldn't happen in normal operation
-            return null_mut();
-        }
-
-        // SAFETY: heap_start is only written once during init, before any allocations.
-        let heap_start = unsafe { *self.heap_start.get() };
-        let size = layout.size();
-        let align = layout.align();
-
-        // Use a CAS loop to atomically bump the offset
-        loop {
-            let current_offset = self.offset.load(Ordering::Acquire);
-
-            // Calculate aligned offset
-            let alloc_start = heap_start + current_offset;
-            let aligned_start = (alloc_start + align - 1) & !(align - 1);
-            let padding = aligned_start - alloc_start;
-            let new_offset = current_offset + padding + size;
-
-            // Check if we have enough space
-            // SAFETY: heap_size is only written once during init, before any allocations
-            let heap_size = unsafe { *self.heap_size.get() };
-            if new_offset > heap_size {
-                log::error!(
-                    "Heap exhausted: requested {} bytes, offset {}, heap_size {}",
-                    size,
-                    current_offset,
-                    heap_size
-                );
-                return null_mut();
-            }
-
-            // Try to update the offset atomically
-            match self.offset.compare_exchange_weak(
-                current_offset,
-                new_offset,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => return aligned_start as *mut u8,
-                Err(_) => continue, // Another allocation happened, retry
-            }
-        }
-    }
-
-    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {
-        // Bump allocator doesn't deallocate individual allocations.
-        // The heap is RuntimeServicesData, so it persists after ExitBootServices
-        // and remains available for runtime service calls.
-    }
-}
+/// Whether [`ALLOCATOR`] has been initialized.
+static HEAP_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 /// Global allocator instance.
 ///
-/// When the `global-allocator` feature is enabled, this is registered as
-/// `#[global_allocator]`. External firmware that provides its own allocator
-/// should not enable this feature.
+/// When the `global-allocator` feature is enabled, this is registered as the
+/// allocator. External firmware that provides its own allocator should not
+/// enable that feature.
 #[cfg_attr(feature = "global-allocator", global_allocator)]
-pub static ALLOCATOR: BumpAllocator = BumpAllocator::new();
+pub static ALLOCATOR: LockedHeap = LockedHeap::empty();
 
-/// Initialize the global allocator
+/// Initialize the global allocator.
 ///
-/// This must be called early in the boot process, after the EFI memory allocator
-/// is initialized but before any code that uses `alloc`.
+/// This must be called early in the boot process, after the EFI page allocator
+/// is initialized and before code that uses `alloc`.
 ///
 /// # Returns
 ///
@@ -171,41 +40,47 @@ pub fn init() -> bool {
     use crate::efi::allocator::{AllocateType, MemoryType, allocate_pages};
     use r_efi::efi::Status;
 
-    // Allocate heap pages as RuntimeServicesData so the OS preserves them
-    // after ExitBootServices. Runtime services (SetVariable, etc.) need
-    // heap allocations for authenticated variable verification, varstore
-    // persistence, and crypto operations.
-    let mut heap_addr: u64 = 0;
+    if HEAP_INITIALIZED.swap(true, Ordering::AcqRel) {
+        log::error!("Global allocator is already initialized");
+        return false;
+    }
+
+    // RuntimeServicesData remains mapped after ExitBootServices, including the
+    // linked-list allocator's in-band free-list metadata.
+    let mut heap_addr = 0;
     let status = allocate_pages(
         AllocateType::AllocateAnyPages,
         MemoryType::RuntimeServicesData,
         HEAP_PAGES,
         &mut heap_addr,
     );
-
     if status != Status::SUCCESS {
+        HEAP_INITIALIZED.store(false, Ordering::Release);
         log::error!("Failed to allocate heap memory: {:?}", status);
         return false;
     }
 
-    // Initialize the bump allocator
-    // SAFETY: Called once before any allocations
+    // SAFETY: `heap_addr` is a newly allocated, page-aligned RuntimeServicesData
+    // range, and this is the sole initialization guarded by HEAP_INITIALIZED.
     unsafe {
-        ALLOCATOR.init(heap_addr as usize, HEAP_SIZE);
+        ALLOCATOR.lock().init(heap_addr as *mut u8, HEAP_SIZE);
     }
 
+    log::info!(
+        "Global allocator initialized: heap at {:#x}, size {} KB",
+        heap_addr,
+        HEAP_SIZE / 1024
+    );
     true
 }
 
-/// Check if the allocator is initialized
+/// Check if the allocator is initialized.
 pub fn is_initialized() -> bool {
-    ALLOCATOR.is_initialized()
+    HEAP_INITIALIZED.load(Ordering::Acquire)
 }
 
-/// Get heap usage statistics
+/// Get heap usage statistics.
 pub fn stats() -> (usize, usize) {
-    let used = ALLOCATOR.offset.load(Ordering::Acquire);
-    // Safety: heap_size is only written once during init
-    let total = unsafe { *ALLOCATOR.heap_size.get() };
-    (used, total)
+    let heap = ALLOCATOR.lock();
+    (heap.used(), heap.size())
 }

--- a/crabefi-core/src/heap.rs
+++ b/crabefi-core/src/heap.rs
@@ -9,7 +9,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use linked_list_allocator::LockedHeap;
 
 /// Heap size (2 MB should be sufficient for crypto operations and EFI state).
-const HEAP_SIZE: usize = 2 * 1024 * 1024;
+const HEAP_SIZE: usize = 4 * 1024 * 1024;
 
 /// Page size (4KB).
 const PAGE_SIZE: usize = 4096;

--- a/crabefi-core/src/lib.rs
+++ b/crabefi-core/src/lib.rs
@@ -125,6 +125,36 @@ pub fn display_secure_boot_error() {
     time::delay_ms(3000);
 }
 
+#[cfg(all(feature = "platform-entry", target_arch = "x86_64"))]
+fn log_stack_usage(phase: &str) {
+    unsafe extern "C" {
+        static _stack_bottom: u8;
+        static _stack_top: u8;
+    }
+
+    // SAFETY: platform-entry's x86_64 linker script defines the contiguous
+    // stack range and assembly fills it with 0xA5 before calling Rust.
+    let (bottom, total) = unsafe {
+        let bottom = &raw const _stack_bottom;
+        let top = &raw const _stack_top;
+        (bottom, top.offset_from(bottom) as usize)
+    };
+    // SAFETY: `bottom..bottom + total` is the linker-defined stack range.
+    let stack = unsafe { core::slice::from_raw_parts(bottom, total) };
+    let used = stack
+        .iter()
+        .position(|&byte| byte != 0xA5)
+        .map_or(0, |first_used| total - first_used);
+
+    log::info!(
+        "MEMORY_REPORT stack_phase={} stack_used={} stack_total={} stack_free={}",
+        phase,
+        used,
+        total,
+        total - used,
+    );
+}
+
 /// Common boot tail: variable persistence, Secure Boot, and boot manager.
 ///
 /// This is the shared sequence executed by both [`init_platform()`] and
@@ -176,8 +206,14 @@ fn init_persistence_and_boot(
     efi::measure_initial_boot();
 
     // ---- Boot manager ----
+    #[cfg(all(feature = "platform-entry", target_arch = "x86_64"))]
+    log_stack_usage("before_boot_manager");
+
     let boot_var_state = boot_vars::read_boot_var_state();
     boot_manager::run(boot_var_state);
+
+    #[cfg(all(feature = "platform-entry", target_arch = "x86_64"))]
+    log_stack_usage("after_boot_manager");
 
     log::info!("Boot manager finished — halting");
 
@@ -436,16 +472,7 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
     log::info!("CrabEFI initialized successfully!");
     log::info!("EFI System Table at: {:p}", efi::get_system_table());
 
-    // ---- 10. Initialize heap ----
-    //
-    // Skipped when the platform already set up the heap before entry
-    // (heap_pre_initialized == true).  The rest of the init sequence is
-    // identical regardless of this flag.
-    if !config.heap_pre_initialized && !heap::init() {
-        log::error!("Failed to initialize heap allocator!");
-    }
-
-    // ---- 11. Runtime log support ----
+    // ---- 10. Runtime log support ----
     #[cfg(feature = "rt-log")]
     {
         efi::rtlog::register_region();

--- a/crabefi-core/src/state.rs
+++ b/crabefi-core/src/state.rs
@@ -68,6 +68,7 @@
 //! 3. They never read or write fields that the enclosing `with_mut()`
 //!    closure is currently modifying.
 
+use alloc::vec::Vec;
 use core::sync::atomic::{AtomicPtr, Ordering};
 
 use crate::fs::fat::FatType;
@@ -91,6 +92,9 @@ static IN_WITH_MUT: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicB
 /// - The `state` reference must remain valid for the entire firmware lifetime
 /// - The firmware must be single-threaded
 pub unsafe fn init(state: &mut FirmwareState) {
+    // SAFETY: The caller guarantees that `state` remains valid for the
+    // firmware lifetime and no other state has been installed.
+    let _ = unsafe { (state as *const FirmwareState).as_ref() };
     STATE_PTR.store(state as *mut FirmwareState, Ordering::Release);
 }
 
@@ -109,6 +113,11 @@ pub fn is_initialized() -> bool {
 /// The new pointer must point to valid `FirmwareState` memory that has been
 /// remapped by the OS.
 pub unsafe fn relocate_state_ptr(new_ptr: *mut FirmwareState) {
+    // SAFETY: The caller guarantees that `new_ptr` is the runtime-mapped
+    // address of the installed firmware state.
+    if unsafe { new_ptr.as_ref() }.is_none() {
+        panic!("FirmwareState pointer is null");
+    }
     STATE_PTR.store(new_ptr, Ordering::Release);
 }
 
@@ -201,6 +210,42 @@ pub fn try_get_mut_ptr() -> Option<*mut FirmwareState> {
     (!ptr.is_null()).then_some(ptr)
 }
 
+/// Allocate fixed-size EFI state tables after heap startup.
+///
+/// All tables keep their maximum length so their backing storage never moves.
+/// Variable payloads remain empty until a variable is loaded or written.
+///
+/// # Returns
+/// `true` when every table is ready.
+pub fn init_efi_caches() -> bool {
+    with_efi_mut(|efi| {
+        init_entries(&mut efi.handles, MAX_HANDLES, HandleEntry::empty)
+            && init_entries(&mut efi.events, MAX_EVENTS, EventEntry::empty)
+            && init_entries(
+                &mut efi.loaded_images,
+                MAX_LOADED_IMAGES,
+                LoadedImageEntry::empty,
+            )
+            && init_entries(
+                &mut efi.config_tables,
+                MAX_CONFIG_TABLES,
+                ConfigurationTable::empty,
+            )
+            && init_entries(&mut efi.variables, MAX_VARIABLES, VariableEntry::empty)
+    })
+}
+
+fn init_entries<T>(entries: &mut Vec<T>, len: usize, init: impl FnMut() -> T) -> bool {
+    if !entries.is_empty() {
+        return true;
+    }
+    if entries.try_reserve_exact(len).is_err() {
+        return false;
+    }
+    entries.resize_with(len, init);
+    true
+}
+
 // ============================================================================
 // Firmware State Structure
 // ============================================================================
@@ -269,14 +314,9 @@ pub const MAX_VARIABLES: usize = 64;
 /// Maximum variable name length (in characters)
 pub const MAX_VARIABLE_NAME_LEN: usize = 64;
 
-/// Maximum variable data size (stored payload, after auth header stripping)
+/// Maximum variable data size (stored payload, after auth header stripping).
 ///
-/// This must be large enough for Secure Boot key databases (PK, KEK, db, dbx).
-/// A single X.509 certificate in an EFI_SIGNATURE_LIST is typically 1-2 KB,
-/// and databases with multiple certificates (e.g. Microsoft CA chain + custom
-/// keys from sbctl) can reach 4-8 KB.  16 KB covers all realistic Secure Boot
-/// configurations while keeping FirmwareState within the 2 MB stack budget
-/// (64 entries * ~8.3 KB ≈ 530 KB).
+/// This covers Secure Boot key databases while bounding each heap allocation.
 pub const MAX_VARIABLE_DATA_SIZE: usize = 16 * 1024;
 
 /// Protocol interface entry
@@ -479,26 +519,62 @@ impl ConfigurationTable {
 }
 
 /// EFI variable entry
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct VariableEntry {
     pub name: [u16; MAX_VARIABLE_NAME_LEN],
     pub vendor_guid: Guid,
     pub attributes: u32,
-    pub data: [u8; MAX_VARIABLE_DATA_SIZE],
+    pub data: Vec<u8>,
     pub data_size: usize,
     pub in_use: bool,
 }
 
 impl VariableEntry {
-    pub const fn empty() -> Self {
+    /// Create an unused variable-cache entry without allocating its payload.
+    ///
+    /// # Returns
+    /// An empty cache entry.
+    pub fn empty() -> Self {
         Self {
             name: [0; MAX_VARIABLE_NAME_LEN],
             vendor_guid: Guid::from_fields(0, 0, 0, 0, 0, &[0, 0, 0, 0, 0, 0]),
             attributes: 0,
-            data: [0; MAX_VARIABLE_DATA_SIZE],
+            data: Vec::new(),
             data_size: 0,
             in_use: false,
         }
+    }
+
+    /// Replace the variable payload without exceeding its UEFI size limit.
+    ///
+    /// # Arguments
+    /// * `data` - New variable payload.
+    ///
+    /// # Returns
+    /// `Err(())` when the payload is too large or the heap is exhausted.
+    pub fn set_data(&mut self, data: &[u8]) -> Result<(), ()> {
+        if data.len() > MAX_VARIABLE_DATA_SIZE {
+            return Err(());
+        }
+        if self.data.capacity() < data.len()
+            && self
+                .data
+                .try_reserve_exact(data.len() - self.data.len())
+                .is_err()
+        {
+            return Err(());
+        }
+        self.data.clear();
+        self.data.extend_from_slice(data);
+        self.data_size = data.len();
+        Ok(())
+    }
+
+    /// Release a deleted variable's heap payload.
+    pub fn clear(&mut self) {
+        self.data = Vec::new();
+        self.data_size = 0;
+        self.in_use = false;
     }
 }
 
@@ -538,28 +614,28 @@ impl Default for VarStoreState {
 
 /// EFI subsystem state
 pub struct EfiState {
-    /// Handle database
-    pub handles: [HandleEntry; MAX_HANDLES],
+    /// Handle database, allocated after heap startup.
+    pub handles: Vec<HandleEntry>,
     /// Number of active handles
     pub handle_count: usize,
     /// Next handle value (unique identifier)
     pub next_handle: usize,
 
-    /// Event database
-    pub events: [EventEntry; MAX_EVENTS],
+    /// Event database, allocated after heap startup.
+    pub events: Vec<EventEntry>,
     /// Next event ID (starting at 2, 1 is reserved for keyboard)
     pub next_event_id: usize,
 
-    /// Loaded images database
-    pub loaded_images: [LoadedImageEntry; MAX_LOADED_IMAGES],
+    /// Loaded images database, allocated after heap startup.
+    pub loaded_images: Vec<LoadedImageEntry>,
 
-    /// Configuration tables
-    pub config_tables: [ConfigurationTable; MAX_CONFIG_TABLES],
+    /// Configuration tables, allocated after heap startup.
+    pub config_tables: Vec<ConfigurationTable>,
     /// Number of configuration tables
     pub config_table_count: usize,
 
-    /// EFI variables
-    pub variables: [VariableEntry; MAX_VARIABLES],
+    /// EFI variables. Entries and payloads are allocated after heap startup.
+    pub variables: Vec<VariableEntry>,
 
     /// Variable store persistence state (SMMSTORE tracking)
     pub varstore: VarStoreState,
@@ -596,15 +672,15 @@ pub struct EfiState {
 impl EfiState {
     pub const fn new() -> Self {
         Self {
-            handles: [const { HandleEntry::empty() }; MAX_HANDLES],
+            handles: Vec::new(),
             handle_count: 0,
             next_handle: 1,
-            events: [const { EventEntry::empty() }; MAX_EVENTS],
+            events: Vec::new(),
             next_event_id: 2, // Start at 2, reserve 1 for keyboard
-            loaded_images: [const { LoadedImageEntry::empty() }; MAX_LOADED_IMAGES],
-            config_tables: [ConfigurationTable::empty(); MAX_CONFIG_TABLES],
+            loaded_images: Vec::new(),
+            config_tables: Vec::new(),
             config_table_count: 0,
-            variables: [const { VariableEntry::empty() }; MAX_VARIABLES],
+            variables: Vec::new(),
             varstore: VarStoreState::new(),
             allocator: MemoryAllocator::new(),
             monotonic_count: 0,

--- a/crabefi-coreboot/aarch64-coreboot.ld
+++ b/crabefi-coreboot/aarch64-coreboot.ld
@@ -68,10 +68,10 @@ SECTIONS
         _bss_end = .;
     }
 
-    /* Stack - 3MB (increased from 2MB for large structs like FirmwareState) */
+    /* Stack - 1MB; variable payloads are heap-backed. */
     .stack (NOLOAD) : ALIGN(65536) {
         _stack_bottom = .;
-        . += 0x300000;
+        . += 0x100000;
         _stack_top = .;
     }
 

--- a/crabefi-coreboot/riscv64-coreboot.ld
+++ b/crabefi-coreboot/riscv64-coreboot.ld
@@ -62,10 +62,10 @@ SECTIONS
         _bss_end = .;
     }
 
-    /* Stack — 3MB */
+    /* Stack — 1MB; variable payloads are heap-backed. */
     .stack (NOLOAD) : ALIGN(4096) {
         _stack_bottom = .;
-        . += 0x300000;
+        . += 0x100000;
         _stack_top = .;
     }
 

--- a/crabefi-coreboot/src/arch/x86_64/entry.rs
+++ b/crabefi-coreboot/src/arch/x86_64/entry.rs
@@ -171,6 +171,14 @@ long_mode_start:
     xor rax, rax
     rep stosq
 
+    // Fill the stack with a marker so Rust can report its high-water mark.
+    // No stack access occurs between this and the call to rust_main below.
+    lea rdi, [rip + _stack_bottom]
+    lea rcx, [rip + _stack_top]
+    sub rcx, rdi
+    mov al, 0xA5
+    rep stosb
+
     // Enable SSE
     mov rax, cr0
     and rax, 0xFFFFFFFFFFFFFFFB  // Clear EM (bit 2)

--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -876,11 +876,8 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
             crabefi::TpmEventLogConfig {
                 existing_log,
                 format,
-                // Probe for a hardware TPM at the standard x86 TIS address.
-                // On aarch64/riscv64, hardware TPM discovery is not yet supported.
-                #[cfg(target_arch = "x86_64")]
-                tpm2_device: crabefi::Tpm2DeviceConfig::TisMmio { base: 0xFED4_0000 },
-                #[cfg(not(target_arch = "x86_64"))]
+                // Hardware TPM transport is selected after ACPI namespace discovery.
+                // Coreboot's TPM log record does not describe the transport.
                 tpm2_device: crabefi::Tpm2DeviceConfig::None,
             }
         }),
@@ -919,6 +916,21 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
     if let Some(rsdp) = crabefi::state::drivers().platform.acpi_rsdp {
         let acpi_info = unsafe { acpi::discover_platform(rsdp) };
         crabefi::state::with_drivers_mut(|d| d.acpi_info = acpi_info);
+
+        #[cfg(target_arch = "x86_64")]
+        if let Some(device) = ["MSFT0101", "PNP0C31"]
+            .iter()
+            .find_map(|hid| acpi_info.find_device(hid))
+            && device.mmio_base <= 0xfed4_0000
+            && device.mmio_base.saturating_add(device.mmio_size) > 0xfed4_0000
+        {
+            if let Some(ref mut tpm) = config.tpm_event_log {
+                tpm.tpm2_device = crabefi::Tpm2DeviceConfig::TisMmio { base: 0xfed4_0000 };
+            }
+            log::info!("ACPI exposes an MMIO TIS TPM at 0xfed40000");
+        } else {
+            log::info!("No ACPI MMIO TIS TPM resource; skipping unsafe probe");
+        }
 
         // PNP0D40 is generic SDHCI; only known AMD eMMC HIDs use this path.
         #[cfg(target_arch = "x86_64")]

--- a/crabefi-coreboot/x86_64-coreboot.ld
+++ b/crabefi-coreboot/x86_64-coreboot.ld
@@ -122,10 +122,10 @@ SECTIONS
         _bss_end = .;
     } :data
 
-    /* Stack - 3MB (increased from 64KB for large structs like FirmwareState) */
+    /* Stack - 1MB; variable payloads are heap-backed. */
     .stack : ALIGN(4096) {
         _stack_bottom = .;
-        . += 0x300000;
+        . += 0x100000;
         _stack_top = .;
     } :data
 

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -489,6 +489,15 @@ pub fn run_tests(config: &QemuConfig, disk_path: &Path, app_name: &str) -> Resul
     println!("Running tests in QEMU...\n");
     let result = run_qemu_with_capture(config, disk_path)?;
 
+    // Keep firmware memory metrics visible in successful CI runs.
+    for line in result
+        .output
+        .lines()
+        .filter(|line| line.contains("MEMORY_REPORT"))
+    {
+        println!("{line}");
+    }
+
     // Analyze results
     println!("\n=== Test Results ===");
     println!("Output captured: {} bytes", result.output.len());


### PR DESCRIPTION
This PR replaces the simple bump allocator with a `linked_list_allocator` (enabling deallocation for variable payloads), moves all EFI state tables (handles, events, loaded images, config tables, variables) from stack-allocated arrays to heap-backed `Vec`s, and reduces stack size from 3 MiB to 1 MiB on all architectures.  It also adds stack high-water mark logging and memory report entries to CI output, and discovers the TPM 2.0 TIS MMIO base via ACPI instead of hardcoding.

Key changes:
- Replaced custom bump allocator (`BumpAllocator`) with `linked_list_allocator::LockedHeap`, supporting `free()` so variable payloads can be released and reallocated.
- Moved `EfiState` fields (`handles`, `events`, `loaded_images`, `config_tables`, `variables`) from fixed-size arrays (`[T; N]`) to `Vec<T>`, allocated after heap init via `init_efi_caches()`.
- Reduced stack from 3 MiB to 1 MiB on x86_64, aarch64, and riscv64; the old size was needed for large inline `FirmwareState`.
- Added `VariableEntry::set_data()` and `VariableEntry::clear()` methods that allocate/free payloads on the heap, enforcing `MAX_VARIABLE_DATA_SIZE` (16 KiB).
- Updated all variable mutation sites (`boot_vars.rs`, `runtime_services.rs`, `persistence.rs`) to use the new methods.
- Added `log_stack_usage()` for x86_64 platform-entry builds, reporting stack high-water mark (filled with `0xA5` marker).
- Added `MEMORY_REPORT` log lines for heap usage before/after EFI table allocation and for stack usage before/after boot manager.
- CI: logs stack size (`readelf`), appends MEMORY_REPORT lines to `GITHUB_STEP_SUMMARY`, and uses `set -o pipefail` and `tee qemu.log` for runtime memory reports.
- ACPI TPM discovery: on x86_64, probes for `MSFT0101` or `PNP0C31` devices and sets TPM2 MMIO base to `0xfed40000` only when the ACPI resource covers that address, removing the hardcoded unsafe probe.
- Fixed `spinning_top` dependency versioning in `Cargo.lock` (added version `0.2.5` for `linked_list_allocator`).
- Bumped heap size from 2 MiB to 4 MiB to accommodate heap-backed state tables and variable payloads.
- Minor: added null pointer check in `relocate_state_ptr`, fixed variable deletion in `boot_vars.rs` to call `clear()`.