### PR TITLE
ACPI update and TPM1.2 support/fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "bd8b2abd55bf1f9cffbf00fd594566c51a9d31402553284920c1309ca8351086"
 [[package]]
 name = "acpi"
 version = "6.1.1"
-source = "git+https://github.com/ArthurHeymans/acpi.git?rev=4f4adebf75234b52fe54c3e6e50c2cc13be41efe#4f4adebf75234b52fe54c3e6e50c2cc13be41efe"
+source = "git+https://github.com/ArthurHeymans/acpi.git?rev=784a35b50bf9c39ce9b0a107cf8a5c296c52ddee#784a35b50bf9c39ce9b0a107cf8a5c296c52ddee"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/crabefi-core/src/efi/mod.rs
+++ b/crabefi-core/src/efi/mod.rs
@@ -219,7 +219,7 @@ fn init_tcg_protocols(config: &mut crate::platform::TpmEventLogConfig) {
         } else {
             None
         };
-        if let Err(e) = init_tcg1_protocol(existing) {
+        if let Err(e) = init_tcg1_protocol(existing, config.tpm1_tis_base) {
             log::error!("TCG protocol init failed: {}", e);
         }
     }
@@ -342,7 +342,10 @@ pub(crate) fn measure_initial_boot() {
 }
 
 /// Initialize and install EFI_TCG_PROTOCOL (TPM 1.2).
-fn init_tcg1_protocol(existing_log: Option<&[u8]>) -> Result<(), &'static str> {
+fn init_tcg1_protocol(
+    existing_log: Option<&[u8]>,
+    tpm_base: Option<u64>,
+) -> Result<(), &'static str> {
     use tcg::event_log::DEFAULT_EVENT_LOG_SIZE;
 
     let log_pages = (DEFAULT_EVENT_LOG_SIZE as u64).div_ceil(allocator::PAGE_SIZE);
@@ -350,11 +353,21 @@ fn init_tcg1_protocol(existing_log: Option<&[u8]>) -> Result<(), &'static str> {
         .map(|buf| &mut buf[..DEFAULT_EVENT_LOG_SIZE])
         .ok_or("failed to allocate TCG event log buffer")?;
 
-    // CrabEFI does not currently have a TPM 1.2 transport. Install the legacy
-    // protocol for log discovery/HashAll compatibility, but do not advertise a
-    // physical TPM or accept PCR extends that would not reach hardware.
-    protocols::tcg::init_state(tcg1_buffer, existing_log, false)
-        .map_err(|_| "failed to initialize TCG state")?;
+    if let Some(base) = tpm_base {
+        let hardware_result =
+            unsafe { protocols::tcg::init_state_with_hardware(tcg1_buffer, existing_log, base) };
+        if hardware_result.is_err() {
+            log::warn!("TPM 1.2 hardware initialization failed; installing log-only TCG protocol");
+            let fallback_buffer = allocate_pages(log_pages)
+                .map(|buf| &mut buf[..DEFAULT_EVENT_LOG_SIZE])
+                .ok_or("failed to allocate fallback TCG event log buffer")?;
+            protocols::tcg::init_state(fallback_buffer, existing_log)
+                .map_err(|_| "failed to initialize fallback TCG state")?;
+        }
+    } else {
+        protocols::tcg::init_state(tcg1_buffer, existing_log)
+            .map_err(|_| "failed to initialize TCG state")?;
+    }
 
     let protocol = protocols::tcg::create_protocol();
     if protocol.is_null() {

--- a/crabefi-core/src/efi/protocols/tcg.rs
+++ b/crabefi-core/src/efi/protocols/tcg.rs
@@ -6,16 +6,13 @@
 //! - `StatusCheck`: Report whether a physical TPM 1.2 backend is available.
 //! - `HashAll`: Hash data using SHA-1.
 //! - `LogEvent`: Append an event to the SHA1 event log.
-//! - `PassThroughToTpm`: Not supported (no TPM 1.2 passthrough — returns UNSUPPORTED).
+//! - `PassThroughToTpm`: Forward raw commands to a TPM 1.2 backend.
 //! - `HashLogExtendEvent`: Hash data, extend PCRs, and log only when a physical
 //!   TPM 1.2 backend is configured.
 //!
-//! # Compatibility mode
-//!
-//! CrabEFI currently has no TPM 1.2 hardware transport. The legacy protocol can
-//! be installed for event-log discovery and SHA-1 hashing compatibility, but it
-//! does not advertise TPM presence and rejects PCR extends unless a real TPM 1.2
-//! backend is added.
+//! Without a hardware backend the legacy protocol remains available for
+//! event-log discovery and SHA-1 hashing compatibility, but does not advertise
+//! TPM presence or accept PCR-extending operations.
 //!
 //! # Reference
 //!
@@ -32,6 +29,7 @@ use spin::Mutex;
 use crate::efi::auth::authenticode::compute_authenticode_digests;
 use crate::efi::tcg::event_log::{EventLog, Sha1EventLog};
 use crate::efi::tcg::pcr::Sha1PcrBank;
+use crate::efi::tcg::tpm_tis::Tpm12Tis;
 use crate::efi::tcg::types::*;
 use crate::efi::utils::allocate_protocol_with_log;
 
@@ -47,8 +45,8 @@ struct TcgState {
     pcr_bank: Sha1PcrBank,
     /// SHA-1-only event log.
     event_log: Sha1EventLog,
-    /// Whether this protocol is backed by a physical TPM 1.2 device.
-    tpm_present: bool,
+    /// Physical TPM 1.2 backend used for PCR extension and passthrough.
+    hardware_tpm: Option<Tpm12Tis>,
 }
 
 /// Initialize the TCG (TPM 1.2) state.
@@ -56,12 +54,7 @@ struct TcgState {
 /// # Arguments
 /// * `buffer` - Pre-allocated buffer for the SHA-1 event log.
 /// * `existing_log` - Optional pre-existing log data to prepend.
-/// * `tpm_present` - Whether a physical TPM 1.2 device backs PCR extends.
-pub fn init_state(
-    buffer: &'static mut [u8],
-    existing_log: Option<&[u8]>,
-    tpm_present: bool,
-) -> Result<(), TcgError> {
+pub fn init_state(buffer: &'static mut [u8], existing_log: Option<&[u8]>) -> Result<(), TcgError> {
     let event_log = if let Some(existing) = existing_log {
         Sha1EventLog::from_existing(buffer, existing)?
     } else {
@@ -71,7 +64,32 @@ pub fn init_state(
     *TCG_STATE.lock() = Some(TcgState {
         pcr_bank: Sha1PcrBank::new(),
         event_log,
-        tpm_present,
+        hardware_tpm: None,
+    });
+
+    Ok(())
+}
+
+/// Initialize the TCG state with a physical TPM 1.2 TIS backend.
+///
+/// # Safety
+/// `tpm_base` must point to a valid TIS MMIO region.
+pub unsafe fn init_state_with_hardware(
+    buffer: &'static mut [u8],
+    existing_log: Option<&[u8]>,
+    tpm_base: u64,
+) -> Result<(), TcgError> {
+    let event_log = if let Some(existing) = existing_log {
+        Sha1EventLog::from_existing(buffer, existing)?
+    } else {
+        Sha1EventLog::new(buffer)
+    };
+    let tpm = unsafe { Tpm12Tis::probe(tpm_base)? };
+
+    *TCG_STATE.lock() = Some(TcgState {
+        pcr_bank: Sha1PcrBank::new(),
+        event_log,
+        hardware_tpm: Some(tpm),
     });
 
     Ok(())
@@ -105,6 +123,8 @@ fn extend_and_log(
         return Err(TcgError::InvalidPcrIndex);
     }
 
+    let tpm = state.hardware_tpm.as_mut().ok_or(TcgError::InternalError)?;
+    tpm.pcr_extend(pcr_index, sha1_digest)?;
     state.pcr_bank.extend(pcr_index as usize, sha1_digest)?;
     state
         .event_log
@@ -123,9 +143,7 @@ pub fn measure_event(
 ) -> Option<Result<(), TcgError>> {
     let mut guard = TCG_STATE.lock();
     let state = guard.as_mut()?;
-    if !state.tpm_present {
-        return None;
-    }
+    state.hardware_tpm.as_ref()?;
     let (sha1_digest, tagged_digest) = make_sha1_digest(data_to_hash);
     Some(extend_and_log(
         state,
@@ -145,9 +163,7 @@ pub fn precompute_pe_image_digests(
 ) -> Option<Result<(usize, [TaggedDigest; 5]), TcgError>> {
     let guard = TCG_STATE.lock();
     let state = guard.as_ref()?;
-    if !state.tpm_present {
-        return None;
-    }
+    state.hardware_tpm.as_ref()?;
     Some(
         compute_authenticode_digests(pe_data, &[TPM_ALG_SHA1]).map_err(|_| TcgError::InternalError),
     )
@@ -164,9 +180,7 @@ pub fn measure_pe_image_digests_event(
 ) -> Option<Result<(), TcgError>> {
     let mut guard = TCG_STATE.lock();
     let state = guard.as_mut()?;
-    if !state.tpm_present {
-        return None;
-    }
+    state.hardware_tpm.as_ref()?;
     Some((|| {
         let tagged_digest = digests
             .iter()
@@ -241,7 +255,7 @@ extern "efiapi" fn tcg_status_check(
                     rev_minor: 0,
                 },
                 hash_algorithm_bitmap: 0x01, // SHA-1
-                tpm_present_flag: u8::from(state.tpm_present),
+                tpm_present_flag: u8::from(state.hardware_tpm.is_some()),
                 tpm_deactivated_flag: 0,
             };
         }
@@ -263,7 +277,7 @@ extern "efiapi" fn tcg_status_check(
 
     if !event_log_last_entry.is_null() {
         unsafe {
-            *event_log_last_entry = if state.tpm_present {
+            *event_log_last_entry = if state.hardware_tpm.is_some() {
                 state
                     .event_log
                     .last_entry_offset()
@@ -274,7 +288,10 @@ extern "efiapi" fn tcg_status_check(
         }
     }
 
-    log::debug!("  -> SUCCESS (TPM present: {})", state.tpm_present);
+    log::debug!(
+        "  -> SUCCESS (TPM present: {})",
+        state.hardware_tpm.is_some()
+    );
     Status::SUCCESS
 }
 
@@ -391,7 +408,7 @@ extern "efiapi" fn tcg_log_event(
         None => return Status::DEVICE_ERROR,
     };
 
-    if !state.tpm_present {
+    if state.hardware_tpm.is_none() {
         return Status::DEVICE_ERROR;
     }
 
@@ -407,17 +424,34 @@ extern "efiapi" fn tcg_log_event(
 }
 
 /// `EFI_TCG_PROTOCOL.PassThroughToTpm`
-///
-/// Not supported — no physical TPM.
 extern "efiapi" fn tcg_pass_through_to_tpm(
-    _this: *mut TcgProtocolFfi,
-    _tpm_input_size: u32,
-    _tpm_input: *const u8,
-    _tpm_output_size: u32,
-    _tpm_output: *mut u8,
+    this: *mut TcgProtocolFfi,
+    tpm_input_size: u32,
+    tpm_input: *const u8,
+    tpm_output_size: u32,
+    tpm_output: *mut u8,
 ) -> Status {
-    log::debug!("TCG.PassThroughToTpm() -> UNSUPPORTED");
-    Status::UNSUPPORTED
+    if this.is_null()
+        || tpm_input.is_null()
+        || tpm_output.is_null()
+        || tpm_input_size < 10
+        || tpm_output_size < 10
+    {
+        return Status::INVALID_PARAMETER;
+    }
+
+    let input = unsafe { core::slice::from_raw_parts(tpm_input, tpm_input_size as usize) };
+    let output = unsafe { core::slice::from_raw_parts_mut(tpm_output, tpm_output_size as usize) };
+    let mut state = TCG_STATE.lock();
+    let Some(tpm) = state.as_mut().and_then(|state| state.hardware_tpm.as_mut()) else {
+        return Status::DEVICE_ERROR;
+    };
+
+    match tpm.submit_command(input, output) {
+        Ok(_) => Status::SUCCESS,
+        Err(TcgError::EventTooLarge) => Status::BUFFER_TOO_SMALL,
+        Err(_) => Status::DEVICE_ERROR,
+    }
 }
 
 /// `EFI_TCG_PROTOCOL.HashLogExtendEvent`
@@ -441,7 +475,7 @@ extern "efiapi" fn tcg_hash_log_extend_event(
         Some(s) => s,
         None => return Status::DEVICE_ERROR,
     };
-    if !state.tpm_present {
+    if state.hardware_tpm.is_none() {
         log::debug!("TCG.HashLogExtendEvent() -> DEVICE_ERROR (no physical TPM 1.2)");
         return Status::DEVICE_ERROR;
     }

--- a/crabefi-core/src/efi/tcg/mod.rs
+++ b/crabefi-core/src/efi/tcg/mod.rs
@@ -57,5 +57,5 @@ pub mod types;
 
 pub use event_log::{CryptoAgileEventLog, EventLog, EventLogFormat, Sha1EventLog};
 pub use pcr::PcrBanks;
-pub use tpm_tis::TpmTis;
+pub use tpm_tis::{Tpm12Tis, TpmFamily, TpmTis};
 pub use types::*;

--- a/crabefi-core/src/efi/tcg/tpm_tis.rs
+++ b/crabefi-core/src/efi/tcg/tpm_tis.rs
@@ -1,7 +1,8 @@
 //! TPM TIS (TPM Interface Specification) MMIO driver.
 //!
 //! This module implements the TCG PC Client Platform TPM Profile (TIS)
-//! register interface for communicating with a hardware TPM 2.0 device
+//! register interface for communicating with hardware TPM 1.2 and TPM 2.0
+//! devices
 //! via memory-mapped I/O. This is the standard interface used by:
 //!
 //! - Discrete TPM chips (dTPM) on x86 platforms
@@ -17,8 +18,8 @@
 //! - TCG PC Client Specific TIS, Family 1.3
 
 use super::types::{
-    TPM_ALG_SHA1, TPM_ALG_SHA256, TPM_ALG_SHA384, TPM_ALG_SHA512, TaggedDigest, TcgError,
-    digest_size_for_algorithm,
+    SHA1_DIGEST_SIZE, TPM_ALG_SHA1, TPM_ALG_SHA256, TPM_ALG_SHA384, TPM_ALG_SHA512, TaggedDigest,
+    TcgError, digest_size_for_algorithm,
 };
 use crate::platform::{Tpm2Device, TpmDigest, TpmError, TpmPcrBanks};
 
@@ -60,6 +61,17 @@ const STS_CANCEL: u8 = 1;
 
 // TPM response codes
 const TPM_RC_SUCCESS: u32 = 0x000;
+
+// TPM 1.2 command and response constants. TPM 1.2 and TPM 2.0 share the
+// TIS FIFO transport, but use disjoint command/response tag spaces.
+const TPM12_TAG_RQU_COMMAND: u16 = 0x00C1;
+const TPM12_TAG_RSP_COMMAND: u16 = 0x00C4;
+const TPM12_TAG_RSP_AUTH1_COMMAND: u16 = 0x00C5;
+const TPM12_TAG_RSP_AUTH2_COMMAND: u16 = 0x00C6;
+const TPM12_ORD_STARTUP: u32 = 0x0000_0099;
+const TPM12_ORD_EXTEND: u32 = 0x0000_0014;
+const TPM12_ST_CLEAR: u16 = 0x0001;
+const TPM12_INVALID_POSTINIT: u32 = 0x0000_0026;
 
 // TPM2 command tags and codes
 const TPM_ST_NO_SESSIONS: u16 = 0x8001;
@@ -163,21 +175,21 @@ pub struct TpmTis {
     max_response_size: u16,
 }
 
+/// TPM family detected behind a TIS FIFO transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TpmFamily {
+    Tpm12,
+    Tpm20,
+}
+
+/// TPM 1.2 device using the TIS FIFO transport.
+pub struct Tpm12Tis {
+    transport: TpmTis,
+}
+
 impl TpmTis {
-    /// Probe for a TPM at the given MMIO base address and initialize it.
-    ///
-    /// This performs:
-    /// 1. Check that a TPM device is present (DID/VID != 0xFFFFFFFF)
-    /// 2. Request locality 0
-    /// 3. Send TPM2_Startup(CLEAR)
-    /// 4. Send TPM2_SelfTest(incremental) best-effort
-    /// 5. Query capabilities (active PCR banks, manufacturer ID)
-    ///
-    /// # Safety
-    ///
-    /// `base` must point to a valid TIS MMIO region (e.g., `0xFED40000`).
-    pub unsafe fn probe(base: u64) -> Result<Self, TcgError> {
-        // Check TPM presence via DID_VID register.
+    /// Open the common TIS transport without assuming a TPM command family.
+    unsafe fn open(base: u64) -> Result<Self, TcgError> {
         let did_vid = unsafe { tis_read32(base, TPM_DID_VID) };
         if did_vid == 0xFFFF_FFFF || did_vid == 0 {
             log::info!(
@@ -203,9 +215,59 @@ impl TpmTis {
             max_command_size: 0,
             max_response_size: 0,
         };
-
-        // Request locality 0.
         unsafe { tpm.request_locality()? };
+        Ok(tpm)
+    }
+
+    fn detect_family_inner(&mut self) -> Result<TpmFamily, TcgError> {
+        // TPM2_GetCapability(TPM_PROPERTIES, MANUFACTURER, 1). A TPM 1.2
+        // device rejects the ordinal using a legacy response tag, while a
+        // TPM 2.0 device always replies with a TPM2 response tag.
+        let mut cmd = [0u8; 22];
+        cmd[0..2].copy_from_slice(&TPM_ST_NO_SESSIONS.to_be_bytes());
+        cmd[2..6].copy_from_slice(&22u32.to_be_bytes());
+        cmd[6..10].copy_from_slice(&TPM2_CC_GET_CAPABILITY.to_be_bytes());
+        cmd[10..14].copy_from_slice(&TPM2_CAP_TPM_PROPERTIES.to_be_bytes());
+        cmd[14..18].copy_from_slice(&TPM2_PT_MANUFACTURER.to_be_bytes());
+        cmd[18..22].copy_from_slice(&1u32.to_be_bytes());
+
+        let mut resp = [0u8; 64];
+        let n = self.send_command(&cmd, &mut resp)?;
+        if n < 10 {
+            return Err(TcgError::InternalError);
+        }
+        classify_response_tag(u16::from_be_bytes([resp[0], resp[1]]))
+    }
+
+    /// Detect whether the TIS device implements TPM 1.2 or TPM 2.0.
+    ///
+    /// # Safety
+    /// `base` must point to a valid TIS MMIO region.
+    pub unsafe fn detect_family(base: u64) -> Result<TpmFamily, TcgError> {
+        let mut tpm = unsafe { Self::open(base)? };
+        let family = tpm.detect_family_inner()?;
+        log::info!("TPM TIS command family: {:?}", family);
+        Ok(family)
+    }
+
+    /// Probe for a TPM at the given MMIO base address and initialize it.
+    ///
+    /// This performs:
+    /// 1. Check that a TPM device is present (DID/VID != 0xFFFFFFFF)
+    /// 2. Request locality 0
+    /// 3. Send TPM2_Startup(CLEAR)
+    /// 4. Send TPM2_SelfTest(incremental) best-effort
+    /// 5. Query capabilities (active PCR banks, manufacturer ID)
+    ///
+    /// # Safety
+    ///
+    /// `base` must point to a valid TIS MMIO region (e.g., `0xFED40000`).
+    pub unsafe fn probe(base: u64) -> Result<Self, TcgError> {
+        let mut tpm = unsafe { Self::open(base)? };
+        if tpm.detect_family_inner()? != TpmFamily::Tpm20 {
+            log::error!("TIS device at {:#x} is not a TPM 2.0 device", base);
+            return Err(TcgError::InternalError);
+        }
 
         // TPM2_Startup(CLEAR).
         tpm.startup()?;
@@ -804,6 +866,94 @@ impl TpmTis {
     }
 }
 
+impl Tpm12Tis {
+    /// Probe and initialize a TPM 1.2 device on a TIS FIFO transport.
+    ///
+    /// # Safety
+    /// `base` must point to a valid TIS MMIO region.
+    pub unsafe fn probe(base: u64) -> Result<Self, TcgError> {
+        let mut transport = unsafe { TpmTis::open(base)? };
+
+        // Coreboot commonly starts the TPM before entering the payload, so a
+        // second TPM_Startup legitimately returns TPM_INVALID_POSTINIT.
+        let mut cmd = [0u8; 12];
+        cmd[0..2].copy_from_slice(&TPM12_TAG_RQU_COMMAND.to_be_bytes());
+        cmd[2..6].copy_from_slice(&12u32.to_be_bytes());
+        cmd[6..10].copy_from_slice(&TPM12_ORD_STARTUP.to_be_bytes());
+        cmd[10..12].copy_from_slice(&TPM12_ST_CLEAR.to_be_bytes());
+        let mut resp = [0u8; 64];
+        let n = transport.send_command(&cmd, &mut resp)?;
+        if n < 10
+            || classify_response_tag(u16::from_be_bytes([resp[0], resp[1]]))? != TpmFamily::Tpm12
+        {
+            log::error!("TIS device at {:#x} is not a TPM 1.2 device", base);
+            return Err(TcgError::InternalError);
+        }
+        let rc = response_code(&resp[..n])?;
+        if rc != TPM_RC_SUCCESS && rc != TPM12_INVALID_POSTINIT {
+            log::error!("TPM_Startup(ST_CLEAR) failed: rc={:#x}", rc);
+            return Err(TcgError::InternalError);
+        }
+
+        log::info!("TPM 1.2 TIS backend initialized");
+        Ok(Self { transport })
+    }
+
+    /// Extend a TPM 1.2 SHA-1 PCR.
+    pub fn pcr_extend(
+        &mut self,
+        pcr_index: u32,
+        digest: &[u8; SHA1_DIGEST_SIZE],
+    ) -> Result<(), TcgError> {
+        let mut cmd = [0u8; 34];
+        cmd[0..2].copy_from_slice(&TPM12_TAG_RQU_COMMAND.to_be_bytes());
+        cmd[2..6].copy_from_slice(&34u32.to_be_bytes());
+        cmd[6..10].copy_from_slice(&TPM12_ORD_EXTEND.to_be_bytes());
+        cmd[10..14].copy_from_slice(&pcr_index.to_be_bytes());
+        cmd[14..34].copy_from_slice(digest);
+
+        let mut resp = [0u8; 64];
+        let n = self.transport.send_command(&cmd, &mut resp)?;
+        let rc = response_code(&resp[..n])?;
+        if rc != TPM_RC_SUCCESS {
+            log::error!("TPM_Extend(pcr={}) failed: rc={:#x}", pcr_index, rc);
+            return Err(TcgError::InternalError);
+        }
+        Ok(())
+    }
+
+    /// Submit an arbitrary TPM 1.2 command through the TIS FIFO.
+    pub fn submit_command(
+        &mut self,
+        command: &[u8],
+        response: &mut [u8],
+    ) -> Result<usize, TcgError> {
+        self.transport.send_command(command, response)
+    }
+}
+
+fn response_code(response: &[u8]) -> Result<u32, TcgError> {
+    if response.len() < 10 {
+        return Err(TcgError::InternalError);
+    }
+    Ok(u32::from_be_bytes([
+        response[6],
+        response[7],
+        response[8],
+        response[9],
+    ]))
+}
+
+fn classify_response_tag(tag: u16) -> Result<TpmFamily, TcgError> {
+    match tag {
+        TPM12_TAG_RSP_COMMAND | TPM12_TAG_RSP_AUTH1_COMMAND | TPM12_TAG_RSP_AUTH2_COMMAND => {
+            Ok(TpmFamily::Tpm12)
+        }
+        TPM_ST_NO_SESSIONS | 0x8002 => Ok(TpmFamily::Tpm20),
+        _ => Err(TcgError::InternalError),
+    }
+}
+
 impl Tpm2Device for TpmTis {
     fn active_pcr_banks(&self) -> TpmPcrBanks {
         TpmPcrBanks::new(self.active_algorithms())
@@ -864,4 +1014,18 @@ fn manufacturer_id_to_str(id: u32) -> alloc::string::String {
         }
     }
     s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TpmFamily, classify_response_tag};
+
+    #[test]
+    fn response_tags_distinguish_tpm_families() {
+        assert_eq!(classify_response_tag(0x00c4), Ok(TpmFamily::Tpm12));
+        assert_eq!(classify_response_tag(0x00c5), Ok(TpmFamily::Tpm12));
+        assert_eq!(classify_response_tag(0x8001), Ok(TpmFamily::Tpm20));
+        assert_eq!(classify_response_tag(0x8002), Ok(TpmFamily::Tpm20));
+        assert!(classify_response_tag(0xffff).is_err());
+    }
 }

--- a/crabefi-core/src/platform.rs
+++ b/crabefi-core/src/platform.rs
@@ -1051,7 +1051,7 @@ impl FramebufferConfig {
 // TPM Event Log
 // ============================================================================
 
-/// TPM event-log and TPM 2.0 backend configuration.
+/// TPM event-log and hardware backend configuration.
 ///
 /// When the platform (e.g., coreboot) has already started measured boot and
 /// maintains a TPM event log, it can pass that log data to CrabEFI via this
@@ -1103,6 +1103,13 @@ pub struct TpmEventLogConfig<'a> {
     /// [`Tpm2DeviceConfig::TisMmio`], while library users can pass a `'static`
     /// driver implementing [`Tpm2Device`].
     pub tpm2_device: Tpm2DeviceConfig,
+
+    /// Optional MMIO base of a TPM 1.2 device using the TIS FIFO transport.
+    ///
+    /// When present with [`TpmLogFormat::Sha1Only`] or [`TpmLogFormat::Both`],
+    /// CrabEFI installs a hardware-backed `EFI_TCG_PROTOCOL` and forwards SHA-1
+    /// PCR extensions and raw TPM 1.2 commands to this device.
+    pub tpm1_tis_base: Option<u64>,
 }
 
 /// TPM event log format selection.

--- a/crabefi-coreboot/Cargo.toml
+++ b/crabefi-coreboot/Cargo.toml
@@ -25,9 +25,12 @@ zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
 # ACPI table parsing and AML interpreter for platform device discovery.
 # Used by the coreboot payload to discover ECAM, GIC, UART, and DSDT
 # devices from ACPI tables before handing off to init_platform().
-# Pin to upstream BankField/IndexField support; crates.io 6.1.1 has todo!()
-# paths that panic-abort while loading AML from real firmware.
-acpi = { git = "https://github.com/ArthurHeymans/acpi.git", rev = "4f4adebf75234b52fe54c3e6e50c2cc13be41efe", default-features = false, features = [
+# Pin to upstream main: crates.io 6.1.1 has todo!() BankField/IndexField paths
+# that panic-abort while loading AML from real firmware, and only loads
+# package-element names eagerly (fails on forward references like
+# \_SB.PCI0.LPCB in the coreboot DSDT/SSDT). Upstream main has both the
+# BankField/IndexField support and lazy package name resolution (PR #320).
+acpi = { git = "https://github.com/ArthurHeymans/acpi.git", rev = "784a35b50bf9c39ce9b0a107cf8a5c296c52ddee", default-features = false, features = [
   "alloc",
   "aml",
 ] }

--- a/crabefi-coreboot/src/acpi.rs
+++ b/crabefi-coreboot/src/acpi.rs
@@ -302,6 +302,100 @@ pub unsafe fn discover_platform(rsdp_addr: u64) -> PlatformInfo {
     info
 }
 
+/// Locate a TPM 1.2 event log described by the ACPI TCPA table.
+///
+/// Some coreboot platforms publish the log through ACPI but do not export the
+/// corresponding standard-log CBMEM entry in the coreboot table. Copying this
+/// log into CrabEFI's EFI_TCG_PROTOCOL log keeps the log replayable against the
+/// PCR values coreboot extended before entering the payload.
+///
+/// # Safety
+/// `rsdp_addr` and all referenced ACPI/log memory must be identity mapped and
+/// remain valid for the firmware boot-services lifetime.
+#[cfg(target_arch = "x86_64")]
+pub unsafe fn find_tcpa_event_log(rsdp_addr: u64) -> Option<&'static [u8]> {
+    unsafe fn read_u32(address: u64) -> u32 {
+        unsafe { core::ptr::read_unaligned(address as *const u32) }
+    }
+    unsafe fn read_u64(address: u64) -> u64 {
+        unsafe { core::ptr::read_unaligned(address as *const u64) }
+    }
+
+    let rsdp = rsdp_addr as *const u8;
+    if unsafe { core::slice::from_raw_parts(rsdp, 8) } != b"RSD PTR " {
+        return None;
+    }
+    let revision = unsafe { core::ptr::read_unaligned(rsdp.add(15)) };
+    let (root, entry_size) = if revision >= 2 {
+        (unsafe { read_u64(rsdp_addr + 24) }, 8usize)
+    } else {
+        (unsafe { read_u32(rsdp_addr + 16) } as u64, 4usize)
+    };
+    if root == 0 {
+        return None;
+    }
+
+    let root_length = unsafe { read_u32(root + 4) } as usize;
+    if root_length < 36 {
+        return None;
+    }
+    let entry_count = (root_length - 36) / entry_size;
+    for index in 0..entry_count {
+        let entry_address = root + 36 + (index * entry_size) as u64;
+        let table = if entry_size == 8 {
+            unsafe { read_u64(entry_address) }
+        } else {
+            (unsafe { read_u32(entry_address) }) as u64
+        };
+        if table == 0 || unsafe { core::slice::from_raw_parts(table as *const u8, 4) } != b"TCPA" {
+            continue;
+        }
+
+        // ACPI TCPA client table: header(36), platform_class(2),
+        // log_area_minimum_length(4), log_area_start_address(8).
+        let table_length = unsafe { read_u32(table + 4) } as usize;
+        if table_length < 50 {
+            return None;
+        }
+        let maximum_length = unsafe { read_u32(table + 38) } as usize;
+        let log_address = unsafe { read_u64(table + 42) };
+        if maximum_length == 0 || log_address == 0 {
+            return None;
+        }
+
+        let allocation =
+            unsafe { core::slice::from_raw_parts(log_address as *const u8, maximum_length) };
+        let used = tcpa_log_used_length(allocation)?;
+        log::info!(
+            "ACPI TCPA event log found at {:#x} ({} used of {} bytes)",
+            log_address,
+            used,
+            maximum_length
+        );
+        return Some(&allocation[..used]);
+    }
+    None
+}
+
+#[cfg(target_arch = "x86_64")]
+fn tcpa_log_used_length(log: &[u8]) -> Option<usize> {
+    const HEADER_SIZE: usize = 4 + 4 + 20 + 4;
+    let mut offset = 0usize;
+    while offset + HEADER_SIZE <= log.len() {
+        let header = &log[offset..offset + HEADER_SIZE];
+        if header.iter().all(|byte| *byte == 0) || header.iter().all(|byte| *byte == 0xff) {
+            break;
+        }
+        let event_size = u32::from_le_bytes(header[28..32].try_into().ok()?) as usize;
+        let next = offset.checked_add(HEADER_SIZE)?.checked_add(event_size)?;
+        if next > log.len() {
+            return None;
+        }
+        offset = next;
+    }
+    (offset != 0).then_some(offset)
+}
+
 // ---------------------------------------------------------------------------
 // MADT — GIC distributor and redistributor (aarch64)
 // ---------------------------------------------------------------------------

--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -1056,6 +1056,7 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
                 // Hardware TPM transport is selected after ACPI namespace discovery.
                 // Coreboot's TPM log record does not describe the transport.
                 tpm2_device: crabefi::Tpm2DeviceConfig::None,
+                tpm1_tis_base: None,
             }
         }),
         heap_pre_initialized: false, // Set to true after Phase 7
@@ -1095,16 +1096,35 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
         crabefi::state::with_drivers_mut(|d| d.acpi_info = acpi_info);
 
         #[cfg(target_arch = "x86_64")]
-        if let Some(device) = ["MSFT0101", "PNP0C31"]
+        if let Some((tpm_hid, device)) = ["MSFT0101", "PNP0C31"]
             .iter()
-            .find_map(|hid| acpi_info.find_device(hid))
+            .find_map(|hid| acpi_info.find_device(hid).map(|device| (*hid, device)))
             && device.mmio_base <= 0xfed4_0000
             && device.mmio_base.saturating_add(device.mmio_size) > 0xfed4_0000
         {
+            log::info!("ACPI exposes an MMIO TIS TPM at 0xfed40000 ({})", tpm_hid);
             if let Some(ref mut tpm) = config.tpm_event_log {
-                tpm.tpm2_device = crabefi::Tpm2DeviceConfig::TisMmio { base: 0xfed4_0000 };
+                match tpm_hid {
+                    "PNP0C31" => {
+                        // A TPM 1.2 platform must not expose EFI_TCG2_PROTOCOL:
+                        // Linux otherwise selects it and receives DEVICE_ERROR
+                        // for every attempted measurement.
+                        if tpm.format != crabefi::TpmLogFormat::Sha1Only {
+                            tpm.existing_log = None;
+                        }
+                        tpm.format = crabefi::TpmLogFormat::Sha1Only;
+                        if tpm.existing_log.is_none() {
+                            tpm.existing_log = unsafe { acpi::find_tcpa_event_log(rsdp) };
+                        }
+                        tpm.tpm1_tis_base = Some(0xfed4_0000);
+                        tpm.tpm2_device = crabefi::Tpm2DeviceConfig::None;
+                    }
+                    "MSFT0101" => {
+                        tpm.tpm2_device = crabefi::Tpm2DeviceConfig::TisMmio { base: 0xfed4_0000 };
+                    }
+                    _ => unreachable!(),
+                }
             }
-            log::info!("ACPI exposes an MMIO TIS TPM at 0xfed40000");
         } else {
             log::info!("No ACPI MMIO TIS TPM resource; skipping unsafe probe");
         }


### PR DESCRIPTION
Code changes:
- Add TPM 1.2 TIS MMIO support, including device probing, startup handling, PCR extension, and raw command passthrough.
- Install a hardware-backed `EFI_TCG_PROTOCOL` when a TPM 1.2 device is detected, with log-only fallback if initialization fails.
- Add TPM family detection to distinguish TPM 1.2 and TPM 2.0 devices sharing the TIS transport.
- Add ACPI TCPA event-log discovery and reuse for TPM 1.2 platforms.
- Update coreboot TPM detection to configure `EFI_TCG_PROTOCOL` for `PNP0C31` devices and preserve `EFI_TCG2_PROTOCOL` behavior for `MSFT0101`.
- Update the ACPI dependency to a revision containing BankField/IndexField support and lazy package-name resolution.
- Add response-tag classification tests for TPM family detection.