### PR TITLE
fix(coreboot): fall back to scanning coreboot tables

### DIFF
--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -641,8 +641,8 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
     // ================================================================
     // Phase 2: Parse coreboot tables (reads raw memory, no heap needed)
     // ================================================================
-    // SAFETY: coreboot_table_ptr is passed from coreboot and points to
-    // valid tables in identity-mapped physical memory.
+    // SAFETY: The parser first tries the payload entry argument and falls back
+    // to scanning the standard coreboot table locations if it is not valid.
     let cb_info = unsafe { tables::parse(coreboot_table_ptr as *const u8) };
 
     // ================================================================

--- a/crabefi-coreboot/src/tables.rs
+++ b/crabefi-coreboot/src/tables.rs
@@ -497,12 +497,20 @@ impl CorebootInfo {
 pub unsafe fn parse(ptr: *const u8) -> CorebootInfo {
     let mut info = CorebootInfo::new();
 
-    // If pointer is null or invalid, scan for the tables in memory
+    // Prefer the table pointer supplied through the payload entry ABI. Some
+    // chainloaders do not preserve that argument, so fall back to scanning the
+    // standard coreboot table locations when it does not identify a table.
     let header = if ptr.is_null() {
         log::warn!("Coreboot table pointer is null, scanning memory...");
         unsafe { scan_for_header() }
+    } else if let Some(header) = unsafe { find_header(ptr) } {
+        Some(header)
     } else {
-        unsafe { find_header(ptr) }
+        log::warn!(
+            "No coreboot table at entry pointer {:p}, scanning memory...",
+            ptr
+        );
+        unsafe { scan_for_header() }
     };
 
     let header = match header {


### PR DESCRIPTION
## Summary

- prefer the coreboot table pointer supplied through the payload entry ABI
- fall back to scanning standard low-memory locations when it does not identify a table
- avoid requiring chainloaders such as GRUB to preserve the coreboot entry argument

## Testing

- original forced-scan version reached the bootloader on a ThinkPad X200 chainloaded from GRUB
- `cargo fmt --check`
- `cargo check`
- `cargo clippy --workspace --release -- -D warnings`
