### PR TITLE
Update rflasher dependency and refactor Secure Boot key state management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32",
- "serde",
  "stable_deref_trait",
 ]
 
@@ -471,12 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,27 +575,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
+name = "rflasher-chip-types"
+version = "0.1.0"
+source = "git+https://github.com/ArthurHeymans/rflasher.git?rev=a06d37b6c45a59b68a3a01b7b8abee73a10ea8a0#a06d37b6c45a59b68a3a01b7b8abee73a10ea8a0"
+dependencies = [
+ "bitflags",
+ "heapless 0.8.0",
+]
+
+[[package]]
 name = "rflasher-core"
 version = "0.1.0"
-source = "git+https://github.com/ArthurHeymans/rflasher.git?rev=2f0b625865c0a530b3f151166be95319543e2aff#2f0b625865c0a530b3f151166be95319543e2aff"
+source = "git+https://github.com/ArthurHeymans/rflasher.git?rev=a06d37b6c45a59b68a3a01b7b8abee73a10ea8a0#a06d37b6c45a59b68a3a01b7b8abee73a10ea8a0"
 dependencies = [
  "bitflags",
  "embedded-io",
  "embedded-io-async",
- "heapless 0.8.0",
  "log",
  "maybe-async",
- "once_cell",
+ "rflasher-chip-types",
  "zerocopy",
 ]
 
 [[package]]
 name = "rflasher-internal"
 version = "0.1.0"
-source = "git+https://github.com/ArthurHeymans/rflasher.git?rev=2f0b625865c0a530b3f151166be95319543e2aff#2f0b625865c0a530b3f151166be95319543e2aff"
+source = "git+https://github.com/ArthurHeymans/rflasher.git?rev=a06d37b6c45a59b68a3a01b7b8abee73a10ea8a0#a06d37b6c45a59b68a3a01b7b8abee73a10ea8a0"
 dependencies = [
  "log",
  "rflasher-core",
+ "rflasher-pci",
+]
+
+[[package]]
+name = "rflasher-pci"
+version = "0.1.0"
+source = "git+https://github.com/ArthurHeymans/rflasher.git?rev=a06d37b6c45a59b68a3a01b7b8abee73a10ea8a0#a06d37b6c45a59b68a3a01b7b8abee73a10ea8a0"
+dependencies = [
+ "pci_types",
 ]
 
 [[package]]
@@ -636,35 +646,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
 
 [[package]]
 name = "sha1"

--- a/crabefi-core/Cargo.toml
+++ b/crabefi-core/Cargo.toml
@@ -46,10 +46,10 @@ noto-sans-mono-bitmap = { version = "0.3", default-features = false, features = 
 ] }
 tock-registers = "0.10"
 zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
-rflasher-core = { git = "https://github.com/ArthurHeymans/rflasher.git", rev = "2f0b625865c0a530b3f151166be95319543e2aff", default-features = false, features = [
+rflasher-core = { git = "https://github.com/ArthurHeymans/rflasher.git", rev = "a06d37b6c45a59b68a3a01b7b8abee73a10ea8a0", default-features = false, features = [
   "is_sync",
 ] }
-rflasher-internal = { git = "https://github.com/ArthurHeymans/rflasher.git", rev = "2f0b625865c0a530b3f151166be95319543e2aff", default-features = false, features = [
+rflasher-internal = { git = "https://github.com/ArthurHeymans/rflasher.git", rev = "a06d37b6c45a59b68a3a01b7b8abee73a10ea8a0", default-features = false, features = [
   "is_sync",
 ] }
 

--- a/crabefi-core/src/drivers/spi/mod.rs
+++ b/crabefi-core/src/drivers/spi/mod.rs
@@ -6,7 +6,9 @@
 
 pub mod qemu;
 
-use rflasher_internal::{Bdf, HostAccess, MmioAccess, PciConfigAccess};
+use rflasher_internal::{
+    HostAccess, MmioAccess, PciAddress as RflasherPciAddress, PciConfigAccess,
+};
 
 use crate::drivers::{mmio::MmioRegion, pci};
 use crate::platform::{FirmwareStorage, FirmwareStorageRegion, StorageError};
@@ -16,25 +18,33 @@ use crate::platform::{FirmwareStorage, FirmwareStorageRegion, StorageError};
 pub struct CrabEfiPciAccess;
 
 impl CrabEfiPciAccess {
-    fn addr(bdf: Bdf) -> pci::PciAddress {
-        // CrabEFI currently enumerates PCI segment 0 only.
-        pci::PciAddress::new(0, bdf.bus, bdf.device, bdf.function)
+    fn addr(address: RflasherPciAddress) -> pci::PciAddress {
+        pci::PciAddress::new(
+            address.segment(),
+            address.bus(),
+            address.device(),
+            address.function(),
+        )
     }
 
-    fn offset_to_u8(bdf: Bdf, offset: u16, write: bool) -> rflasher_internal::Result<u8> {
+    fn offset_to_u8(
+        address: RflasherPciAddress,
+        offset: u16,
+        write: bool,
+    ) -> rflasher_internal::Result<u8> {
         if offset > u8::MAX as u16 {
             let error = if write {
                 rflasher_internal::PciAccessError::ConfigWrite {
-                    bus: bdf.bus,
-                    device: bdf.device,
-                    function: bdf.function,
+                    bus: address.bus(),
+                    device: address.device(),
+                    function: address.function(),
                     register: offset,
                 }
             } else {
                 rflasher_internal::PciAccessError::ConfigRead {
-                    bus: bdf.bus,
-                    device: bdf.device,
-                    function: bdf.function,
+                    bus: address.bus(),
+                    device: address.device(),
+                    function: address.function(),
                     register: offset,
                 }
             };
@@ -46,36 +56,53 @@ impl CrabEfiPciAccess {
 }
 
 impl PciConfigAccess for CrabEfiPciAccess {
-    fn read8(&self, bdf: Bdf, offset: u16) -> rflasher_internal::Result<u8> {
-        let offset = Self::offset_to_u8(bdf, offset, false)?;
-        Ok(pci::read_config_u8(Self::addr(bdf), offset))
+    type Error = rflasher_internal::InternalError;
+
+    fn read8(&self, address: RflasherPciAddress, offset: u16) -> rflasher_internal::Result<u8> {
+        let offset = Self::offset_to_u8(address, offset, false)?;
+        Ok(pci::read_config_u8(Self::addr(address), offset))
     }
 
-    fn read16(&self, bdf: Bdf, offset: u16) -> rflasher_internal::Result<u16> {
-        let offset = Self::offset_to_u8(bdf, offset, false)?;
-        Ok(pci::read_config_u16(Self::addr(bdf), offset))
+    fn read16(&self, address: RflasherPciAddress, offset: u16) -> rflasher_internal::Result<u16> {
+        let offset = Self::offset_to_u8(address, offset, false)?;
+        Ok(pci::read_config_u16(Self::addr(address), offset))
     }
 
-    fn read32(&self, bdf: Bdf, offset: u16) -> rflasher_internal::Result<u32> {
-        let offset = Self::offset_to_u8(bdf, offset, false)?;
-        Ok(pci::read_config_u32(Self::addr(bdf), offset))
+    fn read32(&self, address: RflasherPciAddress, offset: u16) -> rflasher_internal::Result<u32> {
+        let offset = Self::offset_to_u8(address, offset, false)?;
+        Ok(pci::read_config_u32(Self::addr(address), offset))
     }
 
-    fn write8(&self, bdf: Bdf, offset: u16, value: u8) -> rflasher_internal::Result<()> {
-        let offset = Self::offset_to_u8(bdf, offset, true)?;
-        pci::write_config_u8(Self::addr(bdf), offset, value);
+    fn write8(
+        &self,
+        address: RflasherPciAddress,
+        offset: u16,
+        value: u8,
+    ) -> rflasher_internal::Result<()> {
+        let offset = Self::offset_to_u8(address, offset, true)?;
+        pci::write_config_u8(Self::addr(address), offset, value);
         Ok(())
     }
 
-    fn write16(&self, bdf: Bdf, offset: u16, value: u16) -> rflasher_internal::Result<()> {
-        let offset = Self::offset_to_u8(bdf, offset, true)?;
-        pci::write_config_u16(Self::addr(bdf), offset, value);
+    fn write16(
+        &self,
+        address: RflasherPciAddress,
+        offset: u16,
+        value: u16,
+    ) -> rflasher_internal::Result<()> {
+        let offset = Self::offset_to_u8(address, offset, true)?;
+        pci::write_config_u16(Self::addr(address), offset, value);
         Ok(())
     }
 
-    fn write32(&self, bdf: Bdf, offset: u16, value: u32) -> rflasher_internal::Result<()> {
-        let offset = Self::offset_to_u8(bdf, offset, true)?;
-        pci::write_config_u32(Self::addr(bdf), offset, value);
+    fn write32(
+        &self,
+        address: RflasherPciAddress,
+        offset: u16,
+        value: u32,
+    ) -> rflasher_internal::Result<()> {
+        let offset = Self::offset_to_u8(address, offset, true)?;
+        pci::write_config_u32(Self::addr(address), offset, value);
         Ok(())
     }
 }
@@ -399,10 +426,12 @@ fn rflasher_pci_device(dev: &pci::PciDevice) -> rflasher_internal::PciDevice {
         ((dev.class_code as u32) << 16) | ((dev.subclass as u32) << 8) | (dev.prog_if as u32);
 
     rflasher_internal::PciDevice {
-        domain: 0,
-        bus: dev.address.bus(),
-        device: dev.address.device(),
-        function: dev.address.function(),
+        address: RflasherPciAddress::new(
+            0,
+            dev.address.bus(),
+            dev.address.device(),
+            dev.address.function(),
+        ),
         vendor_id: dev.vendor_id,
         device_id: dev.device_id,
         revision_id: dev.revision,
@@ -487,7 +516,7 @@ pub fn detect_and_init() -> Option<AnySpiController> {
             match rflasher_internal::enable_amd_spi100_with_host(
                 &CrabEfiPciAccess,
                 chipset.enable,
-                Bdf::with_segment(chipset.domain, chipset.bus, chipset.device, 0),
+                RflasherPciAddress::new(chipset.domain, chipset.bus, chipset.device, 0),
                 chipset.revision_id,
             )
             .and_then(|info| info.create_controller_with_host(CrabEfiPciAccess))

--- a/crabefi-core/src/efi/auth/boot.rs
+++ b/crabefi-core/src/efi/auth/boot.rs
@@ -476,18 +476,38 @@ pub fn get_enrollment_summary() -> (usize, usize, usize, usize) {
 /// After clearing, the system returns to Setup Mode and Secure Boot
 /// is disabled.
 pub fn clear_all_keys() -> Result<(), AuthError> {
+    log::warn!("Clearing all Secure Boot keys by physical-presence setup action!");
+
+    // Public SetVariable correctly rejects an unsigned PK deletion in User
+    // Mode, even when signature verification has been disabled. Firmware setup
+    // is the physical-presence authority, so remove PK through the privileged
+    // pre-boot persistence/import path first. This transitions the live policy
+    // into Setup Mode; the remaining databases can then use ordinary unsigned
+    // SetVariable deletes.
     if !is_setup_mode() {
-        log::warn!("Refusing unsigned Secure Boot key clearing in User Mode");
-        return Err(AuthError::AccessDenied);
+        let guid = Guid::from_bytes(&EFI_GLOBAL_VARIABLE_GUID);
+        if crate::efi::varstore::persistence::persist_firmware_variable(
+            &guid,
+            PK_NAME,
+            SECURE_BOOT_KEY_ATTRS,
+            &[],
+        )
+        .is_err()
+        {
+            force_refresh_key_databases();
+            return Err(AuthError::CryptoError);
+        }
+        force_refresh_key_databases();
+        if !is_setup_mode() {
+            return Err(AuthError::AccessDenied);
+        }
     }
-    log::warn!("Clearing all Secure Boot keys!");
 
     let zero_timestamp = EfiTime::zero();
     for variable in [
         SecureBootVariable::Dbx,
         SecureBootVariable::Db,
         SecureBootVariable::Kek,
-        SecureBootVariable::PK,
     ] {
         if let Err(error) = persist_key_variable(variable, &[], &zero_timestamp) {
             // A preceding delete may already have changed live image policy.

--- a/crabefi-core/src/efi/auth/boot.rs
+++ b/crabefi-core/src/efi/auth/boot.rs
@@ -132,13 +132,11 @@ pub fn init_secure_boot(config: &SecureBootConfig) -> Result<EnrollmentStatus, A
     // Step 5: Load and apply SecureBootEnable preference from persistent storage
     // This is the user's saved preference from previous boot
     if !is_setup_mode() {
-        let enable_from_storage = load_secure_boot_enable_preference();
-        if enable_from_storage || config.enable_secure_boot {
-            // Use internal function to avoid re-persisting what we just loaded
-            super::set_secure_boot_derived(true);
+        if config.enable_secure_boot && !load_secure_boot_enable_preference() {
+            super::enable_secure_boot();
+        }
+        if super::is_secure_boot_enabled() {
             log::info!("Secure Boot: Enabled (from persisted preference)");
-            // Update status variables to reflect the enabled state
-            let _ = update_status_variables();
         }
     }
 
@@ -244,13 +242,21 @@ fn refresh_key_database(
 /// snapshots. Unchanged values are not reparsed, and this verification-only
 /// path deliberately avoids persistent-store timestamp walks.
 pub(crate) fn refresh_key_databases() {
+    refresh_key_databases_with_force(false);
+}
+
+fn force_refresh_key_databases() {
+    refresh_key_databases_with_force(true);
+}
+
+fn refresh_key_databases_with_force(force: bool) {
     for variable in [
         SecureBootVariable::PK,
         SecureBootVariable::Kek,
         SecureBootVariable::Db,
         SecureBootVariable::Dbx,
     ] {
-        refresh_key_database(variable, false, false);
+        refresh_key_database(variable, false, force);
     }
 }
 
@@ -277,14 +283,33 @@ fn efi_time_from_timestamp(timestamp: VariableTimestamp) -> EfiTime {
 
 // name_matches consolidated into crate::efi::utils::ucs2_eq
 
-/// Enroll default keys and persist them to SMMSTORE
-fn enroll_and_persist_default_keys() -> Result<(), AuthError> {
-    // First, enroll keys in memory
-    enrollment::enroll_default_keys()?;
+/// Enroll the default keys through the authoritative variable-store path.
+///
+/// Enrollment is only allowed in Setup Mode. Existing boot-only caches are
+/// discarded first so retrying after a partial failed enrollment cannot append
+/// duplicate certificates.
+pub fn enroll_and_persist_default_keys() -> Result<(), AuthError> {
+    if !is_setup_mode() {
+        return Err(AuthError::AccessDenied);
+    }
 
-    // Then persist each key database to SMMSTORE
-    persist_key_databases()?;
+    for variable in [
+        SecureBootVariable::PK,
+        SecureBootVariable::Kek,
+        SecureBootVariable::Db,
+        SecureBootVariable::Dbx,
+    ] {
+        key_database(variable).clear();
+    }
 
+    if let Err(error) = enrollment::enroll_default_keys().and_then(|()| persist_key_databases()) {
+        // Persistence may have committed only a prefix of the databases. Make
+        // the runtime store authoritative again before returning to the UI.
+        force_refresh_key_databases();
+        return Err(error);
+    }
+
+    force_refresh_key_databases();
     Ok(())
 }
 
@@ -348,6 +373,8 @@ pub fn persist_key_databases() -> Result<(), AuthError> {
         }
     }
 
+    // Keep snapshots synchronized with the authoritative runtime variables.
+    force_refresh_key_databases();
     log::info!("Secure Boot key databases persisted to SMMSTORE");
     Ok(())
 }
@@ -465,12 +492,14 @@ pub fn clear_all_keys() -> Result<(), AuthError> {
         if let Err(error) = persist_key_variable(variable, &[], &zero_timestamp) {
             // A preceding delete may already have changed live image policy.
             // Always reconcile disposable boot caches before reporting failure.
-            refresh_key_databases();
+            force_refresh_key_databases();
             return Err(error);
         }
-        refresh_key_databases();
     }
 
+    // An already-absent variable is an idempotent delete, but stale boot-only
+    // caches must still be discarded.
+    force_refresh_key_databases();
     update_status_variables()?;
     log::info!("All Secure Boot keys cleared - system in Setup Mode");
     Ok(())

--- a/crabefi-core/src/efi/auth/mod.rs
+++ b/crabefi-core/src/efi/auth/mod.rs
@@ -41,8 +41,6 @@ pub use crypto::*;
 pub use signature::*;
 pub use variables::*;
 
-use core::sync::atomic::{AtomicBool, Ordering};
-
 use crabefi_efi_types::secure_boot::{
     EFI_GLOBAL_VARIABLE_GUID, SECURE_BOOT_ENABLE_NAME, SECURE_BOOT_NAME, SETUP_MODE_NAME,
 };
@@ -236,9 +234,6 @@ pub const WIN_CERT_TYPE_EFI_GUID: u16 = 0x0EF1;
 const SECURE_BOOT_ENABLE_ATTRS: u32 =
     attributes::NON_VOLATILE | attributes::BOOTSERVICE_ACCESS | attributes::RUNTIME_ACCESS;
 
-static SETUP_MODE: AtomicBool = AtomicBool::new(true);
-static SECURE_BOOT_ENABLED: AtomicBool = AtomicBool::new(false);
-
 /// Read the image-owned standard SetupMode variable.
 pub fn is_setup_mode() -> bool {
     crate::efi::runtime_image::client::variables::get(
@@ -266,37 +261,35 @@ pub fn verify_pe_image_secure_boot(pe_data: &[u8]) -> Result<bool, AuthError> {
     authenticode::verify_pe_image_secure_boot(pe_data)
 }
 
-/// Enter User Mode (called when PK is enrolled).
+/// Log the transition requested by key enrollment.
+///
+/// The authoritative mode is synthesized by the runtime variable store from
+/// the PK variable; there is deliberately no second local state copy.
 pub fn enter_user_mode() {
-    SETUP_MODE.store(false, Ordering::Release);
     log::info!("Secure Boot: Entering User Mode");
 }
 
-/// Enter Setup Mode (called when PK is deleted).
+/// Log the transition requested by PK deletion.
 pub fn enter_setup_mode() {
-    SETUP_MODE.store(true, Ordering::Release);
-    SECURE_BOOT_ENABLED.store(false, Ordering::Release);
     log::info!("Secure Boot: Entering Setup Mode");
 }
 
 /// Enable Secure Boot (only valid in User Mode).
 pub fn enable_secure_boot() {
     if !is_setup_mode() {
-        SECURE_BOOT_ENABLED.store(true, Ordering::Release);
-        log::info!("Secure Boot: Enabled");
         persist_secure_boot_enable_preference(true);
+        if is_secure_boot_enabled() {
+            log::info!("Secure Boot: Enabled");
+        }
     }
-}
-
-pub(crate) fn set_secure_boot_derived(enabled: bool) {
-    SECURE_BOOT_ENABLED.store(enabled, Ordering::Release);
 }
 
 /// Disable Secure Boot.
 pub fn disable_secure_boot() {
-    SECURE_BOOT_ENABLED.store(false, Ordering::Release);
-    log::info!("Secure Boot: Disabled");
     persist_secure_boot_enable_preference(false);
+    if !is_secure_boot_enabled() {
+        log::info!("Secure Boot: Disabled");
+    }
 }
 
 /// Persist the SecureBootEnable preference to non-volatile storage

--- a/crabefi-core/src/secure_boot_menu.rs
+++ b/crabefi-core/src/secure_boot_menu.rs
@@ -275,23 +275,9 @@ pub fn show_secure_boot_menu() {
     }
 }
 
-/// Enroll default keys
+/// Enroll default keys through the authoritative runtime variable store.
 fn enroll_default_keys() -> Result<(), &'static str> {
-    use crate::efi::auth::enrollment;
-
-    // Enroll in memory
-    enrollment::enroll_default_keys().map_err(|_| "Failed to enroll keys")?;
-
-    // Enter user mode
-    auth::enter_user_mode();
-
-    // Persist to storage
-    secure_boot::persist_key_databases().map_err(|_| "Failed to persist keys")?;
-
-    // Update status variables
-    secure_boot::update_status_variables().map_err(|_| "Failed to update status")?;
-
-    Ok(())
+    secure_boot::enroll_and_persist_default_keys().map_err(|_| "Failed to enroll keys")
 }
 
 /// Enroll custom PK from ESP

--- a/crabefi-core/src/ui/secure_boot.rs
+++ b/crabefi-core/src/ui/secure_boot.rs
@@ -125,10 +125,16 @@ fn handle_action(idx: usize) -> Option<(&'static str, bool)> {
                 }
             }
         }
-        1 => match auth::enrollment::enroll_default_keys() {
-            Ok(_) => Some(("Default keys enrolled", true)),
-            Err(_) => Some(("Failed to enroll keys", false)),
-        },
+        1 => {
+            if !auth::is_setup_mode() {
+                Some(("Keys already enrolled", false))
+            } else {
+                match auth::boot::enroll_and_persist_default_keys() {
+                    Ok(_) => Some(("Default keys enrolled", true)),
+                    Err(_) => Some(("Failed to enroll keys", false)),
+                }
+            }
+        }
         4 => match auth::boot::clear_all_keys() {
             Ok(_) => Some(("All keys cleared", true)),
             Err(_) => Some(("Failed to clear keys", false)),


### PR DESCRIPTION
## Summary
Bumps the `rflasher` dependency to revision `a06d37b` and adapts the SPI PCI access layer to the new `PciAddress`-based API. Also refactors Secure Boot key enrollment/clearing so the runtime variable store becomes the single source of truth, removing duplicated in-memory state and improving failure recovery.

## Key changes
- **Dependency update**: `rflasher-core`/`rflasher-internal` now use rev `a06d37b`; the lockfile adds `rflasher-chip-types` and `rflasher-pci`, and drops unused `serde`/`once_cell` dependencies.
- **SPI PCI access**: `CrabEfiPciAccess` now uses `RflasherPciAddress` instead of `Bdf`, includes the associated `Error` type, and derives `PciDevice.address` directly from the new upstream API.
- **Secure Boot state**: Removes `SETUP_MODE`/`SECURE_BOOT_ENABLED` atomics; mode and enabled state are now derived from the variable store. `enter_user_mode`/`enter_setup_mode` are now logging-only.
- **Key enrollment**: `enroll_and_persist_default_keys` is now public, validates Setup Mode, clears stale key caches before enrollment, and force-refreshes caches on both success and failure.
- **Key clearing**: `clear_all_keys` now supports clearing from User Mode by first removing PK through the privileged persistence path, then deleting the remaining databases and updating status variables.
- **UI cleanup**: Secure Boot menu and UI actions now share the same enrollment path instead of duplicating enrollment/persistence logic.

## Implementation details
- `refresh_key_databases` gained a `force` variant so boot-only caches can be discarded after authoritative variable-store changes.
- `enable_secure_boot`/`disable_secure_boot` persist the user preference and verify the resulting store state before logging, preventing divergence between in-memory flags and the actual variable store.