### PR TITLE
efi: don't re-type ACPI tables living in platform-reserved memory

### DIFF
--- a/crabefi-core/src/efi/allocator.rs
+++ b/crabefi-core/src/efi/allocator.rs
@@ -738,7 +738,11 @@ impl MemoryAllocator {
             addr,
             num_pages,
             MemoryType::AcpiReclaimMemory,
-            &[MemoryType::AcpiReclaimMemory, MemoryType::AcpiMemoryNvs],
+            &[
+                MemoryType::ReservedMemoryType,
+                MemoryType::AcpiReclaimMemory,
+                MemoryType::AcpiMemoryNvs,
+            ],
         )
     }
 
@@ -1826,6 +1830,41 @@ mod tests {
             ))
             .unwrap();
         allocator
+    }
+
+    #[test]
+    fn acpi_marking_preserves_platform_reserved_memory() {
+        let mut allocator = allocator_with_ram();
+        let reserved_start = 0x20_0000;
+        allocator
+            .entries
+            .push(memory_descriptor(
+                MemoryType::ReservedMemoryType,
+                reserved_start,
+                4,
+                attributes::EFI_MEMORY_RAM_CAPS,
+            ))
+            .unwrap();
+
+        allocator.mark_as_acpi_reclaim(reserved_start, 4).unwrap();
+        allocator.mark_as_acpi_reclaim(0x10_0000, 4).unwrap();
+
+        assert_eq!(
+            allocator
+                .entries
+                .iter()
+                .find(|entry| entry.physical_start == reserved_start)
+                .and_then(MemoryDescriptorExt::get_memory_type),
+            Some(MemoryType::ReservedMemoryType)
+        );
+        assert_eq!(
+            allocator
+                .entries
+                .iter()
+                .find(|entry| entry.physical_start == 0x10_0000)
+                .and_then(MemoryDescriptorExt::get_memory_type),
+            Some(MemoryType::AcpiReclaimMemory)
+        );
     }
 
     #[test]

--- a/crabefi-core/src/efi/system_table.rs
+++ b/crabefi-core/src/efi/system_table.rs
@@ -445,8 +445,6 @@ fn mark_acpi_tables_memory(rsdp_addr: u64) {
 
 /// Install ACPI tables from coreboot
 pub fn install_acpi_tables(rsdp: u64) {
-    use super::allocator::{MemoryType, get_memory_type_at};
-
     if rsdp == 0 {
         log::warn!("ACPI RSDP address is null, skipping ACPI table installation");
         return;
@@ -468,53 +466,11 @@ pub fn install_acpi_tables(rsdp: u64) {
         revision
     );
 
-    // Check what memory type the RSDP is in and mark ACPI regions if needed
-    let needs_marking = match get_memory_type_at(rsdp) {
-        Some(MemoryType::AcpiReclaimMemory) => {
-            log::info!("RSDP is already in AcpiReclaimMemory (correct)");
-            false
-        }
-        Some(MemoryType::AcpiMemoryNvs) => {
-            log::info!("RSDP is in AcpiMemoryNvs (acceptable)");
-            false
-        }
-        Some(MemoryType::ReservedMemoryType) => {
-            // Platform-reserved firmware table area (e.g. coreboot LB_MEM_TABLE
-            // in CBMEM). The OS preserves reserved regions as-is, so the ACPI
-            // tables need no re-typing. Re-typing only the pages holding
-            // tables would carve a small AcpiReclaim island out of the
-            // otherwise uniform firmware region; that fragments the OS
-            // resource tree and trips drivers that remap the whole area
-            // (observed on the x220 as Linux "resource sanity check"
-            // warnings when the coreboot-table driver memremaps the entire
-            // CBMEM region).
-            log::info!(
-                "RSDP at {:#x} is in platform-reserved memory - the OS preserves it, no re-typing needed",
-                rsdp
-            );
-            false
-        }
-        Some(mem_type) => {
-            log::info!(
-                "RSDP at {:#x} is in {:?} memory - will mark ACPI regions",
-                rsdp,
-                mem_type
-            );
-            true
-        }
-        None => {
-            log::info!(
-                "RSDP at {:#x} is not in any known memory region - will mark ACPI regions",
-                rsdp
-            );
-            true
-        }
-    };
-
-    // Mark all ACPI tables as AcpiReclaimMemory if needed
-    if needs_marking {
-        mark_acpi_tables_memory(rsdp);
-    }
+    // Walk the complete table chain so RAM-backed tables are re-typed even
+    // when the RSDP itself lives in platform-reserved memory. The allocator
+    // preserves tables already covered by ReservedMemoryType,
+    // AcpiReclaimMemory, or AcpiMemoryNvs descriptors.
+    mark_acpi_tables_memory(rsdp);
 
     // Install in EFI configuration table.
     //

--- a/crabefi-core/src/efi/system_table.rs
+++ b/crabefi-core/src/efi/system_table.rs
@@ -478,6 +478,22 @@ pub fn install_acpi_tables(rsdp: u64) {
             log::info!("RSDP is in AcpiMemoryNvs (acceptable)");
             false
         }
+        Some(MemoryType::ReservedMemoryType) => {
+            // Platform-reserved firmware table area (e.g. coreboot LB_MEM_TABLE
+            // in CBMEM). The OS preserves reserved regions as-is, so the ACPI
+            // tables need no re-typing. Re-typing only the pages holding
+            // tables would carve a small AcpiReclaim island out of the
+            // otherwise uniform firmware region; that fragments the OS
+            // resource tree and trips drivers that remap the whole area
+            // (observed on the x220 as Linux "resource sanity check"
+            // warnings when the coreboot-table driver memremaps the entire
+            // CBMEM region).
+            log::info!(
+                "RSDP at {:#x} is in platform-reserved memory - the OS preserves it, no re-typing needed",
+                rsdp
+            );
+            false
+        }
         Some(mem_type) => {
             log::info!(
                 "RSDP at {:#x} is in {:?} memory - will mark ACPI regions",


### PR DESCRIPTION
Stacked on #114.

## Problem

`install_acpi_tables()` re-typed the pages holding ACPI tables as `AcpiReclaimMemory` whenever the RSDP was not already in AcpiReclaim/NVS memory. On coreboot the tables live in the `LB_MEM_TABLE` (CBMEM) area, which the platform already reports as **reserved** — so the re-typing carved a 24 KiB `AcpiReclaim` island out of an otherwise uniform firmware region. Linux's e820 on the x220 (CrabEFI boot):

```
0x7fe15000-0x7fe2cfff  device reserved   (rest of the CBMEM area)
0x7fe2d000-0x7fe32fff  ACPI data         (island)   ← carve-up
0x7fe33000-0x889fffff  device reserved
```

The kernel's resource tree then has a hole in the middle of the firmware area. The coreboot-table driver (`drivers/firmware/google/coreboot_table`) memremaps the entire 144 KiB CBMEM region, and that request now spans the island boundary:

```
resource: resource sanity check: requesting [mem 0x7fe2d000-0x7fe50fff],
          which spans more than Reserved [mem 0x7fe33000-0x889fffff]
caller memremap+0x140/0x1f0
```

When the EDK II payload boots the same hardware, the identical remap lands inside one contiguous Reserved region (`[0x1fdda000-0x1ffe1fff]`), so the warning is CrabEFI-specific.

## Change

Skip the re-typing when the RSDP sits in platform-reserved memory — the OS preserves reserved regions as-is, which is sufficient for the tables (and matches the EDK II payload, which keeps the CBMEM area reserved while its own ACPI-table copy carries the `AcpiReclaim` type). Re-typing still happens when the RSDP sits in conventional RAM or outside the memory map, which is the case the marking logic exists for.

## Testing

- `cargo test -p crabefi-core`: 92 unit tests pass.
- Not yet boot-tested on hardware; expected: the `ACPI data` island and the `resource sanity check` warning disappear, leaving one contiguous `device reserved` region covering the firmware area (matching the EDK II boot's shape).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved platform-reserved memory when installing ACPI tables, preventing unnecessary memory type changes.
  * Added logging to clarify when reserved memory is retained for ACPI use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->