### PR TITLE
Harden authenticated variables and runtime state transitions

### DIFF
--- a/crabefi-coreboot/aarch64-coreboot.ld
+++ b/crabefi-coreboot/aarch64-coreboot.ld
@@ -66,7 +66,7 @@ SECTIONS {
     /* Warm-reset retained and excluded from the payload's PT_LOAD extent. */
     .deferred_buffer (NOLOAD) : ALIGN(4096) {
         _deferred_buffer_start = .;
-        . += 64K;
+        . += 128K;
         _deferred_buffer_end = .;
     } :defer
 

--- a/crabefi-coreboot/riscv64-coreboot.ld
+++ b/crabefi-coreboot/riscv64-coreboot.ld
@@ -52,7 +52,7 @@ SECTIONS {
     /* Warm-reset retained and excluded from the payload's PT_LOAD extent. */
     .deferred_buffer (NOLOAD) : ALIGN(4096) {
         _deferred_buffer_start = .;
-        . += 64K;
+        . += 128K;
         _deferred_buffer_end = .;
     } :defer
 

--- a/crabefi-coreboot/x86_64-coreboot.ld
+++ b/crabefi-coreboot/x86_64-coreboot.ld
@@ -57,7 +57,7 @@ SECTIONS {
        CapsuleUpdateData reservation capsule before optional DRAM clearing. */
     .deferred_buffer ALIGN(4096) (NOLOAD) : {
         _deferred_buffer_start = .;
-        . += 64K;
+        . += 128K;
         _deferred_buffer_end = .;
     } :defer
 

--- a/crabefi-runtime-image/src/auth/crypto.rs
+++ b/crabefi-runtime-image/src/auth/crypto.rs
@@ -1,4 +1,20 @@
 //! Borrowed CMS/X.509 parsing and bounded RSA verification.
+//!
+//! # Accepted limitations
+//!
+//! This verifier is deliberately minimal and every gap below fails closed
+//! (unparsable or unverifiable input is rejected):
+//! - No certificate validity-period or revocation checking.
+//! - Issuer/subject chaining compares the DER name bytes exactly instead of
+//!   normalizing alternative encodings; a differently-encoded name simply
+//!   fails to chain.
+//! - The direct-issuance path does not require the trusted (db/PK)
+//!   certificate to be a CA — only intermediates are checked for the CA bit.
+//!   This grants no escalation: a trusted certificate's key can always sign
+//!   the PKCS#7 directly anyway.
+//! - The SignerInfo `signatureAlgorithm` OID is accepted but ignored;
+//!   verification is unconditionally RSA-SHA256, so a mismatched OID just
+//!   fails verification.
 
 use allocator_api2::alloc::Allocator;
 use core::cmp::Ordering;

--- a/crabefi-runtime-image/src/auth/crypto.rs
+++ b/crabefi-runtime-image/src/auth/crypto.rs
@@ -13,8 +13,8 @@
 //!   This grants no escalation: a trusted certificate's key can always sign
 //!   the PKCS#7 directly anyway.
 //! - The SignerInfo `signatureAlgorithm` OID is accepted but ignored;
-//!   verification is unconditionally RSA-SHA256, so a mismatched OID just
-//!   fails verification.
+//!   verification treats every signature as RSA-SHA256 regardless of the
+//!   declared algorithm.
 
 use allocator_api2::alloc::Allocator;
 use core::cmp::Ordering;

--- a/crabefi-runtime-image/src/auth/signature.rs
+++ b/crabefi-runtime-image/src/auth/signature.rs
@@ -63,6 +63,15 @@ pub fn verify_authenticated_variable<'a>(
             return Err(AuthError::InvalidTimestamp);
         }
     }
+    // Every authenticated variable carries its last accepted timestamp —
+    // live or as a deletion tombstone — so replaying an older signed
+    // envelope fails even for variables outside the secure-boot databases.
+    if let Some(previous) = store.auth_history_timestamp(vendor_guid, variable_name) {
+        let previous = super::efi_time_from_timestamp(previous);
+        if !authentication.time_stamp.is_after(&previous) {
+            return Err(AuthError::InvalidTimestamp);
+        }
+    }
 
     if !store.setup_mode() || secure_variable.is_none() {
         if signature.is_empty() {

--- a/crabefi-runtime-image/src/deferred.rs
+++ b/crabefi-runtime-image/src/deferred.rs
@@ -28,6 +28,12 @@ pub const MAX_DATA_SIZE: usize = MAX_AUTHENTICATED_ENVELOPE_SIZE;
 pub const MAX_ENTRY_SIZE: usize =
     core::mem::size_of::<VariableRecordHeader>() + (MAX_NAME_LEN + 1) * 2 + MAX_DATA_SIZE;
 
+// Capacity note: the retained deferred buffer reserved by the payload linker
+// scripts is 128 KiB, of which [`JOURNAL_OFFSET`] is reserved for the private
+// reservation capsule. That leaves room for two full-width entries plus the
+// journal header; smaller entries pack more densely. If `MAX_DATA_SIZE` or
+// `MAX_ENTRY_SIZE` grows, grow the linker reservation to match.
+
 const RECORD_MAGIC: u16 = 0xaa55;
 const STATE_VALID: u8 = 0x7f;
 const STATE_DELETED: u8 = 0x00;

--- a/crabefi-runtime-image/src/deferred.rs
+++ b/crabefi-runtime-image/src/deferred.rs
@@ -1,4 +1,11 @@
 //! Deferred-v2 journal access using a fixed zerocopy wire header.
+//!
+//! The journal is a crash-consistency mechanism, not an authenticity boundary:
+//! its CRC32 guards against torn writes and unrelated memory damage, but any
+//! attacker who can rewrite the journal can already issue runtime service
+//! calls directly. Writes are queued only after the in-image policy checks
+//! (including signature verification for authenticated variables) have
+//! accepted them.
 
 use crabefi_efi_types::crc32;
 use crabefi_runtime_abi::{
@@ -11,11 +18,15 @@ use crabefi_runtime_abi::{
 use zerocopy::byteorder::little_endian::{I16, U16, U32, U64};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
+use crate::auth::MAX_AUTHENTICATED_ENVELOPE_SIZE;
 use crate::efi;
 
 pub const MAX_NAME_LEN: usize = 64;
-pub const MAX_DATA_SIZE: usize = 32 * 1024;
-pub const MAX_ENTRY_SIZE: usize = 16 * 1024;
+/// Records carry the complete authenticated input envelope so a full-width
+/// envelope always fits a single journal entry.
+pub const MAX_DATA_SIZE: usize = MAX_AUTHENTICATED_ENVELOPE_SIZE;
+pub const MAX_ENTRY_SIZE: usize =
+    core::mem::size_of::<VariableRecordHeader>() + (MAX_NAME_LEN + 1) * 2 + MAX_DATA_SIZE;
 
 const RECORD_MAGIC: u16 = 0xaa55;
 const STATE_VALID: u8 = 0x7f;
@@ -322,21 +333,25 @@ pub fn stage_capsule(
             descriptor.add(1).read_unaligned(),
         )
     };
-    if length == 0 || address == 0 || length > u64::from(capsule_size) {
+    if length == 0
+        || address == 0
+        || length > u64::from(capsule_size)
+        // The described physical block must not wrap; coreboot consumes this
+        // descriptor pair verbatim on the next boot.
+        || address.checked_add(length).is_none()
+    {
         return Err(efi::Status::INVALID_PARAMETER);
     }
+    let next_descriptor = scatter_gather_list
+        .checked_add(CAPSULE_DESCRIPTOR_SIZE as u64)
+        .ok_or(efi::Status::INVALID_PARAMETER)?;
     // SAFETY: the retained range has all fixed descriptor slots.
     unsafe {
         write_descriptor(base, 1, length, address);
         if length == u64::from(capsule_size) {
             write_descriptor(base, 2, 0, 0);
         } else {
-            write_descriptor(
-                base,
-                2,
-                0,
-                scatter_gather_list + CAPSULE_DESCRIPTOR_SIZE as u64,
-            );
+            write_descriptor(base, 2, 0, next_descriptor);
         }
     }
     Ok(())
@@ -794,6 +809,25 @@ mod tests {
             0x56, 0x97,
         ];
         assert_ne!(&private[..16], WINDOWS_UX_GUID.as_slice());
+        crate::scratch::reset();
+    }
+
+    #[test]
+    fn stage_capsule_rejects_wrapping_scatter_gather_blocks() {
+        let _guard = crate::scratch::test_lock();
+        let mut buffer = vec![0u8; 64 * 1024];
+        let mut descriptors = [0u8; CAPSULE_DESCRIPTOR_SIZE];
+        descriptors[..8].copy_from_slice(&u64::from(u32::MAX).to_le_bytes());
+        descriptors[8..].copy_from_slice(&u64::MAX.to_le_bytes());
+        assert_eq!(
+            stage_capsule(
+                buffer.as_mut_ptr(),
+                buffer.len(),
+                u32::MAX,
+                descriptors.as_ptr() as u64,
+            ),
+            Err(efi::Status::INVALID_PARAMETER)
+        );
         crate::scratch::reset();
     }
 

--- a/crabefi-runtime-image/src/services.rs
+++ b/crabefi-runtime-image/src/services.rs
@@ -1296,6 +1296,89 @@ mod tests {
     }
 
     #[test]
+    fn imported_secure_database_deletions_keep_authenticated_history() {
+        let _guard = crate::scratch::test_lock();
+        crate::scratch::activate();
+        let mut store = VariableStore::new();
+        let mut transaction = VariableTransaction::new();
+        let mut deferred_transaction = deferred::DeferredTransaction::new();
+        let mut buffer = vec![0u8; 64 * 1024];
+        let variable = secure_boot::SecureBootVariable::PK;
+        let timestamp = |year: u16| VariableTimestamp {
+            year,
+            month: 1,
+            day: 1,
+            ..VariableTimestamp::default()
+        };
+
+        store
+            .import(
+                &mut transaction,
+                *variable.guid(),
+                variable.name(),
+                AUTH_ATTRIBUTES,
+                include_bytes!("../tests/fixtures/pk.esl"),
+                Some(timestamp(2024)),
+            )
+            .unwrap();
+        assert!(!store.setup_mode());
+
+        store
+            .import(
+                &mut transaction,
+                *variable.guid(),
+                variable.name(),
+                AUTH_ATTRIBUTES,
+                &[],
+                Some(timestamp(2025)),
+            )
+            .unwrap();
+
+        assert!(store.setup_mode());
+        assert!(store.find(variable.guid(), variable.name(), false).is_none());
+        assert_eq!(store.auth_timestamp(variable), timestamp(2025));
+        assert_eq!(
+            store.auth_history_timestamp(variable.guid(), variable.name()),
+            Some(timestamp(2025))
+        );
+
+        // Setup Mode permits unsigned authenticated enrollment, but the
+        // deletion history must still reject raw re-creation.
+        assert_eq!(
+            apply(
+                &mut store,
+                &mut transaction,
+                &mut deferred_transaction,
+                &mut buffer,
+                phase::BOOT_ACTIVE,
+                variable,
+                RAW_ATTRIBUTES,
+                include_bytes!("../tests/fixtures/pk.esl"),
+            ),
+            efi::Status::WRITE_PROTECTED
+        );
+        assert!(matches!(
+            auth::verify_authenticated_variable(
+                &store,
+                variable.name(),
+                variable.guid(),
+                AUTH_ATTRIBUTES,
+                &unsigned_envelope(2025),
+            ),
+            Err(auth::AuthError::InvalidTimestamp)
+        ));
+        assert!(auth::verify_authenticated_variable(
+            &store,
+            variable.name(),
+            variable.guid(),
+            AUTH_ATTRIBUTES,
+            &unsigned_envelope(2026),
+        )
+        .is_ok());
+        crate::scratch::reset();
+    }
+
+    #[test]
     fn query_capsule_capabilities_validates_header_like_update_capsule() {
         let header = efi::CapsuleHeader {
             capsule_guid: efi::Guid::from_bytes(&[0; 16]),

--- a/crabefi-runtime-image/src/services.rs
+++ b/crabefi-runtime-image/src/services.rs
@@ -463,16 +463,13 @@ fn apply_variable(
     if secure_variable.is_some() && !authenticated && !store.setup_mode() {
         return efi::Status::SECURITY_VIOLATION;
     }
-    // EDK2 parity (AuthService.c `ProcessVariable`): a variable that exists
-    // with time-based authentication keeps requiring an authenticated
+    // EDK2 parity (AuthService.c `ProcessVariable`): a variable with
+    // time-based authentication history keeps requiring an authenticated
     // envelope for every later update, append, and deletion, whatever its
-    // GUID. Raw requests fail closed instead of silently rewriting or
-    // removing authenticated content.
-    if !authenticated
-        && store.find(&guid, name, false).is_some_and(|slot| {
-            slot.attributes & efi::VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS != 0
-        })
-    {
+    // GUID. This includes tombstones left by authenticated deletions, so a
+    // deleted variable cannot be silently re-created with raw content. Raw
+    // requests fail closed instead.
+    if !authenticated && store.auth_history_timestamp(&guid, name).is_some() {
         return efi::Status::WRITE_PROTECTED;
     }
     let (payload, timestamp, authenticated_variable) = if authenticated {
@@ -509,6 +506,9 @@ fn apply_variable(
         Ok(prepared) => prepared,
         Err(status) => return status,
     };
+    // Authenticated commits (including deletions) record their timestamp so
+    // later envelopes must be strictly newer.
+    prepared.timestamp = timestamp.unwrap_or_default();
     let staged_len = match store.stage(transaction, &mut prepared, payload, append) {
         Ok(staged) => staged.len(),
         Err(status) => return status,
@@ -661,13 +661,15 @@ pub fn replay_deferred(lease: &mut state::Lease) -> Result<usize, efi::Status> {
                 return Err(efi::Status::DEVICE_ERROR);
             }
             let name = &record.name[..name_len];
-            if authenticated
-                && let Some(variable) = secure_boot::identify_key_database(&record.guid.bytes, name)
-            {
-                let floor = store.auth_timestamp(variable);
-                if floor == record.timestamp {
+            if authenticated {
+                let secure_floor = secure_boot::identify_key_database(&record.guid.bytes, name)
+                    .map(|variable| store.auth_timestamp(variable));
+                let already_applied = secure_floor == Some(record.timestamp)
+                    || store.auth_history_timestamp(&record.guid.bytes, name)
+                        == Some(record.timestamp);
+                if already_applied {
                     // Persistence committed before the retained acknowledgement.
-                    // The imported floor proves this authenticated operation has
+                    // The recorded floor proves this authenticated operation has
                     // already taken effect, including append and deletion.
                     return Ok(());
                 }
@@ -1160,6 +1162,136 @@ mod tests {
         let slot = store.find(&guid, &name, false).unwrap();
         assert_eq!(store.data(slot), Some(b"payload".as_slice()));
         assert_eq!(slot.attributes, AUTH_ATTRIBUTES);
+        crate::scratch::reset();
+    }
+
+    /// Minimal authenticated-variable envelope with an empty PKCS#7 payload.
+    /// Enough to pass header validation and carry a timestamp, but never a
+    /// valid signature.
+    fn unsigned_envelope(year: u16) -> Vec<u8> {
+        use crabefi_efi_types::secure_boot::EFI_CERT_TYPE_PKCS7_GUID;
+
+        let mut envelope = Vec::new();
+        envelope.extend_from_slice(&year.to_le_bytes());
+        envelope.extend_from_slice(&[1, 1, 0, 0, 0, 0]); // month..pad1
+        envelope.extend_from_slice(&0u32.to_le_bytes()); // nanosecond
+        envelope.extend_from_slice(&0i16.to_le_bytes()); // timezone
+        envelope.push(0); // daylight
+        envelope.push(0); // pad2
+        envelope.extend_from_slice(&24u32.to_le_bytes()); // dw_length
+        envelope.extend_from_slice(&0x0200u16.to_le_bytes()); // w_revision
+        envelope.extend_from_slice(&0x0ef1u16.to_le_bytes()); // w_certificate_type
+        envelope.extend_from_slice(&EFI_CERT_TYPE_PKCS7_GUID);
+        envelope
+    }
+
+    #[test]
+    fn deleted_authenticated_variables_keep_rollback_floors() {
+        let _guard = crate::scratch::test_lock();
+        crate::scratch::activate();
+        let mut store = VariableStore::new();
+        let mut transaction = VariableTransaction::new();
+        let mut buffer = vec![0u8; 64 * 1024];
+        let guid = [0x42; 16];
+        let name = [b'A' as u16, b'u' as u16, b't' as u16, b'h' as u16];
+        let timestamp = |year: u16| VariableTimestamp {
+            year,
+            month: 1,
+            day: 1,
+            ..VariableTimestamp::default()
+        };
+
+        // Boot import of the live variable followed by its persisted deletion
+        // record (zero-length data, newer timestamp).
+        store
+            .import(
+                &mut transaction,
+                guid,
+                &name,
+                AUTH_ATTRIBUTES,
+                b"payload",
+                Some(timestamp(2024)),
+            )
+            .unwrap();
+        store
+            .import(
+                &mut transaction,
+                guid,
+                &name,
+                AUTH_ATTRIBUTES,
+                &[],
+                Some(timestamp(2025)),
+            )
+            .unwrap();
+
+        // The deletion is invisible as a variable but keeps its floor.
+        assert!(store.find(&guid, &name, false).is_none());
+        assert_eq!(
+            store.auth_history_timestamp(&guid, &name),
+            Some(timestamp(2025))
+        );
+
+        // Raw requests cannot re-create or delete the deleted variable.
+        for attributes in [RAW_ATTRIBUTES, RAW_ATTRIBUTES | efi::VARIABLE_APPEND_WRITE] {
+            assert_eq!(
+                apply_variable(
+                    &mut store,
+                    &mut transaction,
+                    None,
+                    phase::BOOT_ACTIVE,
+                    successful_bridge as *const () as u64,
+                    (buffer.as_mut_ptr(), buffer.len()),
+                    guid,
+                    &name,
+                    attributes,
+                    b"raw",
+                ),
+                efi::Status::WRITE_PROTECTED
+            );
+        }
+
+        // A stale signed envelope is rejected by the timestamp floor before
+        // signature verification even runs.
+        assert!(matches!(
+            auth::verify_authenticated_variable(
+                &store,
+                &name,
+                &guid,
+                AUTH_ATTRIBUTES,
+                &unsigned_envelope(2024),
+            ),
+            Err(auth::AuthError::InvalidTimestamp)
+        ));
+        // A newer envelope passes the floor and fails on the empty signature
+        // instead, proving the floor itself did not reject it.
+        assert!(matches!(
+            auth::verify_authenticated_variable(
+                &store,
+                &name,
+                &guid,
+                AUTH_ATTRIBUTES,
+                &unsigned_envelope(2026),
+            ),
+            Err(auth::AuthError::InvalidHeader)
+        ));
+
+        // Re-creation reclaims the tombstone slot and records the new floor.
+        store
+            .import(
+                &mut transaction,
+                guid,
+                &name,
+                AUTH_ATTRIBUTES,
+                b"new payload",
+                Some(timestamp(2026)),
+            )
+            .unwrap();
+        let slot = store.find(&guid, &name, false).unwrap();
+        assert_eq!(store.data(slot), Some(b"new payload".as_slice()));
+        assert_eq!(
+            store.auth_history_timestamp(&guid, &name),
+            Some(timestamp(2026))
+        );
         crate::scratch::reset();
     }
 

--- a/crabefi-runtime-image/src/services.rs
+++ b/crabefi-runtime-image/src/services.rs
@@ -1335,7 +1335,11 @@ mod tests {
             .unwrap();
 
         assert!(store.setup_mode());
-        assert!(store.find(variable.guid(), variable.name(), false).is_none());
+        assert!(
+            store
+                .find(variable.guid(), variable.name(), false)
+                .is_none()
+        );
         assert_eq!(store.auth_timestamp(variable), timestamp(2025));
         assert_eq!(
             store.auth_history_timestamp(variable.guid(), variable.name()),
@@ -1367,14 +1371,16 @@ mod tests {
             ),
             Err(auth::AuthError::InvalidTimestamp)
         ));
-        assert!(auth::verify_authenticated_variable(
-            &store,
-            variable.name(),
-            variable.guid(),
-            AUTH_ATTRIBUTES,
-            &unsigned_envelope(2026),
-        )
-        .is_ok());
+        assert!(
+            auth::verify_authenticated_variable(
+                &store,
+                variable.name(),
+                variable.guid(),
+                AUTH_ATTRIBUTES,
+                &unsigned_envelope(2026),
+            )
+            .is_ok()
+        );
         crate::scratch::reset();
     }
 

--- a/crabefi-runtime-image/src/services.rs
+++ b/crabefi-runtime-image/src/services.rs
@@ -463,6 +463,18 @@ fn apply_variable(
     if secure_variable.is_some() && !authenticated && !store.setup_mode() {
         return efi::Status::SECURITY_VIOLATION;
     }
+    // EDK2 parity (AuthService.c `ProcessVariable`): a variable that exists
+    // with time-based authentication keeps requiring an authenticated
+    // envelope for every later update, append, and deletion, whatever its
+    // GUID. Raw requests fail closed instead of silently rewriting or
+    // removing authenticated content.
+    if !authenticated
+        && store.find(&guid, name, false).is_some_and(|slot| {
+            slot.attributes & efi::VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS != 0
+        })
+    {
+        return efi::Status::WRITE_PROTECTED;
+    }
     let (payload, timestamp, authenticated_variable) = if authenticated {
         match auth::verify_authenticated_variable(store, name, &guid, attributes, input) {
             Ok(verified) => (
@@ -784,6 +796,13 @@ pub extern "efiapi" fn query_capsule_capabilities(
     {
         return efi::Status::UNSUPPORTED;
     }
+    // Match `update_capsule`'s structural header checks so a capsule cannot
+    // pass the capability query and then fail the update itself.
+    if header.header_size < core::mem::size_of::<efi::CapsuleHeader>() as u32
+        || header.capsule_image_size < header.header_size
+    {
+        return efi::Status::INVALID_PARAMETER;
+    }
     unsafe {
         maximum_capsule_size.write(MAX_CAPSULE_SIZE);
         reset_type.write(efi::RESET_WARM);
@@ -1064,6 +1083,139 @@ mod tests {
 
         let slot = store.find(&guid, name, false).unwrap();
         assert_eq!(store.data(slot), Some(b"firmware".as_slice()));
+    }
+
+    #[test]
+    fn raw_writes_cannot_modify_previously_authenticated_variables() {
+        let _guard = crate::scratch::test_lock();
+        crate::scratch::activate();
+        let mut store = VariableStore::new();
+        let mut transaction = VariableTransaction::new();
+        let mut deferred_transaction = deferred::DeferredTransaction::new();
+        let mut buffer = vec![0u8; 64 * 1024];
+        let guid = [0x42; 16];
+        let name = [b'A' as u16, b'u' as u16, b't' as u16, b'h' as u16];
+
+        // Boot import is firmware-authoritative and may enroll an
+        // authenticated variable directly.
+        store
+            .import(
+                &mut transaction,
+                guid,
+                &name,
+                AUTH_ATTRIBUTES,
+                b"payload",
+                None,
+            )
+            .unwrap();
+
+        for (attributes, value) in [
+            (
+                AUTH_ATTRIBUTES & !efi::VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS,
+                b"raw".as_slice(),
+            ),
+            (
+                (AUTH_ATTRIBUTES & !efi::VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS)
+                    | efi::VARIABLE_APPEND_WRITE,
+                b"append".as_slice(),
+            ),
+            (0, b"".as_slice()),
+        ] {
+            assert_eq!(
+                apply_variable(
+                    &mut store,
+                    &mut transaction,
+                    Some(&mut deferred_transaction),
+                    phase::BOOT_ACTIVE,
+                    successful_bridge as *const () as u64,
+                    (buffer.as_mut_ptr(), buffer.len()),
+                    guid,
+                    &name,
+                    attributes,
+                    value,
+                ),
+                efi::Status::WRITE_PROTECTED
+            );
+        }
+
+        // Authenticated requests pass the gate and reach signature
+        // verification, which rejects the truncated envelope.
+        assert_eq!(
+            apply_variable(
+                &mut store,
+                &mut transaction,
+                Some(&mut deferred_transaction),
+                phase::BOOT_ACTIVE,
+                successful_bridge as *const () as u64,
+                (buffer.as_mut_ptr(), buffer.len()),
+                guid,
+                &name,
+                AUTH_ATTRIBUTES,
+                b"garbage",
+            ),
+            efi::Status::INVALID_PARAMETER
+        );
+
+        // The authenticated content is untouched by every rejected attempt.
+        let slot = store.find(&guid, &name, false).unwrap();
+        assert_eq!(store.data(slot), Some(b"payload".as_slice()));
+        assert_eq!(slot.attributes, AUTH_ATTRIBUTES);
+        crate::scratch::reset();
+    }
+
+    #[test]
+    fn query_capsule_capabilities_validates_header_like_update_capsule() {
+        let header = efi::CapsuleHeader {
+            capsule_guid: efi::Guid::from_bytes(&[0; 16]),
+            header_size: core::mem::size_of::<efi::CapsuleHeader>() as u32,
+            flags: CAPSULE_FLAGS_PERSIST_ACROSS_RESET,
+            capsule_image_size: core::mem::size_of::<efi::CapsuleHeader>() as u32 - 1,
+        };
+        let mut array = [&header as *const efi::CapsuleHeader as *mut efi::CapsuleHeader];
+        let mut maximum = 0u64;
+        let mut reset_type = efi::RESET_COLD;
+        assert_eq!(
+            query_capsule_capabilities(
+                array.as_mut_ptr(),
+                array.len(),
+                &mut maximum,
+                &mut reset_type,
+            ),
+            efi::Status::INVALID_PARAMETER
+        );
+
+        let truncated = efi::CapsuleHeader {
+            header_size: core::mem::size_of::<efi::CapsuleHeader>() as u32 - 1,
+            capsule_image_size: 4096,
+            ..header
+        };
+        let mut array = [&truncated as *const efi::CapsuleHeader as *mut efi::CapsuleHeader];
+        assert_eq!(
+            query_capsule_capabilities(
+                array.as_mut_ptr(),
+                array.len(),
+                &mut maximum,
+                &mut reset_type,
+            ),
+            efi::Status::INVALID_PARAMETER
+        );
+
+        let valid = efi::CapsuleHeader {
+            capsule_image_size: 4096,
+            ..header
+        };
+        let mut array = [&valid as *const efi::CapsuleHeader as *mut efi::CapsuleHeader];
+        assert_eq!(
+            query_capsule_capabilities(
+                array.as_mut_ptr(),
+                array.len(),
+                &mut maximum,
+                &mut reset_type,
+            ),
+            efi::Status::SUCCESS
+        );
+        assert_eq!(maximum, MAX_CAPSULE_SIZE);
+        assert_eq!(reset_type, efi::RESET_WARM);
     }
 
     #[test]

--- a/crabefi-runtime-image/src/state.rs
+++ b/crabefi-runtime-image/src/state.rs
@@ -2,12 +2,12 @@
 
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
-use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 
 use crabefi_runtime_abi::{
     LoadedSection, MAX_EXTERNAL_RANGES, MAX_RELOCATIONS, MAX_SECTIONS, RelocationImport,
     RuntimeExternalRange, RuntimeHandoff, RuntimeResetConfig, RuntimeTimeConfig, phase,
-    relocation_kind,
+    relocation_kind, section_flags,
 };
 
 use crate::{
@@ -177,9 +177,29 @@ impl RuntimeState {
         if self.import_finished || self.relocation_count >= MAX_RELOCATIONS {
             return Err(efi::Status::OUT_OF_RESOURCES);
         }
-        if usize::from(relocation.patch_section) >= self.section_count
-            || usize::from(relocation.target_section) >= self.section_count
-            || relocation.kind != relocation_kind::ABSOLUTE64
+        let patch_index = usize::from(relocation.patch_section);
+        let target_index = usize::from(relocation.target_section);
+        if patch_index >= self.section_count || target_index >= self.section_count {
+            return Err(efi::Status::INVALID_PARAMETER);
+        }
+        let patch = self
+            .sections
+            .get(patch_index)
+            .copied()
+            .ok_or(efi::Status::INVALID_PARAMETER)?;
+        let target = self
+            .sections
+            .get(target_index)
+            .copied()
+            .ok_or(efi::Status::INVALID_PARAMETER)?;
+        // Mirror the normalized-image manifest checks (format.rs) so an
+        // invalid record is rejected at import instead of only at
+        // SetVirtualAddressMap time.
+        if relocation.kind != relocation_kind::ABSOLUTE64
+            || patch.flags & section_flags::RELOCATION_SLOTS == 0
+            || !relocation.patch_offset.is_multiple_of(8)
+            || !offset_within_section(&patch, relocation.patch_offset, 8)
+            || !offset_within_section(&target, relocation.target_offset, 1)
         {
             return Err(efi::Status::INVALID_PARAMETER);
         }
@@ -218,6 +238,20 @@ fn section_from_handoff(section: &LoadedSection) -> SectionRecord {
     }
 }
 
+/// Return whether `[offset, offset + width)` lies fully inside the section's
+/// image-relative `[image_offset, image_offset + byte_len)` range.
+fn offset_within_section(section: &SectionRecord, offset: u32, width: u32) -> bool {
+    section
+        .image_offset
+        .checked_add(section.byte_len)
+        .is_some_and(|section_end| {
+            offset >= section.image_offset
+                && offset
+                    .checked_add(width)
+                    .is_some_and(|end| end <= section_end)
+        })
+}
+
 fn range_from_handoff(range: &RuntimeExternalRange) -> RangeRecord {
     RangeRecord {
         physical_base: range.physical_base,
@@ -227,36 +261,47 @@ fn range_from_handoff(range: &RuntimeExternalRange) -> RangeRecord {
     }
 }
 
-#[repr(transparent)]
-pub struct ResetConfigCell(UnsafeCell<RuntimeResetConfig>);
-
-// SAFETY: the value is published exactly once while the image is
-// Uninitialized, before BootActive is released, and is immutable afterward.
-unsafe impl Sync for ResetConfigCell {}
+/// Lock-free snapshot of the reset configuration for `ResetSystem`.
+///
+/// The pair is published exactly once while the image is Uninitialized: the
+/// base word first, then the header word with `Release`. The `Acquire` header
+/// load in `read` makes the prior base store visible without taking the
+/// operation lease, so a re-entrant reset never reads a torn configuration.
+/// A zero header word means the snapshot has not been published yet, which
+/// leaves the architecture fallbacks in charge.
+#[repr(C)]
+pub struct ResetConfigCell {
+    header: AtomicU64,
+    base: AtomicU64,
+}
 
 impl ResetConfigCell {
     const fn new() -> Self {
-        Self(UnsafeCell::new(RuntimeResetConfig {
-            mechanism: 0,
-            reserved: 0,
-            io_or_mmio_base: 0,
-        }))
+        Self {
+            header: AtomicU64::new(0),
+            base: AtomicU64::new(0),
+        }
     }
 
     fn publish(&self, config: RuntimeResetConfig) {
-        // SAFETY: RuntimeState::initialize is single-shot and serialized by the
-        // operation lock before BootActive publication.
-        unsafe { self.0.get().write(config) };
+        self.base.store(config.io_or_mmio_base, Ordering::Relaxed);
+        self.header.store(
+            u64::from(config.mechanism) | (u64::from(config.reserved) << 32),
+            Ordering::Release,
+        );
     }
 
     fn read(&self) -> RuntimeResetConfig {
-        // SAFETY: callers can observe this only after initialization publishes
-        // the immutable value before BootActive.
-        unsafe { self.0.get().read() }
+        let header = self.header.load(Ordering::Acquire);
+        RuntimeResetConfig {
+            mechanism: header as u32,
+            reserved: (header >> 32) as u32,
+            io_or_mmio_base: self.base.load(Ordering::Relaxed),
+        }
     }
 
     fn address(&self) -> u64 {
-        self.0.get() as u64
+        core::ptr::addr_of!(self.header) as u64
     }
 }
 
@@ -464,8 +509,84 @@ mod tests {
         snapshot.publish(expected);
 
         let mut runtime = RuntimeState::new();
-        let runtime_lease = &mut runtime;
-        runtime_lease.reset.io_or_mmio_base = 0x1234;
+        runtime.reset.io_or_mmio_base = 0x1234;
+        assert_ne!(runtime.reset.io_or_mmio_base, expected.io_or_mmio_base);
         assert_eq!(snapshot.read(), expected);
+    }
+
+    #[test]
+    fn unpublished_reset_snapshot_reads_as_unconfigured() {
+        let snapshot = ResetConfigCell::new();
+        assert_eq!(snapshot.read().mechanism, 0);
+        assert_eq!(snapshot.read().io_or_mmio_base, 0);
+    }
+
+    #[test]
+    fn import_relocation_validates_offsets_against_imported_sections() {
+        let mut runtime = RuntimeState::new();
+        runtime.section_count = 2;
+        runtime.sections[0] = SectionRecord {
+            physical_base: 0x10_0000,
+            virtual_base: 0,
+            image_offset: 0,
+            byte_len: 0x1000,
+            flags: section_flags::EXECUTE,
+        };
+        runtime.sections[1] = SectionRecord {
+            physical_base: 0x10_1000,
+            virtual_base: 0,
+            image_offset: 0x1000,
+            byte_len: 0x1000,
+            flags: section_flags::RELOCATION_SLOTS | section_flags::WRITE,
+        };
+        let valid = RelocationImport {
+            patch_offset: 0x1008,
+            target_offset: 0x0,
+            patch_section: 1,
+            target_section: 0,
+            kind: relocation_kind::ABSOLUTE64,
+            reserved: [0; 12],
+        };
+        assert!(runtime.import_relocation(&valid).is_ok());
+
+        for invalid in [
+            // Patch slot outside the relocation-slot section.
+            RelocationImport {
+                patch_offset: 0x8,
+                ..valid
+            },
+            // Patch slot crosses the section end.
+            RelocationImport {
+                patch_offset: 0x1ff8 + 8,
+                ..valid
+            },
+            // Unaligned patch slot.
+            RelocationImport {
+                patch_offset: 0x1004,
+                ..valid
+            },
+            // Target offset equals the section end.
+            RelocationImport {
+                target_offset: 0x1000,
+                ..valid
+            },
+            // Section index past the imported sections.
+            RelocationImport {
+                patch_section: 2,
+                ..valid
+            },
+            RelocationImport {
+                target_section: 2,
+                ..valid
+            },
+            // Unknown relocation kind.
+            RelocationImport {
+                kind: relocation_kind::ABSOLUTE64 + 1,
+                ..valid
+            },
+        ] {
+            assert!(runtime.import_relocation(&invalid).is_err());
+        }
+        assert_eq!(runtime.relocation_count, 1);
     }
 }

--- a/crabefi-runtime-image/src/state.rs
+++ b/crabefi-runtime-image/src/state.rs
@@ -240,7 +240,7 @@ fn section_from_handoff(section: &LoadedSection) -> SectionRecord {
 
 /// Return whether `[offset, offset + width)` lies fully inside the section's
 /// image-relative `[image_offset, image_offset + byte_len)` range.
-fn offset_within_section(section: &SectionRecord, offset: u32, width: u32) -> bool {
+pub(crate) fn offset_within_section(section: &SectionRecord, offset: u32, width: u32) -> bool {
     section
         .image_offset
         .checked_add(section.byte_len)
@@ -268,7 +268,9 @@ fn range_from_handoff(range: &RuntimeExternalRange) -> RangeRecord {
 /// load in `read` makes the prior base store visible without taking the
 /// operation lease, so a re-entrant reset never reads a torn configuration.
 /// A zero header word means the snapshot has not been published yet, which
-/// leaves the architecture fallbacks in charge.
+/// leaves the architecture fallbacks in charge. This reserves
+/// `mechanism == 0` as "unpublished": every ABI reset mechanism constant
+/// must be nonzero for a published snapshot to ever be read.
 #[repr(C)]
 pub struct ResetConfigCell {
     header: AtomicU64,
@@ -293,6 +295,13 @@ impl ResetConfigCell {
 
     fn read(&self) -> RuntimeResetConfig {
         let header = self.header.load(Ordering::Acquire);
+        if header == 0 {
+            return RuntimeResetConfig {
+                mechanism: 0,
+                reserved: 0,
+                io_or_mmio_base: 0,
+            };
+        }
         RuntimeResetConfig {
             mechanism: header as u32,
             reserved: (header >> 32) as u32,
@@ -517,8 +526,16 @@ mod tests {
     #[test]
     fn unpublished_reset_snapshot_reads_as_unconfigured() {
         let snapshot = ResetConfigCell::new();
-        assert_eq!(snapshot.read().mechanism, 0);
-        assert_eq!(snapshot.read().io_or_mmio_base, 0);
+        snapshot.base.store(0xcf9, Ordering::Relaxed);
+
+        assert_eq!(
+            snapshot.read(),
+            RuntimeResetConfig {
+                mechanism: 0,
+                reserved: 0,
+                io_or_mmio_base: 0,
+            }
+        );
     }
 
     #[test]

--- a/crabefi-runtime-image/src/store.rs
+++ b/crabefi-runtime-image/src/store.rs
@@ -162,13 +162,6 @@ impl VariableStore {
         }
         let secure_variable = identify_key_database(&guid, name);
         if data.is_empty()
-            && let (Some(variable), Some(timestamp)) = (secure_variable, timestamp)
-        {
-            self.auth_timestamps[variable.index()] = timestamp;
-            self.refresh_policy();
-            return Ok(());
-        }
-        if data.is_empty()
             && let Some(timestamp) = timestamp
             && attributes & efi::VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS != 0
         {
@@ -176,6 +169,9 @@ impl VariableStore {
             // records carrying the verified deletion timestamp. Keep it as a
             // tombstone so the floor survives the reboot.
             self.record_tombstone(guid, name, attributes, timestamp)?;
+            if let Some(variable) = secure_variable {
+                self.auth_timestamps[variable.index()] = timestamp;
+            }
             return Ok(());
         }
         let mut prepared = self.prepare(guid, name, attributes, data.len())?;

--- a/crabefi-runtime-image/src/store.rs
+++ b/crabefi-runtime-image/src/store.rs
@@ -39,11 +39,20 @@ pub struct VariableSlot {
     pub data_len: u16,
     pub data_offset: u32,
     pub in_use: u8,
+    /// Bit flags; see [`VariableSlot::FLAG_TOMBSTONE`]. Zero while in use.
     pub reserved: [u8; 3],
     pub name: [u16; MAX_VARIABLE_NAME_LEN],
+    /// Timestamp of the last accepted authenticated write or deletion.
+    pub timestamp: VariableTimestamp,
 }
 
 impl VariableSlot {
+    /// Set on slots left behind by an authenticated deletion. A tombstone is
+    /// invisible to variable lookups but keeps the variable's last
+    /// authentication timestamp alive so it can neither be re-created raw nor
+    /// rolled back past the deletion.
+    pub const FLAG_TOMBSTONE: u8 = 1;
+
     pub const fn empty() -> Self {
         Self {
             guid: [0; 16],
@@ -54,11 +63,23 @@ impl VariableSlot {
             in_use: 0,
             reserved: [0; 3],
             name: [0; MAX_VARIABLE_NAME_LEN],
+            timestamp: ZERO_TIMESTAMP,
         }
     }
 
     pub fn matches(&self, guid: &[u8; 16], name: &[u16]) -> bool {
         self.in_use != 0
+            && self.guid == *guid
+            && usize::from(self.name_len) == name.len()
+            && self.name.get(..name.len()) == Some(name)
+    }
+
+    const fn is_tombstone(&self) -> bool {
+        self.reserved[0] & Self::FLAG_TOMBSTONE != 0
+    }
+
+    fn tombstone_matches(&self, guid: &[u8; 16], name: &[u16]) -> bool {
+        self.is_tombstone()
             && self.guid == *guid
             && usize::from(self.name_len) == name.len()
             && self.name.get(..name.len()) == Some(name)
@@ -111,6 +132,9 @@ pub struct PreparedWrite {
     pub attributes: u32,
     pub guid: [u8; 16],
     pub delete: bool,
+    /// Authentication timestamp to record with the committed slot. Zero for
+    /// unauthenticated writes; callers stamp it before `commit`.
+    pub timestamp: VariableTimestamp,
 }
 
 impl VariableStore {
@@ -144,12 +168,83 @@ impl VariableStore {
             self.refresh_policy();
             return Ok(());
         }
+        if data.is_empty()
+            && let Some(timestamp) = timestamp
+            && attributes & efi::VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS != 0
+        {
+            // The boot side persists authenticated deletions as zero-length
+            // records carrying the verified deletion timestamp. Keep it as a
+            // tombstone so the floor survives the reboot.
+            self.record_tombstone(guid, name, attributes, timestamp)?;
+            return Ok(());
+        }
         let mut prepared = self.prepare(guid, name, attributes, data.len())?;
+        prepared.timestamp = timestamp.unwrap_or_default();
         self.stage(transaction, &mut prepared, data, false)?;
         self.commit(transaction, prepared, name)?;
         if let (Some(variable), Some(timestamp)) = (secure_variable, timestamp) {
             self.auth_timestamps[variable.index()] = timestamp;
         }
+        self.refresh_policy();
+        Ok(())
+    }
+
+    /// Last authentication timestamp recorded for a variable, including the
+    /// tombstone left behind by an authenticated deletion.
+    ///
+    /// Returns `None` when the variable has no authenticated history. This is
+    /// the anti-rollback floor enforced on later authenticated updates.
+    pub fn auth_history_timestamp(
+        &self,
+        guid: &[u8; 16],
+        name: &[u16],
+    ) -> Option<VariableTimestamp> {
+        self.slots.iter().find_map(|slot| {
+            let authenticated_history = (slot.matches(guid, name)
+                && slot.attributes & efi::VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS != 0)
+                || slot.tombstone_matches(guid, name);
+            authenticated_history.then_some(slot.timestamp)
+        })
+    }
+
+    /// Record a deletion tombstone for an authenticated variable.
+    fn record_tombstone(
+        &mut self,
+        guid: [u8; 16],
+        name: &[u16],
+        attributes: u32,
+        timestamp: VariableTimestamp,
+    ) -> Result<(), efi::Status> {
+        if name.is_empty() || name.len() > MAX_VARIABLE_NAME_LEN {
+            return Err(efi::INVALID_PARAMETER);
+        }
+        let index = self
+            .slots
+            .iter()
+            .position(|slot| slot.matches(&guid, name))
+            .or_else(|| {
+                self.slots
+                    .iter()
+                    .position(|slot| slot.tombstone_matches(&guid, name))
+            })
+            .or_else(|| {
+                self.slots
+                    .iter()
+                    .position(|slot| slot.in_use == 0 && !slot.is_tombstone())
+            })
+            .ok_or(efi::OUT_OF_RESOURCES)?;
+        let slot = &mut self.slots[index];
+        slot.in_use = 0;
+        slot.data_len = 0;
+        slot.data_offset = 0;
+        slot.guid = guid;
+        slot.attributes = attributes & !efi::VARIABLE_APPEND_WRITE;
+        slot.name_len = name.len() as u16;
+        let (slot_name, remainder) = slot.name.split_at_mut(name.len());
+        slot_name.copy_from_slice(name);
+        remainder.fill(0);
+        slot.timestamp = timestamp;
+        slot.reserved[0] |= VariableSlot::FLAG_TOMBSTONE;
         self.refresh_policy();
         Ok(())
     }
@@ -239,10 +334,17 @@ impl VariableStore {
                 index
             }
             (None, true) => return Err(efi::NOT_FOUND),
+            // Prefer reclaiming this variable's own tombstone so re-creation
+            // after an authenticated deletion does not leak slots.
             (None, false) => self
                 .slots
                 .iter()
-                .position(|slot| slot.in_use == 0)
+                .position(|slot| slot.tombstone_matches(&guid, name))
+                .or_else(|| {
+                    self.slots
+                        .iter()
+                        .position(|slot| slot.in_use == 0 && !slot.is_tombstone())
+                })
                 .ok_or(efi::OUT_OF_RESOURCES)?,
         };
         Ok(PreparedWrite {
@@ -258,6 +360,7 @@ impl VariableStore {
             }),
             guid,
             delete,
+            timestamp: VariableTimestamp::default(),
         })
     }
 
@@ -293,6 +396,15 @@ impl VariableStore {
             slot.in_use = 0;
             slot.data_len = 0;
             slot.data_offset = 0;
+            if prepared.timestamp != VariableTimestamp::default() {
+                // Authenticated deletions leave a timestamped tombstone so the
+                // variable cannot be re-created raw or rolled back.
+                slot.attributes = prepared.attributes;
+                slot.timestamp = prepared.timestamp;
+                slot.reserved[0] |= VariableSlot::FLAG_TOMBSTONE;
+            } else {
+                slot.timestamp = VariableTimestamp::default();
+            }
             self.refresh_policy();
             return Ok(());
         }
@@ -350,6 +462,8 @@ impl VariableStore {
         let (slot_name, remainder) = slot.name.split_at_mut(prepared.name_len);
         slot_name.copy_from_slice(name);
         remainder.fill(0);
+        slot.reserved[0] &= !VariableSlot::FLAG_TOMBSTONE;
+        slot.timestamp = prepared.timestamp;
         slot.in_use = 1;
         self.refresh_policy();
         Ok(())

--- a/crabefi-runtime-image/src/svam.rs
+++ b/crabefi-runtime-image/src/svam.rs
@@ -539,8 +539,27 @@ fn commit_matching(
     for relocation in runtime.relocations.iter().take(runtime.relocation_count) {
         let patch_index = usize::from(relocation.patch_section);
         let target_index = usize::from(relocation.target_section);
+        // Mirror the validation pass so a future edit there cannot silently
+        // invalidate the safety argument of the unchecked accesses below.
+        debug_assert!(
+            patch_index < runtime.section_count && target_index < runtime.section_count,
+            "relocation section index escaped validation"
+        );
+        debug_assert!(
+            runtime.sections.get(patch_index).is_some_and(|section| {
+                state::offset_within_section(section, relocation.patch_offset, 8)
+            }),
+            "relocation patch slot escaped validation"
+        );
+        debug_assert!(
+            runtime.sections.get(target_index).is_some_and(|section| {
+                state::offset_within_section(section, relocation.target_offset, 1)
+            }),
+            "relocation target escaped validation"
+        );
         // SAFETY: the preceding validation pass checked both section indices,
-        // relocation offsets, and both address additions before commit began.
+        // relocation offsets, and both address additions before commit began;
+        // the debug assertions above pin those invariants to this loop.
         let (patch_section, target_section, target_base) = unsafe {
             (
                 *runtime.sections.get_unchecked(patch_index),

--- a/crabefi-runtime-image/src/svam.rs
+++ b/crabefi-runtime-image/src/svam.rs
@@ -443,11 +443,21 @@ fn validate_and_commit(
             .physical_base
             .checked_add(u64::from(target_relative))
             .ok_or(efi::Status::INVALID_PARAMETER)?;
-        if target_section.flags & section_flags::EXECUTE != 0
+        let tail_required = target_section.flags & section_flags::EXECUTE != 0
             || physical_target == state_address
             || physical_target == store_address
-            || transition_tail_addresses.contains(&physical_target)
+            || transition_tail_addresses.contains(&physical_target);
+        // `commit_matching` skips every patch address inside the Runtime
+        // Services table, so a table-resident slot that is not classified for
+        // the tail would never be patched and would silently keep its stale
+        // physical value after the virtual transition. Reject it instead.
+        if patch_address >= runtime_table_start
+            && patch_address < runtime_table_end
+            && !tail_required
         {
+            return Err(efi::Status::INVALID_PARAMETER);
+        }
+        if tail_required {
             if tail_count >= tail.len() {
                 return Err(efi::Status::OUT_OF_RESOURCES);
             }


### PR DESCRIPTION
Authenticated-variable history and several runtime transition invariants were not enforced consistently, leaving rollback, stale-address, and deferred-capacity failure modes.

Preserve timestamp floors with deletion tombstones, reject raw rewrites of authenticated variables, validate capsule and relocation ranges, publish reset state atomically, and strengthen SetVirtualAddressMap commit checks. The deferred journal reservation now also fits two maximum-width entries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened authenticated variable handling to prevent timestamp rollback and unauthorized raw updates, including after deletion.
  - Improved capsule validation and rejected invalid or overflowing descriptors.
  - Added stronger relocation and memory-boundary validation.
  - Improved reset-state synchronization and handling of unpublished configuration.
  - Fixed deferred journal sizing to support larger authenticated data.

- **Security**
  - Clarified certificate verification limitations and strengthened signature-history enforcement.

- **Reliability**
  - Expanded deferred buffers across supported architectures and improved crash-consistency safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->