### PR TITLE
refactor(efi): give the allocator a page-typed domain

### DIFF
--- a/crabefi-core/src/efi/allocator.rs
+++ b/crabefi-core/src/efi/allocator.rs
@@ -26,7 +26,10 @@ use crate::state;
 mod page_ownership;
 #[path = "pool_free_list.rs"]
 mod pool_free_list;
-use page_ownership::{MemoryRange, exact_cover, split_allocation};
+pub use page_ownership::PAGE_SIZE;
+use page_ownership::{
+    PageCount, PageRange, RangeSplit, exact_cover, fits_after_replacement, split_allocation,
+};
 use pool_free_list::{
     POOL_ALLOCATED_MAGIC, POOL_FREE_MAGIC, PoolHeader, PoolListError, PoolState, align_pool_size,
 };
@@ -48,11 +51,8 @@ const MAX_MEMORY_ENTRIES: usize = 2048;
 /// The table occupies about 64 KiB with the ownership metadata below.
 const MAX_PAGE_ALLOCATIONS: usize = 2048;
 
-/// Page size (4KB)
-pub const PAGE_SIZE: u64 = 4096;
-
 /// Page size as usize for convenience
-pub const PAGE_SIZE_USIZE: usize = 4096;
+pub const PAGE_SIZE_USIZE: usize = PAGE_SIZE as usize;
 
 /// Maximum address that is identity-mapped in page tables.
 /// On x86_64: Our assembly code sets up identity mapping for the first 64GB
@@ -191,16 +191,13 @@ pub mod attributes {
 }
 
 trait MemoryDescriptorExt {
-    fn range(&self) -> MemoryRange;
+    fn page_range(&self) -> Option<PageRange>;
     fn get_memory_type(&self) -> Option<MemoryType>;
 }
 
 impl MemoryDescriptorExt for MemoryDescriptor {
-    fn range(&self) -> MemoryRange {
-        MemoryRange {
-            start: self.physical_start,
-            end: self.end(),
-        }
+    fn page_range(&self) -> Option<PageRange> {
+        PageRange::from_bytes(self.physical_start, self.number_of_pages)
     }
 
     fn get_memory_type(&self) -> Option<MemoryType> {
@@ -222,29 +219,26 @@ fn memory_descriptor(
     )
 }
 
+fn descriptor_for_range(
+    memory_type: MemoryType,
+    range: PageRange,
+    attribute: u64,
+) -> MemoryDescriptor {
+    memory_descriptor(
+        memory_type,
+        range.start_bytes(),
+        range.pages().get(),
+        attribute,
+    )
+}
+
 fn can_merge(left: &MemoryDescriptor, right: &MemoryDescriptor) -> bool {
-    left.end() == right.physical_start
-        && left.memory_type == right.memory_type
+    left.memory_type == right.memory_type
         && left.attribute == right.attribute
-}
-
-#[derive(Clone, Copy)]
-struct DescriptorSplit {
-    keep_before: bool,
-    keep_after: bool,
-}
-
-impl DescriptorSplit {
-    fn for_range(descriptor: &MemoryDescriptor, range: MemoryRange) -> Self {
-        Self {
-            keep_before: descriptor.physical_start < range.start,
-            keep_after: descriptor.end() > range.end,
-        }
-    }
-
-    const fn replacement_count(self) -> usize {
-        1 + self.keep_before as usize + self.keep_after as usize
-    }
+        && left
+            .page_range()
+            .zip(right.page_range())
+            .is_some_and(|(left, right)| left.is_adjacent_to(right))
 }
 
 /// Memory allocator state
@@ -276,7 +270,7 @@ impl MemoryAllocator {
         }
     }
 
-    fn find_allocation(&self, range: MemoryRange) -> Option<(usize, PageAllocation)> {
+    fn find_allocation(&self, range: PageRange) -> Option<(usize, PageAllocation)> {
         self.allocations
             .iter()
             .copied()
@@ -284,13 +278,27 @@ impl MemoryAllocator {
             .find(|(_, allocation)| allocation.contains(range))
     }
 
-    fn find_descriptor(&self, range: MemoryRange, types: &[MemoryType]) -> Option<usize> {
+    fn find_descriptor(&self, range: PageRange, types: &[MemoryType]) -> Option<usize> {
         self.entries.iter().position(|entry| {
             entry
                 .get_memory_type()
                 .is_some_and(|memory_type| types.contains(&memory_type))
-                && entry.range().contains(range)
+                && entry
+                    .page_range()
+                    .is_some_and(|entry| entry.contains(range))
         })
+    }
+
+    /// How the descriptor at `descriptor_index` splits around `range`.
+    fn descriptor_split(
+        &self,
+        descriptor_index: usize,
+        range: PageRange,
+    ) -> Result<RangeSplit, efi::Status> {
+        self.entries[descriptor_index]
+            .page_range()
+            .and_then(|descriptor| descriptor.split_around(range))
+            .ok_or(efi::Status::NOT_FOUND)
     }
 
     fn record_allocation(&mut self, allocation: PageAllocation) -> Result<(), efi::Status> {
@@ -309,24 +317,33 @@ impl MemoryAllocator {
     fn allocation_replacement_fits(
         &self,
         allocation: PageAllocation,
-        range: MemoryRange,
+        range: PageRange,
         replacement: Option<PageAllocation>,
     ) -> bool {
         split_allocation(allocation, range, replacement).is_ok_and(|parts| {
-            self.allocations.len() - 1 + parts.iter().flatten().count() <= MAX_PAGE_ALLOCATIONS
+            fits_after_replacement(
+                self.allocations.len(),
+                1,
+                parts.iter().flatten().count(),
+                MAX_PAGE_ALLOCATIONS,
+            )
         })
     }
 
     fn replace_allocation_range(
         &mut self,
         allocation_index: usize,
-        range: MemoryRange,
+        range: PageRange,
         replacement: Option<PageAllocation>,
     ) -> Result<(), efi::Status> {
         let parts = split_allocation(self.allocations[allocation_index], range, replacement)
             .map_err(|_| efi::Status::NOT_FOUND)?;
-        let replacement_count = parts.iter().flatten().count();
-        if self.allocations.len() - 1 + replacement_count > MAX_PAGE_ALLOCATIONS {
+        if !fits_after_replacement(
+            self.allocations.len(),
+            1,
+            parts.iter().flatten().count(),
+            MAX_PAGE_ALLOCATIONS,
+        ) {
             return Err(efi::Status::OUT_OF_RESOURCES);
         }
 
@@ -344,7 +361,7 @@ impl MemoryAllocator {
     fn compact_for_split(
         &mut self,
         descriptor_index: usize,
-        range: MemoryRange,
+        range: PageRange,
     ) -> Result<(), efi::Status> {
         let mut merged_start = descriptor_index;
         while merged_start > 0
@@ -358,17 +375,21 @@ impl MemoryAllocator {
         {
             merged_end += 1;
         }
-        let compacted = MemoryDescriptor {
-            physical_start: self.entries[merged_start].physical_start,
-            number_of_pages: (self.entries[merged_end].end()
-                - self.entries[merged_start].physical_start)
-                / PAGE_SIZE,
-            ..self.entries[descriptor_index]
-        };
 
-        let split = DescriptorSplit::for_range(&compacted, range);
+        let merged = self.entries[merged_start]
+            .page_range()
+            .zip(self.entries[merged_end].page_range())
+            .and_then(|(first, last)| PageRange::spanning(first.start(), last.end()))
+            .ok_or(efi::Status::NOT_FOUND)?;
+        let split = merged.split_around(range).ok_or(efi::Status::NOT_FOUND)?;
+
         let compacted_len = self.count_merged_entries();
-        if compacted_len - 1 + split.replacement_count() > MAX_MEMORY_ENTRIES {
+        if !fits_after_replacement(
+            compacted_len,
+            1,
+            split.replacement_count(),
+            MAX_MEMORY_ENTRIES,
+        ) {
             log::warn!(
                 "Memory map full ({} entries, {} after compaction), cannot split descriptor",
                 self.entries.len(),
@@ -384,65 +405,44 @@ impl MemoryAllocator {
     fn retype_range(
         &mut self,
         mut descriptor_index: usize,
-        range: MemoryRange,
+        range: PageRange,
         memory_type: MemoryType,
         attribute: u64,
     ) -> Result<(), efi::Status> {
-        let mut descriptor = self.entries[descriptor_index];
-        if !descriptor.range().contains(range) {
-            return Err(efi::Status::NOT_FOUND);
-        }
+        let mut split = self.descriptor_split(descriptor_index, range)?;
+        let original = self.entries[descriptor_index];
+        let original_type = original.get_memory_type().ok_or(efi::Status::NOT_FOUND)?;
 
-        let original_type = descriptor.get_memory_type().ok_or(efi::Status::NOT_FOUND)?;
-        let mut split = DescriptorSplit::for_range(&descriptor, range);
-        if self.entries.len() - 1 + split.replacement_count() > MAX_MEMORY_ENTRIES {
+        if !fits_after_replacement(
+            self.entries.len(),
+            1,
+            split.replacement_count(),
+            MAX_MEMORY_ENTRIES,
+        ) {
             self.compact_for_split(descriptor_index, range)?;
             descriptor_index = self
                 .find_descriptor(range, &[original_type])
                 .ok_or(efi::Status::NOT_FOUND)?;
-            descriptor = self.entries[descriptor_index];
-            split = DescriptorSplit::for_range(&descriptor, range);
-            debug_assert!(self.entries.len() - 1 + split.replacement_count() <= MAX_MEMORY_ENTRIES);
+            split = self.descriptor_split(descriptor_index, range)?;
+            debug_assert!(fits_after_replacement(
+                self.entries.len(),
+                1,
+                split.replacement_count(),
+                MAX_MEMORY_ENTRIES
+            ));
         }
 
+        // The residual head and tail keep the original type and attributes;
+        // only the middle part takes the requested ones.
+        let retyped_index = descriptor_index + split.head.is_some() as usize;
         self.entries.remove(descriptor_index);
-        let mut insert_at = descriptor_index;
-
-        if split.keep_before {
-            self.insert_descriptor_prechecked(
-                insert_at,
-                memory_descriptor(
-                    original_type,
-                    descriptor.physical_start,
-                    (range.start - descriptor.physical_start) / PAGE_SIZE,
-                    descriptor.attribute,
-                ),
-            );
-            insert_at += 1;
-        }
-
-        let retyped_index = insert_at;
-        self.insert_descriptor_prechecked(
-            insert_at,
-            memory_descriptor(
-                memory_type,
-                range.start,
-                range.number_of_pages(PAGE_SIZE),
-                attribute,
-            ),
-        );
-        insert_at += 1;
-
-        if split.keep_after {
-            self.insert_descriptor_prechecked(
-                insert_at,
-                memory_descriptor(
-                    original_type,
-                    range.end,
-                    (descriptor.end() - range.end) / PAGE_SIZE,
-                    descriptor.attribute,
-                ),
-            );
+        for (offset, part) in split.parts().enumerate() {
+            let descriptor = if part == split.middle {
+                descriptor_for_range(memory_type, part, attribute)
+            } else {
+                descriptor_for_range(original_type, part, original.attribute)
+            };
+            self.insert_descriptor_prechecked(descriptor_index + offset, descriptor);
         }
 
         self.merge_near(retyped_index);
@@ -479,16 +479,7 @@ impl MemoryAllocator {
                 PlatMemType::BootServicesData => MemoryType::BootServicesData,
             };
 
-            let num_pages = match region.size.checked_add(PAGE_SIZE - 1) {
-                Some(size_rounded) => size_rounded / PAGE_SIZE,
-                None => {
-                    log::warn!(
-                        "Region at {:#x} has size that overflows, skipping",
-                        region.base
-                    );
-                    continue;
-                }
-            };
+            let num_pages = PageCount::covering_bytes(region.size);
 
             log::info!(
                 "  {:#010x}-{:#010x} {:?} -> {:?}",
@@ -498,14 +489,21 @@ impl MemoryAllocator {
                 memory_type
             );
 
-            let desc = memory_descriptor(
-                memory_type,
-                region.base,
-                num_pages,
-                memory_type.default_attributes(),
-            );
+            let attribute = memory_type.default_attributes();
 
-            if self.entries.push(desc).is_err() {
+            let Some(range) = PageRange::from_bytes(region.base, num_pages.get()) else {
+                log::warn!(
+                    "Region at {:#x} is misaligned or overflows, skipping",
+                    region.base
+                );
+                continue;
+            };
+
+            if self
+                .entries
+                .push(descriptor_for_range(memory_type, range, attribute))
+                .is_err()
+            {
                 log::warn!("Memory map full, ignoring region at {:#x}", region.base);
             }
         }
@@ -543,33 +541,27 @@ impl MemoryAllocator {
         num_pages: u64,
         memory_type: MemoryType,
     ) -> Result<(), efi::Status> {
-        let size = num_pages
-            .checked_mul(PAGE_SIZE)
-            .ok_or(efi::Status::INVALID_PARAMETER)?;
-        let end = physical_start
-            .checked_add(size)
+        let range = PageRange::from_bytes(physical_start, num_pages)
             .ok_or(efi::Status::INVALID_PARAMETER)?;
 
-        let mut fragments: heapless::Vec<(u64, u64), MAX_MEMORY_ENTRIES> = heapless::Vec::new();
+        let mut fragments: heapless::Vec<PageRange, MAX_MEMORY_ENTRIES> = heapless::Vec::new();
         for entry in &self.entries {
-            let Some(entry_type) = entry.get_memory_type() else {
+            if entry.get_memory_type() != Some(MemoryType::ConventionalMemory) {
+                continue;
+            }
+            let Some(fragment) = entry
+                .page_range()
+                .and_then(|entry| entry.intersection(range))
+            else {
                 continue;
             };
-            if entry.end() <= physical_start || entry.physical_start >= end {
-                continue;
-            }
-            if entry_type == MemoryType::ConventionalMemory {
-                let start = entry.physical_start.max(physical_start);
-                let stop = entry.end().min(end);
-                if start < stop && fragments.push((start, stop)).is_err() {
-                    return Err(efi::Status::OUT_OF_RESOURCES);
-                }
-            }
+            fragments
+                .push(fragment)
+                .map_err(|_| efi::Status::OUT_OF_RESOURCES)?;
         }
 
-        for (start, stop) in fragments {
-            let pages = (stop - start).div_ceil(PAGE_SIZE);
-            self.carve_out(start, pages, memory_type)?;
+        for fragment in fragments {
+            self.carve_out(fragment.start_bytes(), fragment.pages().get(), memory_type)?;
         }
 
         Ok(())
@@ -639,51 +631,42 @@ impl MemoryAllocator {
         target_type: MemoryType,
         skip_types: &[MemoryType],
     ) -> Result<(), efi::Status> {
-        // Check for overflow in size calculation
-        let size = num_pages
-            .checked_mul(PAGE_SIZE)
-            .ok_or(efi::Status::INVALID_PARAMETER)?;
-        let end = addr
-            .checked_add(size)
-            .ok_or(efi::Status::INVALID_PARAMETER)?;
+        let range = PageRange::from_bytes(addr, num_pages).ok_or(efi::Status::INVALID_PARAMETER)?;
 
-        // Find the entry containing this region (any memory type)
-        let found_idx = self
-            .entries
-            .iter()
-            .position(|entry| entry.physical_start <= addr && entry.end() >= end);
-
-        let idx = match found_idx {
-            Some(i) => i,
-            None => {
-                // Region not found — check for overlaps (only for ACPI reclaim
-                // which has stricter validation)
-                if target_type == MemoryType::AcpiReclaimMemory
-                    && self
-                        .entries
-                        .iter()
-                        .any(|entry| addr < entry.end() && end > entry.physical_start)
-                {
-                    return Err(efi::Status::INVALID_PARAMETER);
-                }
-                // No containing entry — add as a new entry
-                let desc = memory_descriptor(
-                    target_type,
-                    addr,
-                    num_pages,
-                    attributes::EFI_MEMORY_RAM_CAPS,
-                );
-                if self.entries.push(desc).is_err() {
-                    return Err(efi::Status::OUT_OF_RESOURCES);
-                }
-                self.map_key += 1;
-                self.sort_entries();
-                return Ok(());
+        // Unlike carve_out this accepts any source type, so it cannot reuse
+        // find_descriptor's type filter.
+        let containing = self.entries.iter().position(|entry| {
+            entry
+                .page_range()
+                .is_some_and(|entry| entry.contains(range))
+        });
+        let Some(descriptor_index) = containing else {
+            // Region not found — check for overlaps (only for ACPI reclaim
+            // which has stricter validation)
+            if target_type == MemoryType::AcpiReclaimMemory
+                && self.entries.iter().any(|entry| {
+                    entry
+                        .page_range()
+                        .is_some_and(|entry| entry.overlaps(range))
+                })
+            {
+                return Err(efi::Status::INVALID_PARAMETER);
             }
+            // No containing entry — add as a new entry
+            self.entries
+                .push(descriptor_for_range(
+                    target_type,
+                    range,
+                    attributes::EFI_MEMORY_RAM_CAPS,
+                ))
+                .map_err(|_| efi::Status::OUT_OF_RESOURCES)?;
+            self.map_key += 1;
+            self.sort_entries();
+            return Ok(());
         };
 
-        let entry = self.entries[idx];
-        let original_type = entry
+        let descriptor = self.entries[descriptor_index];
+        let original_type = descriptor
             .get_memory_type()
             .unwrap_or(MemoryType::ReservedMemoryType);
 
@@ -692,40 +675,9 @@ impl MemoryAllocator {
             return Ok(());
         }
 
-        let attribute = entry.attribute;
-
-        // Remove the old entry
-        self.entries.remove(idx);
-
-        // Add up to 3 new entries: before, target, after
-        // Region before the target portion (keep original type)
-        if entry.physical_start < addr {
-            let before_pages = (addr - entry.physical_start) / PAGE_SIZE;
-            let before =
-                memory_descriptor(original_type, entry.physical_start, before_pages, attribute);
-            if self.entries.push(before).is_err() {
-                return Err(efi::Status::OUT_OF_RESOURCES);
-            }
-        }
-
-        // The target region
-        let target = memory_descriptor(target_type, addr, num_pages, attribute);
-        if self.entries.push(target).is_err() {
-            return Err(efi::Status::OUT_OF_RESOURCES);
-        }
-
-        // Region after the target portion (keep original type)
-        if entry.end() > end {
-            let after_pages = (entry.end() - end) / PAGE_SIZE;
-            let after = memory_descriptor(original_type, end, after_pages, attribute);
-            if self.entries.push(after).is_err() {
-                return Err(efi::Status::OUT_OF_RESOURCES);
-            }
-        }
+        self.retype_range(descriptor_index, range, target_type, descriptor.attribute)?;
 
         self.map_key += 1;
-        self.sort_entries();
-
         Ok(())
     }
 
@@ -770,7 +722,7 @@ impl MemoryAllocator {
 
     fn allocate_conventional_range(
         &mut self,
-        range: MemoryRange,
+        range: PageRange,
         memory_type: MemoryType,
     ) -> Result<(), efi::Status> {
         let descriptor_index = self
@@ -792,10 +744,10 @@ impl MemoryAllocator {
     /// image. Public AllocateAddress deliberately cannot claim runtime data.
     fn retype_runtime_image_code(
         &mut self,
-        image_range: MemoryRange,
-        code_range: MemoryRange,
+        image_range: PageRange,
+        code_range: PageRange,
     ) -> Result<(), efi::Status> {
-        if code_range.start != image_range.start || !image_range.contains(code_range) {
+        if code_range.start() != image_range.start() || !image_range.contains(code_range) {
             return Err(efi::Status::INVALID_PARAMETER);
         }
         let (allocation_index, _) = self
@@ -849,10 +801,8 @@ impl MemoryAllocator {
                 Some(*memory)
             }
         };
-        let Some(address) = address else {
-            return efi::Status::OUT_OF_RESOURCES;
-        };
-        let Some(range) = MemoryRange::from_pages(address, num_pages, PAGE_SIZE) else {
+        let Some(range) = address.and_then(|address| PageRange::from_bytes(address, num_pages))
+        else {
             return efi::Status::OUT_OF_RESOURCES;
         };
 
@@ -910,7 +860,7 @@ impl MemoryAllocator {
 
         match result {
             Ok(()) => {
-                *memory = address;
+                *memory = range.start_bytes();
                 efi::Status::SUCCESS
             }
             Err(status) => status,
@@ -928,13 +878,12 @@ impl MemoryAllocator {
     /// typed loader subclaim has no single memory descriptor to restore and
     /// returns [`efi::Status::NOT_FOUND`].
     pub fn free_pages(&mut self, memory: u64, num_pages: u64) -> efi::Status {
-        if !memory.is_multiple_of(PAGE_SIZE) || num_pages == 0 {
-            return efi::Status::INVALID_PARAMETER;
-        }
         if self.boot_services_exited {
             return efi::Status::UNSUPPORTED;
         }
-        let Some(range) = MemoryRange::from_pages(memory, num_pages, PAGE_SIZE) else {
+        // Rejects misaligned addresses, zero page counts, and ranges that would
+        // leave the address space in one construction.
+        let Some(range) = PageRange::from_bytes(memory, num_pages) else {
             return efi::Status::INVALID_PARAMETER;
         };
         let allocation = self.find_allocation(range);
@@ -1088,13 +1037,13 @@ impl MemoryAllocator {
             self.count_merged_entries()
         );
         for (i, e) in self.entries.iter().enumerate() {
-            let end = e.end();
-            let size_mb = (e.number_of_pages * PAGE_SIZE) >> 20;
+            let pages = PageCount::new(e.number_of_pages);
+            let size_mb = pages.bytes().unwrap_or(u64::MAX) >> 20;
             log::info!(
                 "  [{:2}] {:#012x}-{:#012x} {:>12} {:6} pages ({} MB) attr={:#x}",
                 i,
                 e.physical_start,
-                end,
+                e.page_range().map_or(u64::MAX, PageRange::end_bytes),
                 type_name(e.memory_type),
                 e.number_of_pages,
                 size_mb,
@@ -1262,8 +1211,7 @@ impl MemoryAllocator {
         memory_type: MemoryType,
         source_types: &[MemoryType],
     ) -> Result<(), efi::Status> {
-        let range = MemoryRange::from_pages(addr, num_pages, PAGE_SIZE)
-            .ok_or(efi::Status::INVALID_PARAMETER)?;
+        let range = PageRange::from_bytes(addr, num_pages).ok_or(efi::Status::INVALID_PARAMETER)?;
         let descriptor_index = self
             .find_descriptor(range, source_types)
             .ok_or(efi::Status::NOT_FOUND)?;
@@ -1537,10 +1485,10 @@ pub fn allocate_runtime_image_layout(
         if status != efi::Status::SUCCESS {
             return Err(status);
         }
-        let image_range = MemoryRange::from_pages(base, image_pages, PAGE_SIZE)
-            .ok_or(efi::Status::OUT_OF_RESOURCES)?;
-        let code_range = MemoryRange::from_pages(base, code_pages, PAGE_SIZE)
-            .ok_or(efi::Status::OUT_OF_RESOURCES)?;
+        let image_range =
+            PageRange::from_bytes(base, image_pages).ok_or(efi::Status::OUT_OF_RESOURCES)?;
+        let code_range =
+            PageRange::from_bytes(base, code_pages).ok_or(efi::Status::OUT_OF_RESOURCES)?;
         if let Err(status) = allocator.retype_runtime_image_code(image_range, code_range) {
             let _ = allocator.free_pages(base, image_pages);
             return Err(status);
@@ -1853,8 +1801,8 @@ mod tests {
             ),
             efi::Status::SUCCESS
         );
-        let image = MemoryRange::from_pages(base, 4, PAGE_SIZE).unwrap();
-        let code = MemoryRange::from_pages(base, 1, PAGE_SIZE).unwrap();
+        let image = PageRange::from_bytes(base, 4).unwrap();
+        let code = PageRange::from_bytes(base, 1).unwrap();
         allocator.retype_runtime_image_code(image, code).unwrap();
         let code_descriptor = allocator
             .entries

--- a/crabefi-core/src/efi/page_ownership.rs
+++ b/crabefi-core/src/efi/page_ownership.rs
@@ -1,32 +1,254 @@
-//! Page-allocation ownership range primitives.
+//! Page-allocation ownership primitives.
 //!
-//! This module is dependency-free so subrange ownership behavior can be tested
-//! directly with `rustc --test` in the host regression job.
+//! Addresses and sizes here are counted in *pages*, never in bytes. Byte values
+//! are converted at the boundary ([`PageAddr::from_bytes`], [`PageRange::from_bytes`])
+//! and the conversion is where overflow and misalignment are rejected, so the
+//! interior arithmetic needs no `checked_mul`/`checked_add` and no `/ PAGE_SIZE`.
+//!
+//! This module is dependency-free so ownership behavior can be tested directly
+//! with `rustc --test` in the host regression job.
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct MemoryRange {
-    pub start: u64,
-    pub end: u64,
+/// Page size (4KB)
+pub const PAGE_SIZE: u64 = 4096;
+
+/// Largest page index whose byte address still fits in a `u64`.
+const MAX_PAGE_INDEX: u64 = u64::MAX / PAGE_SIZE;
+
+/// A page-aligned physical address, stored as a page index.
+///
+/// Constructing one proves the address is page-aligned and that its byte form
+/// fits in a `u64`, so [`PageAddr::bytes`] is infallible.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PageAddr(u64);
+
+impl PageAddr {
+    /// Convert a byte address, rejecting anything not page-aligned.
+    pub const fn from_bytes(address: u64) -> Option<Self> {
+        if address.is_multiple_of(PAGE_SIZE) {
+            Some(Self(address / PAGE_SIZE))
+        } else {
+            None
+        }
+    }
+
+    /// Byte address of the start of this page.
+    pub const fn bytes(self) -> u64 {
+        self.0 * PAGE_SIZE
+    }
+
+    /// Advance by `count` pages, rejecting addresses beyond the `u64` byte space.
+    pub const fn checked_add(self, count: PageCount) -> Option<Self> {
+        match self.0.checked_add(count.0) {
+            Some(index) if index <= MAX_PAGE_INDEX => Some(Self(index)),
+            _ => None,
+        }
+    }
+
+    /// Pages from `earlier` to `self`, or zero when `self` is not later.
+    pub const fn pages_since(self, earlier: Self) -> PageCount {
+        PageCount(self.0.saturating_sub(earlier.0))
+    }
 }
 
-impl MemoryRange {
-    pub fn from_pages(start: u64, number_of_pages: u64, page_size: u64) -> Option<Self> {
-        let size = number_of_pages.checked_mul(page_size)?;
-        let end = start.checked_add(size)?;
-        Some(Self { start, end })
+/// A number of pages.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PageCount(u64);
+
+impl PageCount {
+    pub const fn new(pages: u64) -> Self {
+        Self(pages)
     }
 
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    pub const fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Size in bytes, or `None` when it does not fit in a `u64`.
+    pub const fn bytes(self) -> Option<u64> {
+        self.0.checked_mul(PAGE_SIZE)
+    }
+
+    /// Pages needed to cover `bytes`, rounding up.
+    pub const fn covering_bytes(bytes: u64) -> Self {
+        Self(bytes.div_ceil(PAGE_SIZE))
+    }
+}
+
+/// A half-open range of pages: `start` inclusive, `end` exclusive.
+///
+/// The `start <= end` invariant is established at construction, so `pages()`,
+/// `head_before()`, and `tail_after()` never underflow.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PageRange {
+    start: PageAddr,
+    end: PageAddr,
+}
+
+impl PageRange {
+    /// Build a range from a start page and a length.
+    pub const fn new(start: PageAddr, count: PageCount) -> Option<Self> {
+        match start.checked_add(count) {
+            Some(end) => Some(Self { start, end }),
+            None => None,
+        }
+    }
+
+    /// Build a range from its bounds, rejecting an inverted pair.
+    pub const fn spanning(start: PageAddr, end: PageAddr) -> Option<Self> {
+        if start.0 <= end.0 {
+            Some(Self { start, end })
+        } else {
+            None
+        }
+    }
+
+    /// Build a range from a byte address and a page count.
+    ///
+    /// Rejects misaligned addresses, zero-length ranges, and ranges whose end
+    /// would leave the `u64` byte space.
+    pub const fn from_bytes(address: u64, number_of_pages: u64) -> Option<Self> {
+        if number_of_pages == 0 {
+            return None;
+        }
+        match PageAddr::from_bytes(address) {
+            Some(start) => Self::new(start, PageCount::new(number_of_pages)),
+            None => None,
+        }
+    }
+
+    pub const fn start(self) -> PageAddr {
+        self.start
+    }
+
+    pub const fn end(self) -> PageAddr {
+        self.end
+    }
+
+    pub const fn pages(self) -> PageCount {
+        self.end.pages_since(self.start)
+    }
+
+    pub const fn start_bytes(self) -> u64 {
+        self.start.bytes()
+    }
+
+    pub const fn end_bytes(self) -> u64 {
+        self.end.bytes()
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.pages().is_zero()
+    }
+
+    /// Whether `other` lies entirely within `self`.
     pub const fn contains(self, other: Self) -> bool {
-        self.start <= other.start && self.end >= other.end
+        self.start.0 <= other.start.0 && self.end.0 >= other.end.0
     }
 
-    pub const fn number_of_pages(self, page_size: u64) -> u64 {
-        (self.end - self.start) / page_size
+    /// The pages shared by both ranges, or `None` when they are disjoint.
+    pub const fn intersection(self, other: Self) -> Option<Self> {
+        let start = if self.start.0 > other.start.0 {
+            self.start
+        } else {
+            other.start
+        };
+        let end = if self.end.0 < other.end.0 {
+            self.end
+        } else {
+            other.end
+        };
+        if start.0 < end.0 {
+            Some(Self { start, end })
+        } else {
+            None
+        }
     }
 
-    /// Whether the two ranges share at least one byte.
+    /// Whether the two ranges share at least one page.
     pub const fn overlaps(self, other: Self) -> bool {
-        self.start < other.end && other.start < self.end
+        self.intersection(other).is_some()
+    }
+
+    /// Whether `later` begins exactly where `self` ends.
+    pub const fn is_adjacent_to(self, later: Self) -> bool {
+        self.end.0 == later.start.0
+    }
+
+    /// Split `self` around the contained range `inner`.
+    ///
+    /// Returns `None` when `inner` is not contained, so callers cannot compute
+    /// a residual from ranges that do not nest.
+    pub const fn split_around(self, inner: Self) -> Option<RangeSplit> {
+        if !self.contains(inner) {
+            return None;
+        }
+        let head = if self.start.0 < inner.start.0 {
+            Some(Self {
+                start: self.start,
+                end: inner.start,
+            })
+        } else {
+            None
+        };
+        let tail = if self.end.0 > inner.end.0 {
+            Some(Self {
+                start: inner.end,
+                end: self.end,
+            })
+        } else {
+            None
+        };
+        Some(RangeSplit {
+            head,
+            middle: inner,
+            tail,
+        })
+    }
+}
+
+/// The ranges that replace a range when a contained subrange is carved out.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RangeSplit {
+    pub head: Option<PageRange>,
+    pub middle: PageRange,
+    pub tail: Option<PageRange>,
+}
+
+impl RangeSplit {
+    /// How many ranges replace the original one.
+    pub const fn replacement_count(self) -> usize {
+        1 + self.head.is_some() as usize + self.tail.is_some() as usize
+    }
+
+    /// The replacements in ascending address order.
+    pub fn parts(self) -> impl Iterator<Item = PageRange> {
+        self.head
+            .into_iter()
+            .chain(core::iter::once(self.middle))
+            .chain(self.tail)
+    }
+}
+
+/// Whether a fixed-capacity table still fits after a replacement.
+///
+/// Written as checked arithmetic so an inconsistent `removed` count can never
+/// wrap the subtraction into a spuriously successful capacity check.
+pub const fn fits_after_replacement(
+    len: usize,
+    removed: usize,
+    inserted: usize,
+    capacity: usize,
+) -> bool {
+    match len.checked_sub(removed) {
+        Some(remaining) => match remaining.checked_add(inserted) {
+            Some(total) => total <= capacity,
+            None => false,
+        },
+        None => false,
     }
 }
 
@@ -34,13 +256,13 @@ impl MemoryRange {
 /// independent of the allocator's EFI `MemoryType` definition.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PageAllocation<T: Copy> {
-    pub range: MemoryRange,
+    pub range: PageRange,
     pub memory_type: T,
     pub restore_attribute: u64,
 }
 
 impl<T: Copy> PageAllocation<T> {
-    pub const fn contains(self, range: MemoryRange) -> bool {
+    pub const fn contains(self, range: PageRange) -> bool {
         self.range.contains(range)
     }
 }
@@ -66,28 +288,25 @@ pub enum SplitError {
 /// overlap would retype pages that another record still claims.
 pub fn exact_cover<T: Copy + Eq>(
     allocations: &[PageAllocation<T>],
-    range: MemoryRange,
+    range: PageRange,
 ) -> Option<PageAllocation<T>> {
-    let mut cursor = range.start;
-    let first = allocations
-        .iter()
-        .find(|allocation| allocation.range.start == cursor && range.contains(allocation.range))?;
+    let mut cursor = range.start();
+    let first = allocations.iter().find(|allocation| {
+        allocation.range.start() == cursor && range.contains(allocation.range)
+    })?;
     let memory_type = first.memory_type;
     let restore_attribute = first.restore_attribute;
     let mut chain_len = 0usize;
 
-    while cursor < range.end {
+    while cursor < range.end() {
         let allocation = allocations.iter().find(|allocation| {
-            allocation.range.start == cursor
+            allocation.range.start() == cursor
+                && !allocation.range.is_empty()
                 && range.contains(allocation.range)
                 && allocation.memory_type == memory_type
                 && allocation.restore_attribute == restore_attribute
         })?;
-        // A zero-length record would leave the cursor in place and spin here.
-        if allocation.range.end <= cursor {
-            return None;
-        }
-        cursor = allocation.range.end;
+        cursor = allocation.range.end();
         chain_len += 1;
     }
 
@@ -98,7 +317,7 @@ pub fn exact_cover<T: Copy + Eq>(
         .filter(|allocation| allocation.range.overlaps(range))
         .count();
 
-    (cursor == range.end && touching == chain_len).then_some(PageAllocation {
+    (cursor == range.end() && touching == chain_len).then_some(PageAllocation {
         range,
         memory_type,
         restore_attribute,
@@ -111,42 +330,31 @@ pub fn exact_cover<T: Copy + Eq>(
 /// suffix. Empty slots are omitted from the returned array.
 pub fn split_allocation<T: Copy>(
     allocation: PageAllocation<T>,
-    range: MemoryRange,
+    range: PageRange,
     replacement: Option<PageAllocation<T>>,
 ) -> Result<[Option<PageAllocation<T>>; 3], SplitError> {
-    if !allocation.contains(range) {
-        return Err(SplitError::RangeNotContained);
-    }
     // The residuals are computed around `range`, so a replacement covering
     // anything else would leave a gap or an overlap in the ownership table.
     if replacement.is_some_and(|replacement| replacement.range != range) {
         return Err(SplitError::ReplacementRangeMismatch);
     }
+    let split = allocation
+        .range
+        .split_around(range)
+        .ok_or(SplitError::RangeNotContained)?;
 
+    let residual = |range| PageAllocation {
+        range,
+        ..allocation
+    };
     let mut output = [None; 3];
-    let mut index = 0;
-    if allocation.range.start < range.start {
-        output[index] = Some(PageAllocation {
-            range: MemoryRange {
-                start: allocation.range.start,
-                end: range.start,
-            },
-            ..allocation
-        });
-        index += 1;
-    }
-    if let Some(replacement) = replacement {
-        output[index] = Some(replacement);
-        index += 1;
-    }
-    if allocation.range.end > range.end {
-        output[index] = Some(PageAllocation {
-            range: MemoryRange {
-                start: range.end,
-                end: allocation.range.end,
-            },
-            ..allocation
-        });
+    let parts = [
+        split.head.map(residual),
+        replacement,
+        split.tail.map(residual),
+    ];
+    for (slot, part) in output.iter_mut().zip(parts.into_iter().flatten()) {
+        *slot = Some(part);
     }
     Ok(output)
 }
@@ -157,58 +365,111 @@ mod tests {
 
     use super::*;
 
-    const ORIGINAL: PageAllocation<u32> = PageAllocation {
-        range: MemoryRange {
-            start: 0x1000,
-            end: 0x9000,
-        },
-        memory_type: 2,
-        restore_attribute: 0x8008,
-    };
+    fn range(start: u64, end: u64) -> PageRange {
+        PageRange::from_bytes(start, (end - start) / PAGE_SIZE).unwrap()
+    }
+
+    fn original() -> PageAllocation<u32> {
+        PageAllocation {
+            range: range(0x1000, 0x9000),
+            memory_type: 2,
+            restore_attribute: 0x8008,
+        }
+    }
+
+    #[test]
+    fn byte_conversion_rejects_misaligned_and_overflowing_ranges() {
+        assert_eq!(PageAddr::from_bytes(0x1001), None);
+        assert_eq!(PageAddr::from_bytes(0x1000).unwrap().bytes(), 0x1000);
+        assert_eq!(PageRange::from_bytes(0x1000, 0), None);
+        assert_eq!(PageRange::from_bytes(PAGE_SIZE, u64::MAX), None);
+        assert_eq!(range(0x1000, 0x9000).pages(), PageCount::new(8));
+        assert_eq!(range(0x1000, 0x9000).end_bytes(), 0x9000);
+        assert_eq!(PageCount::covering_bytes(PAGE_SIZE + 1).get(), 2);
+    }
+
+    #[test]
+    fn split_around_yields_residual_ranges_without_page_arithmetic() {
+        let split = range(0x1000, 0x9000)
+            .split_around(range(0x3000, 0x6000))
+            .unwrap();
+        assert_eq!(split.head, Some(range(0x1000, 0x3000)));
+        assert_eq!(split.middle, range(0x3000, 0x6000));
+        assert_eq!(split.tail, Some(range(0x6000, 0x9000)));
+        assert_eq!(split.replacement_count(), 3);
+
+        let whole = range(0x1000, 0x9000)
+            .split_around(range(0x1000, 0x9000))
+            .unwrap();
+        assert_eq!((whole.head, whole.tail), (None, None));
+        assert_eq!(whole.replacement_count(), 1);
+
+        assert_eq!(range(0x1000, 0x9000).split_around(range(0, 0x2000)), None);
+    }
+
+    #[test]
+    fn split_parts_are_contiguous_and_cover_the_original() {
+        let split = range(0x1000, 0x9000)
+            .split_around(range(0x3000, 0x6000))
+            .unwrap();
+        let parts: std::vec::Vec<_> = split.parts().collect();
+        assert_eq!(parts.len(), 3);
+        assert!(parts.windows(2).all(|pair| pair[0].is_adjacent_to(pair[1])));
+        assert_eq!(parts[0].start(), range(0x1000, 0x9000).start());
+        assert_eq!(parts[2].end(), range(0x1000, 0x9000).end());
+    }
+
+    #[test]
+    fn intersection_clips_to_the_shared_pages() {
+        let region = range(0x2000, 0x8000);
+        assert_eq!(
+            region.intersection(range(0x1000, 0x4000)),
+            Some(range(0x2000, 0x4000))
+        );
+        assert_eq!(
+            region.intersection(range(0x4000, 0x9000)),
+            Some(range(0x4000, 0x8000))
+        );
+        assert_eq!(region.intersection(range(0x1000, 0x9000)), Some(region));
+        assert_eq!(region.intersection(range(0x8000, 0x9000)), None);
+        assert!(!region.overlaps(range(0x8000, 0x9000)));
+        assert!(region.overlaps(range(0x7000, 0x9000)));
+    }
+
+    #[test]
+    fn capacity_check_never_wraps() {
+        assert!(fits_after_replacement(10, 1, 3, 12));
+        assert!(!fits_after_replacement(10, 1, 4, 12));
+        assert!(!fits_after_replacement(0, 1, 1, 12));
+    }
 
     #[test]
     fn cover_rejects_records_that_overlap_the_chain() {
         // A parent plus a still-live subclaim of the same metadata: the chain
         // walk alone would accept the parent and drop both records.
         let records = [
-            ORIGINAL,
+            original(),
             PageAllocation {
-                range: MemoryRange {
-                    start: 0x3000,
-                    end: 0x5000,
-                },
-                ..ORIGINAL
+                range: range(0x3000, 0x5000),
+                ..original()
             },
         ];
-        assert_eq!(exact_cover(&records, ORIGINAL.range), None);
+        assert_eq!(exact_cover(&records, original().range), None);
 
         // Two records claiming the same start are equally untrustworthy.
-        let duplicates = [ORIGINAL, ORIGINAL];
-        assert_eq!(exact_cover(&duplicates, ORIGINAL.range), None);
+        let duplicates = [original(), original()];
+        assert_eq!(exact_cover(&duplicates, original().range), None);
     }
 
     #[test]
     fn split_rejects_a_replacement_that_does_not_cover_the_split_range() {
-        let range = MemoryRange {
-            start: 0x3000,
-            end: 0x6000,
-        };
-        for bad in [
-            MemoryRange {
-                start: 0x3000,
-                end: 0x5000,
-            },
-            MemoryRange {
-                start: 0x2000,
-                end: 0x6000,
-            },
-        ] {
+        for bad in [range(0x3000, 0x5000), range(0x2000, 0x6000)] {
             let replacement = PageAllocation {
                 range: bad,
-                ..ORIGINAL
+                ..original()
             };
             assert_eq!(
-                split_allocation(ORIGINAL, range, Some(replacement)),
+                split_allocation(original(), range(0x3000, 0x6000), Some(replacement)),
                 Err(SplitError::ReplacementRangeMismatch)
             );
         }
@@ -216,33 +477,13 @@ mod tests {
 
     #[test]
     fn partial_free_preserves_both_residual_records_and_metadata() {
-        let parts = split_allocation(
-            ORIGINAL,
-            MemoryRange {
-                start: 0x3000,
-                end: 0x6000,
-            },
-            None,
-        )
-        .unwrap();
-        assert_eq!(
-            parts[0].unwrap().range,
-            MemoryRange {
-                start: 0x1000,
-                end: 0x3000
-            }
-        );
-        assert_eq!(
-            parts[1].unwrap().range,
-            MemoryRange {
-                start: 0x6000,
-                end: 0x9000
-            }
-        );
-        assert_eq!(parts[0].unwrap().memory_type, ORIGINAL.memory_type);
+        let parts = split_allocation(original(), range(0x3000, 0x6000), None).unwrap();
+        assert_eq!(parts[0].unwrap().range, range(0x1000, 0x3000));
+        assert_eq!(parts[1].unwrap().range, range(0x6000, 0x9000));
+        assert_eq!(parts[0].unwrap().memory_type, original().memory_type);
         assert_eq!(
             parts[1].unwrap().restore_attribute,
-            ORIGINAL.restore_attribute
+            original().restore_attribute
         );
         assert!(parts[2].is_none());
     }
@@ -250,77 +491,71 @@ mod tests {
     #[test]
     fn whole_parent_is_freeable_after_loader_subclaim() {
         let replacement = PageAllocation {
-            range: MemoryRange {
-                start: 0x3000,
-                end: 0x5000,
-            },
-            memory_type: ORIGINAL.memory_type,
-            restore_attribute: ORIGINAL.restore_attribute,
+            range: range(0x3000, 0x5000),
+            ..original()
         };
-        let parts = split_allocation(ORIGINAL, replacement.range, Some(replacement)).unwrap();
-        assert_eq!(parts[0].unwrap().range.end, parts[1].unwrap().range.start);
-        assert_eq!(parts[1].unwrap().range.end, parts[2].unwrap().range.start);
+        let parts = split_allocation(original(), replacement.range, Some(replacement)).unwrap();
+        assert!(
+            parts[0]
+                .unwrap()
+                .range
+                .is_adjacent_to(parts[1].unwrap().range)
+        );
+        assert!(
+            parts[1]
+                .unwrap()
+                .range
+                .is_adjacent_to(parts[2].unwrap().range)
+        );
         assert_eq!(parts[1].unwrap(), replacement);
 
         let records = parts.into_iter().flatten().collect::<alloc::vec::Vec<_>>();
-        assert_eq!(exact_cover(&records, ORIGINAL.range), Some(ORIGINAL));
+        assert_eq!(exact_cover(&records, original().range), Some(original()));
     }
 
     #[test]
     fn whole_parent_cover_rejects_gaps_or_mismatched_metadata() {
         let mut records = [
             PageAllocation {
-                range: MemoryRange {
-                    start: 0x1000,
-                    end: 0x3000,
-                },
-                ..ORIGINAL
+                range: range(0x1000, 0x3000),
+                ..original()
             },
             PageAllocation {
-                range: MemoryRange {
-                    start: 0x3000,
-                    end: 0x9000,
-                },
-                ..ORIGINAL
+                range: range(0x3000, 0x9000),
+                ..original()
             },
         ];
-        assert_eq!(exact_cover(&records, ORIGINAL.range), Some(ORIGINAL));
+        assert_eq!(exact_cover(&records, original().range), Some(original()));
 
-        records[1].range.start = 0x4000;
-        assert_eq!(exact_cover(&records, ORIGINAL.range), None);
-        records[1].range.start = 0x3000;
+        records[1].range = range(0x4000, 0x9000);
+        assert_eq!(exact_cover(&records, original().range), None);
+        records[1].range = range(0x3000, 0x9000);
         records[1].memory_type = 4;
-        assert_eq!(exact_cover(&records, ORIGINAL.range), None);
-        records[1].memory_type = ORIGINAL.memory_type;
+        assert_eq!(exact_cover(&records, original().range), None);
+        records[1].memory_type = original().memory_type;
         records[1].restore_attribute = 0;
-        assert_eq!(exact_cover(&records, ORIGINAL.range), None);
+        assert_eq!(exact_cover(&records, original().range), None);
     }
 
     #[test]
     fn cover_ignores_records_that_leave_the_requested_range() {
         let records = [
             PageAllocation {
-                range: MemoryRange {
-                    start: 0x1000,
-                    end: 0x3000,
-                },
-                ..ORIGINAL
+                range: range(0x1000, 0x3000),
+                ..original()
             },
             PageAllocation {
-                range: MemoryRange {
-                    start: 0x3000,
-                    end: 0xA000,
-                },
-                ..ORIGINAL
+                range: range(0x3000, 0xA000),
+                ..original()
             },
         ];
-        assert_eq!(exact_cover(&records, ORIGINAL.range), None);
+        assert_eq!(exact_cover(&records, original().range), None);
     }
 
     #[test]
     fn whole_range_free_produces_no_residual_records() {
         assert_eq!(
-            split_allocation(ORIGINAL, ORIGINAL.range, None).unwrap(),
+            split_allocation(original(), original().range, None).unwrap(),
             [None; 3]
         );
     }
@@ -328,14 +563,7 @@ mod tests {
     #[test]
     fn rejects_ranges_outside_the_owned_allocation() {
         assert_eq!(
-            split_allocation(
-                ORIGINAL,
-                MemoryRange {
-                    start: 0,
-                    end: 0x2000,
-                },
-                None,
-            ),
+            split_allocation(original(), range(0, 0x2000), None),
             Err(SplitError::RangeNotContained)
         );
     }


### PR DESCRIPTION
Follow-up to #90, which it is based on. Review #90 first; this PR's diff is only the refactor commit.

## Problem

Addresses and lengths in the allocator were all bare `u64`, so byte quantities and page counts shared one type. Nothing prevented mixing them, and every operation had to re-derive the relationship by hand:

```rust
// construction: manual overflow plumbing, at every call site
let size = num_pages.checked_mul(PAGE_SIZE)?;
let end  = addr.checked_add(size)?;

// consumption: manual division, at every call site
let before_pages = (addr - entry.physical_start) / PAGE_SIZE;
let after_pages  = (entry.end() - end) / PAGE_SIZE;
```

Those subtractions are only safe because a `contains()` check ran earlier somewhere else. The compiler cannot see that, so the correctness argument lives outside the code.

## Change

`page_ownership.rs` gains a page-typed domain. Byte values are validated once at the boundary and do not appear again:

```rust
pub struct PageAddr(u64);   // a page index, not a byte address
pub struct PageCount(u64);
pub struct PageRange { start: PageAddr, end: PageAddr }   // invariant: start <= end
```

`PageAddr::from_bytes` is the only alignment check; `PageRange::from_bytes` is the only place overflow and zero length are rejected. Because construction proves those properties, `bytes()` and `pages()` are infallible and the interior arithmetic needs no `checked_*` and no `/ PAGE_SIZE`.

Residual computation becomes one total function that cannot be applied to non-nesting ranges:

```rust
pub const fn split_around(self, inner: Self) -> Option<RangeSplit>
//  -> RangeSplit { head: Option<PageRange>, middle: PageRange, tail: Option<PageRange> }
```

so `retype_range` writes its replacements by iterating the split instead of constructing three descriptors by hand.

Two more open-coded patterns get names:

- `fits_after_replacement(len, removed, inserted, capacity)` replaces `self.entries.len() - 1 + count > MAX` at 4 sites. It uses `checked_sub`, so an inconsistent `removed` count cannot wrap the subtraction into a passing capacity check.
- `PageRange::intersection` / `overlaps` / `is_adjacent_to` replace `entry.end() <= start || entry.physical_start >= end` and the `.max()`/`.min()` clipping in `reserve_region_fragments`, and make `can_merge` adjacency-checked rather than dependent on `end()`'s silent `u64::MAX` saturation.

## Fallout

`mark_region_as` turned out to be a fourth copy of the descriptor split, with its own `push` + `sort_entries` and no merge. It is now four lines on top of `retype_range`, so it inherits the capacity check, compaction retry, ordered insert, and local merge it previously lacked.

One behaviour change: a descriptor whose type value is unrecognised is now refused instead of having its residual head and tail silently relabelled `ReservedMemoryType`. All descriptors produced by `init_from_platform` and `force_add_region` have valid types, so this is unreachable in practice.

|  | before | after |
| --- | --- | --- |
| `PAGE_SIZE` uses in `allocator.rs` | 31 | 16 |
| of which byte/page conversions | 15 | 0 |
| copies of the descriptor-split logic | 2 (4 before #90) | 1 |
| `checked_mul` / `checked_add` in allocator | 6 | 2 |

The 16 remaining `PAGE_SIZE` uses are genuinely byte-domain: pool chunk sizing, `find_free_pages`' alignment masks, and linker-symbol rounding in `reserve_runtime_region`.

## Testing

`page_ownership.rs` stays dependency-free, so the new behaviour is covered by the host regression job (`ci/run-coreboot-feature-tests.sh`, 11 tests in that module): misaligned, zero-length, and overflowing construction; `split_around` residuals and non-containment; split parts being contiguous and covering the original; intersection clipping; and the capacity check not wrapping.

```
cargo fmt --all --check                                                          clean
ci/run-coreboot-feature-tests.sh                                                 24 tests pass
cargo clippy --workspace --release -- -D warnings                                clean
cargo clippy --workspace --release --target aarch64-unknown-none -- -D warnings  clean
./crabefi test --app hello --disable-kvm                                         3/3 pass
```
