### PR TITLE
Eliminate global allocation from runtime RSA verification

### DIFF
--- a/crabefi-core/src/efi/tcg/types.rs
+++ b/crabefi-core/src/efi/tcg/types.rs
@@ -322,8 +322,13 @@ impl SpecIdEvent {
     /// The caller must wrap this in a `TcgPcrEventHdr` with PCR=0,
     /// event_type=EV_NO_ACTION, digest=all-zeros.
     ///
-    /// Returns the number of bytes written, or `None` if the buffer is too small.
+    /// Returns the number of bytes written, or `None` if the algorithm count is
+    /// invalid or the buffer is too small.
     pub fn serialize(&self, buf: &mut [u8]) -> Option<usize> {
+        if self.num_algorithms as usize > self.digest_sizes.len() {
+            return None;
+        }
+
         // Minimum: signature(16) + platformClass(4) + specVersionMinor(1)
         //        + specVersionMajor(1) + specErrata(1) + uintnSize(1)
         //        + numberOfAlgorithms(4) + algorithms(4*n) + vendorInfoSize(1)

--- a/crabefi-runtime-image/Cargo.lock
+++ b/crabefi-runtime-image/Cargo.lock
@@ -3,24 +3,30 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
+name = "base16ct"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -30,16 +36,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
+name = "cmov"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -59,8 +77,10 @@ version = "0.1.0"
 name = "crabefi-runtime-image"
 version = "0.1.0"
 dependencies = [
+ "allocator-api2",
  "crabefi-efi-types",
  "crabefi-runtime-abi",
+ "crypto-bigint",
  "r-efi",
  "rsa",
  "sha2",
@@ -68,30 +88,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+name = "crypto-bigint"
+version = "0.7.5"
+source = "git+https://github.com/ArthurHeymans/crypto-bigint?rev=8da705a86237f2c9804ddb30140715bd360983c3#8da705a86237f2c9804ddb30140715bd360983c3"
 dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
+ "allocator-api2",
+ "cpubits",
+ "ctutils",
+ "num-traits",
+ "rand_core",
+ "serdect",
  "zeroize",
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
+name = "crypto-common"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
+dependencies = [
+ "crypto-bigint",
+ "rand_core",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -99,22 +141,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
+name = "hybrid-array"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
- "version_check",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
 ]
 
 [[package]]
@@ -124,84 +156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
-]
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -229,56 +189,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rsa"
-version = "0.9.10"
+version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
  "const-oid",
+ "crypto-bigint",
+ "crypto-primes",
  "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
  "rand_core",
  "signature",
- "spki",
- "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
+name = "serde"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -287,47 +261,30 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
  "digest",
  "rand_core",
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
-name = "spin"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -347,12 +304,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "zerocopy"
 version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,7 +320,7 @@ checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/crabefi-runtime-image/Cargo.toml
+++ b/crabefi-runtime-image/Cargo.toml
@@ -8,12 +8,30 @@ build = "build.rs"
 [workspace]
 
 [dependencies]
+allocator-api2 = { version = "=0.3.1", default-features = false }
 crabefi-efi-types = { path = "../crabefi-efi-types" }
 crabefi-runtime-abi = { path = "../crabefi-runtime-abi" }
+crypto-bigint = { version = "=0.7.5", default-features = false, features = ["allocator-api2"] }
 r-efi = "5.3"
-rsa = { version = "0.9", default-features = false }
-sha2 = { version = "0.10", default-features = false, features = ["force-soft", "oid"] }
+# This crate is a standalone workspace and intentionally uses sha2 0.11 so its
+# rsa 0.10 host tests share the same digest traits; other firmware crates remain
+# independently on sha2 0.10. Exact-pin so a new 0.11.x release cannot silently
+# change the verifier's digest implementation.
+sha2 = { version = "=0.11.0", default-features = false, features = ["oid"] }
 zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
+
+[dev-dependencies]
+# Host-test-only signing dependency. Keep the exact prerelease pinned so test
+# certificate generation does not drift independently of the verifier.
+rsa = { version = "=0.10.0-rc.18", default-features = false }
+
+[patch.crates-io]
+# Temporary audited fork of 0.7.5 adding allocator-api2-backed BoxedUintIn and
+# bounded-stack variable-time modular exponentiation without a global allocator.
+# Fork audit reference: https://github.com/ArthurHeymans/crypto-bigint/commit/8da705a86237f2c9804ddb30140715bd360983c3
+# Upstream status: no PR/issue yet. Remove this patch once those APIs are in a
+# published upstream release.
+crypto-bigint = { git = "https://github.com/ArthurHeymans/crypto-bigint", rev = "8da705a86237f2c9804ddb30140715bd360983c3" }
 
 [[bin]]
 name = "crabefi-runtime-image"

--- a/crabefi-runtime-image/src/auth/crypto.rs
+++ b/crabefi-runtime-image/src/auth/crypto.rs
@@ -1,7 +1,10 @@
 //! Borrowed CMS/X.509 parsing and bounded RSA verification.
 
+use allocator_api2::alloc::Allocator;
+use core::cmp::Ordering;
+
 use crabefi_efi_types::constant_time_eq;
-use rsa::traits::PublicKeyParts;
+use crypto_bigint::{BoxedUintIn, PowModInError};
 use sha2::{Digest, Sha256};
 
 use super::AuthError;
@@ -12,6 +15,14 @@ const MAX_SIGNERS: usize = 8;
 const MAX_CERTIFICATE_SIZE: usize = 16 * 1024;
 const MAX_CHAIN_DEPTH: usize = 5;
 const MAX_RSA_BITS: usize = 4096;
+const MAX_RSA_BYTES: usize = MAX_RSA_BITS / 8;
+// Match the 32-bit publicExponent accepted by Windows certificate tooling and
+// cap attacker-controlled exponentiation work during runtime verification.
+const MAX_RSA_EXPONENT: u64 = u32::MAX as u64;
+const SHA256_DIGEST_INFO_PREFIX: &[u8] = &[
+    0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05,
+    0x00, 0x04, 0x20,
+];
 
 const OID_SIGNED_DATA: &[u8] = &[0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x07, 0x02];
 const OID_DATA: &[u8] = &[0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x07, 0x01];
@@ -103,25 +114,26 @@ struct SignerView<'a> {
     signature: &'a [u8],
 }
 
+#[cfg(test)]
+// The integration-test include uses this wrapper, while the binary's unit-test
+// configuration compiles it without a local caller.
+#[allow(dead_code)]
 pub fn verify_pkcs7_signature(
     pkcs7_data: &[u8],
     signed_content: &[u8],
     trusted_cert: &[u8],
 ) -> Result<bool, AuthError> {
-    let checkpoint = scratch::checkpoint();
-    let result = verify_pkcs7_signature_inner(pkcs7_data, signed_content, trusted_cert);
-    scratch::rewind(checkpoint);
-    result
+    let content_hash: [u8; 32] = Sha256::digest(signed_content).into();
+    verify_pkcs7_signature_hash(pkcs7_data, &content_hash, trusted_cert)
 }
 
-fn verify_pkcs7_signature_inner(
+pub fn verify_pkcs7_signature_hash(
     pkcs7_data: &[u8],
-    signed_content: &[u8],
+    content_hash: &[u8; 32],
     trusted_cert: &[u8],
 ) -> Result<bool, AuthError> {
     if pkcs7_data.len() > super::MAX_AUTHENTICATED_ENVELOPE_SIZE
         || trusted_cert.len() > MAX_CERTIFICATE_SIZE
-        || !scratch::preflight(256 * 1024)
     {
         return Err(AuthError::OutOfResources);
     }
@@ -137,7 +149,7 @@ fn verify_pkcs7_signature_inner(
     let _version = expect(signed.next()?, 0x02)?;
     validate_digest_set(expect(signed.next()?, 0x31)?)?;
     let encapsulated = expect(signed.next()?, 0x30)?;
-    let content_hash = encapsulated_content_hash(encapsulated, signed_content)?;
+    validate_detached_content(encapsulated)?;
 
     let mut certificates = [None; MAX_CERTIFICATES];
     let mut certificate_count = 0usize;
@@ -176,9 +188,8 @@ fn verify_pkcs7_signature_inner(
         else {
             continue;
         };
-        let content_digest = signed_attributes_digest(signer.signed_attributes, &content_hash)?;
-        let key = rsa_key(&signer_certificate)?;
-        if verify_rsa_signature(&key, signer.signature, &content_digest)?
+        let content_digest = signed_attributes_digest(signer.signed_attributes, content_hash)?;
+        if verify_rsa_signature(signer_certificate, signer.signature, &content_digest)?
             && certificate_authorized(
                 signer_certificate,
                 trusted,
@@ -260,10 +271,7 @@ fn validate_sha256_algorithm(algorithm: Tlv<'_>) -> Result<(), AuthError> {
     fields.finish()
 }
 
-fn encapsulated_content_hash(
-    encapsulated: Tlv<'_>,
-    detached: &[u8],
-) -> Result<[u8; 32], AuthError> {
+fn validate_detached_content(encapsulated: Tlv<'_>) -> Result<(), AuthError> {
     let mut fields = Reader::new(encapsulated.value);
     if expect(fields.next()?, 0x06)?.value != OID_DATA {
         return Err(AuthError::InvalidHeader);
@@ -274,8 +282,7 @@ fn encapsulated_content_hash(
     if fields.optional(0xa0)?.is_some() {
         return Err(AuthError::InvalidHeader);
     }
-    fields.finish()?;
-    Ok(Sha256::digest(detached).into())
+    fields.finish()
 }
 
 fn parse_signer(sequence: Tlv<'_>) -> Result<SignerView<'_>, AuthError> {
@@ -565,29 +572,132 @@ fn verify_certificate(
     issuer: CertificateView<'_>,
 ) -> Result<bool, AuthError> {
     let digest: [u8; 32] = Sha256::digest(certificate.tbs).into();
-    verify_rsa_signature(&rsa_key(&issuer)?, certificate.signature, &digest)
-}
-
-fn rsa_key(certificate: &CertificateView<'_>) -> Result<rsa::RsaPublicKey, AuthError> {
-    let modulus = rsa::BigUint::from_bytes_be(certificate.modulus);
-    let exponent = rsa::BigUint::from_bytes_be(certificate.exponent);
-    let key =
-        rsa::RsaPublicKey::new(modulus, exponent).map_err(|_| AuthError::CertificateParseError)?;
-    if key.n().bits() > MAX_RSA_BITS {
-        return Err(AuthError::OutOfResources);
-    }
-    Ok(key)
+    verify_rsa_signature(issuer, certificate.signature, &digest)
 }
 
 fn verify_rsa_signature(
-    key: &rsa::RsaPublicKey,
+    certificate: CertificateView<'_>,
     signature: &[u8],
     digest: &[u8; 32],
 ) -> Result<bool, AuthError> {
-    use rsa::signature::hazmat::PrehashVerifier;
+    if !scratch::preflight(super::AUTH_OPERATION_SCRATCH_BOUND) {
+        return Err(AuthError::OutOfResources);
+    }
+    let verification = scratch::with_scope(|allocator| {
+        verify_rsa_signature_with_allocator(certificate, signature, digest, allocator)
+    });
+    debug_assert!(
+        verification.is_some(),
+        "RSA verification attempted to nest scratch scopes"
+    );
+    verification.unwrap_or(Err(AuthError::OutOfResources))
+}
 
+fn verify_rsa_signature_with_allocator<A: Allocator + Copy>(
+    certificate: CertificateView<'_>,
+    signature: &[u8],
+    digest: &[u8; 32],
+    allocator: A,
+) -> Result<bool, AuthError> {
+    if certificate.modulus.is_empty()
+        || certificate.modulus.len() > MAX_RSA_BYTES
+        || certificate.exponent.is_empty()
+        || certificate.exponent.len() > core::mem::size_of::<u64>()
+    {
+        return Ok(false);
+    }
+    // DER INTEGER minimal encoding may strip the leading zero byte, so a
+    // valid signature can be one byte shorter than the modulus. Left-pad it
+    // back to modulus width; the value-below-modulus check below still holds.
+    if signature.len() + 1 < certificate.modulus.len()
+        || signature.len() > certificate.modulus.len()
+    {
+        return Ok(false);
+    }
+    let mut padded_signature = [0u8; MAX_RSA_BYTES];
+    let offset = certificate.modulus.len() - signature.len();
+    padded_signature[offset..offset + signature.len()].copy_from_slice(signature);
+    let signature = &padded_signature[..certificate.modulus.len()];
+
+    let exponent_value = certificate
+        .exponent
+        .iter()
+        .fold(0u64, |value, byte| (value << 8) | u64::from(*byte));
+    if !(2..=MAX_RSA_EXPONENT).contains(&exponent_value) || exponent_value & 1 == 0 {
+        return Ok(false);
+    }
+
+    let modulus = BoxedUintIn::try_from_be_slice_vartime(certificate.modulus, allocator)
+        .map_err(map_bigint_error)?;
+    let exponent = BoxedUintIn::try_from_be_slice_vartime(certificate.exponent, allocator)
+        .map_err(map_bigint_error)?;
     let signature =
-        rsa::pkcs1v15::Signature::try_from(signature).map_err(|_| AuthError::CryptoError)?;
-    let verifier = rsa::pkcs1v15::VerifyingKey::<Sha256>::new(key.clone());
-    Ok(verifier.verify_prehash(digest, &signature).is_ok())
+        BoxedUintIn::try_from_be_slice_vartime(signature, allocator).map_err(map_bigint_error)?;
+    if modulus.bits_vartime() > MAX_RSA_BITS as u32
+        || !bool::from(modulus.is_odd())
+        || exponent.cmp_vartime(&modulus) != Ordering::Less
+        || signature.cmp_vartime(&modulus) != Ordering::Less
+    {
+        return Ok(false);
+    }
+
+    let encoded = signature
+        .pow_mod_vartime(&exponent, &modulus)
+        .map_err(map_bigint_error)?;
+    let mut encoded_bytes = [0u8; MAX_RSA_BYTES];
+    let encoded_bytes = &mut encoded_bytes[..certificate.modulus.len()];
+    encoded
+        .write_be_bytes(encoded_bytes)
+        .map_err(|_| AuthError::CryptoError)?;
+    Ok(verify_pkcs1v15_sha256_encoding(encoded_bytes, digest))
+}
+
+fn map_bigint_error(error: PowModInError) -> AuthError {
+    match error {
+        PowModInError::Alloc => AuthError::OutOfResources,
+        PowModInError::InvalidInput => AuthError::CertificateParseError,
+    }
+}
+
+fn verify_pkcs1v15_sha256_encoding(encoded: &[u8], digest: &[u8; 32]) -> bool {
+    let payload_len = SHA256_DIGEST_INFO_PREFIX.len() + digest.len();
+    let Some(separator) = encoded.len().checked_sub(payload_len + 1) else {
+        return false;
+    };
+    separator >= 10
+        && encoded.starts_with(&[0x00, 0x01])
+        && encoded[2..separator].iter().all(|byte| *byte == 0xff)
+        && encoded[separator] == 0
+        && encoded[separator + 1..separator + 1 + SHA256_DIGEST_INFO_PREFIX.len()]
+            == *SHA256_DIGEST_INFO_PREFIX
+        && encoded[separator + 1 + SHA256_DIGEST_INFO_PREFIX.len()..] == *digest
+}
+
+#[cfg(test)]
+// The integration-test include compiles this helper unused; auth unit tests
+// call it to measure the production RSA allocation path.
+#[allow(dead_code)]
+pub(super) fn verify_rsa_parts_for_test(
+    modulus: &[u8],
+    exponent: &[u8],
+    signature: &[u8],
+    digest: &[u8; 32],
+) -> Result<bool, AuthError> {
+    verify_rsa_signature(
+        CertificateView {
+            raw: &[],
+            tbs: &[],
+            serial: &[],
+            issuer: &[],
+            subject: &[],
+            subject_key_identifier: None,
+            basic_constraints_ca: None,
+            key_usage: None,
+            modulus,
+            exponent,
+            signature: &[],
+        },
+        signature,
+        digest,
+    )
 }

--- a/crabefi-runtime-image/src/auth/limits.rs
+++ b/crabefi-runtime-image/src/auth/limits.rs
@@ -1,0 +1,10 @@
+//! Resource limits for authenticated-variable parsing and RSA verification.
+
+/// Maximum accepted PKCS#7 authenticated-variable envelope size.
+pub const MAX_AUTHENTICATED_ENVELOPE_SIZE: usize = 48 * 1024;
+
+/// Scratch required by one RSA exponentiation.
+///
+/// Each RSA verification runs in its own rewind scope, so this is also the
+/// maximum authentication scratch reservation needed by a service operation.
+pub const AUTH_OPERATION_SCRATCH_BOUND: usize = 16 * 1024;

--- a/crabefi-runtime-image/src/auth/mod.rs
+++ b/crabefi-runtime-image/src/auth/mod.rs
@@ -1,8 +1,10 @@
 //! Image-local UEFI time-based authenticated-variable enforcement.
 
 mod crypto;
+mod limits;
 mod signature;
 
+pub use limits::{AUTH_OPERATION_SCRATCH_BOUND, MAX_AUTHENTICATED_ENVELOPE_SIZE};
 pub use signature::verify_authenticated_variable;
 
 use crabefi_efi_types::authentication::EfiTime;
@@ -42,9 +44,6 @@ pub fn timestamp_from_efi_time(value: EfiTime) -> VariableTimestamp {
     }
 }
 
-pub const MAX_AUTHENTICATED_ENVELOPE_SIZE: usize = 48 * 1024;
-/// Complete RSA/CMS service-operation reservation, including signed-data assembly.
-pub const AUTH_OPERATION_SCRATCH_BOUND: usize = 440 * 1024;
 pub const WIN_CERT_REVISION: u16 = 0x0200;
 pub const WIN_CERT_TYPE_EFI_GUID: u16 = 0x0ef1;
 
@@ -88,9 +87,38 @@ mod tests {
         let _guard = crate::scratch::test_lock();
         crate::scratch::activate();
         crate::scratch::set_limit_for_test(0);
-        let error = crypto::verify_pkcs7_signature(&[0x30, 0], &[], &[0x30, 0]).unwrap_err();
+        let error = crypto::verify_rsa_parts_for_test(&[3], &[3], &[1], &[0; 32]).unwrap_err();
         assert_eq!(efi::Status::from(error), efi::Status::OUT_OF_RESOURCES);
         crate::scratch::reset();
         crate::scratch::set_limit_for_test(crate::scratch::SCRATCH_SIZE);
+    }
+
+    #[test]
+    fn maximum_width_rsa_stays_within_operation_scratch_bound() {
+        let _guard = crate::scratch::test_lock();
+        crate::scratch::activate();
+        crate::scratch::set_limit_for_test(AUTH_OPERATION_SCRATCH_BOUND);
+
+        const MAX_RSA_BYTES: usize = 4096 / 8;
+        let modulus = [0xff; MAX_RSA_BYTES];
+        let signature = [0xa5; MAX_RSA_BYTES];
+        // Three operations would exceed the bound without per-operation
+        // rewinding (a single 4096-bit op uses roughly half the bound), so a
+        // missing rewind is caught by the high-water assertion below.
+        for _ in 0..3 {
+            let verified = crypto::verify_rsa_parts_for_test(
+                &modulus,
+                &[0x01, 0x00, 0x01],
+                &signature,
+                &[0u8; 32],
+            )
+            .unwrap();
+            assert!(!verified);
+        }
+        let high_water = crate::scratch::high_water_for_test();
+        crate::scratch::reset();
+        crate::scratch::set_limit_for_test(crate::scratch::SCRATCH_SIZE);
+
+        assert!(high_water <= AUTH_OPERATION_SCRATCH_BOUND);
     }
 }

--- a/crabefi-runtime-image/src/auth/signature.rs
+++ b/crabefi-runtime-image/src/auth/signature.rs
@@ -1,7 +1,5 @@
 //! Authentication-envelope parsing and Secure Boot authorization selection.
 
-use alloc::vec::Vec;
-
 use crabefi_efi_types::{
     authentication::{
         EfiTime, EfiVariableAuthentication2, SignatureIterator, SignatureListIterator,
@@ -11,6 +9,7 @@ use crabefi_efi_types::{
         EFI_CERT_TYPE_PKCS7_GUID, EFI_CERT_X509_GUID, SecureBootVariable, identify_key_database,
     },
 };
+use sha2::{Digest, Sha256};
 use zerocopy::IntoBytes;
 
 use super::{
@@ -69,20 +68,20 @@ pub fn verify_authenticated_variable<'a>(
         if signature.is_empty() {
             return Err(AuthError::InvalidHeader);
         }
-        let signed = build_signed_data(
+        let signed_hash = signed_data_hash(
             variable_name,
             vendor_guid,
             attributes,
             &authentication.time_stamp,
             payload,
-        )?;
+        );
         let authorized = if let Some(variable) = secure_variable {
             let database = variable.authorizing_database();
-            verify_database(store, database, signature, &signed)?
+            verify_database(store, database, signature, &signed_hash)?
                 || (database == SecureBootVariable::Kek
-                    && verify_database(store, SecureBootVariable::PK, signature, &signed)?)
+                    && verify_database(store, SecureBootVariable::PK, signature, &signed_hash)?)
         } else {
-            verify_database(store, SecureBootVariable::Db, signature, &signed)?
+            verify_database(store, SecureBootVariable::Db, signature, &signed_hash)?
         };
         if !authorized {
             return Err(AuthError::SignatureVerificationFailed);
@@ -100,7 +99,7 @@ fn verify_database(
     store: &VariableStore,
     database: SecureBootVariable,
     signature: &[u8],
-    signed_data: &[u8],
+    signed_hash: &[u8; 32],
 ) -> Result<bool, AuthError> {
     let Some(data) = store.key_database_data(database) else {
         return Ok(false);
@@ -116,7 +115,7 @@ fn verify_database(
             if count > MAX_DATABASE_CERTIFICATES {
                 return Err(AuthError::OutOfResources);
             }
-            match super::crypto::verify_pkcs7_signature(signature, signed_data, certificate) {
+            match super::crypto::verify_pkcs7_signature_hash(signature, signed_hash, certificate) {
                 Ok(true) => return Ok(true),
                 Ok(false) => {}
                 Err(AuthError::InvalidHeader | AuthError::CertificateParseError) => {}
@@ -127,31 +126,22 @@ fn verify_database(
     Ok(false)
 }
 
-fn build_signed_data(
+fn signed_data_hash(
     name: &[u16],
     guid: &[u8; 16],
     attributes: u32,
     timestamp: &EfiTime,
     data: &[u8],
-) -> Result<Vec<u8>, AuthError> {
-    let capacity = name
-        .len()
-        .checked_mul(2)
-        .and_then(|size| size.checked_add(16 + 4 + 16))
-        .and_then(|size| size.checked_add(data.len()))
-        .ok_or(AuthError::OutOfResources)?;
-    let mut result = Vec::new();
-    result
-        .try_reserve_exact(capacity)
-        .map_err(|_| AuthError::OutOfResources)?;
+) -> [u8; 32] {
+    let mut hash = Sha256::new();
     for unit in name.iter().take_while(|unit| **unit != 0) {
-        result.extend_from_slice(&unit.to_le_bytes());
+        hash.update(unit.to_le_bytes());
     }
-    result.extend_from_slice(guid);
-    result.extend_from_slice(&attributes.to_le_bytes());
-    result.extend_from_slice(timestamp.as_bytes());
-    result.extend_from_slice(data);
-    Ok(result)
+    hash.update(guid);
+    hash.update(attributes.to_le_bytes());
+    hash.update(timestamp.as_bytes());
+    hash.update(data);
+    hash.finalize().into()
 }
 
 const _: () = assert!(core::mem::size_of::<efi::Time>() == core::mem::size_of::<EfiTime>());
@@ -326,7 +316,9 @@ mod tests {
             crate::auth::timestamp_from_efi_time(deletion.timestamp),
         );
         assert!(store.key_database_data(SecureBootVariable::Db).is_none());
-        assert!(crate::scratch::high_water_for_test() < crate::scratch::SCRATCH_SIZE);
+        assert!(
+            crate::scratch::high_water_for_test() <= super::super::AUTH_OPERATION_SCRATCH_BOUND
+        );
         crate::scratch::reset();
     }
 
@@ -354,7 +346,9 @@ mod tests {
                 .unwrap_err(),
             AuthError::SignatureVerificationFailed
         );
-        assert!(crate::scratch::high_water_for_test() < 384 * 1024);
+        assert!(
+            crate::scratch::high_water_for_test() <= super::super::AUTH_OPERATION_SCRATCH_BOUND
+        );
         crate::scratch::reset();
     }
 

--- a/crabefi-runtime-image/src/main.rs
+++ b/crabefi-runtime-image/src/main.rs
@@ -2,13 +2,10 @@
 
 #![cfg_attr(all(not(test), target_os = "none"), no_std)]
 #![cfg_attr(all(not(test), target_os = "none"), no_main)]
-#![cfg_attr(all(not(test), target_os = "none"), feature(alloc_error_handler))]
 #![deny(unsafe_op_in_unsafe_fn)]
 // Exported C ABI entry points validate every pointer and copy all retained
 // fields immediately; keeping them safe matches firmware caller conventions.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
-
-extern crate alloc;
 
 mod arch;
 mod auth;
@@ -32,14 +29,6 @@ use crabefi_runtime_abi::{
 #[cfg(all(not(test), target_os = "none"))]
 #[panic_handler]
 fn panic(_info: &PanicInfo<'_>) -> ! {
-    loop {
-        core::hint::spin_loop();
-    }
-}
-
-#[cfg(all(not(test), target_os = "none"))]
-#[alloc_error_handler]
-fn allocation_error(_layout: core::alloc::Layout) -> ! {
     loop {
         core::hint::spin_loop();
     }

--- a/crabefi-runtime-image/src/scratch.rs
+++ b/crabefi-runtime-image/src/scratch.rs
@@ -1,11 +1,11 @@
 //! Bounded image-local scratch allocation for authenticated runtime operations.
 
-use core::alloc::{GlobalAlloc, Layout};
+use allocator_api2::alloc::{AllocError, Allocator};
+use core::alloc::Layout;
 use core::cell::UnsafeCell;
-use core::ptr;
-#[cfg(not(test))]
-use core::sync::atomic::AtomicBool;
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::marker::PhantomData;
+use core::ptr::{self, NonNull};
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 pub const SCRATCH_SIZE: usize = 512 * 1024;
 
@@ -24,11 +24,33 @@ static ACTIVE: AtomicBool = AtomicBool::new(false);
 static OFFSET: AtomicUsize = AtomicUsize::new(0);
 static HIGH_WATER: AtomicUsize = AtomicUsize::new(0);
 static LIMIT: AtomicUsize = AtomicUsize::new(SCRATCH_SIZE);
+static SCOPE_ACTIVE: AtomicBool = AtomicBool::new(false);
 
-pub struct ScratchAllocator;
+/// Lifetime brand for explicit allocations made within a scratch scope.
+#[derive(Clone, Copy)]
+pub struct ScratchAlloc<'scope> {
+    _scope: PhantomData<&'scope Scope>,
+}
 
-#[global_allocator]
-static ALLOCATOR: ScratchAllocator = ScratchAllocator;
+/// Rewinds all scoped allocations when dropped.
+struct Scope {
+    checkpoint: usize,
+}
+
+impl Scope {
+    fn allocator(&self) -> ScratchAlloc<'_> {
+        ScratchAlloc {
+            _scope: PhantomData,
+        }
+    }
+}
+
+impl Drop for Scope {
+    fn drop(&mut self) {
+        rewind(self.checkpoint);
+        SCOPE_ACTIVE.store(false, Ordering::Release);
+    }
+}
 
 #[cfg(test)]
 std::thread_local! {
@@ -42,66 +64,66 @@ fn active() -> bool {
     return TEST_ACTIVE.with(core::cell::Cell::get);
 }
 
-// SAFETY: allocations are handed out monotonically from the aligned BSS arena
-// only while the sole runtime operation lease is active. Deallocation is a
-// no-op; the complete arena is cleared when that lease is released.
-unsafe impl GlobalAlloc for ScratchAllocator {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        #[cfg(test)]
-        if !active() {
-            // SAFETY: inactive host-test allocations belong to the system
-            // allocator and are returned to it by the matching deallocator.
-            return unsafe { std::alloc::System.alloc(layout) };
-        }
-        if !active() || layout.size() == 0 || layout.align() > core::mem::align_of::<ScratchBytes>()
-        {
+fn allocate(layout: Layout) -> *mut u8 {
+    if !active() || layout.size() == 0 || layout.align() > core::mem::align_of::<ScratchBytes>() {
+        return ptr::null_mut();
+    }
+    let align = layout.align();
+    let limit = LIMIT.load(Ordering::Relaxed).min(SCRATCH_SIZE);
+    let mut current = OFFSET.load(Ordering::Relaxed);
+    loop {
+        let Some(aligned) = current
+            .checked_add(align - 1)
+            .map(|value| value & !(align - 1))
+        else {
+            return ptr::null_mut();
+        };
+        let Some(end) = aligned.checked_add(layout.size()) else {
+            return ptr::null_mut();
+        };
+        if end > limit {
             return ptr::null_mut();
         }
-        let align = layout.align();
-        let limit = LIMIT.load(Ordering::Relaxed).min(SCRATCH_SIZE);
-        let mut current = OFFSET.load(Ordering::Relaxed);
-        loop {
-            let Some(aligned) = current
-                .checked_add(align - 1)
-                .map(|value| value & !(align - 1))
-            else {
-                return ptr::null_mut();
-            };
-            let Some(end) = aligned.checked_add(layout.size()) else {
-                return ptr::null_mut();
-            };
-            if end > limit {
-                return ptr::null_mut();
+        match OFFSET.compare_exchange_weak(current, end, Ordering::AcqRel, Ordering::Relaxed) {
+            Ok(_) => {
+                HIGH_WATER.fetch_max(end, Ordering::Relaxed);
+                // SAFETY: `aligned..end` was reserved atomically inside the
+                // arena and its base alignment is at least one page.
+                return unsafe { (*SCRATCH.0.get()).0.as_mut_ptr().add(aligned) };
             }
-            match OFFSET.compare_exchange_weak(current, end, Ordering::AcqRel, Ordering::Relaxed) {
-                Ok(_) => {
-                    HIGH_WATER.fetch_max(end, Ordering::Relaxed);
-                    // SAFETY: `aligned..end` was reserved atomically inside the
-                    // arena and its base alignment is at least one page.
-                    return unsafe { (*SCRATCH.0.get()).0.as_mut_ptr().add(aligned) };
-                }
-                Err(observed) => current = observed,
-            }
+            Err(observed) => current = observed,
         }
     }
+}
 
-    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
-        #[cfg(test)]
-        {
-            let base = unsafe { (*SCRATCH.0.get()).0.as_ptr() as usize };
-            if !(base..base + SCRATCH_SIZE).contains(&(pointer as usize)) {
-                // SAFETY: pointers outside the scratch arena were allocated by
-                // the host system fallback above.
-                unsafe { std::alloc::System.dealloc(pointer, layout) };
-            }
+// SAFETY: the lifetime brand prevents containers using this allocator from
+// outliving their scope. Clones share the same monotonic arena and remain valid
+// until the scope is dropped after all branded containers.
+unsafe impl Allocator for ScratchAlloc<'_> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        if layout.size() == 0 {
+            let pointer = NonNull::new(layout.align() as *mut u8).ok_or(AllocError)?;
+            return Ok(NonNull::slice_from_raw_parts(pointer, 0));
         }
-        #[cfg(not(test))]
+        let pointer = NonNull::new(allocate(layout)).ok_or(AllocError)?;
+        Ok(NonNull::slice_from_raw_parts(pointer, layout.size()))
+    }
+
+    unsafe fn deallocate(&self, pointer: NonNull<u8>, layout: Layout) {
         let _ = (pointer, layout);
     }
 }
 
 /// Activate allocation after the runtime operation lock has been acquired.
 pub fn activate() {
+    let scope_active = SCOPE_ACTIVE.load(Ordering::Acquire);
+    debug_assert!(
+        !scope_active,
+        "cannot activate scratch during an active scope"
+    );
+    if scope_active {
+        return;
+    }
     OFFSET.store(0, Ordering::Relaxed);
     HIGH_WATER.store(0, Ordering::Relaxed);
     #[cfg(not(test))]
@@ -121,13 +143,28 @@ pub fn preflight(required: usize) -> bool {
         .is_some_and(|end| end <= LIMIT.load(Ordering::Relaxed).min(SCRATCH_SIZE))
 }
 
-/// Snapshot the cursor for one nested cryptographic verification.
-pub fn checkpoint() -> usize {
+/// Run `body` in an allocation scope which rewinds on return.
+///
+/// Returns `None` rather than nesting scopes. An outer allocator could otherwise
+/// allocate after the inner checkpoint and retain aliased storage after rewind.
+pub fn with_scope<R>(body: impl for<'scope> FnOnce(ScratchAlloc<'scope>) -> R) -> Option<R> {
+    if SCOPE_ACTIVE
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return None;
+    }
+    let scope = Scope {
+        checkpoint: checkpoint(),
+    };
+    Some(body(scope.allocator()))
+}
+
+fn checkpoint() -> usize {
     OFFSET.load(Ordering::Relaxed)
 }
 
-/// Release and scrub allocations made after a checkpoint.
-pub fn rewind(checkpoint: usize) {
+fn rewind(checkpoint: usize) {
     let current = OFFSET.load(Ordering::Relaxed);
     if !active() || checkpoint > current {
         return;
@@ -146,6 +183,11 @@ pub fn rewind(checkpoint: usize) {
 
 /// Zero and deactivate the complete arena at operation end.
 pub fn reset() {
+    let scope_active = SCOPE_ACTIVE.load(Ordering::Acquire);
+    debug_assert!(!scope_active, "cannot reset scratch during an active scope");
+    if scope_active {
+        return;
+    }
     #[cfg(not(test))]
     ACTIVE.store(false, Ordering::Release);
     #[cfg(test)]
@@ -175,6 +217,20 @@ pub fn high_water_for_test() -> usize {
 }
 
 #[cfg(test)]
+pub fn checkpoint_for_test() -> usize {
+    checkpoint()
+}
+
+/// Rewind test-only scratch allocations after all users have been dropped.
+///
+/// # Safety
+/// No allocation at or above `checkpoint` may still be live.
+#[cfg(test)]
+pub unsafe fn rewind_for_test(checkpoint: usize) {
+    rewind(checkpoint);
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -183,11 +239,62 @@ mod tests {
         let _guard = test_lock();
         activate();
         set_limit_for_test(64);
-        let first = unsafe { ALLOCATOR.alloc(Layout::from_size_align(32, 16).unwrap()) };
-        assert!(!first.is_null());
-        let exhausted = unsafe { ALLOCATOR.alloc(Layout::from_size_align(40, 8).unwrap()) };
-        assert!(exhausted.is_null());
-        assert_eq!(high_water_for_test(), 32);
+        with_scope(|allocator| {
+            let first = allocator
+                .allocate(Layout::from_size_align(32, 16).unwrap())
+                .unwrap();
+            assert_eq!(first.cast::<u8>().as_ptr() as usize % 16, 0);
+            assert!(
+                allocator
+                    .allocate(Layout::from_size_align(40, 8).unwrap())
+                    .is_err()
+            );
+            assert_eq!(high_water_for_test(), 32);
+        })
+        .unwrap();
+        reset();
+        set_limit_for_test(SCRATCH_SIZE);
+    }
+
+    #[test]
+    fn explicit_allocator_is_bounded_by_scope() {
+        let _guard = test_lock();
+        activate();
+        with_scope(|allocator| {
+            let value =
+                crypto_bigint::BoxedUintIn::try_from_be_slice_vartime(&[0x5a; 128], allocator)
+                    .unwrap();
+            assert_eq!(value.bits_vartime(), 1023);
+            assert!(high_water_for_test() >= 128);
+        })
+        .unwrap();
+        assert_eq!(checkpoint_for_test(), 0);
+        reset();
+    }
+
+    #[test]
+    fn nested_scopes_are_rejected() {
+        let _guard = test_lock();
+        activate();
+        with_scope(|_allocator| {
+            assert!(with_scope(|_nested| ()).is_none());
+        })
+        .unwrap();
+        reset();
+    }
+
+    #[test]
+    fn explicit_allocator_reports_exhaustion() {
+        let _guard = test_lock();
+        activate();
+        set_limit_for_test(64);
+        with_scope(|allocator| {
+            assert!(
+                crypto_bigint::BoxedUintIn::try_from_be_slice_vartime(&[0x5a; 128], allocator)
+                    .is_err()
+            );
+        })
+        .unwrap();
         reset();
         set_limit_for_test(SCRATCH_SIZE);
     }
@@ -196,18 +303,22 @@ mod tests {
     fn arena_rejects_alignment_above_its_base_alignment() {
         let _guard = test_lock();
         activate();
-        for alignment in [1, 16, 4096] {
-            let pointer = unsafe {
-                ALLOCATOR.alloc(Layout::from_size_align(1, alignment).expect("valid layout"))
-            };
-            assert!(!pointer.is_null());
-            assert_eq!(pointer as usize % alignment, 0);
-        }
-        let before = high_water_for_test();
-        let pointer =
-            unsafe { ALLOCATOR.alloc(Layout::from_size_align(1, 8192).expect("valid layout")) };
-        assert!(pointer.is_null());
-        assert_eq!(high_water_for_test(), before);
+        with_scope(|allocator| {
+            for alignment in [1, 16, 4096] {
+                let pointer = allocator
+                    .allocate(Layout::from_size_align(1, alignment).expect("valid layout"))
+                    .unwrap();
+                assert_eq!(pointer.cast::<u8>().as_ptr() as usize % alignment, 0);
+            }
+            let before = high_water_for_test();
+            assert!(
+                allocator
+                    .allocate(Layout::from_size_align(1, 8192).expect("valid layout"))
+                    .is_err()
+            );
+            assert_eq!(high_water_for_test(), before);
+        })
+        .unwrap();
         reset();
     }
 }

--- a/crabefi-runtime-image/src/services.rs
+++ b/crabefi-runtime-image/src/services.rs
@@ -461,9 +461,6 @@ fn apply_variable(
         return efi::Status::SECURITY_VIOLATION;
     }
     let (payload, timestamp, authenticated_variable) = if authenticated {
-        if !crate::scratch::preflight(auth::AUTH_OPERATION_SCRATCH_BOUND) {
-            return efi::Status::OUT_OF_RESOURCES;
-        }
         match auth::verify_authenticated_variable(store, name, &guid, attributes, input) {
             Ok(verified) => (
                 verified.payload,
@@ -967,7 +964,7 @@ mod tests {
         attributes: u32,
         data: &[u8],
     ) -> efi::Status {
-        let checkpoint = crate::scratch::checkpoint();
+        let checkpoint = crate::scratch::checkpoint_for_test();
         let status = apply_variable(
             store,
             transaction,
@@ -980,7 +977,8 @@ mod tests {
             attributes,
             data,
         );
-        crate::scratch::rewind(checkpoint);
+        // SAFETY: `apply_variable` returned, so no scratch-backed value remains live.
+        unsafe { crate::scratch::rewind_for_test(checkpoint) };
         status
     }
 

--- a/crabefi-runtime-image/tests/auth/mod.rs
+++ b/crabefi-runtime-image/tests/auth/mod.rs
@@ -1,4 +1,7 @@
-pub const MAX_AUTHENTICATED_ENVELOPE_SIZE: usize = 48 * 1024;
+#[path = "../../src/auth/limits.rs"]
+mod limits;
+
+pub use limits::{AUTH_OPERATION_SCRATCH_BOUND, MAX_AUTHENTICATED_ENVELOPE_SIZE};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthError {

--- a/crabefi-runtime-image/tests/pkcs7_adversarial.rs
+++ b/crabefi-runtime-image/tests/pkcs7_adversarial.rs
@@ -1,20 +1,44 @@
 //! Adversarial host tests for the runtime image's bounded CMS/DER parser.
 
-use rsa::rand_core::{CryptoRng, RngCore};
+use core::convert::Infallible;
+
+use rsa::rand_core::{TryCryptoRng, TryRng};
 use rsa::signature::{SignatureEncoding, hazmat::PrehashSigner};
 use rsa::traits::PublicKeyParts;
 use sha2::{Digest, Sha256};
 
 mod scratch {
-    pub fn checkpoint() -> usize {
-        0
+    use allocator_api2::alloc::{AllocError, Allocator};
+    use core::{alloc::Layout, ptr::NonNull};
+    use std::alloc::{GlobalAlloc, System};
+
+    #[derive(Clone, Copy)]
+    pub struct TestAlloc;
+
+    // SAFETY: all operations delegate to the process system allocator.
+    unsafe impl Allocator for TestAlloc {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+            if layout.size() == 0 {
+                let pointer = NonNull::new(layout.align() as *mut u8).ok_or(AllocError)?;
+                return Ok(NonNull::slice_from_raw_parts(pointer, 0));
+            }
+            let pointer = unsafe { System.alloc(layout) };
+            let pointer = NonNull::new(pointer).ok_or(AllocError)?;
+            Ok(NonNull::slice_from_raw_parts(pointer, layout.size()))
+        }
+
+        unsafe fn deallocate(&self, pointer: NonNull<u8>, layout: Layout) {
+            unsafe { System.dealloc(pointer.as_ptr(), layout) }
+        }
+    }
+
+    pub fn with_scope<R>(body: impl FnOnce(TestAlloc) -> R) -> Option<R> {
+        Some(body(TestAlloc))
     }
 
     pub fn preflight(_required: usize) -> bool {
         true
     }
-
-    pub fn rewind(_checkpoint: usize) {}
 }
 
 mod auth;
@@ -105,8 +129,8 @@ fn subject_public_key(key: &rsa::RsaPublicKey) -> Vec<u8> {
     let key_sequence = tlv(
         0x30,
         &concat(&[
-            integer(&key.n().to_bytes_be()),
-            integer(&key.e().to_bytes_be()),
+            integer(&key.n().to_be_bytes_trimmed_vartime()),
+            integer(&key.e().to_be_bytes_trimmed_vartime()),
         ]),
     );
     let mut bits = vec![0];
@@ -360,34 +384,32 @@ fn signed_attributes_require_unique_matching_content_type_and_digest() {
 fn test_key() -> rsa::RsaPrivateKey {
     struct DeterministicRng(u64);
 
-    impl RngCore for DeterministicRng {
-        fn next_u32(&mut self) -> u32 {
-            self.next_u64() as u32
+    impl TryRng for DeterministicRng {
+        type Error = Infallible;
+
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            Ok(self.try_next_u64()? as u32)
         }
 
-        fn next_u64(&mut self) -> u64 {
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
             let mut value = self.0;
             value ^= value << 13;
             value ^= value >> 7;
             value ^= value << 17;
             self.0 = value;
-            value
+            Ok(value)
         }
 
-        fn fill_bytes(&mut self, destination: &mut [u8]) {
+        fn try_fill_bytes(&mut self, destination: &mut [u8]) -> Result<(), Self::Error> {
             for chunk in destination.chunks_mut(8) {
-                let bytes = self.next_u64().to_le_bytes();
+                let bytes = self.try_next_u64()?.to_le_bytes();
                 chunk.copy_from_slice(&bytes[..chunk.len()]);
             }
-        }
-
-        fn try_fill_bytes(&mut self, destination: &mut [u8]) -> Result<(), rsa::rand_core::Error> {
-            self.fill_bytes(destination);
             Ok(())
         }
     }
 
-    impl CryptoRng for DeterministicRng {}
+    impl TryCryptoRng for DeterministicRng {}
 
     rsa::RsaPrivateKey::new(&mut DeterministicRng(0x5eed_cafe_f00d_beef), 1024)
         .expect("deterministic test key generation")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,9 +43,11 @@ names/GUIDs are single-sourced in `crabefi-efi-types` on both sides of the image
 boundary.
 
 Certificate verification remains intentionally split by execution domain. The
-runtime image's authenticated-variable path uses its bounded, allocation-free,
-hand-rolled PKCS#7/X.509 verifier; boot uses `cms`/`x509_cert` only for
-Authenticode. Neither path enforces certificate `notBefore`/`notAfter`,
+runtime image's authenticated-variable path uses a hand-rolled PKCS#7/X.509
+parser and allocator-aware `crypto-bigint` RSA exponentiation whose temporaries
+are lifetime-scoped to the bounded image-local BSS scratch arena. Signed-data
+hashing is incremental, so the runtime image requires no global allocator;
+boot uses `cms`/`x509_cert` only for Authenticode. Neither path enforces certificate `notBefore`/`notAfter`,
 preserving the old `check_validity_period = false` policy and matching EDK2 and
 U-Boot.
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -10,8 +10,26 @@ BootServicesData. Payload text, rodata, globals, stack, page tables, drivers,
 protocol databases, event callbacks, the global heap, and allocator metadata
 are reclaimable after ExitBootServices.
 
-The 4 MiB Rust allocation heap is BootServicesData. Runtime code has no global
-allocator and cannot retain a heap object.
+The 4 MiB Rust allocation heap is BootServicesData and is reclaimed after
+ExitBootServices. Runtime code must never retain an object allocated from that
+heap: the old in-payload Runtime Services design could otherwise carry a boot
+heap pointer across EBS or SetVirtualAddressMap, after the backing pages became
+conventional memory or were no longer reachable at their physical address.
+
+The separate runtime image instead has a fixed 512 KiB allocation arena in the
+image's `.bss`. The arena is therefore part of the image-owned
+RuntimeServicesData mapping and is converted with the rest of the image during
+SetVirtualAddressMap; it never calls UEFI allocation services or depends on the
+boot heap. Allocation is enabled only while the serialized runtime-operation
+lease is held, is monotonic within each non-nesting scratch scope, and is fully
+scrubbed and reset before the service returns.
+
+RSA uses `allocator-api2` explicitly. A scratch scope lends a lifetime-branded
+allocator to `crypto_bigint::BoxedUintIn`, so the compiler prevents RSA bigint
+results or temporaries from outliving the scope which rewinds their arena
+region. Authenticated-variable signed data is fed incrementally into SHA-256
+rather than assembled in a `Vec`. The runtime image therefore has no global
+allocator, allocation error handler, or general-purpose allocation API.
 
 ## Runtime image memory
 
@@ -23,6 +41,28 @@ to split the leading code range to RuntimeServicesCode; public
 data. The loader then copies/zeros sections and applies only normalized
 relocation slots. The image-owned MAT publishes the exact code/data protection
 domains even where the EFI memory map merges adjacent data descriptors.
+
+The audited release images currently reserve about 756 KiB of runtime address
+space on both x86_64 and AArch64:
+
+| Mapping | Size | Contents |
+| --- | ---: | --- |
+| RX | 60 KiB | runtime code plus leading page/alignment space |
+| RO/NX | 4 KiB | immutable data |
+| RW/NX | 692 KiB | variable store, runtime state, scratch arena, and padding |
+
+Normalized on-disk images are currently about 240 KiB. The dominant resident
+allocations are the 512 KiB scratch arena, roughly 170 KiB of variable-store
+state, and under 5 KiB of runtime state. The remainder is code, immutable data,
+dynamic metadata, small synchronization globals, and page/alignment padding.
+
+Scratch capacity is deliberately larger than observed demand. Normal
+certificate fixtures use under 8 KiB. A regression test executes repeated full
+public exponentiations with maximum-width 4096-bit operands and enforces a
+16 KiB per-exponentiation bound. Each RSA verification has its own non-nesting
+scope, so certificate-chain and signer traversal reuse that same arena region
+instead of accumulating allocations. The complete 512 KiB arena is still
+scrubbed at operation end and remains reserved as image-owned runtime memory.
 
 Every runtime descriptor is one of:
 

--- a/docs/RUNTIME_IMAGE_PLAN.md
+++ b/docs/RUNTIME_IMAGE_PLAN.md
@@ -23,9 +23,22 @@ synchronization. ELF normalization rejects missing, zero, or inconsistent
 The runtime image owns all Runtime Services entry points and unsupported stubs,
 Runtime/System Tables, configuration storage, Runtime Properties, Memory
 Attributes Table (MAT), ESRT storage, variable metadata/payload arena,
-transaction buffer, manifests, phase machine, and image-local time/reset code.
-The packed variable arena is 128 KiB; its per-variable limit remains 16 KiB.
-Large zero-initialized store state is in `.bss`, not ROM data.
+transaction buffer, manifests, phase machine, image-local time/reset code, and
+a fixed 512 KiB scratch allocator. The packed variable arena is 128 KiB; its
+per-variable limit remains 16 KiB. Large zero-initialized store and scratch
+state is in `.bss`, not ROM data.
+
+The scratch arena is intentionally different from the boot payload heap. Its
+storage is image-owned RuntimeServicesData, so SVAM maps it with the image
+rather than leaving allocations in reclaimed BootServicesData. It is active
+only under the single runtime-operation lease and resets and scrubs all
+allocations before each service returns. RSA bigint allocations use an
+`allocator-api2` allocator branded with a nested scratch-scope lifetime, which
+prevents those containers from escaping the scope in safe Rust. Signed-data
+assembly is allocation-free and updates SHA-256 incrementally. The runtime
+image has no global allocator. This avoids the pre-split failure mode where
+Runtime Services could retain a pointer into the boot heap across EBS or
+address conversion.
 
 Boot code owns drivers, persistence hardware, heap, logging, protocols, and
 Boot Services. Before EBS, one typed BootActive persistence bridge may write
@@ -71,9 +84,11 @@ authoritative key databases, replay timestamps, and bounded BSS scratch
 allocator. Boot enrollment uses the same standard `SetVariable` entry point.
 
 The split intentionally has two narrowly scoped certificate verifiers. The
-runtime image uses the bounded, allocation-free, hand-rolled PKCS#7/X.509
-verifier in `crabefi-runtime-image/src/auth/crypto.rs`; boot retains the
-`cms`/`x509_cert`-based verifier solely for Authenticode image verification.
+runtime image uses the hand-rolled PKCS#7/X.509 parser in
+`crabefi-runtime-image/src/auth/crypto.rs` together with allocator-aware
+`crypto-bigint` RSA public exponentiation over a lifetime-scoped image-local
+scratch allocator; boot retains the `cms`/`x509_cert`-based verifier solely for
+Authenticode image verification.
 Both deliberately skip certificate `notBefore`/`notAfter` checks. This
 preserves the pre-split `check_validity_period = false` behavior and matches
 EDK2 and U-Boot Secure Boot handling, where firmware time does not gate trust


### PR DESCRIPTION
Runtime RSA verification depended on global allocation, which made firmware memory use harder to bound and reason about.

Replace it with allocator-aware `crypto-bigint` exponentiation backed by the runtime image's bounded scratch arena, and hash authenticated-variable input incrementally. The change also accepts DER-minimal certificate signatures, exact-pins the SHA-256 implementation, and keeps the current nightly Clippy jobs warning-free.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened authenticated-variable and RSA signature verification with stricter signature and key validation.
  * Improved detached-content handling and SHA-256 verification.

* **Reliability**
  * Added bounded, automatically scrubbed memory for authentication operations.
  * Removed reliance on general-purpose runtime allocation.
  * Added limits for authenticated envelope size and verification memory usage.

* **Documentation**
  * Updated architecture, runtime, and memory documentation to reflect revised verification and resource-management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->