### PR TITLE
De-orphan ACPI crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "bd8b2abd55bf1f9cffbf00fd594566c51a9d31402553284920c1309ca8351086"
 [[package]]
 name = "acpi"
 version = "6.1.1"
-source = "git+https://github.com/ArthurHeymans/acpi.git?rev=784a35b50bf9c39ce9b0a107cf8a5c296c52ddee#784a35b50bf9c39ce9b0a107cf8a5c296c52ddee"
+source = "git+https://github.com/rust-osdev/acpi.git?rev=cb34d9d42c8d2795bfac4955ff83b04a060a797d#cb34d9d42c8d2795bfac4955ff83b04a060a797d"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/crabefi-coreboot/Cargo.toml
+++ b/crabefi-coreboot/Cargo.toml
@@ -33,7 +33,7 @@ zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
 # package-element names eagerly (fails on forward references like
 # \_SB.PCI0.LPCB in the coreboot DSDT/SSDT). Upstream main has both the
 # BankField/IndexField support and lazy package name resolution (PR #320).
-acpi = { git = "https://github.com/ArthurHeymans/acpi.git", rev = "784a35b50bf9c39ce9b0a107cf8a5c296c52ddee", default-features = false, features = [
+acpi = { git = "https://github.com/rust-osdev/acpi.git", rev = "cb34d9d42c8d2795bfac4955ff83b04a060a797d", default-features = false, features = [
   "alloc",
   "aml",
 ] }


### PR DESCRIPTION
I can't package this otherwise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ACPI component dependency source and revision.
  * Preserved the existing feature configuration and disabled default features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->