### PR TITLE
Prove the runtime image is panic-free

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           cargo test --manifest-path "$GITHUB_WORKSPACE/crabefi-runtime-abi/Cargo.toml"
           cargo test --manifest-path "$GITHUB_WORKSPACE/crabefi-runtime-image/Cargo.toml"
           cargo test --manifest-path "$GITHUB_WORKSPACE/crabefi-runtime-bundle/Cargo.toml"
+          cargo test --manifest-path "$GITHUB_WORKSPACE/xtask/Cargo.toml"
 
   # ── x86_64 ────────────────────────────────────────────────────────────
 

--- a/crabefi-efi-types/src/authentication.rs
+++ b/crabefi-efi-types/src/authentication.rs
@@ -204,7 +204,10 @@ pub fn validate_signature_database(mut data: &[u8]) -> bool {
         {
             return false;
         }
-        data = &data[size..];
+        let Some(remaining) = data.get(size..) else {
+            return false;
+        };
+        data = remaining;
         list_count += 1;
     }
     list_count != 0
@@ -284,9 +287,11 @@ impl<'a> Iterator for SignatureIterator<'a> {
             .checked_add(self.index.checked_mul(size)?)?;
         let bytes = self.data.get(start..start.checked_add(size)?)?;
         let mut owner = [0u8; 16];
-        owner.copy_from_slice(bytes.get(..16)?);
+        for (destination, source) in owner.iter_mut().zip(bytes.get(..16)?.iter()) {
+            *destination = *source;
+        }
         self.index += 1;
-        Some((owner, &bytes[16..]))
+        Some((owner, bytes.get(16..)?))
     }
 }
 

--- a/crabefi-efi-types/src/crc32.rs
+++ b/crabefi-efi-types/src/crc32.rs
@@ -2,7 +2,11 @@
 
 /// Calculate the IEEE CRC-32 of a byte slice.
 pub fn calculate(bytes: &[u8]) -> u32 {
-    calculate_with(bytes.len(), |index| bytes[index])
+    bytes.iter().copied().fold(u32::MAX, |crc, byte| {
+        (0..8).fold(crc ^ u32::from(byte), |value, _| {
+            (value >> 1) ^ (0xedb8_8320 & 0u32.wrapping_sub(value & 1))
+        })
+    }) ^ u32::MAX
 }
 
 /// Calculate IEEE CRC-32 over bytes supplied by index.

--- a/crabefi-efi-types/src/secure_boot.rs
+++ b/crabefi-efi-types/src/secure_boot.rs
@@ -128,7 +128,7 @@ pub fn name_matches(left: &[u16], right: &[u16]) -> bool {
             .iter()
             .position(|unit| *unit == 0)
             .unwrap_or(name.len());
-        &name[..length]
+        name.get(..length).unwrap_or(&[])
     }
 
     unterminated(left) == unterminated(right)

--- a/crabefi-runtime-abi/src/capsule.rs
+++ b/crabefi-runtime-abi/src/capsule.rs
@@ -64,7 +64,7 @@ pub fn is_esrt_last_attempt_variable(guid: &[u8; 16], name: &[u16]) -> bool {
         .iter()
         .position(|unit| *unit == 0)
         .unwrap_or(name.len());
-    &name[..name_len] == ESRT_LAST_ATTEMPT_VARIABLE_NAME
+    name.get(..name_len) == Some(ESRT_LAST_ATTEMPT_VARIABLE_NAME)
 }
 
 #[cfg(test)]

--- a/crabefi-runtime-abi/src/handoff.rs
+++ b/crabefi-runtime-abi/src/handoff.rs
@@ -203,8 +203,9 @@ impl RuntimeHandoff {
         self.image_base
             .checked_add(u64::from(self.image_size))
             .ok_or(HandoffError::Overflow)?;
-        self.sections[..section_count]
+        self.sections
             .iter()
+            .take(section_count)
             .try_fold(0u64, |watermark, section| {
                 if section.physical_base == 0
                     || !section
@@ -247,7 +248,7 @@ impl RuntimeHandoff {
                 .deferred_buffer_base
                 .checked_add(self.deferred_buffer_size)
                 .is_none()
-            || self.sections[..section_count].iter().any(|section| {
+            || self.sections.iter().take(section_count).any(|section| {
                 ranges_overlap(
                     section.physical_base,
                     u64::from(section.byte_len),
@@ -259,8 +260,9 @@ impl RuntimeHandoff {
             return Err(HandoffError::Range);
         }
 
-        self.ranges[..range_count]
+        self.ranges
             .iter()
+            .take(range_count)
             .enumerate()
             .try_for_each(|(index, range)| {
                 if range.physical_base == 0
@@ -276,14 +278,14 @@ impl RuntimeHandoff {
                     range.byte_len,
                     self.deferred_buffer_base,
                     self.deferred_buffer_size,
-                ) || self.ranges[..index].iter().any(|previous| {
+                ) || self.ranges.iter().take(index).any(|previous| {
                     ranges_overlap(
                         previous.physical_base,
                         previous.byte_len,
                         range.physical_base,
                         range.byte_len,
                     )
-                }) || self.sections[..section_count].iter().any(|section| {
+                }) || self.sections.iter().take(section_count).any(|section| {
                     ranges_overlap(
                         section.physical_base,
                         u64::from(section.byte_len),
@@ -318,7 +320,7 @@ impl RuntimeHandoff {
                 .ok_or(HandoffError::Overflow)?;
             if self.time.io_or_mmio_base == 0
                 || !self.time.io_or_mmio_base.is_multiple_of(4)
-                || !self.ranges[..range_count].iter().any(|range| {
+                || !self.ranges.iter().take(range_count).any(|range| {
                     range.physical_base <= self.time.io_or_mmio_base
                         && range
                             .physical_base

--- a/crabefi-runtime-image/Cargo.lock
+++ b/crabefi-runtime-image/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
  "allocator-api2",
  "crabefi-efi-types",
  "crabefi-runtime-abi",
- "crypto-bigint",
+ "crypto-bigint 0.7.5 (git+https://github.com/ArthurHeymans/crypto-bigint?rev=07a5d396134739ac0d02b15b1cd9c3f0ed60350e)",
  "r-efi",
  "rsa",
  "sha2",
@@ -90,15 +90,26 @@ dependencies = [
 [[package]]
 name = "crypto-bigint"
 version = "0.7.5"
-source = "git+https://github.com/ArthurHeymans/crypto-bigint?rev=8da705a86237f2c9804ddb30140715bd360983c3#8da705a86237f2c9804ddb30140715bd360983c3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
- "allocator-api2",
  "cpubits",
  "ctutils",
  "num-traits",
  "rand_core",
  "serdect",
  "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "git+https://github.com/ArthurHeymans/crypto-bigint?rev=07a5d396134739ac0d02b15b1cd9c3f0ed60350e#07a5d396134739ac0d02b15b1cd9c3f0ed60350e"
+dependencies = [
+ "allocator-api2",
+ "cpubits",
+ "ctutils",
+ "num-traits",
 ]
 
 [[package]]
@@ -116,7 +127,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3633a51a39c69ebbaa4feaa694bd83d241e4093901c84a0963b19d9bb3f0cf8f"
 dependencies = [
- "crypto-bigint",
+ "crypto-bigint 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core",
 ]
 
@@ -201,7 +212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
  "const-oid",
- "crypto-bigint",
+ "crypto-bigint 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-primes",
  "digest",
  "rand_core",
@@ -305,18 +316,18 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crabefi-runtime-image/Cargo.toml
+++ b/crabefi-runtime-image/Cargo.toml
@@ -11,7 +11,12 @@ build = "build.rs"
 allocator-api2 = { version = "=0.3.1", default-features = false }
 crabefi-efi-types = { path = "../crabefi-efi-types" }
 crabefi-runtime-abi = { path = "../crabefi-runtime-abi" }
-crypto-bigint = { version = "=0.7.5", default-features = false, features = ["allocator-api2"] }
+# Temporary audited fork adding allocator-api2-backed BoxedUintIn, bounded-stack
+# variable-time modular exponentiation, and panic-free verification primitives.
+# Fork audit reference: https://github.com/ArthurHeymans/crypto-bigint/commit/07a5d396134739ac0d02b15b1cd9c3f0ed60350e
+# Upstream status: no PR/issue yet. Replace this pin once those APIs are in a
+# published upstream release.
+crypto-bigint = { git = "https://github.com/ArthurHeymans/crypto-bigint", rev = "07a5d396134739ac0d02b15b1cd9c3f0ed60350e", default-features = false, features = ["allocator-api2"] }
 r-efi = "5.3"
 # This crate is a standalone workspace and intentionally uses sha2 0.11 so its
 # rsa 0.10 host tests share the same digest traits; other firmware crates remain
@@ -24,14 +29,6 @@ zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
 # Host-test-only signing dependency. Keep the exact prerelease pinned so test
 # certificate generation does not drift independently of the verifier.
 rsa = { version = "=0.10.0-rc.18", default-features = false }
-
-[patch.crates-io]
-# Temporary audited fork of 0.7.5 adding allocator-api2-backed BoxedUintIn and
-# bounded-stack variable-time modular exponentiation without a global allocator.
-# Fork audit reference: https://github.com/ArthurHeymans/crypto-bigint/commit/8da705a86237f2c9804ddb30140715bd360983c3
-# Upstream status: no PR/issue yet. Remove this patch once those APIs are in a
-# published upstream release.
-crypto-bigint = { git = "https://github.com/ArthurHeymans/crypto-bigint", rev = "8da705a86237f2c9804ddb30140715bd360983c3" }
 
 [[bin]]
 name = "crabefi-runtime-image"

--- a/crabefi-runtime-image/src/auth/crypto.rs
+++ b/crabefi-runtime-image/src/auth/crypto.rs
@@ -183,8 +183,12 @@ pub fn verify_pkcs7_signature_hash(
             return Err(AuthError::OutOfResources);
         }
         let signer = parse_signer(expect(signer_reader.next()?, 0x30)?)?;
-        let Some(signer_certificate) =
-            find_signer(signer.identity, &certificates[..certificate_count])?
+        let Some(signer_certificate) = find_signer(
+            signer.identity,
+            certificates
+                .get(..certificate_count)
+                .ok_or(AuthError::CertificateParseError)?,
+        )?
         else {
             continue;
         };
@@ -193,7 +197,9 @@ pub fn verify_pkcs7_signature_hash(
             && certificate_authorized(
                 signer_certificate,
                 trusted,
-                &certificates[..certificate_count],
+                certificates
+                    .get(..certificate_count)
+                    .ok_or(AuthError::CertificateParseError)?,
                 0,
             )?
         {
@@ -358,7 +364,11 @@ fn signed_attributes_digest(
     }
     let mut hash = Sha256::new();
     hash.update([0x31]);
-    hash.update(&attributes.full[1..]);
+    let attributes_body = attributes
+        .full
+        .get(1..)
+        .ok_or(AuthError::CertificateParseError)?;
+    hash.update(attributes_body);
     Ok(hash.finalize().into())
 }
 
@@ -634,7 +644,7 @@ fn verify_rsa_signature_with_allocator<A: Allocator + Copy>(
     let signature =
         BoxedUintIn::try_from_be_slice_vartime(signature, allocator).map_err(map_bigint_error)?;
     if modulus.bits_vartime() > MAX_RSA_BITS as u32
-        || !bool::from(modulus.is_odd())
+        || !modulus.is_odd()
         || exponent.cmp_vartime(&modulus) != Ordering::Less
         || signature.cmp_vartime(&modulus) != Ordering::Less
     {
@@ -645,7 +655,9 @@ fn verify_rsa_signature_with_allocator<A: Allocator + Copy>(
         .pow_mod_vartime(&exponent, &modulus)
         .map_err(map_bigint_error)?;
     let mut encoded_bytes = [0u8; MAX_RSA_BYTES];
-    let encoded_bytes = &mut encoded_bytes[..certificate.modulus.len()];
+    let encoded_bytes = encoded_bytes
+        .get_mut(..certificate.modulus.len())
+        .ok_or(AuthError::CertificateParseError)?;
     encoded
         .write_be_bytes(encoded_bytes)
         .map_err(|_| AuthError::CryptoError)?;
@@ -664,13 +676,27 @@ fn verify_pkcs1v15_sha256_encoding(encoded: &[u8], digest: &[u8; 32]) -> bool {
     let Some(separator) = encoded.len().checked_sub(payload_len + 1) else {
         return false;
     };
-    separator >= 10
-        && encoded.starts_with(&[0x00, 0x01])
-        && encoded[2..separator].iter().all(|byte| *byte == 0xff)
-        && encoded[separator] == 0
-        && encoded[separator + 1..separator + 1 + SHA256_DIGEST_INFO_PREFIX.len()]
-            == *SHA256_DIGEST_INFO_PREFIX
-        && encoded[separator + 1 + SHA256_DIGEST_INFO_PREFIX.len()..] == *digest
+    if separator < 10 || !encoded.starts_with(&[0x00, 0x01]) {
+        return false;
+    }
+    let Some(padding) = encoded.get(2..separator) else {
+        return false;
+    };
+    let Some(separator_byte) = encoded.get(separator) else {
+        return false;
+    };
+    let prefix_start = separator + 1;
+    let prefix_end = prefix_start + SHA256_DIGEST_INFO_PREFIX.len();
+    let Some(prefix) = encoded.get(prefix_start..prefix_end) else {
+        return false;
+    };
+    let Some(encoded_digest) = encoded.get(prefix_end..) else {
+        return false;
+    };
+    padding.iter().all(|byte| *byte == 0xff)
+        && *separator_byte == 0
+        && prefix == SHA256_DIGEST_INFO_PREFIX
+        && encoded_digest == digest
 }
 
 #[cfg(test)]

--- a/crabefi-runtime-image/src/auth/signature.rs
+++ b/crabefi-runtime-image/src/auth/signature.rs
@@ -287,7 +287,7 @@ mod tests {
         store
             .stage(&mut transaction, &mut prepared, append.payload, true)
             .unwrap();
-        store.commit(&transaction, prepared, DB_NAME);
+        store.commit(&transaction, prepared, DB_NAME).unwrap();
         store.commit_auth_timestamp(
             SecureBootVariable::Db,
             crate::auth::timestamp_from_efi_time(append.timestamp),
@@ -310,7 +310,7 @@ mod tests {
         store
             .stage(&mut transaction, &mut prepared, &[], false)
             .unwrap();
-        store.commit(&transaction, prepared, DB_NAME);
+        store.commit(&transaction, prepared, DB_NAME).unwrap();
         store.commit_auth_timestamp(
             SecureBootVariable::Db,
             crate::auth::timestamp_from_efi_time(deletion.timestamp),
@@ -369,7 +369,7 @@ mod tests {
         store
             .stage(&mut transaction, &mut prepared, verified.payload, false)
             .unwrap();
-        store.commit(&transaction, prepared, PK_NAME);
+        store.commit(&transaction, prepared, PK_NAME).unwrap();
         store.commit_auth_timestamp(SecureBootVariable::PK, timestamp);
         assert!(!store.setup_mode());
 
@@ -383,7 +383,7 @@ mod tests {
         store
             .stage(&mut transaction, &mut deletion, &[], false)
             .unwrap();
-        store.commit(&transaction, deletion, PK_NAME);
+        store.commit(&transaction, deletion, PK_NAME).unwrap();
         assert!(store.setup_mode());
         assert!(!store.secure_boot_enabled());
         assert_eq!(store.auth_timestamp(SecureBootVariable::PK), timestamp);

--- a/crabefi-runtime-image/src/deferred.rs
+++ b/crabefi-runtime-image/src/deferred.rs
@@ -419,15 +419,44 @@ pub fn queue_write(
         crc: U32::new(0),
     };
     let header_len = core::mem::size_of::<VariableRecordHeader>();
-    transaction.bytes[..header_len].copy_from_slice(record.as_bytes());
+    transaction
+        .bytes
+        .get_mut(..header_len)
+        .ok_or(efi::Status::OUT_OF_RESOURCES)?
+        .iter_mut()
+        .zip(record.as_bytes())
+        .for_each(|(destination, source)| *destination = *source);
     let mut offset = header_len;
     for unit in name.iter().copied().chain(core::iter::once(0)) {
-        transaction.bytes[offset..offset + 2].copy_from_slice(&unit.to_le_bytes());
-        offset += 2;
+        let end = offset.checked_add(2).ok_or(efi::Status::OUT_OF_RESOURCES)?;
+        transaction
+            .bytes
+            .get_mut(offset..end)
+            .ok_or(efi::Status::OUT_OF_RESOURCES)?
+            .iter_mut()
+            .zip(unit.to_le_bytes())
+            .for_each(|(destination, source)| *destination = source);
+        offset = end;
     }
-    transaction.bytes[offset..record_len].copy_from_slice(data);
-    record.crc = U32::new(record_crc(&transaction.bytes[..record_len]));
-    transaction.bytes[..header_len].copy_from_slice(record.as_bytes());
+    transaction
+        .bytes
+        .get_mut(offset..record_len)
+        .ok_or(efi::Status::OUT_OF_RESOURCES)?
+        .iter_mut()
+        .zip(data)
+        .for_each(|(destination, source)| *destination = *source);
+    let serialized = transaction
+        .bytes
+        .get(..record_len)
+        .ok_or(efi::Status::OUT_OF_RESOURCES)?;
+    record.crc = U32::new(record_crc(serialized));
+    transaction
+        .bytes
+        .get_mut(..header_len)
+        .ok_or(efi::Status::OUT_OF_RESOURCES)?
+        .iter_mut()
+        .zip(record.as_bytes())
+        .for_each(|(destination, source)| *destination = *source);
 
     // SAFETY: fixed header lies inside the validated retained journal.
     let mut header = unsafe { base.cast::<DeferredHeader>().read_unaligned() };

--- a/crabefi-runtime-image/src/main.rs
+++ b/crabefi-runtime-image/src/main.rs
@@ -28,10 +28,24 @@ use crabefi_runtime_abi::{
 
 #[cfg(all(not(test), target_os = "none"))]
 #[panic_handler]
+#[inline(never)]
 fn panic(_info: &PanicInfo<'_>) -> ! {
+    crabefi_runtime_panic_is_possible();
     loop {
         core::hint::spin_loop();
     }
+}
+
+/// Stable panic sink used by the audited runtime build.
+///
+/// The runtime ELF retains panic support for its freestanding panic lang item,
+/// so the audit examines direct callers and permits this sink only from that
+/// support code. Any service path reaching a panic helper fails the build.
+#[cfg(all(not(test), target_os = "none"))]
+#[unsafe(no_mangle)]
+#[inline(never)]
+fn crabefi_runtime_panic_is_possible() {
+    core::hint::black_box(());
 }
 
 #[cfg(all(not(test), not(target_os = "none")))]
@@ -283,11 +297,16 @@ pub extern "C" fn runtime_image_prepare_ebs(
     let runtime = lease.state_mut();
     let sections = runtime.sections;
     let ranges = runtime.ranges;
-    match runtime.tables.prepare_memory_attributes(
-        descriptors,
-        &sections[..runtime.section_count],
-        &ranges[..runtime.range_count],
-    ) {
+    let Some(sections) = sections.get(..runtime.section_count) else {
+        return efi::Status::DEVICE_ERROR.as_usize();
+    };
+    let Some(ranges) = ranges.get(..runtime.range_count) else {
+        return efi::Status::DEVICE_ERROR.as_usize();
+    };
+    match runtime
+        .tables
+        .prepare_memory_attributes(descriptors, sections, ranges)
+    {
         Ok(()) => efi::Status::SUCCESS.as_usize(),
         Err(status) => status.as_usize(),
     }

--- a/crabefi-runtime-image/src/services.rs
+++ b/crabefi-runtime-image/src/services.rs
@@ -318,8 +318,11 @@ pub extern "efiapi" fn get_next_variable_name(
     let Some(slot) = next else {
         return efi::Status::NOT_FOUND;
     };
+    let Some(name) = slot.name.get(..usize::from(slot.name_len)) else {
+        return efi::Status::DEVICE_ERROR;
+    };
     write_next_name(
-        &slot.name[..usize::from(slot.name_len)],
+        name,
         slot.guid,
         supplied,
         variable_name_size,
@@ -571,7 +574,9 @@ fn apply_variable(
         }
     }
 
-    store.commit(transaction, prepared, name);
+    if let Err(status) = store.commit(transaction, prepared, name) {
+        return status;
+    }
     if let (Some(variable), Some(timestamp)) = (authenticated_variable, timestamp) {
         store.commit_auth_timestamp(variable, timestamp);
     }

--- a/crabefi-runtime-image/src/state.rs
+++ b/crabefi-runtime-image/src/state.rs
@@ -149,14 +149,18 @@ impl RuntimeState {
         self.deferred_buffer_physical = handoff.deferred_buffer_base;
         self.deferred_buffer_size = usize::try_from(handoff.deferred_buffer_size)
             .map_err(|_| efi::Status::INVALID_PARAMETER)?;
-        for (destination, source) in self.sections[..self.section_count]
+        for (destination, source) in self
+            .sections
             .iter_mut()
+            .take(self.section_count)
             .zip(handoff.sections.iter())
         {
             *destination = section_from_handoff(source);
         }
-        for (destination, source) in self.ranges[..self.range_count]
+        for (destination, source) in self
+            .ranges
             .iter_mut()
+            .take(self.range_count)
             .zip(handoff.ranges.iter())
         {
             *destination = range_from_handoff(source);

--- a/crabefi-runtime-image/src/store.rs
+++ b/crabefi-runtime-image/src/store.rs
@@ -146,7 +146,7 @@ impl VariableStore {
         }
         let mut prepared = self.prepare(guid, name, attributes, data.len())?;
         self.stage(transaction, &mut prepared, data, false)?;
-        self.commit(transaction, prepared, name);
+        self.commit(transaction, prepared, name)?;
         if let (Some(variable), Some(timestamp)) = (secure_variable, timestamp) {
             self.auth_timestamps[variable.index()] = timestamp;
         }
@@ -268,9 +268,9 @@ impl VariableStore {
         input: &[u8],
         append: bool,
     ) -> Result<&'a [u8], efi::Status> {
-        let old = if append && self.slots[prepared.slot].in_use != 0 {
-            self.data(&self.slots[prepared.slot])
-                .ok_or(efi::DEVICE_ERROR)?
+        let slot = self.slots.get(prepared.slot).ok_or(efi::DEVICE_ERROR)?;
+        let old = if append && slot.in_use != 0 {
+            self.data(slot).ok_or(efi::DEVICE_ERROR)?
         } else {
             &[]
         };
@@ -287,13 +287,14 @@ impl VariableStore {
         transaction: &VariableTransaction,
         prepared: PreparedWrite,
         name: &[u16],
-    ) {
+    ) -> Result<(), efi::Status> {
         if prepared.delete {
-            self.slots[prepared.slot].in_use = 0;
-            self.slots[prepared.slot].data_len = 0;
-            self.slots[prepared.slot].data_offset = 0;
+            let slot = self.slots.get_mut(prepared.slot).ok_or(efi::DEVICE_ERROR)?;
+            slot.in_use = 0;
+            slot.data_len = 0;
+            slot.data_offset = 0;
             self.refresh_policy();
-            return;
+            return Ok(());
         }
 
         let mut used = 0usize;
@@ -303,26 +304,55 @@ impl VariableStore {
             }
             let old = slot.data_offset as usize;
             let len = usize::from(slot.data_len);
+            let old_end = old.checked_add(len).ok_or(efi::DEVICE_ERROR)?;
+            let new_end = used.checked_add(len).ok_or(efi::DEVICE_ERROR)?;
+            if old_end > self.arena.len() || new_end > self.arena.len() {
+                return Err(efi::DEVICE_ERROR);
+            }
             if old != used {
-                self.arena.copy_within(old..old + len, used);
+                // SAFETY: both source and destination ranges were checked
+                // against the arena above. `ptr::copy` permits overlap.
+                unsafe {
+                    core::ptr::copy(
+                        self.arena.as_ptr().add(old),
+                        self.arena.as_mut_ptr().add(used),
+                        len,
+                    );
+                }
                 slot.data_offset = used as u32;
             }
-            used += len;
+            used = new_end;
         }
 
-        let slot = &mut self.slots[prepared.slot];
+        let data_end = used
+            .checked_add(prepared.data_len)
+            .ok_or(efi::OUT_OF_RESOURCES)?;
+        let source = transaction
+            .bytes
+            .get(..prepared.data_len)
+            .ok_or(efi::DEVICE_ERROR)?;
+        let destination = self
+            .arena
+            .get_mut(used..data_end)
+            .ok_or(efi::OUT_OF_RESOURCES)?;
+        destination.copy_from_slice(source);
+
+        let slot = self.slots.get_mut(prepared.slot).ok_or(efi::DEVICE_ERROR)?;
+        if prepared.name_len != name.len() || prepared.name_len > slot.name.len() {
+            return Err(efi::DEVICE_ERROR);
+        }
         slot.in_use = 0;
         slot.guid = prepared.guid;
         slot.attributes = prepared.attributes;
         slot.name_len = prepared.name_len as u16;
         slot.data_len = prepared.data_len as u16;
         slot.data_offset = used as u32;
-        slot.name[..prepared.name_len].copy_from_slice(name);
-        slot.name[prepared.name_len..].fill(0);
-        self.arena[used..used + prepared.data_len]
-            .copy_from_slice(&transaction.bytes[..prepared.data_len]);
+        let (slot_name, remainder) = slot.name.split_at_mut(prepared.name_len);
+        slot_name.copy_from_slice(name);
+        remainder.fill(0);
         slot.in_use = 1;
         self.refresh_policy();
+        Ok(())
     }
 
     pub const fn maximum_storage() -> u64 {

--- a/crabefi-runtime-image/src/svam.rs
+++ b/crabefi-runtime-image/src/svam.rs
@@ -193,7 +193,12 @@ fn resolve_sections(
     count: usize,
 ) -> Result<[Mapping; MAX_SECTIONS], efi::Status> {
     let mut resolved = [Mapping::empty(); MAX_SECTIONS];
-    for (index, section) in runtime.sections[..runtime.section_count].iter().enumerate() {
+    for (index, section) in runtime
+        .sections
+        .iter()
+        .take(runtime.section_count)
+        .enumerate()
+    {
         let expected_type = if section.flags & section_flags::EXECUTE != 0 {
             efi::RUNTIME_SERVICES_CODE
         } else {
@@ -203,7 +208,9 @@ fn resolve_sections(
             .physical_base
             .checked_add(u64::from(section.byte_len))
             .ok_or(efi::Status::INVALID_PARAMETER)?;
-        resolved[index] = (0..count)
+        *resolved
+            .get_mut(index)
+            .ok_or(efi::Status::INVALID_PARAMETER)? = (0..count)
             .try_fold(None, |found, descriptor_index| {
                 let candidate = mapping(read_descriptor(map, stride, descriptor_index)?)?;
                 if candidate.memory_type != expected_type
@@ -233,13 +240,15 @@ fn resolve_ranges(
     count: usize,
 ) -> Result<[Mapping; MAX_EXTERNAL_RANGES], efi::Status> {
     let mut resolved = [Mapping::empty(); MAX_EXTERNAL_RANGES];
-    for (index, range) in runtime.ranges[..runtime.range_count].iter().enumerate() {
+    for (index, range) in runtime.ranges.iter().take(runtime.range_count).enumerate() {
         let range_end = range
             .physical_base
             .checked_add(range.byte_len)
             .ok_or(efi::Status::INVALID_PARAMETER)?;
         let expected_type = efi::MEMORY_MAPPED_IO;
-        resolved[index] = (0..count)
+        *resolved
+            .get_mut(index)
+            .ok_or(efi::Status::INVALID_PARAMETER)? = (0..count)
             .try_fold(None, |found, descriptor_index| {
                 let candidate = mapping(read_descriptor(map, stride, descriptor_index)?)?;
                 if candidate.memory_type != expected_type
@@ -303,8 +312,10 @@ fn virtual_time_config(
         .io_or_mmio_base
         .checked_add(width)
         .ok_or(efi::Status::INVALID_PARAMETER)?;
-    let (index, range) = runtime.ranges[..runtime.range_count]
+    let (index, range) = runtime
+        .ranges
         .iter()
+        .take(runtime.range_count)
         .enumerate()
         .find(|(_, range)| {
             range.physical_base <= runtime.time.io_or_mmio_base
@@ -320,8 +331,9 @@ fn virtual_time_config(
         .checked_sub(range.physical_base)
         .ok_or(efi::Status::INVALID_PARAMETER)?;
     let mut config = runtime.time;
-    config.io_or_mmio_base = range_virtual_bases[index]
-        .checked_add(offset)
+    config.io_or_mmio_base = range_virtual_bases
+        .get(index)
+        .and_then(|base| base.checked_add(offset))
         .ok_or(efi::Status::INVALID_PARAMETER)?;
     Ok(config)
 }
@@ -334,8 +346,10 @@ fn validate_and_commit(
     deferred_mapping: Mapping,
 ) -> Result<(), efi::Status> {
     let mut section_virtual_bases = [0u64; MAX_SECTIONS];
-    for ((section, mapping), virtual_base) in runtime.sections[..runtime.section_count]
+    for ((section, mapping), virtual_base) in runtime
+        .sections
         .iter()
+        .take(runtime.section_count)
         .zip(section_mappings.iter())
         .zip(section_virtual_bases.iter_mut())
     {
@@ -349,8 +363,10 @@ fn validate_and_commit(
             .ok_or(efi::Status::INVALID_PARAMETER)?;
     }
     let mut range_virtual_bases = [0u64; MAX_EXTERNAL_RANGES];
-    for ((range, mapping), virtual_base) in runtime.ranges[..runtime.range_count]
+    for ((range, mapping), virtual_base) in runtime
+        .ranges
         .iter()
+        .take(runtime.range_count)
         .zip(range_mappings.iter())
         .zip(range_virtual_bases.iter_mut())
     {
@@ -386,7 +402,7 @@ fn validate_and_commit(
     let mut tail_count = 0usize;
 
     // Validation pass: no writes.
-    for relocation in &runtime.relocations[..runtime.relocation_count] {
+    for relocation in runtime.relocations.iter().take(runtime.relocation_count) {
         let patch_section = runtime
             .sections
             .get(usize::from(relocation.patch_section))
@@ -419,8 +435,9 @@ fn validate_and_commit(
             .physical_base
             .checked_add(u64::from(patch_relative))
             .ok_or(efi::Status::INVALID_PARAMETER)?;
-        let virtual_target = section_virtual_bases[usize::from(relocation.target_section)]
-            .checked_add(u64::from(target_relative))
+        let virtual_target = section_virtual_bases
+            .get(usize::from(relocation.target_section))
+            .and_then(|base| base.checked_add(u64::from(target_relative)))
             .ok_or(efi::Status::INVALID_PARAMETER)?;
         let physical_target = target_section
             .physical_base
@@ -434,7 +451,9 @@ fn validate_and_commit(
             if tail_count >= tail.len() {
                 return Err(efi::Status::OUT_OF_RESOURCES);
             }
-            tail[tail_count] = SlotPatch {
+            *tail
+                .get_mut(tail_count)
+                .ok_or(efi::Status::OUT_OF_RESOURCES)? = SlotPatch {
                 address: patch_address,
                 value: virtual_target,
             };
@@ -443,14 +462,18 @@ fn validate_and_commit(
     }
 
     // Infallible commit begins. First publish resolved bases in image state.
-    for (section, virtual_base) in runtime.sections[..runtime.section_count]
+    for (section, virtual_base) in runtime
+        .sections
         .iter_mut()
+        .take(runtime.section_count)
         .zip(section_virtual_bases.iter())
     {
         section.virtual_base = *virtual_base;
     }
-    for (range, virtual_base) in runtime.ranges[..runtime.range_count]
+    for (range, virtual_base) in runtime
+        .ranges
         .iter_mut()
+        .take(runtime.range_count)
         .zip(range_virtual_bases.iter())
     {
         range.virtual_base = *virtual_base;
@@ -461,7 +484,7 @@ fn validate_and_commit(
     let sections = runtime.sections;
     let section_count = runtime.section_count;
     runtime.tables.convert_internal_pointers(|physical| {
-        sections[..section_count].iter().find_map(|section| {
+        sections.iter().take(section_count).find_map(|section| {
             let offset = physical.checked_sub(section.physical_base)?;
             (offset < u64::from(section.byte_len))
                 .then(|| section.virtual_base.checked_add(offset))?
@@ -474,11 +497,11 @@ fn validate_and_commit(
     core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
     runtime.tables.recompute_crcs();
     runtime.tables.recompute_runtime_crc_with(|address, byte| {
-        tail[..tail_count]
-            .iter()
+        tail.iter()
+            .take(tail_count)
             .find_map(|slot| {
                 let offset = address.checked_sub(slot.address)?;
-                (offset < 8).then(|| slot.value.to_le_bytes()[offset as usize])
+                slot.value.to_le_bytes().get(offset as usize).copied()
             })
             .unwrap_or(byte)
     });
@@ -486,8 +509,9 @@ fn validate_and_commit(
     // Patch every non-tail slot while physical aliases are executable.
     commit_matching(runtime, &section_virtual_bases, |address| {
         !(address >= runtime_table_start && address < runtime_table_end)
-            && !tail[..tail_count]
+            && !tail
                 .iter()
+                .take(tail_count)
                 .any(|slot| slot.address == address)
     });
 
@@ -502,18 +526,31 @@ fn commit_matching(
     virtual_bases: &[u64; MAX_SECTIONS],
     predicate: impl Fn(u64) -> bool,
 ) {
-    for relocation in &runtime.relocations[..runtime.relocation_count] {
-        let patch_section = runtime.sections[usize::from(relocation.patch_section)];
-        let target_section = runtime.sections[usize::from(relocation.target_section)];
-        let patch_relative = relocation.patch_offset - patch_section.image_offset;
-        let target_relative = relocation.target_offset - target_section.image_offset;
-        let patch_address = patch_section.physical_base + u64::from(patch_relative);
+    for relocation in runtime.relocations.iter().take(runtime.relocation_count) {
+        let patch_index = usize::from(relocation.patch_section);
+        let target_index = usize::from(relocation.target_section);
+        // SAFETY: the preceding validation pass checked both section indices,
+        // relocation offsets, and both address additions before commit began.
+        let (patch_section, target_section, target_base) = unsafe {
+            (
+                *runtime.sections.get_unchecked(patch_index),
+                *runtime.sections.get_unchecked(target_index),
+                *virtual_bases.get_unchecked(target_index),
+            )
+        };
+        let patch_relative = relocation
+            .patch_offset
+            .wrapping_sub(patch_section.image_offset);
+        let target_relative = relocation
+            .target_offset
+            .wrapping_sub(target_section.image_offset);
+        let patch_address = patch_section
+            .physical_base
+            .wrapping_add(u64::from(patch_relative));
         if !predicate(patch_address) {
             continue;
         }
-        let value = virtual_bases[usize::from(relocation.target_section)]
-            .checked_add(u64::from(target_relative))
-            .expect("validated relocation target overflowed during SVAM commit");
+        let value = target_base.wrapping_add(u64::from(target_relative));
         // SAFETY: the loader exposed these firmware addresses and validation
         // proved this complete aligned-width destination before commit.
         unsafe { write_slot_at_address(patch_address, value) };

--- a/crabefi-runtime-image/src/tables.rs
+++ b/crabefi-runtime-image/src/tables.rs
@@ -229,25 +229,50 @@ impl ImageTables {
         {
             return Err(efi::Status::UNSUPPORTED);
         }
-        if let Some(index) = self.configuration[..self.configuration_count]
+        if let Some(index) = self
+            .configuration
             .iter()
+            .take(self.configuration_count)
             .position(|entry| *entry.vendor_guid.as_bytes() == registration.guid)
         {
             if registration.table_address == 0 {
-                self.configuration
-                    .copy_within(index + 1..self.configuration_count, index);
-                self.configuration_metadata
-                    .copy_within(index + 1..self.configuration_count, index);
+                let move_count = self.configuration_count - index - 1;
+                // SAFETY: `index` came from the initialized prefix and
+                // configuration_count never exceeds either fixed array. The
+                // source and destination may overlap, so use `ptr::copy`.
+                unsafe {
+                    core::ptr::copy(
+                        self.configuration.as_ptr().add(index + 1),
+                        self.configuration.as_mut_ptr().add(index),
+                        move_count,
+                    );
+                    core::ptr::copy(
+                        self.configuration_metadata.as_ptr().add(index + 1),
+                        self.configuration_metadata.as_mut_ptr().add(index),
+                        move_count,
+                    );
+                }
                 self.configuration_count -= 1;
-                self.configuration[self.configuration_count] = efi::ConfigurationTable {
+                *self
+                    .configuration
+                    .get_mut(self.configuration_count)
+                    .ok_or(efi::Status::DEVICE_ERROR)? = efi::ConfigurationTable {
                     vendor_guid: efi::Guid::from_bytes(&[0; 16]),
                     vendor_table: core::ptr::null_mut(),
                 };
-                self.configuration_metadata[self.configuration_count] =
-                    ConfigurationMetadata::empty();
+                *self
+                    .configuration_metadata
+                    .get_mut(self.configuration_count)
+                    .ok_or(efi::Status::DEVICE_ERROR)? = ConfigurationMetadata::empty();
             } else {
-                self.configuration[index].vendor_table = registration.table_address as *mut c_void;
-                self.configuration_metadata[index] = ConfigurationMetadata {
+                self.configuration
+                    .get_mut(index)
+                    .ok_or(efi::Status::DEVICE_ERROR)?
+                    .vendor_table = registration.table_address as *mut c_void;
+                *self
+                    .configuration_metadata
+                    .get_mut(index)
+                    .ok_or(efi::Status::DEVICE_ERROR)? = ConfigurationMetadata {
                     policy: registration.policy,
                     physical_address: registration.table_address,
                 };
@@ -262,11 +287,17 @@ impl ImageTables {
         if index >= MAX_CONFIGURATION_TABLES {
             return Err(efi::Status::OUT_OF_RESOURCES);
         }
-        self.configuration[index] = efi::ConfigurationTable {
+        *self
+            .configuration
+            .get_mut(index)
+            .ok_or(efi::Status::OUT_OF_RESOURCES)? = efi::ConfigurationTable {
             vendor_guid: efi::Guid::from_bytes(&registration.guid),
             vendor_table: registration.table_address as *mut c_void,
         };
-        self.configuration_metadata[index] = ConfigurationMetadata {
+        *self
+            .configuration_metadata
+            .get_mut(index)
+            .ok_or(efi::Status::OUT_OF_RESOURCES)? = ConfigurationMetadata {
             policy: registration.policy,
             physical_address: registration.table_address,
         };
@@ -372,12 +403,16 @@ impl ImageTables {
         self.system.configuration_table = convert(self.system.configuration_table as u64)
             .unwrap_or(self.system.configuration_table as u64)
             as *mut efi::ConfigurationTable;
-        for index in 0..self.configuration_count {
-            if self.configuration_metadata[index].policy == configuration_policy::IMAGE_RUNTIME {
-                let physical = self.configuration_metadata[index].physical_address;
-                if let Some(virtual_address) = convert(physical) {
-                    self.configuration[index].vendor_table = virtual_address as *mut c_void;
-                }
+        for (entry, metadata) in self
+            .configuration
+            .iter_mut()
+            .zip(self.configuration_metadata.iter())
+            .take(self.configuration_count)
+        {
+            if metadata.policy == configuration_policy::IMAGE_RUNTIME
+                && let Some(virtual_address) = convert(metadata.physical_address)
+            {
+                entry.vendor_table = virtual_address as *mut c_void;
             }
         }
     }

--- a/xtask/src/runtime.rs
+++ b/xtask/src/runtime.rs
@@ -864,6 +864,11 @@ fn audit_reachable_panic_calls(text: &str) -> Vec<String> {
         "handle_alloc_error",
         "crabefi_runtime_panic_is_possible",
     ];
+    // Direct calls plus the tail-call form each architecture uses for
+    // noreturn destinations such as panic handlers.
+    const TRANSFER_MNEMONICS: &[&str] = &[
+        "call", "callq", "jmp", "jmpq", "b", "br", "braa", "bl", "jal", "jalr", "j", "jr", "tail",
+    ];
     let mut function = "<unknown>";
     let mut violations = Vec::new();
     for line in text.lines() {
@@ -875,11 +880,12 @@ fn audit_reachable_panic_calls(text: &str) -> Vec<String> {
             function = name;
             continue;
         }
-        let is_call = trimmed.contains("call")
-            || trimmed.starts_with("bl\t")
-            || trimmed.contains(" bl ")
-            || trimmed.contains("jal");
-        if !is_call || !PANIC_TARGETS.iter().any(|target| trimmed.contains(target)) {
+        let Some(instruction) = parse_instruction(trimmed) else {
+            continue;
+        };
+        if !TRANSFER_MNEMONICS.contains(&instruction.mnemonic)
+            || !PANIC_TARGETS.iter().any(|target| trimmed.contains(target))
+        {
             continue;
         }
         let support_function = PANIC_TARGETS.iter().any(|target| function.contains(target));
@@ -1113,6 +1119,27 @@ mod tests {
         let violations = audit_reachable_panic_calls(reachable);
         assert_eq!(violations.len(), 1);
         assert!(violations[0].contains("runtime_image_init"));
+    }
+
+    #[test]
+    fn panic_audit_rejects_tail_calls_into_panic_machinery() {
+        for line in [
+            "1004: jmp 0x20 <crabefi_runtime_panic_is_possible>",
+            "1008: jmpq 0x20 <__rustc::rust_begin_unwind>",
+            "100c: b 0x20 <core::panicking::panic_fmt>",
+            "1010: j 0x20 <core::panicking::panic_bounds_check>",
+        ] {
+            let text = concat!("1000 <runtime_image_init>:\n").to_string() + line + "\n";
+            let violations = audit_reachable_panic_calls(&text);
+            assert_eq!(violations.len(), 1, "missed tail call: {line}");
+        }
+
+        // Ordinary control flow must not be flagged.
+        let text = concat!(
+            "1000 <runtime_image_init>:\n",
+            "1004: jmp 0x20 <runtime_image_init+0x24>\n",
+        );
+        assert!(audit_reachable_panic_calls(text).is_empty());
     }
 
     #[test]

--- a/xtask/src/runtime.rs
+++ b/xtask/src/runtime.rs
@@ -380,7 +380,14 @@ fn normalize(elf_path: &Path, output: &Path, arch: Arch) -> Result<RuntimeArtifa
         })
         .collect::<String>();
     fs::write(output.join("symbols.txt"), &symbols)?;
-    fs::write(output.join("runtime-image.sym"), symbols)?;
+    fs::write(output.join("runtime-image.sym"), &symbols)?;
+    let panic_symbols = audit_panic_symbols(&symbols);
+    if !panic_symbols.is_empty() {
+        bail!(
+            "runtime ELF contains Rust panic symbols:\n{}",
+            panic_symbols.join("\n")
+        );
+    }
     ValidatedImage::parse(&normalized, architecture_id(arch)).map_err(|error| {
         anyhow::anyhow!("normalized runtime image failed ABI self-validation: {error}")
     })?;
@@ -761,6 +768,13 @@ fn run_audit_tools(elf: &Path, output: &Path, arch: Arch, relocation_slots: usiz
             bail!("runtime tail relocation function contains a call or indirect tail jump");
         }
     }
+    let panic_calls = audit_reachable_panic_calls(&text);
+    if !panic_calls.is_empty() {
+        bail!(
+            "runtime disassembly contains reachable Rust panic calls:\n{}",
+            panic_calls.join("\n")
+        );
+    }
     let call_audit = audit_indirect_calls(arch, &text)?;
     let indirect_calls = call_audit.indirect;
     let register_indirect_calls = call_audit.register_indirect;
@@ -782,6 +796,7 @@ fn run_audit_tools(elf: &Path, output: &Path, arch: Arch, relocation_slots: usiz
             "register_indirect_calls": register_indirect_calls,
             "relocation_slots": relocation_slots,
             "allowed_indirect_calls": allowed_indirect_calls,
+            "reachable_panic_calls": panic_calls.len(),
             "violations": violations,
         }),
     )?;
@@ -815,6 +830,64 @@ fn run_audit_tools(elf: &Path, output: &Path, arch: Arch, relocation_slots: usiz
         }),
     )?;
     Ok(())
+}
+
+fn audit_panic_symbols(symbols: &str) -> Vec<String> {
+    const PANIC_SYMBOLS: &[&str] = &[
+        "rust_begin_unwind",
+        "panic_is_possible",
+        "panicking",
+        "panic_fmt",
+        "panic_bounds_check",
+        "unwrap_failed",
+        "expect_failed",
+        "slice_index_fail",
+        "len_mismatch_fail",
+        "handle_alloc_error",
+    ];
+    symbols
+        .lines()
+        .filter(|line| PANIC_SYMBOLS.iter().any(|symbol| line.contains(symbol)))
+        .map(str::to_owned)
+        .collect()
+}
+
+fn audit_reachable_panic_calls(text: &str) -> Vec<String> {
+    const PANIC_TARGETS: &[&str] = &[
+        "rust_begin_unwind",
+        "panicking",
+        "panic_",
+        "unwrap_failed",
+        "expect_failed",
+        "slice_index_fail",
+        "len_mismatch_fail",
+        "handle_alloc_error",
+        "crabefi_runtime_panic_is_possible",
+    ];
+    let mut function = "<unknown>";
+    let mut violations = Vec::new();
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.ends_with(">:")
+            && let Some((_, rest)) = trimmed.split_once('<')
+            && let Some((name, _)) = rest.rsplit_once(">:")
+        {
+            function = name;
+            continue;
+        }
+        let is_call = trimmed.contains("call")
+            || trimmed.starts_with("bl\t")
+            || trimmed.contains(" bl ")
+            || trimmed.contains("jal");
+        if !is_call || !PANIC_TARGETS.iter().any(|target| trimmed.contains(target)) {
+            continue;
+        }
+        let support_function = PANIC_TARGETS.iter().any(|target| function.contains(target));
+        if !support_function {
+            violations.push(format!("{function}: {trimmed}"));
+        }
+    }
+    violations
 }
 
 fn disassembly_body<'a>(text: &'a str, symbol: &str) -> Option<&'a str> {
@@ -1011,6 +1084,35 @@ mod tests {
             instruction_is_forbidden_in_transition_tail(Arch::Riscv64, non_linking_jalr).unwrap()
         );
         assert!(audit_indirect_calls(Arch::Aarch64, "0: blraa x0, x1\n").is_err());
+    }
+
+    #[test]
+    fn panic_symbol_audit_rejects_retained_panic_support() {
+        assert!(audit_panic_symbols("0x10 runtime_image_init\n").is_empty());
+        let violations = audit_panic_symbols(concat!(
+            "0x20 __rustc::rust_begin_unwind\n",
+            "0x30 crabefi_runtime_panic_is_possible\n",
+        ));
+        assert_eq!(violations.len(), 2);
+    }
+
+    #[test]
+    fn panic_audit_ignores_support_code_and_rejects_runtime_callers() {
+        let support_only = concat!(
+            "0000 <core::panicking::panic_fmt>:\n",
+            "  0: callq 0x10 <__rustc::rust_begin_unwind>\n",
+            "0010 <__rustc::rust_begin_unwind>:\n",
+            " 10: callq 0x20 <crabefi_runtime_panic_is_possible>\n",
+        );
+        assert!(audit_reachable_panic_calls(support_only).is_empty());
+
+        let reachable = concat!(
+            "1000 <runtime_image_init>:\n",
+            "1004: callq 0x20 <core::panicking::panic_bounds_check>\n",
+        );
+        let violations = audit_reachable_panic_calls(reachable);
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].contains("runtime_image_init"));
     }
 
     #[test]


### PR DESCRIPTION
Malformed runtime inputs could still reach Rust panic machinery, which is not acceptable once firmware Runtime Services are active.

Replace panic-capable indexing and arithmetic with checked, bounded handling throughout the shipped runtime image. Extend the disassembly audit to detect direct calls and tail transfers into panic machinery, and run its regression tests in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened Secure Boot and PKCS#7/RSA signature verification, including safer certificate, hash, and signature validation.
* **Reliability**
  * Improved handling of malformed or truncated firmware data, variable records, runtime tables, relocations, and handoff information.
  * Invalid inputs now return appropriate errors instead of risking crashes.
  * Improved error propagation during variable-store updates.
* **Testing**
  * Expanded runtime-image audits to detect retained or reachable panic paths, including architecture-specific cases.
  * Added coverage for signature validation and runtime safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->