### PR TITLE
Fix NVMe controller initialization

### DIFF
--- a/crabefi-core/src/drivers/nvme/mod.rs
+++ b/crabefi-core/src/drivers/nvme/mod.rs
@@ -112,10 +112,14 @@ pub struct NvmeRegisters {
     pub nssr: ReadWrite<u32>,
     /// Admin Queue Attributes
     pub aqa: ReadWrite<u32, AQA::Register>,
-    /// Admin Submission Queue Base Address
-    pub asq: ReadWrite<u64>,
-    /// Admin Completion Queue Base Address
-    pub acq: ReadWrite<u64>,
+    /// Admin Submission Queue Base Address, low DWORD
+    pub asq_low: ReadWrite<u32>,
+    /// Admin Submission Queue Base Address, high DWORD
+    pub asq_high: ReadWrite<u32>,
+    /// Admin Completion Queue Base Address, low DWORD
+    pub acq_low: ReadWrite<u32>,
+    /// Admin Completion Queue Base Address, high DWORD
+    pub acq_high: ReadWrite<u32>,
 }
 
 /// NVMe admin commands
@@ -539,9 +543,29 @@ impl NvmeController {
     /// Write a doorbell register (doorbells are outside the typed register struct)
     #[inline]
     fn write_doorbell(&self, offset: u64, value: u32) {
+        // Order queue-memory updates before notifying the controller through MMIO.
+        barrier::mmio_write();
         unsafe {
             ptr::write_volatile((self.mmio_base + offset) as *mut u32, value);
         }
+    }
+
+    /// Write a 64-bit NVMe queue-base register as ordered low/high DWORDs.
+    ///
+    /// NVMe queue-base address registers must be programmed by writing the low
+    /// DWORD first and the high DWORD second. This also matches Linux, EDK2 DXE,
+    /// SeaBIOS, and U-Boot and avoids controllers that do not accept a native
+    /// 64-bit MMIO transaction for ASQ or ACQ.
+    #[inline]
+    fn write_queue_base(low: &ReadWrite<u32>, high: &ReadWrite<u32>, address: u64) {
+        low.set(address as u32);
+        high.set((address >> 32) as u32);
+    }
+
+    /// Read a 64-bit NVMe queue-base register as low/high DWORDs.
+    #[inline]
+    fn read_queue_base(low: &ReadWrite<u32>, high: &ReadWrite<u32>) -> u64 {
+        u64::from(low.get()) | (u64::from(high.get()) << 32)
     }
 
     /// Get doorbell register offset for a queue
@@ -569,12 +593,18 @@ impl NvmeController {
         // The pointer is valid for the lifetime of the NvmeController.
         let regs = unsafe { &*self.regs };
 
+        // CAP.TO specifies the maximum controller-ready transition time in
+        // 500 ms units. A zero value still permits one 500 ms unit.
+        let controller_timeout_ms = core::cmp::max(regs.cap.read(CAP::TO), 1) * 500;
+
         // Disable the controller
         regs.cc.modify(CC::EN::CLEAR);
 
-        // Wait for controller to become disabled (up to 1 second)
-        if !wait_for(1000, || regs.csts.read(CSTS::RDY) == 0) {
-            log::error!("NVMe: Timeout waiting for controller to disable");
+        if !wait_for(controller_timeout_ms, || regs.csts.read(CSTS::RDY) == 0) {
+            log::error!(
+                "NVMe: Timeout waiting {} ms for controller to disable",
+                controller_timeout_ms
+            );
             return Err(NvmeError::Timeout);
         }
 
@@ -584,11 +614,29 @@ impl NvmeController {
                 + AQA::ACQS.val((ADMIN_QUEUE_SIZE - 1) as u32),
         );
 
-        // Set admin submission queue base address
-        regs.asq.set(self.admin_sq as u64);
+        // Program 64-bit queue addresses as low then high DWORD writes, as
+        // required for NVMe queue-base registers.
+        let admin_sq_address = self.admin_sq as u64;
+        let admin_cq_address = self.admin_cq as u64;
+        Self::write_queue_base(&regs.asq_low, &regs.asq_high, admin_sq_address);
+        Self::write_queue_base(&regs.acq_low, &regs.acq_high, admin_cq_address);
 
-        // Set admin completion queue base address
-        regs.acq.set(self.admin_cq as u64);
+        let programmed_asq = Self::read_queue_base(&regs.asq_low, &regs.asq_high);
+        let programmed_acq = Self::read_queue_base(&regs.acq_low, &regs.acq_high);
+        log::debug!(
+            "NVMe admin queues: AQA={:#010x}, ASQ={:#018x}, ACQ={:#018x}",
+            regs.aqa.get(),
+            programmed_asq,
+            programmed_acq
+        );
+        if programmed_asq != admin_sq_address || programmed_acq != admin_cq_address {
+            log::error!(
+                "NVMe admin queue register readback mismatch: expected ASQ={:#018x} ACQ={:#018x}",
+                admin_sq_address,
+                admin_cq_address
+            );
+            return Err(NvmeError::NotReady);
+        }
 
         // Configure controller:
         // - Memory Page Size (MPS) = 0 (4KB)
@@ -607,8 +655,8 @@ impl NvmeController {
                 + CC::IOCQES.val(4),
         );
 
-        // Wait for controller to become ready (up to 2 seconds per spec)
-        let timeout = Timeout::from_ms(2000);
+        // Wait for the CAP.TO-defined controller-ready transition.
+        let timeout = Timeout::from_ms(controller_timeout_ms);
         while !timeout.is_expired() {
             if regs.csts.read(CSTS::RDY) != 0 {
                 log::debug!("NVMe controller ready");
@@ -652,7 +700,7 @@ impl NvmeController {
         unsafe {
             ptr::write_volatile(self.admin_sq.add(tail), *cmd);
         }
-        barrier::mmio_write();
+        barrier::dma_write();
 
         self.admin_sq_tail = ((tail + 1) % ADMIN_QUEUE_SIZE) as u16;
         self.ring_sq_doorbell(0, self.admin_sq_tail);
@@ -861,7 +909,7 @@ impl NvmeController {
         unsafe {
             ptr::write_volatile(self.io_sq.add(tail), *cmd);
         }
-        barrier::mmio_write();
+        barrier::dma_write();
 
         self.io_sq_tail = ((tail + 1) % IO_QUEUE_SIZE) as u16;
         self.ring_sq_doorbell(1, self.io_sq_tail);

--- a/crabefi-core/src/drivers/nvme/mod.rs
+++ b/crabefi-core/src/drivers/nvme/mod.rs
@@ -37,7 +37,11 @@ register_bitfields! [
         /// Memory Page Size Minimum (2^(12+MPSMIN) bytes)
         MPSMIN OFFSET(48) NUMBITS(4) [],
         /// Memory Page Size Maximum (2^(12+MPSMAX) bytes)
-        MPSMAX OFFSET(52) NUMBITS(4) []
+        MPSMAX OFFSET(52) NUMBITS(4) [],
+        /// Controller Ready With Media mode supported
+        CRMS_CRWMS OFFSET(59) NUMBITS(1) [],
+        /// Controller Ready Independent of Media mode supported
+        CRMS_CRIMS OFFSET(60) NUMBITS(1) []
     ]
 ];
 
@@ -88,6 +92,13 @@ register_bitfields! [
         ASQS OFFSET(0) NUMBITS(12) [],
         /// Admin Completion Queue Size (0's based)
         ACQS OFFSET(16) NUMBITS(12) []
+    ],
+    /// Controller Ready Timeouts (CRTO)
+    CRTO [
+        /// Controller Ready With Media Timeout (in 500ms units)
+        CRWMT OFFSET(0) NUMBITS(16) [],
+        /// Controller Ready Independent of Media Timeout (in 500ms units)
+        CRIMT OFFSET(16) NUMBITS(16) []
     ]
 ];
 
@@ -120,6 +131,10 @@ pub struct NvmeRegisters {
     pub acq_low: ReadWrite<u32>,
     /// Admin Completion Queue Base Address, high DWORD
     pub acq_high: ReadWrite<u32>,
+    /// Registers between ACQ (0x30) and CRTO (0x68)
+    _reserved1: [u32; 12],
+    /// Controller Ready Timeouts
+    pub crto: ReadOnly<u32, CRTO::Register>,
 }
 
 /// NVMe admin commands
@@ -593,17 +608,18 @@ impl NvmeController {
         // The pointer is valid for the lifetime of the NvmeController.
         let regs = unsafe { &*self.regs };
 
-        // CAP.TO specifies the maximum controller-ready transition time in
-        // 500 ms units. A zero value still permits one 500 ms unit.
-        let controller_timeout_ms = core::cmp::max(regs.cap.read(CAP::TO), 1) * 500;
+        // CAP.TO specifies the maximum disable transition time in 500 ms
+        // units. A zero value still permits one 500 ms unit.
+        let disable_timeout_units = core::cmp::max(regs.cap.read(CAP::TO), 1);
+        let disable_timeout_ms = disable_timeout_units * 500;
 
         // Disable the controller
         regs.cc.modify(CC::EN::CLEAR);
 
-        if !wait_for(controller_timeout_ms, || regs.csts.read(CSTS::RDY) == 0) {
+        if !wait_for(disable_timeout_ms, || regs.csts.read(CSTS::RDY) == 0) {
             log::error!(
                 "NVMe: Timeout waiting {} ms for controller to disable",
-                controller_timeout_ms
+                disable_timeout_ms
             );
             return Err(NvmeError::Timeout);
         }
@@ -646,8 +662,7 @@ impl NvmeController {
         // - I/O Submission Queue Entry Size (IOSQES) = 6 (64 bytes)
         // - I/O Completion Queue Entry Size (IOCQES) = 4 (16 bytes)
         regs.cc.write(
-            CC::EN::SET
-                + CC::CSS.val(0)
+            CC::CSS.val(0)
                 + CC::MPS.val(0)
                 + CC::AMS.val(0)
                 + CC::SHN.val(0)
@@ -655,8 +670,28 @@ impl NvmeController {
                 + CC::IOCQES.val(4),
         );
 
-        // Wait for the CAP.TO-defined controller-ready transition.
-        let timeout = Timeout::from_ms(controller_timeout_ms);
+        // NVMe 2.0 controllers may advertise the wider Controller Ready With
+        // Media timeout in CRTO. Use the larger value because some devices
+        // report a CRTO value smaller than the legacy CAP.TO value.
+        let cap_timeout_units = core::cmp::max(regs.cap.read(CAP::TO), 1);
+        let enable_timeout_units = if regs.cap.read(CAP::CRMS_CRWMS) != 0 {
+            let crto_timeout_units = u64::from(regs.crto.read(CRTO::CRWMT));
+            if crto_timeout_units < cap_timeout_units {
+                log::warn!(
+                    "NVMe: CRTO.CRWMT {} is smaller than CAP.TO {}; using CAP.TO",
+                    crto_timeout_units,
+                    cap_timeout_units
+                );
+            }
+            core::cmp::max(crto_timeout_units, cap_timeout_units)
+        } else {
+            cap_timeout_units
+        };
+        let enable_timeout_ms = enable_timeout_units * 500;
+
+        regs.cc.modify(CC::EN::SET);
+
+        let timeout = Timeout::from_ms(enable_timeout_ms);
         while !timeout.is_expired() {
             if regs.csts.read(CSTS::RDY) != 0 {
                 log::debug!("NVMe controller ready");

--- a/crabefi-core/src/efi/boot_services.rs
+++ b/crabefi-core/src/efi/boot_services.rs
@@ -1996,10 +1996,10 @@ extern "efiapi" fn protocols_per_handle(
     let ptr_array = buf as *mut *mut Guid;
     let guid_array = unsafe { buf.add(ptrs_size) } as *mut Guid;
 
-    for i in 0..count {
+    for (i, protocol) in entry.protocols.iter().take(count).enumerate() {
         unsafe {
             let guid_ptr = guid_array.add(i);
-            *guid_ptr = entry.protocols[i].guid;
+            *guid_ptr = protocol.guid;
             *ptr_array.add(i) = guid_ptr;
         }
     }

--- a/crabefi-core/src/efi/tcg/types.rs
+++ b/crabefi-core/src/efi/tcg/types.rs
@@ -361,8 +361,7 @@ impl SpecIdEvent {
         off += 4;
 
         // Algorithm entries: (algorithmId: u16, digestSize: u16)
-        for i in 0..self.num_algorithms as usize {
-            let (alg, size) = self.digest_sizes[i];
+        for &(alg, size) in self.digest_sizes.iter().take(self.num_algorithms as usize) {
             buf[off..off + 2].copy_from_slice(&alg.to_le_bytes());
             off += 2;
             buf[off..off + 2].copy_from_slice(&size.to_le_bytes());

--- a/crabefi-core/src/fs/fat.rs
+++ b/crabefi-core/src/fs/fat.rs
@@ -1259,8 +1259,7 @@ impl<'a> FatFilesystem<'a> {
 
         if lfn.active && lfn.len > 0 {
             // Use LFN - convert UTF-16 to UTF-8
-            for i in 0..lfn.len {
-                let ch = lfn.chars[i];
+            for &ch in lfn.chars.iter().take(lfn.len) {
                 if ch == 0 {
                     break;
                 }

--- a/crabefi-core/src/lib.rs
+++ b/crabefi-core/src/lib.rs
@@ -5,7 +5,6 @@
 
 #![no_std]
 #![cfg_attr(target_arch = "x86_64", feature(abi_x86_interrupt))]
-#![feature(never_type)] // Used for -> ! return type in payload chainloading
 #![deny(unsafe_op_in_unsafe_fn)]
 // Allow common firmware code patterns
 #![allow(clippy::result_unit_err)] // Result<(), ()> is common in embedded code

--- a/crabefi-core/src/payload/mod.rs
+++ b/crabefi-core/src/payload/mod.rs
@@ -198,7 +198,7 @@ pub unsafe fn chainload_payload(
     fs: &mut FatFilesystem<'_>,
     entry: &PayloadEntry,
     cbtable_ptr: *const u8,
-) -> Result<!, PayloadError> {
+) -> Result<core::convert::Infallible, PayloadError> {
     log::info!("Loading payload: {} from {}", entry.name, entry.path);
 
     // Static buffer for payload loading. Using UnsafeCell wrapped in a

--- a/crabefi-coreboot/src/acpi.rs
+++ b/crabefi-coreboot/src/acpi.rs
@@ -276,8 +276,7 @@ pub unsafe fn discover_platform(rsdp_addr: u64) -> PlatformInfo {
     }
     if info.dsdt_device_count > 0 {
         log::info!("  DSDT devices: {}", info.dsdt_device_count);
-        for i in 0..info.dsdt_device_count {
-            let dev = &info.dsdt_devices[i];
+        for dev in info.dsdt_devices.iter().take(info.dsdt_device_count) {
             if let Some(irq) = dev.irq {
                 log::info!(
                     "    {} [{}] mmio={:#x}+{:#x} irq={}",


### PR DESCRIPTION
CrabEFI's NVMe controller can reach the ready state but time out on its first Identify command because the admin queue base registers are written using native 64-bit MMIO transactions.

Program ASQ and ACQ as ordered low/high DWORD writes, matching Linux, EDK2 DXE, SeaBIOS, and U-Boot. Also use the controller's advertised CAP timeout, validate queue register readback, and order DMA queue updates before ringing doorbells.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVMe controller initialization by reliably programming and verifying admin queue addresses.
  * Added controller-specific timeout handling for disable and ready operations.
  * Improved memory ordering for NVMe queue submissions and doorbell notifications.
  * NVMe initialization now reports a not-ready state when queue configuration verification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->