### PR TITLE
Default firmware builds to the x86-64 payload target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,6 +3,14 @@
 # Linker scripts are handled by crabefi-coreboot/build.rs.
 # Build-std is passed by xtask so host-side Cargo commands remain unaffected.
 
+[build]
+# Every workspace member is firmware and cannot link for the host triple, so
+# default to the x86_64 payload target. This keeps plain `cargo build`,
+# `cargo check`, and `cargo clippy` working; pass --target for the other
+# architectures. Sub-projects that need a different default override this in
+# their own .cargo/config.toml (xtask -> host, test-apps -> *-unknown-uefi).
+target = "x86_64-unknown-none"
+
 [target.x86_64-unknown-none]
 rustflags = [
     "-C", "relocation-model=pic",


### PR DESCRIPTION
Every workspace member is firmware and cannot link for the host triple, so a bare `cargo build --release` currently passes the payload linker script to the host linker and fails.

Set the workspace default target to `x86_64-unknown-none`. xtask and the test applications retain their nested target configuration, while explicit `--target` invocations remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Configured the default build target for firmware projects, allowing standard build, check, and lint commands to run successfully.
  * Preserved project-specific target overrides for host tools and UEFI applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->