### PR TITLE
update flake, fixup bad practices, add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/crabefi
+++ b/crabefi
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # CrabEFI build and test wrapper
 #
 # This script runs the xtask build system on the host (not the firmware target).

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769789167,
-        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,8 +20,11 @@
       {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
+            # Rust
+            rustup
+
             # QEMU and TPM emulator for testing
-            qemu_full
+            qemu
             swtpm
 
             # Disk image tools
@@ -41,12 +44,10 @@
           ];
 
           # Rust is managed by rustup via rust-toolchain.toml files
-          # Install rustup separately: https://rustup.rs/
           shellHook = ''
             echo "CrabEFI development environment"
             echo ""
-            echo "Rust is managed by rustup via rust-toolchain.toml files."
-            echo "If you don't have rustup, install it from https://rustup.rs/"
+            echo "Rust is managed by rustup via the rust-toolchain.toml file."
             echo ""
             echo "Run './crabefi --help' for build commands"
           '';


### PR DESCRIPTION
Rundown of changes: 

- Fix shebang of the `crabefi` script since `/usr/bin/env` is the only useful executable that is actually POSIX compliant (required to be present)
- Get rustup from nix. Relying on non-nix rust(up) can lead to impure and non-reproducable results. Also script-installed rustup wouldnt work in NixOS at all.
- `qemu_full` is extremely bloated, breaks often and is not needed in this context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated weekly update checks for project dependencies and development tooling.
  - Improved compatibility of the project’s command-line setup across environments.
  - Updated the development environment to use Rust managed through rustup.
  - Simplified setup instructions and refreshed the included virtualization tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->