### PR TITLE
efi: publish the RSDP under a single configuration-table GUID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches: [main, master, SBSA, RISCV64]
-  pull_request:
-    branches: [main, master]
+  pull_request: {}
 
 env:
   CARGO_TERM_COLOR: always

--- a/crabefi-core/src/efi/system_table.rs
+++ b/crabefi-core/src/efi/system_table.rs
@@ -500,23 +500,28 @@ pub fn install_acpi_tables(rsdp: u64) {
         mark_acpi_tables_memory(rsdp);
     }
 
-    // Install in EFI configuration table
-    if revision >= 2 {
-        // ACPI 2.0+
-        let status = install_configuration_table(&ACPI_20_TABLE_GUID, rsdp as *mut c_void);
-        if status == efi::Status::SUCCESS {
-            log::info!("Installed ACPI 2.0 configuration table");
-        } else {
-            log::error!("Failed to install ACPI 2.0 table: {:?}", status);
-        }
-    }
-
-    // Also install as ACPI 1.0 for compatibility
-    let status = install_configuration_table(&ACPI_TABLE_GUID, rsdp as *mut c_void);
-    if status == efi::Status::SUCCESS {
-        log::info!("Installed ACPI 1.0 configuration table");
+    // Install in EFI configuration table.
+    //
+    // Publish the RSDP under exactly one GUID, chosen to match its own
+    // revision. Handing an ACPI 2.0 (rev >= 2) RSDP to the OS twice via both
+    // GUIDs makes it walk/reserve the table chain twice (e.g. Linux reports
+    // and reserves FACS twice) and violates the expectation that the legacy
+    // GUID carries a genuine rev-1 RSDP. Only use the legacy GUID when the
+    // RSDP really is rev 1.
+    let status = if revision >= 2 {
+        install_configuration_table(&ACPI_20_TABLE_GUID, rsdp as *mut c_void)
     } else {
-        log::error!("Failed to install ACPI 1.0 table: {:?}", status);
+        install_configuration_table(&ACPI_TABLE_GUID, rsdp as *mut c_void)
+    };
+    if status == efi::Status::SUCCESS {
+        let version = if revision >= 2 { "2.0" } else { "1.0" };
+        log::info!("Installed ACPI {} configuration table", version);
+    } else {
+        log::error!(
+            "Failed to install ACPI {} table: {:?}",
+            if revision >= 2 { "2.0" } else { "1.0" },
+            status
+        );
     }
 
     let system_table = get_system_table();


### PR DESCRIPTION
Stacked on #112.

## Problem

`install_acpi_tables()` installed the same ACPI 2.0 RSDP under **both** `ACPI_20_TABLE_GUID` and the legacy `ACPI_TABLE_GUID` ("Also install as ACPI 1.0 for compatibility"). The legacy GUID is specified to carry a genuine revision-1 RSDP, so publishing a rev-2 pointer there makes the OS process the table chain twice.

Observed on the x220 (same coreboot BIOS, EDK II vs CrabEFI payload):

- EDK II boot: `efi: ... ACPI=0x1fffe000 ACPI 2.0=0x1fffe014 ...` — distinct pointers, FACS parsed once.
- CrabEFI boot: `efi: ... ACPI 2.0=0x7fe2d000 ACPI=0x7fe2d000 ...` — same pointer twice, and dmesg shows:
  ```
  ACPI: FACS 0x000000007FE2D240 000040
  ACPI: FACS 0x000000007FE2D240 000040
  ACPI: Reserving FACS table memory at [mem 0x7fe2d240-0x7fe2d27f]
  ACPI: Reserving FACS table memory at [mem 0x7fe2d240-0x7fe2d27f]
  ```

## Change

Publish the RSDP under exactly one GUID, chosen to match its own revision: `ACPI_20_TABLE_GUID` for rev ≥ 2, the legacy `ACPI_TABLE_GUID` only for a genuine rev-1 RSDP.

## Testing

- `cargo test -p crabefi-core`: 92 unit tests pass.
- Not yet boot-tested on hardware; expected effect is the duplicated FACS report/reservation lines disappearing from the Linux e820/ACPI walk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ACPI system information is now published under the correct table identifier based on the firmware revision, improving compatibility with systems that consume this data.

* **Chores**
  * Continuous integration checks now run for pull requests targeting any branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->