### PR TITLE
Use canonical EFI protocol ABI definitions

### DIFF
--- a/crabefi-core/src/efi/protocols/block_io.rs
+++ b/crabefi-core/src/efi/protocols/block_io.rs
@@ -4,83 +4,22 @@
 //! use its built-in filesystem drivers (ISO9660, ext4, etc.) to read partitions.
 
 use core::ffi::c_void;
-use r_efi::efi::{Guid, Status};
+use r_efi::efi::{Boolean, Status};
+use r_efi::protocols::block_io;
 
 use crate::efi::utils::allocate_protocol_with_log;
 
-/// Block I/O Protocol GUID
-pub const BLOCK_IO_PROTOCOL_GUID: Guid = Guid::from_fields(
-    0x964e5b21,
-    0x6459,
-    0x11d2,
-    0x8e,
-    0x39,
-    &[0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b],
-);
+/// Block I/O Protocol GUID.
+pub const BLOCK_IO_PROTOCOL_GUID: r_efi::efi::Guid = block_io::PROTOCOL_GUID;
 
-/// Block I/O Protocol revision
-pub const BLOCK_IO_REVISION: u64 = 0x00010000; // EFI_BLOCK_IO_PROTOCOL_REVISION
+/// Block I/O Protocol revision.
+pub const BLOCK_IO_REVISION: u64 = block_io::REVISION;
 
-/// Block I/O Media structure
-///
-/// Note: UEFI `BOOLEAN` is defined as `UINT8`, not C `_Bool`. Using `u8` here
-/// instead of Rust `bool` ensures correct ABI layout matching the UEFI spec's
-/// `EFI_BLOCK_IO_MEDIA` structure. Three bytes of padding after `write_caching`
-/// align `block_size` to its natural 4-byte boundary.
-#[repr(C)]
-pub struct BlockIoMedia {
-    /// Media ID - changes when media is changed
-    pub media_id: u32,
-    /// True (1) if media is removable
-    pub removable_media: u8,
-    /// True (1) if media is present
-    pub media_present: u8,
-    /// True (1) if this is a logical partition
-    pub logical_partition: u8,
-    /// True (1) if media is read-only
-    pub read_only: u8,
-    /// True (1) if WriteBlocks() must be called with entire blocks
-    pub write_caching: u8,
-    /// Padding to align block_size to 4-byte boundary
-    _pad1: [u8; 3],
-    /// Block size in bytes
-    pub block_size: u32,
-    /// IO alignment requirement (0 or power of 2)
-    pub io_align: u32,
-    /// Padding for alignment
-    _pad2: u32,
-    /// Last logical block address
-    pub last_block: u64,
-}
-/// Block I/O Protocol structure
-#[repr(C)]
-pub struct BlockIoProtocol {
-    /// Protocol revision
-    pub revision: u64,
-    /// Pointer to BlockIoMedia
-    pub media: *mut BlockIoMedia,
-    /// Reset function
-    pub reset:
-        extern "efiapi" fn(this: *mut BlockIoProtocol, extended_verification: bool) -> Status,
-    /// Read blocks function
-    pub read_blocks: extern "efiapi" fn(
-        this: *mut BlockIoProtocol,
-        media_id: u32,
-        lba: u64,
-        buffer_size: usize,
-        buffer: *mut c_void,
-    ) -> Status,
-    /// Write blocks function
-    pub write_blocks: extern "efiapi" fn(
-        this: *mut BlockIoProtocol,
-        media_id: u32,
-        lba: u64,
-        buffer_size: usize,
-        buffer: *mut c_void,
-    ) -> Status,
-    /// Flush blocks function
-    pub flush_blocks: extern "efiapi" fn(this: *mut BlockIoProtocol) -> Status,
-}
+/// Block I/O media structure supplied by `r-efi`.
+pub type BlockIoMedia = block_io::Media;
+
+/// Block I/O protocol ABI supplied by `r-efi`.
+pub type BlockIoProtocol = block_io::Protocol;
 
 /// Internal context for BlockIO protocol instance
 #[derive(Clone, Copy)]
@@ -109,7 +48,7 @@ static CTX_MAP: ProtocolContextMap<BlockIoContext, BlockIoProtocol, MAX_BLOCK_IO
 /// Reset the block device
 extern "efiapi" fn block_io_reset(
     _this: *mut BlockIoProtocol,
-    _extended_verification: bool,
+    _extended_verification: Boolean,
 ) -> Status {
     log::debug!("BlockIO.Reset()");
     Status::SUCCESS
@@ -282,16 +221,17 @@ fn create_block_io_internal(
     // Allocate media structure
     let media_ptr = allocate_protocol_with_log::<BlockIoMedia>("BlockIoMedia", |m| {
         m.media_id = media_id;
-        m.removable_media = 1; // Assume removable for now
-        m.media_present = 1;
-        m.logical_partition = if is_partition { 1 } else { 0 };
-        m.read_only = 1; // We only support read for booting
-        m.write_caching = 0;
-        m._pad1 = [0; 3];
+        m.removable_media = true; // Assume removable for now
+        m.media_present = true;
+        m.logical_partition = is_partition;
+        m.read_only = true; // We only support read for booting
+        m.write_caching = false;
         m.block_size = block_size;
         m.io_align = 0;
-        m._pad2 = 0;
         m.last_block = num_blocks.saturating_sub(1);
+        m.lowest_aligned_lba = 0;
+        m.logical_blocks_per_physical_block = 1;
+        m.optimal_transfer_length_granularity = 0;
     });
     if media_ptr.is_null() {
         return core::ptr::null_mut();

--- a/crabefi-core/src/efi/protocols/disk_io.rs
+++ b/crabefi-core/src/efi/protocols/disk_io.rs
@@ -7,43 +7,20 @@
 
 use core::ffi::c_void;
 use r_efi::efi::{Handle, Status};
+use r_efi::protocols::disk_io;
 
 use super::block_io::{BLOCK_IO_PROTOCOL_GUID, BlockIoProtocol};
 use crate::efi::boot_services;
 use crate::efi::utils::allocate_protocol_with_log;
 
-/// Disk I/O Protocol GUID
-pub const DISK_IO_PROTOCOL_GUID: r_efi::efi::Guid = r_efi::efi::Guid::from_fields(
-    0xCE345171,
-    0xBA0B,
-    0x11d2,
-    0x8E,
-    0x4F,
-    &[0x00, 0xA0, 0xC9, 0x69, 0x72, 0x3B],
-);
+/// Disk I/O Protocol GUID supplied by `r-efi`.
+pub const DISK_IO_PROTOCOL_GUID: r_efi::efi::Guid = disk_io::PROTOCOL_GUID;
 
-/// Disk I/O Protocol revision
-const DISK_IO_REVISION: u64 = 0x0001_0000;
+/// Disk I/O Protocol revision supplied by `r-efi`.
+const DISK_IO_REVISION: u64 = disk_io::REVISION;
 
-/// Disk I/O Protocol structure (matches r_efi::protocols::disk_io::Protocol)
-#[repr(C)]
-pub struct DiskIoProtocol {
-    pub revision: u64,
-    pub read_disk: extern "efiapi" fn(
-        this: *mut DiskIoProtocol,
-        media_id: u32,
-        offset: u64,
-        buffer_size: usize,
-        buffer: *mut c_void,
-    ) -> Status,
-    pub write_disk: extern "efiapi" fn(
-        this: *mut DiskIoProtocol,
-        media_id: u32,
-        offset: u64,
-        buffer_size: usize,
-        buffer: *mut c_void,
-    ) -> Status,
-}
+/// Disk I/O protocol ABI supplied by `r-efi`.
+pub type DiskIoProtocol = disk_io::Protocol;
 
 /// Maximum number of DiskIO instances (must match MAX_BLOCK_IO_INSTANCES)
 const MAX_DISK_IO_INSTANCES: usize = 16;

--- a/crabefi-core/src/efi/protocols/graphics_output.rs
+++ b/crabefi-core/src/efi/protocols/graphics_output.rs
@@ -4,130 +4,31 @@
 //! framebuffer access to the OS. We expose the framebuffer information from
 //! coreboot tables.
 
-use r_efi::efi::{Guid, Status};
+use r_efi::efi::Status;
+use r_efi::protocols::graphics_output;
 
 use crate::efi::allocator::{MemoryType, allocate_pool};
 use crate::efi::protocols::console;
 use crate::efi::utils::allocate_protocol_with_log;
 use crate::platform::FramebufferConfig;
 
-/// EFI_GRAPHICS_OUTPUT_PROTOCOL GUID
-pub const GRAPHICS_OUTPUT_GUID: Guid = Guid::from_fields(
-    0x9042a9de,
-    0x23dc,
-    0x4a38,
-    0x96,
-    0xfb,
-    &[0x7a, 0xde, 0xd0, 0x80, 0x51, 0x6a],
-);
+/// Graphics Output Protocol GUID supplied by `r-efi`.
+pub const GRAPHICS_OUTPUT_GUID: r_efi::efi::Guid = graphics_output::PROTOCOL_GUID;
 
-/// Pixel format enumeration
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PixelFormat {
-    /// Red-Green-Blue-Reserved 8-bit per color
-    RedGreenBlueReserved8BitPerColor = 0,
-    /// Blue-Green-Red-Reserved 8-bit per color
-    BlueGreenRedReserved8BitPerColor = 1,
-    /// Pixel format defined by pixel_bitmask
-    BitMask = 2,
-    /// Only valid for Blt operations
-    BltOnly = 3,
-}
-
-/// Pixel bitmask structure for BitMask pixel format
-#[repr(C)]
-#[derive(Debug, Clone, Copy, Default)]
-pub struct PixelBitmask {
-    pub red_mask: u32,
-    pub green_mask: u32,
-    pub blue_mask: u32,
-    pub reserved_mask: u32,
-}
-
-/// GOP Mode Information structure
-#[repr(C)]
-#[derive(Debug, Clone)]
-pub struct GopModeInfo {
-    /// Version of the structure (should be 0)
-    pub version: u32,
-    /// Horizontal resolution in pixels
-    pub horizontal_resolution: u32,
-    /// Vertical resolution in pixels
-    pub vertical_resolution: u32,
-    /// Pixel format
-    pub pixel_format: PixelFormat,
-    /// Pixel bitmask (only valid if pixel_format is BitMask)
-    pub pixel_information: PixelBitmask,
-    /// Number of pixels per video memory scan line
-    pub pixels_per_scan_line: u32,
-}
-
-/// GOP Mode structure
-#[repr(C)]
-pub struct GopMode {
-    /// Maximum mode number supported (0-based, so max_mode=1 means mode 0 only)
-    pub max_mode: u32,
-    /// Current mode number
-    pub mode: u32,
-    /// Pointer to mode information
-    pub info: *mut GopModeInfo,
-    /// Size of the mode information structure
-    pub size_of_info: usize,
-    /// Physical address of the framebuffer
-    pub frame_buffer_base: u64,
-    /// Size of the framebuffer in bytes
-    pub frame_buffer_size: usize,
-}
-
-/// BLT (Block Transfer) operation types
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum BltOperation {
-    /// Fill rectangle with color
-    VideoFill = 0,
-    /// Copy from video to buffer
-    VideoToBltBuffer = 1,
-    /// Copy from buffer to video
-    BufferToVideo = 2,
-    /// Copy within video memory
-    VideoToVideo = 3,
-}
-
-/// BLT pixel structure (BGRA format)
-#[repr(C)]
-#[derive(Debug, Clone, Copy, Default)]
-pub struct BltPixel {
-    pub blue: u8,
-    pub green: u8,
-    pub red: u8,
-    pub reserved: u8,
-}
-
-/// Graphics Output Protocol structure
-#[repr(C)]
-pub struct GraphicsOutputProtocol {
-    pub query_mode: extern "efiapi" fn(
-        this: *mut GraphicsOutputProtocol,
-        mode_number: u32,
-        size_of_info: *mut usize,
-        info: *mut *mut GopModeInfo,
-    ) -> Status,
-    pub set_mode: extern "efiapi" fn(this: *mut GraphicsOutputProtocol, mode_number: u32) -> Status,
-    pub blt: extern "efiapi" fn(
-        this: *mut GraphicsOutputProtocol,
-        blt_buffer: *mut BltPixel,
-        blt_operation: BltOperation,
-        source_x: usize,
-        source_y: usize,
-        destination_x: usize,
-        destination_y: usize,
-        width: usize,
-        height: usize,
-        delta: usize,
-    ) -> Status,
-    pub mode: *mut GopMode,
-}
+/// Pixel format ABI supplied by `r-efi`.
+pub type PixelFormat = graphics_output::GraphicsPixelFormat;
+/// Pixel bitmask ABI supplied by `r-efi`.
+pub type PixelBitmask = graphics_output::PixelBitmask;
+/// GOP mode information ABI supplied by `r-efi`.
+pub type GopModeInfo = graphics_output::ModeInformation;
+/// GOP mode ABI supplied by `r-efi`.
+pub type GopMode = graphics_output::Mode;
+/// BLT operation ABI supplied by `r-efi`.
+pub type BltOperation = graphics_output::BltOperation;
+/// BLT pixel ABI supplied by `r-efi`.
+pub type BltPixel = graphics_output::BltPixel;
+/// Graphics Output Protocol ABI supplied by `r-efi`.
+pub type GraphicsOutputProtocol = graphics_output::Protocol;
 
 /// Query available video mode information
 extern "efiapi" fn gop_query_mode(
@@ -240,7 +141,7 @@ extern "efiapi" fn gop_blt(
     };
 
     match blt_operation {
-        BltOperation::VideoFill => {
+        graphics_output::BLT_VIDEO_FILL => {
             // Fill a rectangle with a single color
             if blt_buffer.is_null() {
                 return Status::INVALID_PARAMETER;
@@ -263,7 +164,7 @@ extern "efiapi" fn gop_blt(
             }
         }
 
-        BltOperation::VideoToBltBuffer => {
+        graphics_output::BLT_VIDEO_TO_BLT_BUFFER => {
             // Copy from video memory to buffer
             if blt_buffer.is_null() {
                 return Status::INVALID_PARAMETER;
@@ -287,7 +188,7 @@ extern "efiapi" fn gop_blt(
             }
         }
 
-        BltOperation::BufferToVideo => {
+        graphics_output::BLT_BUFFER_TO_VIDEO => {
             // Copy from buffer to video memory
             if blt_buffer.is_null() {
                 return Status::INVALID_PARAMETER;
@@ -311,7 +212,7 @@ extern "efiapi" fn gop_blt(
             }
         }
 
-        BltOperation::VideoToVideo => {
+        graphics_output::BLT_VIDEO_TO_VIDEO => {
             // Copy within video memory
             if source_x + width > fb_width || source_y + height > fb_height {
                 return Status::INVALID_PARAMETER;
@@ -356,6 +257,7 @@ extern "efiapi" fn gop_blt(
                 }
             }
         }
+        _ => return Status::INVALID_PARAMETER,
     }
 
     Status::SUCCESS
@@ -458,7 +360,12 @@ unsafe fn read_pixel_from_fb(
                     reserved: 0,
                 }
             }
-            _ => BltPixel::default(),
+            _ => BltPixel {
+                blue: 0,
+                green: 0,
+                red: 0,
+                reserved: 0,
+            },
         }
     }
 }
@@ -476,8 +383,13 @@ pub fn create_gop(framebuffer: &FramebufferConfig) -> *mut GraphicsOutputProtoco
         {
             // BGRA (most common)
             (
-                PixelFormat::BlueGreenRedReserved8BitPerColor,
-                PixelBitmask::default(),
+                graphics_output::PIXEL_BLUE_GREEN_RED_RESERVED_8_BIT_PER_COLOR,
+                PixelBitmask {
+                    red_mask: 0,
+                    green_mask: 0,
+                    blue_mask: 0,
+                    reserved_mask: 0,
+                },
             )
         } else if framebuffer.red_mask_pos == 0
             && framebuffer.green_mask_pos == 8
@@ -485,8 +397,13 @@ pub fn create_gop(framebuffer: &FramebufferConfig) -> *mut GraphicsOutputProtoco
         {
             // RGBA
             (
-                PixelFormat::RedGreenBlueReserved8BitPerColor,
-                PixelBitmask::default(),
+                graphics_output::PIXEL_RED_GREEN_BLUE_RESERVED_8_BIT_PER_COLOR,
+                PixelBitmask {
+                    red_mask: 0,
+                    green_mask: 0,
+                    blue_mask: 0,
+                    reserved_mask: 0,
+                },
             )
         } else {
             // Custom bitmask
@@ -496,7 +413,7 @@ pub fn create_gop(framebuffer: &FramebufferConfig) -> *mut GraphicsOutputProtoco
                 blue_mask: 0xFF << framebuffer.blue_mask_pos,
                 reserved_mask: 0,
             };
-            (PixelFormat::BitMask, bitmask)
+            (graphics_output::PIXEL_BIT_MASK, bitmask)
         }
     } else {
         // For non-32bpp, use bitmask
@@ -506,7 +423,7 @@ pub fn create_gop(framebuffer: &FramebufferConfig) -> *mut GraphicsOutputProtoco
             blue_mask: ((1u32 << framebuffer.blue_mask_size) - 1) << framebuffer.blue_mask_pos,
             reserved_mask: 0,
         };
-        (PixelFormat::BitMask, bitmask)
+        (graphics_output::PIXEL_BIT_MASK, bitmask)
     };
 
     // Allocate mode info

--- a/crabefi-core/src/efi/protocols/memory_attribute.rs
+++ b/crabefi-core/src/efi/protocols/memory_attribute.rs
@@ -5,20 +5,13 @@
 //!
 //! Reference: UEFI Specification 2.10, Section 7.2
 
-use r_efi::efi::{Guid, PhysicalAddress, Status};
+use r_efi::efi::{PhysicalAddress, Status};
+use r_efi::protocols::memory_attribute;
 
 use crate::efi::utils::allocate_protocol_with_log;
 
-/// Memory Attribute Protocol GUID
-/// {f4560cf6-40ec-4b4a-a192-bf1d57d0b189}
-pub const MEMORY_ATTRIBUTE_PROTOCOL_GUID: Guid = Guid::from_fields(
-    0xf4560cf6,
-    0x40ec,
-    0x4b4a,
-    0xa1,
-    0x92,
-    &[0xbf, 0x1d, 0x57, 0xd0, 0xb1, 0x89],
-);
+/// Memory Attribute Protocol GUID supplied by `r-efi`.
+pub const MEMORY_ATTRIBUTE_PROTOCOL_GUID: r_efi::efi::Guid = memory_attribute::PROTOCOL_GUID;
 
 /// Memory attribute bits
 /// Read Protect - memory cannot be read
@@ -31,28 +24,8 @@ pub const EFI_MEMORY_RO: u64 = 0x0000000000020000;
 /// Mask of all valid memory protection attributes
 pub const EFI_MEMORY_ACCESS_MASK: u64 = EFI_MEMORY_RP | EFI_MEMORY_XP | EFI_MEMORY_RO;
 
-/// EFI Memory Attribute Protocol structure
-#[repr(C)]
-pub struct Protocol {
-    pub get_memory_attributes: extern "efiapi" fn(
-        this: *mut Protocol,
-        base_address: PhysicalAddress,
-        length: u64,
-        attributes: *mut u64,
-    ) -> Status,
-    pub set_memory_attributes: extern "efiapi" fn(
-        this: *mut Protocol,
-        base_address: PhysicalAddress,
-        length: u64,
-        attributes: u64,
-    ) -> Status,
-    pub clear_memory_attributes: extern "efiapi" fn(
-        this: *mut Protocol,
-        base_address: PhysicalAddress,
-        length: u64,
-        attributes: u64,
-    ) -> Status,
-}
+/// Memory Attribute protocol ABI supplied by `r-efi`.
+pub type Protocol = memory_attribute::Protocol;
 
 /// Get memory attributes for a region
 ///

--- a/crabefi-core/src/efi/protocols/simple_text_input_ex.rs
+++ b/crabefi-core/src/efi/protocols/simple_text_input_ex.rs
@@ -14,82 +14,30 @@ use crate::efi::boot_services::KEYBOARD_EVENT_ID;
 use crate::efi::protocols::console;
 use crate::efi::utils::allocate_protocol_with_log;
 use core::ffi::c_void;
-use r_efi::efi::{Boolean, Event, Guid, Handle, Status};
+use r_efi::efi::{Boolean, Event, Handle, Status};
 use r_efi::protocols::simple_text_input::InputKey;
+use r_efi::protocols::simple_text_input_ex;
 
 // ============================================================================
 // Protocol GUID
 // ============================================================================
 
-/// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID
-/// {DD9E7534-7762-4698-8C14-F58517A625AA}
-pub const SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID: Guid = Guid::from_fields(
-    0xdd9e7534,
-    0x7762,
-    0x4698,
-    0x8c,
-    0x14,
-    &[0xf5, 0x85, 0x17, 0xa6, 0x25, 0xaa],
-);
+/// Simple Text Input Ex Protocol GUID supplied by `r-efi`.
+pub const SIMPLE_TEXT_INPUT_EX_PROTOCOL_GUID: r_efi::efi::Guid =
+    simple_text_input_ex::PROTOCOL_GUID;
 
 // ============================================================================
 // Protocol Structures (matching UEFI spec)
 // ============================================================================
 
-/// EFI_KEY_STATE - describes the shift/toggle state of the keyboard
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default)]
-pub struct KeyState {
-    /// Shift key state (EFI_SHIFT_STATE_VALID | modifier bits)
-    pub key_shift_state: u32,
-    /// Toggle key state (EFI_TOGGLE_STATE_VALID | toggle bits)
-    pub key_toggle_state: u8,
-}
-
-/// EFI_KEY_DATA - a key press with associated state
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default)]
-pub struct KeyData {
-    /// The EFI scan code and Unicode value
-    pub key: InputKey,
-    /// Shift and toggle state at time of key press
-    pub key_state: KeyState,
-}
-
-// Compile-time layout assertions matching UEFI spec sizes:
-// EFI_KEY_STATE: UINT32 + UINT8 = 5 bytes + 3 padding = 8 bytes (repr(C))
-// EFI_KEY_DATA: EFI_INPUT_KEY (4 bytes) + EFI_KEY_STATE (8 bytes) = 12 bytes
-const _: () = assert!(core::mem::size_of::<KeyState>() == 8);
-const _: () = assert!(core::mem::size_of::<KeyData>() == 12);
-
-/// Key notification callback function type
-pub type KeyNotifyFunction = extern "efiapi" fn(key_data: *mut KeyData) -> Status;
-
-/// EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL
-#[repr(C)]
-pub struct SimpleTextInputExProtocol {
-    pub reset: extern "efiapi" fn(
-        this: *mut SimpleTextInputExProtocol,
-        extended_verification: Boolean,
-    ) -> Status,
-    pub read_key_stroke_ex:
-        extern "efiapi" fn(this: *mut SimpleTextInputExProtocol, key_data: *mut KeyData) -> Status,
-    pub wait_for_key_ex: Event,
-    pub set_state: extern "efiapi" fn(
-        this: *mut SimpleTextInputExProtocol,
-        key_toggle_state: *mut u8,
-    ) -> Status,
-    pub register_key_notify: extern "efiapi" fn(
-        this: *mut SimpleTextInputExProtocol,
-        key_data: *mut KeyData,
-        key_notification_function: KeyNotifyFunction,
-        notify_handle: *mut Handle,
-    ) -> Status,
-    pub unregister_key_notify: extern "efiapi" fn(
-        this: *mut SimpleTextInputExProtocol,
-        notification_handle: Handle,
-    ) -> Status,
-}
+/// Key state ABI supplied by `r-efi`.
+pub type KeyState = simple_text_input_ex::KeyState;
+/// Key data ABI supplied by `r-efi`.
+pub type KeyData = simple_text_input_ex::KeyData;
+/// Key notification callback ABI supplied by `r-efi`.
+pub type KeyNotifyFunction = simple_text_input_ex::KeyNotifyFunction;
+/// Simple Text Input Ex protocol ABI supplied by `r-efi`.
+pub type SimpleTextInputExProtocol = simple_text_input_ex::Protocol;
 
 // ============================================================================
 // Key Notification Registry


### PR DESCRIPTION
Several EFI protocol layouts and constants were duplicated locally, including a Block I/O reset callback using Rust `bool` at an EFI `BOOLEAN` boundary.

Use the canonical r-efi definitions for Block I/O, Disk I/O, Graphics Output, Memory Attribute and Simple Text Input Ex, and use EFI `Boolean` for BlockIo.Reset.
