### PR TITLE
Make firmware state access sound

### DIFF
--- a/crabefi-core/src/arch/aarch64/rng.rs
+++ b/crabefi-core/src/arch/aarch64/rng.rs
@@ -146,7 +146,7 @@ pub fn init() {
 
 /// Check if hardware RNG is available and functional
 pub fn is_supported() -> bool {
-    crate::state::drivers().rng_available
+    unsafe { &*crate::state::drivers_ptr() }.rng_available
 }
 
 /// Fill a byte buffer with random data

--- a/crabefi-core/src/arch/x86_64/rng.rs
+++ b/crabefi-core/src/arch/x86_64/rng.rs
@@ -63,7 +63,7 @@ pub fn init() {
 
 /// Check if RDRAND is available and functional
 pub fn is_supported() -> bool {
-    crate::state::drivers().rng_available
+    unsafe { &*crate::state::drivers_ptr() }.rng_available
 }
 
 /// Fill a byte buffer with random data from RDRAND

--- a/crabefi-core/src/boot_manager.rs
+++ b/crabefi-core/src/boot_manager.rs
@@ -672,13 +672,15 @@ fn boot_linux_entry(
 
     // Get memory regions and ACPI RSDP from state
     let (memory_regions, acpi_rsdp) = {
-        let state = state::get();
-        // Copy memory regions to a local buffer (we can't borrow across the disk operations)
+        let drivers = state::drivers_ptr();
+        // Copy memory regions to a local buffer (we can't borrow across the disk operations).
         let mut regions = heapless::Vec::<crate::platform::MemoryRegion, 64>::new();
-        for region in state.drivers.platform.memory_regions.iter() {
-            let _ = regions.push(*region);
+        unsafe {
+            for region in (*drivers).platform.memory_regions.iter() {
+                let _ = regions.push(*region);
+            }
+            (regions, (*drivers).platform.acpi_rsdp)
         }
-        (regions, state.drivers.platform.acpi_rsdp)
     };
 
     // Get framebuffer info for Linux console

--- a/crabefi-core/src/drivers/pci/mod.rs
+++ b/crabefi-core/src/drivers/pci/mod.rs
@@ -72,7 +72,7 @@ fn with_access<F, R>(f: F) -> R
 where
     F: FnOnce(&AnyPciAccess) -> R,
 {
-    let access = &state::drivers().pci.access;
+    let access = &unsafe { &*state::drivers_ptr() }.pci.access;
     f(access)
 }
 
@@ -342,7 +342,7 @@ pub fn dma_domain(address: PciAddress) -> Option<DmaDomain> {
     }
     #[cfg(not(target_arch = "x86_64"))]
     {
-        let drivers = state::drivers();
+        let drivers = unsafe { &*state::drivers_ptr() };
         drivers
             .fdt_info
             .pci_dma_domain(address.segment())
@@ -362,7 +362,7 @@ pub fn dma_domain(address: PciAddress) -> Option<DmaDomain> {
 pub fn init() {
     log::info!("Initializing PCI subsystem...");
     let (regions, ecam_configured) = {
-        let drivers = state::drivers();
+        let drivers = unsafe { &*state::drivers_ptr() };
         (
             drivers.pci.ecam_regions.clone(),
             drivers.pci.ecam_configured,
@@ -471,7 +471,7 @@ fn enumerate_region(
 pub fn bind_drivers() {
     log::info!("Binding PCI drivers to devices...");
 
-    let devices = state::drivers().pci.devices.clone();
+    let devices = unsafe { &*state::drivers_ptr() }.pci.devices.clone();
 
     let mut bound_count = 0;
     for device in devices.iter() {
@@ -497,7 +497,7 @@ pub fn shutdown_drivers() {
 /// by firmware.  Any device left bus-mastering can scribble over pages Linux
 /// has already repurposed for early stacks or metadata.
 pub fn disable_all_bus_mastering_for_handoff() {
-    let devices = state::drivers().pci.devices.clone();
+    let devices = unsafe { &*state::drivers_ptr() }.pci.devices.clone();
     if devices.is_empty() {
         return;
     }
@@ -535,7 +535,7 @@ pub fn disable_all_bus_mastering_for_handoff() {
 
 /// Find all NVMe controllers
 pub fn find_nvme_controllers() -> heapless::Vec<PciDevice, 8> {
-    let drivers = state::drivers();
+    let drivers = unsafe { &*state::drivers_ptr() };
     let devices = &drivers.pci.devices;
     let mut result = heapless::Vec::new();
     for dev in devices.iter() {
@@ -554,7 +554,7 @@ pub fn find_nvme_controllers() -> heapless::Vec<PciDevice, 8> {
 
 /// Find all AHCI controllers
 pub fn find_ahci_controllers() -> heapless::Vec<PciDevice, 8> {
-    let drivers = state::drivers();
+    let drivers = unsafe { &*state::drivers_ptr() };
     let devices = &drivers.pci.devices;
     let mut result = heapless::Vec::new();
     for dev in devices.iter() {
@@ -573,7 +573,7 @@ pub fn find_ahci_controllers() -> heapless::Vec<PciDevice, 8> {
 
 /// Find all SDHCI controllers
 pub fn find_sdhci_controllers() -> heapless::Vec<PciDevice, 8> {
-    let drivers = state::drivers();
+    let drivers = unsafe { &*state::drivers_ptr() };
     let devices = &drivers.pci.devices;
     let mut result = heapless::Vec::new();
     for dev in devices.iter() {
@@ -592,12 +592,12 @@ pub fn find_sdhci_controllers() -> heapless::Vec<PciDevice, 8> {
 
 /// Get all enumerated PCI devices
 pub fn get_all_devices() -> heapless::Vec<PciDevice, { state::MAX_PCI_DEVICES }> {
-    state::drivers().pci.devices.clone()
+    unsafe { &*state::drivers_ptr() }.pci.devices.clone()
 }
 
 /// Print information about all PCI devices
 pub fn print_devices() {
-    let drivers = state::drivers();
+    let drivers = unsafe { &*state::drivers_ptr() };
     let devices = &drivers.pci.devices;
 
     log::info!("PCI Devices:");

--- a/crabefi-core/src/drivers/serial.rs
+++ b/crabefi-core/src/drivers/serial.rs
@@ -406,7 +406,7 @@ impl Write for Pl011Port {
 /// Adapter that wraps a platform-provided `DebugOutput` trait object.
 ///
 /// Stores a raw pointer because the serial subsystem is accessed via
-/// `drivers_mut_ptr()` (raw pointers) throughout CrabEFI to avoid
+/// `drivers_ptr()` (raw pointers) throughout CrabEFI to avoid
 /// aliasing with active `&mut FirmwareState` references in closures.
 pub(crate) struct PlatformSerial {
     /// Raw pointer to the platform's debug output trait object.
@@ -551,7 +551,7 @@ pub fn init_from_config(info: &SerialConfig) {
                 // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
                 // issues since serial is called from log macros inside other state closures.
                 unsafe {
-                    (*crate::state::drivers_mut_ptr()).serial.driver = Some(AnySerial::Pl011(port));
+                    (*crate::state::drivers_ptr()).serial.driver = Some(AnySerial::Pl011(port));
                 }
                 return;
             }
@@ -573,8 +573,7 @@ pub fn init_from_config(info: &SerialConfig) {
             // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
             // issues since serial is called from log macros inside other state closures.
             unsafe {
-                (*crate::state::drivers_mut_ptr()).serial.driver =
-                    Some(AnySerial::Uart16550(serial));
+                (*crate::state::drivers_ptr()).serial.driver = Some(AnySerial::Uart16550(serial));
             }
         }
     } else {
@@ -592,7 +591,7 @@ pub fn init_from_config(info: &SerialConfig) {
                 // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
                 // issues since serial is called from log macros inside other state closures.
                 unsafe {
-                    (*crate::state::drivers_mut_ptr()).serial.driver =
+                    (*crate::state::drivers_ptr()).serial.driver =
                         Some(AnySerial::Uart16550(serial));
                 }
             }
@@ -619,7 +618,7 @@ pub unsafe fn init_from_platform_raw(raw: *mut dyn crate::platform::DebugOutput)
     // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
     // issues since serial is called from log macros inside other state closures.
     unsafe {
-        (*crate::state::drivers_mut_ptr()).serial.driver = Some(AnySerial::Platform(plat));
+        (*crate::state::drivers_ptr()).serial.driver = Some(AnySerial::Platform(plat));
     }
 }
 
@@ -639,7 +638,7 @@ pub unsafe fn add_platform_debug_sink_raw(raw: *mut dyn crate::platform::DebugOu
     // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
     // issues since serial is called from log macros inside other state closures.
     unsafe {
-        (*crate::state::drivers_mut_ptr()).serial.debug_sink = Some(sink);
+        (*crate::state::drivers_ptr()).serial.debug_sink = Some(sink);
     }
 }
 
@@ -647,7 +646,7 @@ pub unsafe fn add_platform_debug_sink_raw(raw: *mut dyn crate::platform::DebugOu
 pub fn write_str(s: &str) {
     // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
     // issues since serial is called from log macros inside other state closures.
-    let serial_state = unsafe { &mut (*crate::state::drivers_mut_ptr()).serial };
+    let serial_state = unsafe { &mut (*crate::state::drivers_ptr()).serial };
     if let Some(serial) = &mut serial_state.driver {
         let _ = serial.write_str(s);
     }
@@ -665,7 +664,7 @@ pub fn write_fmt(args: fmt::Arguments) {
 pub fn write_byte(byte: u8) {
     // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
     // issues since serial is called from log macros inside other state closures.
-    let serial_state = unsafe { &mut (*crate::state::drivers_mut_ptr()).serial };
+    let serial_state = unsafe { &mut (*crate::state::drivers_ptr()).serial };
     if let Some(serial) = &mut serial_state.driver {
         serial.write_byte(byte);
     }
@@ -678,7 +677,7 @@ pub fn write_byte(byte: u8) {
 pub fn has_input() -> bool {
     // Read-only check -- use immutable access (no raw pointer needed). The debug
     // mirror is output-only, so it is intentionally ignored for input.
-    crate::state::drivers()
+    unsafe { &*crate::state::drivers_ptr() }
         .serial
         .driver
         .as_ref()
@@ -689,7 +688,7 @@ pub fn has_input() -> bool {
 pub fn try_read() -> Option<u8> {
     // SAFETY: Single-threaded firmware; raw pointer avoids re-entrancy
     // issues since serial is called from log macros inside other state closures.
-    let driver = unsafe { &mut (*crate::state::drivers_mut_ptr()).serial.driver };
+    let driver = unsafe { &mut (*crate::state::drivers_ptr()).serial.driver };
     driver.as_mut().and_then(AnySerial::try_read_byte)
 }
 

--- a/crabefi-core/src/drivers/storage.rs
+++ b/crabefi-core/src/drivers/storage.rs
@@ -183,7 +183,7 @@ pub fn register_device(device_type: StorageType, num_blocks: u64, block_size: u3
 
 /// Get a storage device by ID
 pub fn get_device(device_id: u32) -> Option<StorageDevice> {
-    let registry = &crate::state::drivers().storage_registry;
+    let registry = &unsafe { &*crate::state::drivers_ptr() }.storage_registry;
     registry
         .devices
         .iter()

--- a/crabefi-core/src/efi/allocator.rs
+++ b/crabefi-core/src/efi/allocator.rs
@@ -10,7 +10,7 @@
 //! # State Management
 //!
 //! The allocator state is stored in the centralized `FirmwareState` structure.
-//! Access it via `crate::state::allocator()` or `crate::state::allocator_mut()`.
+//! Access it via `unsafe { &*crate::state::allocator_ptr() }` or `crate::state::allocator_mut()`.
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
@@ -1380,19 +1380,19 @@ pub fn free_pages(memory: u64, num_pages: u64) -> efi::Status {
 
 /// Dump the full memory map to the log (for debugging).
 pub fn dump_memory_map() {
-    let alloc = state::allocator();
+    let alloc = unsafe { &*state::allocator_ptr() };
     alloc.dump_entries();
 }
 
 /// Get the memory map size
 pub fn get_memory_map_size() -> usize {
-    let alloc = state::allocator();
+    let alloc = unsafe { &*state::allocator_ptr() };
     alloc.entry_count() * core::mem::size_of::<MemoryDescriptor>()
 }
 
 /// Get current map key
 pub fn get_map_key() -> usize {
-    let alloc = state::allocator();
+    let alloc = unsafe { &*state::allocator_ptr() };
     alloc.map_key()
 }
 
@@ -1401,7 +1401,7 @@ pub fn get_map_key() -> usize {
 /// Returns the memory type if the address is within a known memory region,
 /// or None if the address is not in any known region.
 pub fn copy_runtime_descriptors(output: &mut [MemoryDescriptor]) -> Result<usize, efi::Status> {
-    let allocator = state::allocator();
+    let allocator = unsafe { &*state::allocator_ptr() };
     let runtime = allocator
         .entries
         .iter()
@@ -1419,7 +1419,7 @@ pub fn copy_runtime_descriptors(output: &mut [MemoryDescriptor]) -> Result<usize
 
 /// Find the memory type for a given physical address.
 pub fn get_memory_type_at(address: u64) -> Option<MemoryType> {
-    let alloc = state::allocator();
+    let alloc = unsafe { &*state::allocator_ptr() };
     alloc
         .entries
         .iter()
@@ -1435,7 +1435,7 @@ pub fn range_has_memory_type(base: u64, size: u64, memory_type: MemoryType) -> b
     if size == 0 {
         return false;
     }
-    let allocator = state::allocator();
+    let allocator = unsafe { &*state::allocator_ptr() };
     let mut covered = base;
     for descriptor in allocator.entries.iter() {
         if descriptor.end() <= covered {
@@ -1462,7 +1462,7 @@ pub fn get_memory_map(
     descriptor_size: &mut usize,
     descriptor_version: &mut u32,
 ) -> efi::Status {
-    let alloc = state::allocator();
+    let alloc = unsafe { &*state::allocator_ptr() };
     alloc.get_memory_map(
         memory_map_size,
         memory_map,
@@ -1474,7 +1474,7 @@ pub fn get_memory_map(
 
 /// Validate an ExitBootServices map key without changing allocator state.
 pub fn validate_map_key(map_key: usize) -> efi::Status {
-    state::allocator().validate_map_key(map_key)
+    unsafe { &*state::allocator_ptr() }.validate_map_key(map_key)
 }
 
 /// Exit boot services

--- a/crabefi-core/src/efi/boot_services.rs
+++ b/crabefi-core/src/efi/boot_services.rs
@@ -742,7 +742,7 @@ pub(crate) fn measure_efi_application_start(is_application: bool) {
 
 /// Measure return from an EFI boot application attempt.
 pub(crate) fn measure_efi_application_return(is_application: bool) {
-    if is_application && crate::state::efi().ready_to_boot_signaled {
+    if is_application && unsafe { &*crate::state::efi_ptr() }.ready_to_boot_signaled {
         super::tcg::measured_boot::measure_action_all(
             4,
             "Returning from EFI Application from Boot Option",
@@ -954,7 +954,7 @@ extern "efiapi" fn locate_handle(
         buffer
     );
 
-    let efi_state = state::efi();
+    let efi_state = unsafe { &*state::efi_ptr() };
 
     // Collect matching handles based on search type
     let matching: heapless::Vec<Handle, MAX_HANDLES> = match search_type {
@@ -1079,7 +1079,7 @@ extern "efiapi" fn locate_device_path(
     }
 
     // Find a handle with both the specified protocol and a DEVICE_PATH protocol
-    let efi_state = state::efi();
+    let efi_state = unsafe { &*state::efi_ptr() };
 
     let found = efi_state.handles[..efi_state.handle_count]
         .iter()
@@ -1405,7 +1405,7 @@ extern "efiapi" fn start_image(
 
     // Find the loaded image entry
     let (entry_point, image_base, image_subsystem) = {
-        let efi_state = state::efi();
+        let efi_state = unsafe { &*state::efi_ptr() };
         match efi_state
             .loaded_images
             .iter()
@@ -1611,7 +1611,7 @@ extern "efiapi" fn exit_boot_services(image_handle: Handle, map_key: usize) -> S
     if key_status != Status::SUCCESS {
         return key_status;
     }
-    let Some(runtime_image) = crate::state::efi().runtime_image else {
+    let Some(runtime_image) = unsafe { &*crate::state::efi_ptr() }.runtime_image else {
         log::error!("ExitBootServices refused: runtime image client is missing");
         return Status::DEVICE_ERROR;
     };
@@ -1637,7 +1637,7 @@ extern "efiapi" fn exit_boot_services(image_handle: Handle, map_key: usize) -> S
         });
         for event_id in &legacy_events {
             let notify_fn = {
-                let efi_state = state::efi();
+                let efi_state = unsafe { &*state::efi_ptr() };
                 let entry = &efi_state.events[*event_id];
                 entry.notify_function.map(|f| (f, entry.notify_context))
             };
@@ -1704,7 +1704,7 @@ extern "efiapi" fn exit_boot_services(image_handle: Handle, map_key: usize) -> S
         // Let platform glue clean up integration-specific handoff state only
         // after the final fallible step; hooks may disable non-runtime log
         // buffers needed to diagnose a seal failure.
-        if let Some(hooks) = crate::state::drivers().platform.hooks {
+        if let Some(hooks) = unsafe { &*crate::state::drivers_ptr() }.platform.hooks {
             hooks.on_exit_boot_services();
         }
 
@@ -1830,7 +1830,7 @@ extern "efiapi" fn open_protocol(
         attributes
     );
 
-    let efi_state = state::efi();
+    let efi_state = unsafe { &*state::efi_ptr() };
 
     // Find the handle entry
     let handle_entry = efi_state.handles[..efi_state.handle_count]
@@ -1902,7 +1902,7 @@ extern "efiapi" fn close_protocol(
     }
 
     // Verify the handle exists and has this protocol
-    let efi_state = state::efi();
+    let efi_state = unsafe { &*state::efi_ptr() };
     let handle_exists = efi_state.handles[..efi_state.handle_count]
         .iter()
         .any(|entry| {
@@ -1956,7 +1956,7 @@ extern "efiapi" fn protocols_per_handle(
         return Status::INVALID_PARAMETER;
     }
 
-    let efi_state = state::efi();
+    let efi_state = unsafe { &*state::efi_ptr() };
 
     // Find the handle entry
     let entry = match efi_state.handles[..efi_state.handle_count]
@@ -2119,7 +2119,7 @@ extern "efiapi" fn locate_protocol(
     let guid = unsafe { *protocol };
     log::trace!("BS.LocateProtocol(protocol={})", GuidFmt(guid));
 
-    let efi_state = state::efi();
+    let efi_state = unsafe { &*state::efi_ptr() };
 
     // Find first handle with this protocol
     let found = efi_state.handles[..efi_state.handle_count]
@@ -2380,7 +2380,7 @@ pub fn install_protocol(handle: Handle, guid: &Guid, interface: *mut c_void) -> 
 ///
 /// Returns the interface pointer, or null if not found.
 pub fn get_protocol_on_handle(handle: Handle, guid: &Guid) -> *mut c_void {
-    let efi_state = state::efi();
+    let efi_state = unsafe { &*state::efi_ptr() };
 
     efi_state.handles[..efi_state.handle_count]
         .iter()

--- a/crabefi-core/src/efi/capsule/mod.rs
+++ b/crabefi-core/src/efi/capsule/mod.rs
@@ -55,7 +55,9 @@ pub fn process_pending_capsules(backend: &mut dyn CapsuleBackend) -> usize {
     let mut applied_count = 0;
 
     // Source 1: Capsules from platform-provided reserved memory regions.
-    let platform_capsules = &crate::state::drivers().platform.capsule_regions;
+    let platform_capsules = &unsafe { &*crate::state::drivers_ptr() }
+        .platform
+        .capsule_regions;
     let platform_capsule_count = platform_capsules.len();
     if platform_capsule_count > 0 {
         log::info!("Processing {} platform capsule(s)", platform_capsule_count);

--- a/crabefi-core/src/efi/esrt.rs
+++ b/crabefi-core/src/efi/esrt.rs
@@ -26,7 +26,7 @@ pub const LAST_ATTEMPT_STATUS_ERROR_AUTH_ERROR: u32 = 5;
 
 /// Copy value-only firmware metadata into runtime-image ESRT storage.
 pub fn install_esrt(firmware: &FirmwareInfo, capsule_delivery_usable: bool) {
-    let Some(client) = crate::state::efi().runtime_image else {
+    let Some(client) = unsafe { &*crate::state::efi_ptr() }.runtime_image else {
         log::error!("Cannot install ESRT before runtime image activation");
         return;
     };

--- a/crabefi-core/src/efi/image_loader.rs
+++ b/crabefi-core/src/efi/image_loader.rs
@@ -255,7 +255,7 @@ pub(crate) fn load_image_from_device_path(
 
 /// Find a handle that has a specific protocol installed
 pub(crate) fn find_handle_with_protocol(protocol_guid: &Guid) -> Option<Handle> {
-    let efi_state = state::efi();
+    let efi_state = unsafe { &*state::efi_ptr() };
 
     efi_state.handles[..efi_state.handle_count]
         .iter()
@@ -363,7 +363,7 @@ fn find_best_sfs_handle_for_device_path(device_path: *mut DevicePathProtocol) ->
         return None;
     }
 
-    let efi_state = state::efi();
+    let efi_state = unsafe { &*state::efi_ptr() };
     let dp_guid = r_efi::protocols::device_path::PROTOCOL_GUID;
 
     let mut best_handle: Option<Handle> = None;
@@ -413,7 +413,7 @@ pub(crate) fn get_device_handle_from_parent(parent_handle: Handle) -> Handle {
     }
 
     // Try to get the LoadedImageProtocol from the parent
-    let efi_state = state::efi();
+    let efi_state = unsafe { &*state::efi_ptr() };
     efi_state
         .handles
         .iter()

--- a/crabefi-core/src/efi/mod.rs
+++ b/crabefi-core/src/efi/mod.rs
@@ -934,7 +934,7 @@ pub fn add_platform_mmio_regions() {
     };
 
     // Try to get platform info from FDT (if available)
-    let plat = crate::state::drivers().fdt_info.clone();
+    let plat = unsafe { &*crate::state::drivers_ptr() }.fdt_info.clone();
 
     // Interrupt controller — from FDT only (GIC on aarch64, PLIC on riscv64).
     // The `gicd` field is reused for PLIC on RISC-V (see fdt.rs:extract_gic).

--- a/crabefi-core/src/efi/protocols/console.rs
+++ b/crabefi-core/src/efi/protocols/console.rs
@@ -274,7 +274,7 @@ pub fn get_text_output_protocol() -> *mut SimpleTextOutputProtocol {
     // at the centralized console state so EFI callers can read it directly.
     unsafe {
         TEXT_OUTPUT_PROTOCOL.mode =
-            core::ptr::addr_of_mut!((*crate::state::console_mut_ptr()).output_mode);
+            core::ptr::addr_of_mut!((*crate::state::console_ptr()).output_mode);
         &raw mut TEXT_OUTPUT_PROTOCOL
     }
 }
@@ -553,7 +553,7 @@ extern "efiapi" fn text_output_reset(
     // Reset console state
     // SAFETY: Single-threaded firmware; raw pointer to centralized console state.
     unsafe {
-        let mode = &mut (*crate::state::console_mut_ptr()).output_mode;
+        let mode = &mut (*crate::state::console_ptr()).output_mode;
         mode.cursor_column = 0;
         mode.cursor_row = 0;
         mode.attribute = 0x07;
@@ -580,8 +580,7 @@ extern "efiapi" fn text_output_string(
     // Holding an `&mut ConsoleState.output_mode` across those calls would
     // create aliasing &mut references (UB).  Raw pointer writes are fine
     // in single-threaded firmware.
-    let mode_ptr =
-        unsafe { core::ptr::addr_of_mut!((*crate::state::console_mut_ptr()).output_mode) };
+    let mode_ptr = unsafe { core::ptr::addr_of_mut!((*crate::state::console_ptr()).output_mode) };
     let mut ptr = string;
     unsafe {
         while *ptr != 0 {
@@ -686,7 +685,7 @@ extern "efiapi" fn text_output_set_mode(
 
     // SAFETY: Single-threaded firmware; raw pointer to centralized console state.
     unsafe {
-        (*crate::state::console_mut_ptr()).output_mode.mode = mode_number as i32;
+        (*crate::state::console_ptr()).output_mode.mode = mode_number as i32;
     }
 
     Status::SUCCESS
@@ -732,7 +731,7 @@ extern "efiapi" fn text_output_set_attribute(
 ) -> Status {
     // SAFETY: Single-threaded firmware; raw pointer to centralized console state.
     unsafe {
-        (*crate::state::console_mut_ptr()).output_mode.attribute = attribute as i32;
+        (*crate::state::console_ptr()).output_mode.attribute = attribute as i32;
     }
 
     let fg = attribute & 0x0F;
@@ -794,7 +793,7 @@ extern "efiapi" fn text_output_clear_screen(_this: *mut SimpleTextOutputProtocol
 
     // SAFETY: Single-threaded firmware; raw pointer to centralized console state.
     unsafe {
-        let mode = &mut (*crate::state::console_mut_ptr()).output_mode;
+        let mode = &mut (*crate::state::console_ptr()).output_mode;
         mode.cursor_column = 0;
         mode.cursor_row = 0;
     }
@@ -839,7 +838,7 @@ extern "efiapi" fn text_output_set_cursor_position(
 
     // SAFETY: Single-threaded firmware; raw pointer to centralized console state.
     unsafe {
-        let mode = &mut (*crate::state::console_mut_ptr()).output_mode;
+        let mode = &mut (*crate::state::console_ptr()).output_mode;
         mode.cursor_column = column as i32;
         mode.cursor_row = row as i32;
     }
@@ -861,9 +860,7 @@ extern "efiapi" fn text_output_enable_cursor(
     let is_visible: bool = visible.into();
     // SAFETY: Single-threaded firmware; raw pointer to centralized console state.
     unsafe {
-        (*crate::state::console_mut_ptr())
-            .output_mode
-            .cursor_visible = visible;
+        (*crate::state::console_ptr()).output_mode.cursor_visible = visible;
     }
 
     if is_visible {

--- a/crabefi-core/src/efi/protocols/console_control.rs
+++ b/crabefi-core/src/efi/protocols/console_control.rs
@@ -45,7 +45,7 @@ extern "efiapi" fn console_get_mode(
     if !mode.is_null() {
         // SAFETY: mode is a non-null pointer from the caller; single-threaded firmware.
         unsafe {
-            *mode = crate::state::console().screen_mode;
+            *mode = (&*crate::state::console_ptr()).screen_mode;
         }
     }
 
@@ -79,10 +79,10 @@ extern "efiapi" fn console_set_mode(
         return Status::INVALID_PARAMETER;
     }
 
-    let prev_mode = crate::state::console().screen_mode;
+    let prev_mode = unsafe { &*crate::state::console_ptr() }.screen_mode;
     // SAFETY: Single-threaded firmware; no aliasing &mut exists at this point.
     unsafe {
-        (*crate::state::console_mut_ptr()).screen_mode = mode;
+        (*crate::state::console_ptr()).screen_mode = mode;
     }
 
     log::debug!("ConsoleControl.SetMode({:?} -> {:?})", prev_mode, mode);

--- a/crabefi-core/src/efi/protocols/graphics_output.rs
+++ b/crabefi-core/src/efi/protocols/graphics_output.rs
@@ -224,7 +224,7 @@ extern "efiapi" fn gop_blt(
         return Status::INVALID_PARAMETER;
     }
 
-    let console = state::console();
+    let console = unsafe { &*state::console_ptr() };
     let fb = match console.gop_framebuffer.as_ref() {
         Some(fb) => fb,
         None => return Status::DEVICE_ERROR,

--- a/crabefi-core/src/efi/protocols/serial_io.rs
+++ b/crabefi-core/src/efi/protocols/serial_io.rs
@@ -299,8 +299,7 @@ pub fn create_protocol() -> *mut Protocol {
         p.get_control = serial_get_control;
         p.write = serial_write;
         p.read = serial_read;
-        p.mode =
-            unsafe { core::ptr::addr_of_mut!((*crate::state::drivers_mut_ptr()).serial.io_mode) };
+        p.mode = unsafe { core::ptr::addr_of_mut!((*crate::state::drivers_ptr()).serial.io_mode) };
         p.device_type_guid = core::ptr::null();
     });
     if ptr.is_null() {

--- a/crabefi-core/src/efi/protocols/simple_file_system.rs
+++ b/crabefi-core/src/efi/protocols/simple_file_system.rs
@@ -142,8 +142,8 @@ pub fn init(block_device: AnyBlockDevice, partition_start: u64) -> *mut efi_sfs:
 
     state::with_efi_mut(|efi| {
         efi.filesystem = Some(fs_state);
-        efi.block_device = Some(temp_device);
     });
+    state::set_block_device(temp_device);
 
     log::info!(
         "SimpleFileSystem: initialized with partition at LBA {}",
@@ -185,7 +185,7 @@ extern "efiapi" fn sfs_open_volume(
     };
 
     // Initialize as root directory
-    let fs_state = match state::efi().filesystem {
+    let fs_state = match unsafe { &*state::efi_ptr() }.filesystem {
         Some(s) => s,
         None => {
             log::error!("SFS.OpenVolume: filesystem not initialized");
@@ -265,7 +265,7 @@ extern "efiapi" fn file_open(
     log::info!("File.Open: full path = {:?}", full_path_str);
 
     // Get partition start
-    let partition_start = match state::efi().filesystem {
+    let partition_start = match unsafe { &*state::efi_ptr() }.filesystem {
         Some(s) => s.partition_start,
         None => return Status::NOT_READY,
     };
@@ -396,7 +396,7 @@ extern "efiapi" fn file_read(
         return Status::SUCCESS;
     }
 
-    let partition_start = match state::efi().filesystem {
+    let partition_start = match unsafe { &*state::efi_ptr() }.filesystem {
         Some(s) => s.partition_start,
         None => return Status::NOT_READY,
     };
@@ -581,7 +581,7 @@ extern "efiapi" fn file_get_info(
             return Status::INVALID_PARAMETER;
         }
 
-        let fs_state = match state::efi().filesystem {
+        let fs_state = match unsafe { &*state::efi_ptr() }.filesystem {
             Some(s) => s,
             None => return Status::NOT_READY,
         };
@@ -842,7 +842,7 @@ fn create_file_entry(first_cluster: u32, file_size: u32) -> DirectoryEntry {
 
 /// Read directory entries
 fn read_directory(buffer_size: *mut usize, buffer: *mut c_void, handle_idx: usize) -> Status {
-    let partition_start = match state::efi().filesystem {
+    let partition_start = match unsafe { &*state::efi_ptr() }.filesystem {
         Some(s) => s.partition_start,
         None => return Status::NOT_READY,
     };

--- a/crabefi-core/src/efi/runtime_image/client.rs
+++ b/crabefi-core/src/efi/runtime_image/client.rs
@@ -200,7 +200,10 @@ fn status_result(status: usize) -> Result<(), Status> {
 }
 
 fn client() -> Option<RuntimeImageClient> {
-    crate::state::try_get().and_then(|state| state.efi.runtime_image)
+    if !crate::state::is_initialized() {
+        return None;
+    }
+    unsafe { (*crate::state::efi_ptr()).runtime_image }
 }
 
 pub fn get_system_table() -> *mut efi::SystemTable {

--- a/crabefi-core/src/efi/system_table.rs
+++ b/crabefi-core/src/efi/system_table.rs
@@ -143,7 +143,7 @@ pub(crate) fn set_std_err(handle: Handle, protocol: *mut SimpleTextOutputProtoco
 }
 
 fn set_console(kind: u32, handle: Handle, protocol: *mut c_void) {
-    let status = state::efi()
+    let status = unsafe { &*state::efi_ptr() }
         .runtime_image
         .ok_or(efi::Status::NOT_READY)
         .and_then(|client| {
@@ -166,7 +166,7 @@ fn set_console(kind: u32, handle: Handle, protocol: *mut c_void) {
 /// tables before EBS. Their payload storage remains at its physical address;
 /// only image-owned runtime tables are converted during SVAM.
 pub fn install_configuration_table(guid: &Guid, table: *mut c_void) -> efi::Status {
-    let Some(client) = state::efi().runtime_image else {
+    let Some(client) = unsafe { &*state::efi_ptr() }.runtime_image else {
         return efi::Status::NOT_READY;
     };
     let mut guid_bytes = [0u8; 16];
@@ -904,7 +904,7 @@ pub fn rebuild_memory_attributes_table_in_place() -> efi::Status {
             return status;
         }
     };
-    let Some(client) = state::efi().runtime_image else {
+    let Some(client) = unsafe { &*state::efi_ptr() }.runtime_image else {
         return efi::Status::NOT_READY;
     };
     match client.prepare_ebs(&descriptors[..count]) {

--- a/crabefi-core/src/efi/varstore/persistence.rs
+++ b/crabefi-core/src/efi/varstore/persistence.rs
@@ -91,8 +91,8 @@ pub fn init(locator: Option<&dyn VariableStoreLocator>) -> Result<(), VarStoreEr
     configure_from_locator(&mut backend, locator)?;
 
     // Store the backend in global state
-    state::with_mut(|s| {
-        s.drivers.platform.storage = Some(backend);
+    state::with_drivers_mut(|drivers| {
+        drivers.platform.storage = Some(backend);
     });
 
     // Initialize the variable store region
@@ -385,7 +385,7 @@ fn preflight_non_auth_migration(
 
 /// Load variables from storage into the in-memory cache
 fn load_variables_from_storage() -> Result<(), VarStoreError> {
-    let vs = state::varstore();
+    let vs = unsafe { &*state::varstore_ptr() };
     if !vs.initialized {
         return Err(VarStoreError::NotInitialized);
     }
@@ -414,7 +414,7 @@ fn load_variables_from_storage() -> Result<(), VarStoreError> {
         active_vars.push(var);
     }
 
-    let client = state::efi()
+    let client = unsafe { &*state::efi_ptr() }
         .runtime_image
         .ok_or(VarStoreError::NotInitialized)?;
     for variable in &active_vars {
@@ -453,7 +453,7 @@ fn load_variables_from_storage() -> Result<(), VarStoreError> {
 
 /// Get the latest durable authenticated timestamp, including deletion floors.
 pub fn get_variable_timestamp(guid: &r_efi::efi::Guid, name: &[u16]) -> Option<VariableTimestamp> {
-    let variable_store = state::varstore();
+    let variable_store = unsafe { &*state::varstore_ptr() };
     if !variable_store.initialized || !variable_store.auth_format {
         return None;
     }
@@ -498,7 +498,7 @@ pub(crate) fn write_variable_to_storage_internal(
     data: &[u8],
     timestamp: Option<VariableTimestamp>,
 ) -> Result<(), VarStoreError> {
-    let vs = state::varstore();
+    let vs = unsafe { &*state::varstore_ptr() };
     require_writable_store(vs.initialized, vs.auth_format)?;
 
     let guid_bytes = edk2::guid_to_bytes(guid);
@@ -511,10 +511,10 @@ pub(crate) fn write_variable_to_storage_internal(
     let storage_size =
         state::with_storage_mut(|s| s.size()).ok_or(VarStoreError::NotInitialized)?;
 
-    let mut write_offset = state::varstore().write_offset;
+    let mut write_offset = unsafe { &*state::varstore_ptr() }.write_offset;
     if !write_slot_available(write_offset, record_len, storage_size)? {
         compact_variable_store()?;
-        write_offset = state::varstore().write_offset;
+        write_offset = unsafe { &*state::varstore_ptr() }.write_offset;
         if !write_slot_available(write_offset, record_len, storage_size)? {
             return Err(VarStoreError::StoreFull);
         }
@@ -580,7 +580,7 @@ fn write_slot_available(offset: u32, len: u32, storage_size: u32) -> Result<bool
 /// the normal header-valid then VAR_ADDED protocol rather than becoming
 /// permanently unreclaimable after ordinary updates.
 fn compact_variable_store() -> Result<(), VarStoreError> {
-    let vs = state::varstore();
+    let vs = unsafe { &*state::varstore_ptr() };
     if !vs.initialized || !vs.auth_format {
         return Err(VarStoreError::StoreFull);
     }
@@ -739,7 +739,7 @@ pub(crate) fn write_variable_deletion_internal(
     attributes: u32,
     timestamp: Option<VariableTimestamp>,
 ) -> Result<(), VarStoreError> {
-    let vs = state::varstore();
+    let vs = unsafe { &*state::varstore_ptr() };
     require_writable_store(vs.initialized, vs.auth_format)?;
     if timestamp.is_some() {
         // An active zero-length authenticated record is invisible to coreboot's
@@ -757,7 +757,7 @@ fn delete_existing_record_except(
     name: &[u16],
     keep_state_offset: Option<u32>,
 ) -> Result<(), VarStoreError> {
-    let vs = state::varstore();
+    let vs = unsafe { &*state::varstore_ptr() };
     require_writable_store(vs.initialized, vs.auth_format)?;
     let auth_format = vs.auth_format;
     let data_size = vs.data_size;
@@ -824,12 +824,12 @@ pub fn is_storage_available() -> bool {
 
 /// Check if variable store is initialized.
 pub fn is_varstore_initialized() -> bool {
-    state::varstore().initialized
+    unsafe { &*state::varstore_ptr() }.initialized
 }
 
 /// Check whether the initialized store accepts durable authenticated writes.
 pub fn is_varstore_writable() -> bool {
-    let store = state::varstore();
+    let store = unsafe { &*state::varstore_ptr() };
     store.initialized && store.auth_format
 }
 
@@ -837,7 +837,7 @@ pub fn is_varstore_writable() -> bool {
 ///
 /// Returns (base_offset, size, write_offset)
 pub fn get_varstore_stats() -> Option<(u32, u32, u32)> {
-    let vs = state::varstore();
+    let vs = unsafe { &*state::varstore_ptr() };
     let (base, size) = state::with_storage_mut(|s| (s.base_offset(), s.size()))?;
     Some((base, size, vs.write_offset))
 }
@@ -871,7 +871,7 @@ pub(crate) fn persist_firmware_variable(
         None,
     )?;
 
-    let client = state::efi()
+    let client = unsafe { &*state::efi_ptr() }
         .runtime_image
         .ok_or(VarStoreError::NotInitialized)?;
     client

--- a/crabefi-core/src/fb_log.rs
+++ b/crabefi-core/src/fb_log.rs
@@ -16,14 +16,14 @@ pub fn set_framebuffer(fb: FramebufferConfig) {
     unsafe {
         fb.clear(0, 0, 0);
     }
-    let console = unsafe { &mut (*crate::state::console_mut_ptr()) };
+    let console = unsafe { &mut (*crate::state::console_ptr()) };
     console.logger_framebuffer = Some(fb);
     console.logger_cursor = (0, 0);
 }
 
 /// Log a message to the framebuffer
 pub fn log_to_framebuffer(level: Level, ts: u64, args: &core::fmt::Arguments) {
-    let fb_info = match unsafe { (*crate::state::console_mut_ptr()).logger_framebuffer } {
+    let fb_info = match unsafe { (*crate::state::console_ptr()).logger_framebuffer } {
         Some(fb) => fb,
         None => return,
     };
@@ -37,7 +37,7 @@ pub fn log_to_framebuffer(level: Level, ts: u64, args: &core::fmt::Arguments) {
         Level::Trace => ("TRACE", Color::new(192, 64, 192)), // Purple
     };
 
-    let (mut row, mut col) = unsafe { (*crate::state::console_mut_ptr()).logger_cursor };
+    let (mut row, mut col) = unsafe { (*crate::state::console_ptr()).logger_cursor };
     let cols = fb_info.width / CHAR_WIDTH;
     let rows = fb_info.height / CHAR_HEIGHT;
 
@@ -98,7 +98,7 @@ pub fn log_to_framebuffer(level: Level, ts: u64, args: &core::fmt::Arguments) {
 
     // Update cursor
     unsafe {
-        (*crate::state::console_mut_ptr()).logger_cursor = (row, col);
+        (*crate::state::console_ptr()).logger_cursor = (row, col);
     }
 }
 

--- a/crabefi-core/src/lib.rs
+++ b/crabefi-core/src/lib.rs
@@ -54,7 +54,9 @@ use crate::drivers::block::{AhciDisk, NvmeDisk, SdhciDisk, UsbDisk};
 pub fn reset_system() -> ! {
     log::info!("System reset requested");
 
-    if let Some(reset) = state::try_get().and_then(|state| state.drivers.platform.reset) {
+    if state::is_initialized()
+        && let Some(reset) = unsafe { (*state::drivers_ptr()).platform.reset }
+    {
         reset.reset(ResetType::Cold);
     }
 
@@ -201,7 +203,7 @@ fn init_persistence_and_boot(
         log::warn!("Variable store is preserved read-only; capsule updates are disabled");
     }
 
-    let runtime = state::efi()
+    let runtime = unsafe { &*state::efi_ptr() }
         .runtime_image
         .expect("runtime image missing before deferred replay");
     let capsule_backend_available = capsule_backend.is_some();
@@ -249,7 +251,7 @@ fn init_persistence_and_boot(
 
     // Reinstall ESRT after persistent variables and this boot's capsule attempts
     // are visible so its last-attempt fields are authoritative across reboots.
-    if let Some(firmware) = state::drivers().platform.efi_fw_info {
+    if let Some(firmware) = unsafe { &*state::drivers_ptr() }.platform.efi_fw_info {
         efi::esrt::install_esrt(&firmware, capsule_delivery_usable);
     }
     efi::capsule::disk::install_os_indications_supported(capsule_delivery_usable);
@@ -542,7 +544,7 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
     // The ESRT is built from platform-provided firmware info and installed as
     // an EFI Configuration Table for fwupd/LVFS discovery. Delivery flags and
     // OsIndicationsSupported are finalized after persistence is initialized.
-    if let Some(fw_info) = state::drivers().platform.efi_fw_info {
+    if let Some(fw_info) = unsafe { &*state::drivers_ptr() }.platform.efi_fw_info {
         efi::esrt::install_esrt(&fw_info, false);
         log::info!("ESRT installed for firmware updates");
     }
@@ -563,8 +565,8 @@ fn init_platform_impl(mut config: PlatformConfig) -> ! {
             log::error!("PCI ECAM regions from platform rejected: {:?}", error);
         }
     } else {
-        let acpi_info = state::drivers().acpi_info.clone();
-        let fdt_info = state::drivers().fdt_info.clone();
+        let acpi_info = unsafe { &*state::drivers_ptr() }.acpi_info.clone();
+        let fdt_info = unsafe { &*state::drivers_ptr() }.fdt_info.clone();
         if !acpi_info.ecam_regions().is_empty() {
             log::info!(
                 "PCI ECAM regions from ACPI MCFG: {}",

--- a/crabefi-core/src/logger.rs
+++ b/crabefi-core/src/logger.rs
@@ -72,7 +72,7 @@ pub fn get_us_since_boot() -> u64 {
     // SAFETY: single-threaded firmware; field is written once at init,
     // only read afterwards. Raw pointer avoids aliasing with &mut held
     // by with_*_mut() closures that may log.
-    let boot = unsafe { (*crate::state::drivers_mut_ptr()).timing.boot_counter };
+    let boot = unsafe { (*crate::state::drivers_ptr()).timing.boot_counter };
     let delta = current.saturating_sub(boot);
     let freq = crate::time::counter_frequency().max(1);
     ((delta as u128 * 1_000_000) / freq as u128) as u64
@@ -128,7 +128,7 @@ pub fn init() {
         // SAFETY: single-threaded init; raw pointer avoids re-entrancy
         // issues with the state lock.
         unsafe {
-            (*crate::state::drivers_mut_ptr()).timing.boot_counter = read_counter();
+            (*crate::state::drivers_ptr()).timing.boot_counter = read_counter();
         }
         log::set_max_level(DEFAULT_LEVEL);
     }

--- a/crabefi-core/src/menu.rs
+++ b/crabefi-core/src/menu.rs
@@ -1021,7 +1021,7 @@ pub fn show_menu(menu: &mut BootMenu) -> Option<usize> {
                 }
                 KeyPress::Char('f') | KeyPress::Char('F') => {
                     // Open platform-provided firmware settings menu.
-                    if let Some(hooks) = crate::state::drivers().platform.hooks {
+                    if let Some(hooks) = unsafe { &*crate::state::drivers_ptr() }.platform.hooks {
                         if !hooks.show_firmware_settings() {
                             draw_status("Firmware settings not available", &mut fb_console);
                             delay_ms(500);

--- a/crabefi-core/src/secure_boot_menu.rs
+++ b/crabefi-core/src/secure_boot_menu.rs
@@ -252,7 +252,8 @@ pub fn show_secure_boot_menu() {
                         break;
                     }
                     KeyPress::Char('f') | KeyPress::Char('F') => {
-                        if let Some(hooks) = crate::state::drivers().platform.hooks {
+                        if let Some(hooks) = unsafe { &*crate::state::drivers_ptr() }.platform.hooks
+                        {
                             if !hooks.show_firmware_settings() {
                                 status_message = Some(("Firmware settings not available", false));
                             }

--- a/crabefi-core/src/state.rs
+++ b/crabefi-core/src/state.rs
@@ -1,74 +1,21 @@
 //! Global Firmware State
 //!
-//! This module provides a centralized state structure for CrabEFI that holds all
-//! mutable state. Instead of having many scattered `static Mutex<T>` variables,
-//! we allocate a single `FirmwareState` struct on the stack in the entry point
-//! and store a pointer to it in a single global.
+//! `FirmwareState` is allocated by the entry point and published through one
+//! raw pointer. It does not expose `&'static` references. Instead, each major
+//! subsystem lives in its own `UnsafeCell` and has a raw-pointer projection
+//! (`efi_ptr`, `drivers_ptr`, `allocator_ptr`, and so on).
 //!
-//! This is more idiomatic Rust because:
-//! - State ownership is clear (it lives on the main stack)
-//! - All state is colocated, making it easier to reason about
-//! - We minimize the number of global statics
+//! The subsystem split matters: an EFI mutation no longer creates an exclusive
+//! borrow of driver, console, allocator, or variable-store state. Mutable
+//! closure accessors borrow only one cell and use always-on re-entrancy guards.
+//! Log sinks use raw projections and must restrict themselves to their assigned
+//! fields so logging can remain allocation-free and non-locking.
 //!
-//! # Architecture
-//!
-//! ```text
-//! init() in lib.rs
-//!   |
-//!   v
-//! FirmwareState on stack
-//!   |
-//!   +-- efi: EfiState
-//!   |     +-- handles, events, loaded_images
-//!   |     +-- config_tables, variables, varstore
-//!   |     +-- allocator, secure boot flags
-//!   |
-//!   +-- drivers: DriverState
-//!   |     +-- pci: PciState (devices, ecam, access method)
-//!   |     +-- serial: SerialState (driver, port, EFI mode)
-//!   |     +-- timing: TimingState (counter freq, boot timestamp)
-//!   |     +-- platform: PlatformInfo (framebuffer, SPI, handoff data)
-//!   |     +-- keyboard, usb_keyboard, storage_registry, rng
-//!   |
-//!   +-- console: ConsoleState
-//!         +-- framebuffer, cursor, dimensions, colors
-//!         +-- input state, screen_mode, output_mode
-//! ```
-//!
-//! # Thread Safety
-//!
-//! CrabEFI is single-threaded firmware. We use `UnsafeCell` for interior
-//! mutability without the overhead of `Mutex`. The UEFI spec guarantees
-//! that Boot Services are not reentrant.
-//!
-//! # Log-Path Contract
-//!
-//! Functions called from the `log` crate macros — serial output
-//! ([`crate::drivers::serial`]), platform log sinks, framebuffer logging
-//! ([`crate::fb_log`]), and the timestamp helper
-//! ([`crate::logger::get_us_since_boot`]) — must **never** create Rust
-//! references (`&` or `&mut`) into `FirmwareState`.
-//!
-//! This is necessary because `log::info!()` and friends may fire *inside*
-//! a `with_mut()` / `with_drivers_mut()` closure, which holds a live
-//! `&mut FirmwareState`.  Creating any `&FirmwareState` (e.g. via
-//! [`drivers()`] or [`try_get()`]) would alias with that `&mut` — UB
-//! under Rust's reference rules.
-//!
-//! Instead, log-path code uses **raw-pointer field access**:
-//!
-//! - **Writes**: `(*drivers_mut_ptr()).serial.driver` (serial, fb_log)
-//! - **Reads**: `(*drivers_mut_ptr()).timing.boot_counter` (timestamps)
-//!
-//! Raw-pointer access is sound here because:
-//!
-//! 1. The firmware is single-threaded — no data races.
-//! 2. The log-path functions only touch their own disjoint fields
-//!    (e.g. `serial.driver`, `console.logger_*`, `timing.boot_counter`).
-//! 3. They never read or write fields that the enclosing `with_mut()`
-//!    closure is currently modifying.
+//! CrabEFI is single-threaded. The atomic pointer and borrow flags therefore use
+//! `Ordering::Relaxed`; they publish no cross-thread synchronization guarantee.
 
 use alloc::vec::Vec;
+use core::cell::UnsafeCell;
 use core::sync::atomic::{AtomicPtr, Ordering};
 
 use crate::fs::fat::FatType;
@@ -78,11 +25,33 @@ use crate::fs::fat::FatType;
 /// This is the ONLY global mutable state. It points to a `FirmwareState`
 /// allocated on the stack in `init()`.
 static STATE_PTR: AtomicPtr<FirmwareState> = AtomicPtr::new(core::ptr::null_mut());
+static EFI_BORROWED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+static DRIVER_BORROWED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+static CONSOLE_BORROWED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+static ALLOCATOR_BORROWED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+static VARSTORE_BORROWED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
 
-/// Re-entrancy guard for `with_mut`. In debug builds, detects nested calls
-/// that would create aliasing `&mut` references (undefined behavior).
-#[cfg(debug_assertions)]
-static IN_WITH_MUT: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+struct BorrowGuard(&'static core::sync::atomic::AtomicBool);
+
+impl BorrowGuard {
+    #[inline]
+    fn enter(flag: &'static core::sync::atomic::AtomicBool, name: &str) -> Self {
+        assert!(
+            !flag.swap(true, Ordering::Relaxed),
+            "re-entrant mutable {name} state access"
+        );
+        Self(flag)
+    }
+}
+
+impl Drop for BorrowGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Relaxed);
+    }
+}
 
 /// Initialize the global state pointer.
 ///
@@ -95,100 +64,29 @@ pub unsafe fn init(state: &mut FirmwareState) {
     // SAFETY: The caller guarantees that `state` remains valid for the
     // firmware lifetime and no other state has been installed.
     let _ = unsafe { (state as *const FirmwareState).as_ref() };
-    STATE_PTR.store(state as *mut FirmwareState, Ordering::Release);
+    STATE_PTR.store(state as *mut FirmwareState, Ordering::Relaxed);
 }
 
 /// Check if state has been initialized.
 pub fn is_initialized() -> bool {
-    !STATE_PTR.load(Ordering::Acquire).is_null()
+    !STATE_PTR.load(Ordering::Relaxed).is_null()
 }
 
-/// Get a reference to the global firmware state.
+/// Get the raw pointer to the global firmware state.
 ///
-/// # Panics
-///
-/// Panics if called before `init()`.
+/// No reference is returned: callers must project a subsystem pointer before
+/// accessing state, so aliasing is explicit at every unsafe access site.
 #[inline]
-pub fn get() -> &'static FirmwareState {
-    let ptr = STATE_PTR.load(Ordering::Acquire);
-    assert!(!ptr.is_null(), "FirmwareState not initialized");
-    unsafe { &*ptr }
-}
-
-/// Get a raw mutable pointer to the global firmware state.
-///
-/// This returns a raw pointer rather than a reference to avoid creating
-/// multiple aliasing `&mut` references which would be undefined behavior.
-///
-/// # Panics
-///
-/// Panics if called before `init()`.
-///
-/// # Safety Note
-///
-/// The returned pointer is valid for the firmware lifetime. Callers must
-/// ensure they don't create overlapping mutable references when dereferencing.
-/// In single-threaded firmware this is typically safe, but care must be taken
-/// with nested function calls.
-#[inline]
-pub fn get_mut_ptr() -> *mut FirmwareState {
-    let ptr = STATE_PTR.load(Ordering::Acquire);
+pub fn state_ptr() -> *mut FirmwareState {
+    let ptr = STATE_PTR.load(Ordering::Relaxed);
     assert!(!ptr.is_null(), "FirmwareState not initialized");
     ptr
 }
 
-/// Access the firmware state mutably through a closure.
-///
-/// This is the preferred way to mutate firmware state as it makes the
-/// borrowing scope explicit and prevents accidental aliasing.
-///
-/// # Example
-///
-/// ```ignore
-/// state::with_mut(|state| {
-///     state.efi.handle_count += 1;
-/// });
-/// ```
+/// Try to get the raw global state pointer before initialization completes.
 #[inline]
-pub fn with_mut<F, R>(f: F) -> R
-where
-    F: FnOnce(&mut FirmwareState) -> R,
-{
-    #[cfg(debug_assertions)]
-    assert!(
-        !IN_WITH_MUT.swap(true, Ordering::Acquire),
-        "Nested with_mut call detected — this creates aliasing &mut references (UB). \
-         Refactor to avoid re-entrant state access."
-    );
-
-    let ptr = STATE_PTR.load(Ordering::Acquire);
-    assert!(!ptr.is_null(), "FirmwareState not initialized");
-    // SAFETY: Single-threaded firmware, closure scope limits aliasing.
-    // The debug_assertions guard above detects re-entrant calls at runtime.
-    let result = unsafe { f(&mut *ptr) };
-
-    #[cfg(debug_assertions)]
-    IN_WITH_MUT.store(false, Ordering::Release);
-
-    result
-}
-
-/// Try to get a reference to the global firmware state.
-///
-/// Returns `None` if state has not been initialized yet.
-#[inline]
-pub fn try_get() -> Option<&'static FirmwareState> {
-    let ptr = STATE_PTR.load(Ordering::Acquire);
-    (!ptr.is_null()).then(|| unsafe { &*ptr })
-}
-
-/// Try to get a raw mutable pointer to the global firmware state.
-///
-/// Returns `None` if state has not been initialized yet.
-/// See `get_mut_ptr()` for safety considerations.
-#[inline]
-pub fn try_get_mut_ptr() -> Option<*mut FirmwareState> {
-    let ptr = STATE_PTR.load(Ordering::Acquire);
+pub fn try_state_ptr() -> Option<*mut FirmwareState> {
+    let ptr = STATE_PTR.load(Ordering::Relaxed);
     (!ptr.is_null()).then_some(ptr)
 }
 
@@ -231,14 +129,18 @@ fn init_entries<T>(entries: &mut Vec<T>, len: usize, init: impl FnMut() -> T) ->
 /// This struct holds all mutable state for the firmware, organized into
 /// logical subsystems.
 pub struct FirmwareState {
-    /// EFI subsystem state (handles, events, allocator, etc.)
-    pub efi: EfiState,
-
-    /// Hardware driver state
-    pub drivers: DriverState,
-
-    /// Console and display state
-    pub console: ConsoleState,
+    /// EFI service state.
+    efi: UnsafeCell<EfiState>,
+    /// Page and pool allocator state, isolated from EFI service bookkeeping.
+    allocator: UnsafeCell<MemoryAllocator>,
+    /// Persistent variable-store bookkeeping.
+    varstore: UnsafeCell<VarStoreState>,
+    /// Filesystem block device.
+    block_device: UnsafeCell<Option<crate::drivers::block::AnyBlockDevice>>,
+    /// Hardware driver state.
+    drivers: UnsafeCell<DriverState>,
+    /// Console and display state.
+    console: UnsafeCell<ConsoleState>,
 }
 
 impl FirmwareState {
@@ -248,9 +150,12 @@ impl FirmwareState {
     /// or stack allocation.
     pub const fn new() -> Self {
         Self {
-            efi: EfiState::new(),
-            drivers: DriverState::new(),
-            console: ConsoleState::new(),
+            efi: UnsafeCell::new(EfiState::new()),
+            allocator: UnsafeCell::new(MemoryAllocator::new()),
+            varstore: UnsafeCell::new(VarStoreState::new()),
+            block_device: UnsafeCell::new(None),
+            drivers: UnsafeCell::new(DriverState::new()),
+            console: UnsafeCell::new(ConsoleState::new()),
         }
     }
 }
@@ -508,12 +413,6 @@ pub struct EfiState {
     /// Loaded images database, allocated after heap startup.
     pub loaded_images: Vec<LoadedImageEntry>,
 
-    /// Variable store persistence state (SMMSTORE tracking)
-    pub varstore: VarStoreState,
-
-    /// Memory allocator
-    pub allocator: MemoryAllocator,
-
     /// Monotonic counter for GetNextMonotonicCount
     pub monotonic_count: u64,
 
@@ -524,9 +423,6 @@ pub struct EfiState {
 
     /// Filesystem state for SimpleFileSystem protocol
     pub filesystem: Option<FilesystemState>,
-
-    /// Block device for filesystem access
-    pub block_device: Option<crate::drivers::block::AnyBlockDevice>,
 }
 
 impl EfiState {
@@ -539,12 +435,10 @@ impl EfiState {
             events: Vec::new(),
             next_event_id: 2, // Start at 2, reserve 1 for keyboard
             loaded_images: Vec::new(),
-            varstore: VarStoreState::new(),
-            allocator: MemoryAllocator::new(),
+
             monotonic_count: 0,
             ready_to_boot_signaled: false,
             filesystem: None,
-            block_device: None,
         }
     }
 }
@@ -1015,52 +909,36 @@ impl FilesystemState {
 // Helper functions for accessing state components
 // ============================================================================
 
-/// Get a reference to the EFI state.
+/// Get a raw pointer to EFI service state.
 #[inline]
-pub fn efi() -> &'static EfiState {
-    &get().efi
+pub fn efi_ptr() -> *mut EfiState {
+    unsafe { UnsafeCell::raw_get(core::ptr::addr_of!((*state_ptr()).efi)) }
 }
 
-/// Get a raw mutable pointer to the EFI state.
-/// See `get_mut_ptr()` for safety considerations.
-#[inline]
-pub fn efi_mut_ptr() -> *mut EfiState {
-    let ptr = get_mut_ptr();
-    // Safety: ptr is valid, we're just computing an offset
-    unsafe { core::ptr::addr_of_mut!((*ptr).efi) }
-}
-
-/// Access EFI state mutably through a closure.
+/// Access EFI service state mutably through its disjoint cell.
 #[inline]
 pub fn with_efi_mut<F, R>(f: F) -> R
 where
     F: FnOnce(&mut EfiState) -> R,
 {
-    with_mut(|state| f(&mut state.efi))
+    let _guard = BorrowGuard::enter(&EFI_BORROWED, "EFI");
+    unsafe { f(&mut *efi_ptr()) }
 }
 
-/// Get a reference to the driver state.
+/// Get a raw pointer to driver state.
 #[inline]
-pub fn drivers() -> &'static DriverState {
-    &get().drivers
+pub fn drivers_ptr() -> *mut DriverState {
+    unsafe { UnsafeCell::raw_get(core::ptr::addr_of!((*state_ptr()).drivers)) }
 }
 
-/// Get a raw mutable pointer to the driver state.
-/// See `get_mut_ptr()` for safety considerations.
-#[inline]
-pub fn drivers_mut_ptr() -> *mut DriverState {
-    let ptr = get_mut_ptr();
-    // Safety: ptr is valid, we're just computing an offset
-    unsafe { core::ptr::addr_of_mut!((*ptr).drivers) }
-}
-
-/// Access driver state mutably through a closure.
+/// Access driver state mutably through its disjoint cell.
 #[inline]
 pub fn with_drivers_mut<F, R>(f: F) -> R
 where
     F: FnOnce(&mut DriverState) -> R,
 {
-    with_mut(|state| f(&mut state.drivers))
+    let _guard = BorrowGuard::enter(&DRIVER_BORROWED, "driver");
+    unsafe { f(&mut *drivers_ptr()) }
 }
 
 // ---------------------------------------------------------------------------
@@ -1085,55 +963,39 @@ pub fn store_framebuffer(fb: crate::platform::FramebufferConfig) {
 /// or the platform library's `FramebufferConfig`. Used by boot menus,
 /// `boot_linux()` (screen_info), and error display.
 pub fn get_framebuffer() -> Option<crate::platform::FramebufferConfig> {
-    try_get().and_then(|state| state.drivers.platform.framebuffer)
+    unsafe { (*drivers_ptr()).platform.framebuffer }
 }
 
-/// Get a reference to the console state.
+/// Get a raw pointer to console state.
 #[inline]
-pub fn console() -> &'static ConsoleState {
-    &get().console
+pub fn console_ptr() -> *mut ConsoleState {
+    unsafe { UnsafeCell::raw_get(core::ptr::addr_of!((*state_ptr()).console)) }
 }
 
-/// Get a raw mutable pointer to the console state.
-/// See `get_mut_ptr()` for safety considerations.
-#[inline]
-pub fn console_mut_ptr() -> *mut ConsoleState {
-    let ptr = get_mut_ptr();
-    // Safety: ptr is valid, we're just computing an offset
-    unsafe { core::ptr::addr_of_mut!((*ptr).console) }
-}
-
-/// Access console state mutably through a closure.
+/// Access console state mutably through its disjoint cell.
 #[inline]
 pub fn with_console_mut<F, R>(f: F) -> R
 where
     F: FnOnce(&mut ConsoleState) -> R,
 {
-    with_mut(|state| f(&mut state.console))
+    let _guard = BorrowGuard::enter(&CONSOLE_BORROWED, "console");
+    unsafe { f(&mut *console_ptr()) }
 }
 
-/// Get a reference to the memory allocator.
+/// Get a raw pointer to allocator state.
 #[inline]
-pub fn allocator() -> &'static MemoryAllocator {
-    &get().efi.allocator
+pub fn allocator_ptr() -> *mut MemoryAllocator {
+    unsafe { UnsafeCell::raw_get(core::ptr::addr_of!((*state_ptr()).allocator)) }
 }
 
-/// Get a raw mutable pointer to the memory allocator.
-/// See `get_mut_ptr()` for safety considerations.
-#[inline]
-pub fn allocator_mut_ptr() -> *mut MemoryAllocator {
-    let ptr = get_mut_ptr();
-    // Safety: ptr is valid, we're just computing an offset
-    unsafe { core::ptr::addr_of_mut!((*ptr).efi.allocator) }
-}
-
-/// Access allocator state mutably through a closure.
+/// Access allocator state mutably through its disjoint cell.
 #[inline]
 pub fn with_allocator_mut<F, R>(f: F) -> R
 where
     F: FnOnce(&mut MemoryAllocator) -> R,
 {
-    with_mut(|state| f(&mut state.efi.allocator))
+    let _guard = BorrowGuard::enter(&ALLOCATOR_BORROWED, "allocator");
+    unsafe { f(&mut *allocator_ptr()) }
 }
 
 /// Access the block device mutably through a closure.
@@ -1144,7 +1006,17 @@ pub fn with_block_device_mut<F, R>(f: F) -> Option<R>
 where
     F: FnOnce(&mut crate::drivers::block::AnyBlockDevice) -> R,
 {
-    with_mut(|state| state.efi.block_device.as_mut().map(f))
+    unsafe { (*block_device_ptr()).as_mut().map(f) }
+}
+
+/// Replace the filesystem block device.
+pub fn set_block_device(device: crate::drivers::block::AnyBlockDevice) {
+    unsafe { *block_device_ptr() = Some(device) };
+}
+
+#[inline]
+fn block_device_ptr() -> *mut Option<crate::drivers::block::AnyBlockDevice> {
+    unsafe { UnsafeCell::raw_get(core::ptr::addr_of!((*state_ptr()).block_device)) }
 }
 
 /// Access the storage backend mutably through a closure.
@@ -1155,20 +1027,21 @@ pub fn with_storage_mut<F, R>(f: F) -> Option<R>
 where
     F: FnOnce(&mut crate::efi::varstore::SpiStorageBackend) -> R,
 {
-    with_mut(|state| state.drivers.platform.storage.as_mut().map(f))
+    unsafe { (*drivers_ptr()).platform.storage.as_mut().map(f) }
 }
 
-/// Get a reference to the varstore state.
+/// Get a raw pointer to variable-store state.
 #[inline]
-pub fn varstore() -> &'static VarStoreState {
-    &get().efi.varstore
+pub fn varstore_ptr() -> *mut VarStoreState {
+    unsafe { UnsafeCell::raw_get(core::ptr::addr_of!((*state_ptr()).varstore)) }
 }
 
-/// Access varstore state mutably through a closure.
+/// Access variable-store state mutably through its disjoint cell.
 #[inline]
 pub fn with_varstore_mut<F, R>(f: F) -> R
 where
     F: FnOnce(&mut VarStoreState) -> R,
 {
-    with_mut(|state| f(&mut state.efi.varstore))
+    let _guard = BorrowGuard::enter(&VARSTORE_BORROWED, "variable-store");
+    unsafe { f(&mut *varstore_ptr()) }
 }

--- a/crabefi-core/src/time.rs
+++ b/crabefi-core/src/time.rs
@@ -34,7 +34,9 @@ pub fn read_counter() -> u64 {
 
 /// Get the counter frequency in Hz
 pub fn counter_frequency() -> u64 {
-    crate::state::drivers().timing.counter_freq_hz
+    unsafe { &*crate::state::drivers_ptr() }
+        .timing
+        .counter_freq_hz
 }
 
 // Re-export read_counter as rdtsc on x86 for backwards compat with existing callers
@@ -57,7 +59,9 @@ pub fn rdtsc() -> u64 {
 
 // Re-export counter_frequency as tsc_frequency for backwards compat
 pub fn tsc_frequency() -> u64 {
-    crate::state::drivers().timing.counter_freq_hz
+    unsafe { &*crate::state::drivers_ptr() }
+        .timing
+        .counter_freq_hz
 }
 
 // ============================================================================
@@ -300,7 +304,7 @@ mod x86_calibration {
                 // SAFETY: single-threaded init; raw pointer avoids re-entrancy
                 // issues with the state lock.
                 unsafe {
-                    let t = &mut (*crate::state::drivers_mut_ptr()).timing;
+                    let t = &mut (*crate::state::drivers_ptr()).timing;
                     t.counter_freq_hz = freq;
                     t.counter_cycles_per_us = cycles_per_us;
                 }
@@ -334,7 +338,7 @@ mod aarch64_timer {
             // SAFETY: single-threaded init; raw pointer avoids re-entrancy
             // issues with the state lock.
             unsafe {
-                let t = &mut (*crate::state::drivers_mut_ptr()).timing;
+                let t = &mut (*crate::state::drivers_ptr()).timing;
                 t.counter_freq_hz = fallback;
                 t.counter_cycles_per_us = fallback / 1_000_000;
             }
@@ -345,7 +349,7 @@ mod aarch64_timer {
         // SAFETY: single-threaded init; raw pointer avoids re-entrancy
         // issues with the state lock.
         unsafe {
-            let t = &mut (*crate::state::drivers_mut_ptr()).timing;
+            let t = &mut (*crate::state::drivers_ptr()).timing;
             t.counter_freq_hz = freq;
             t.counter_cycles_per_us = cycles_per_us.max(1);
         }
@@ -374,7 +378,9 @@ mod riscv64_timer {
     /// If not set yet (e.g., no FDT parsed before timer init), we use
     /// 10 MHz which is the QEMU virt default.
     pub fn init(_acpi_rsdp: Option<u64>) {
-        let freq = crate::state::drivers().timing.counter_freq_hz;
+        let freq = unsafe { &*crate::state::drivers_ptr() }
+            .timing
+            .counter_freq_hz;
 
         if freq == 0 {
             log::error!(
@@ -387,7 +393,7 @@ mod riscv64_timer {
         let cycles_per_us = (freq / 1_000_000).max(1);
         // SAFETY: single-threaded init
         unsafe {
-            let t = &mut (*crate::state::drivers_mut_ptr()).timing;
+            let t = &mut (*crate::state::drivers_ptr()).timing;
             t.counter_cycles_per_us = cycles_per_us;
         }
 
@@ -425,7 +431,7 @@ pub fn init_from_platform(timer: &dyn crate::platform::Timer) {
         // SAFETY: single-threaded init; raw pointer avoids re-entrancy
         // issues with the state lock.
         unsafe {
-            let t = &mut (*crate::state::drivers_mut_ptr()).timing;
+            let t = &mut (*crate::state::drivers_ptr()).timing;
             t.counter_freq_hz = fallback;
             t.counter_cycles_per_us = 1;
         }
@@ -436,7 +442,7 @@ pub fn init_from_platform(timer: &dyn crate::platform::Timer) {
     // SAFETY: single-threaded init; raw pointer avoids re-entrancy
     // issues with the state lock.
     unsafe {
-        let t = &mut (*crate::state::drivers_mut_ptr()).timing;
+        let t = &mut (*crate::state::drivers_ptr()).timing;
         t.counter_freq_hz = freq;
         t.counter_cycles_per_us = cycles_per_us;
         t.boot_counter = timer.current_ticks();
@@ -452,7 +458,10 @@ pub fn init_from_platform(timer: &dyn crate::platform::Timer) {
 /// Spin-wait for approximately `us` microseconds
 #[inline]
 pub fn delay_us(us: u64) {
-    let cycles = us * crate::state::drivers().timing.counter_cycles_per_us;
+    let cycles = us
+        * unsafe { &*crate::state::drivers_ptr() }
+            .timing
+            .counter_cycles_per_us;
     let start = read_counter();
     while read_counter().wrapping_sub(start) < cycles {
         core::hint::spin_loop();
@@ -488,7 +497,10 @@ impl Timeout {
     /// Create a timeout that expires after `us` microseconds
     #[inline]
     pub fn from_us(us: u64) -> Self {
-        let cycles = us * crate::state::drivers().timing.counter_cycles_per_us;
+        let cycles = us
+            * unsafe { &*crate::state::drivers_ptr() }
+                .timing
+                .counter_cycles_per_us;
         Self {
             deadline: read_counter().wrapping_add(cycles),
         }

--- a/crabefi-core/src/timestamp.rs
+++ b/crabefi-core/src/timestamp.rs
@@ -31,7 +31,10 @@ pub const TS_CRABEFI_EXIT_BOOT_SERVICES: u32 = 1508;
 ///
 /// This is a no-op when the platform did not provide a timestamp recorder.
 pub fn record(id: u32) {
-    if let Some(recorder) = crate::state::drivers().platform.timestamp_recorder {
+    if let Some(recorder) = unsafe { &*crate::state::drivers_ptr() }
+        .platform
+        .timestamp_recorder
+    {
         recorder.record(id);
     }
 }

--- a/crabefi-core/src/ui/firmware_settings.rs
+++ b/crabefi-core/src/ui/firmware_settings.rs
@@ -11,7 +11,7 @@ use crate::time::delay_ms;
 use render::FontSize;
 
 pub fn show(fb: &FramebufferInfo) -> ScreenNav {
-    let Some(hooks) = crate::state::drivers().platform.hooks else {
+    let Some(hooks) = unsafe { &*crate::state::drivers_ptr() }.platform.hooks else {
         return show_no_settings(fb);
     };
 

--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -634,7 +634,7 @@ fn extract_timer_freq_from_fdt(fdt_ptr: u64, fdt_size: u32) {
         if freq > 0 {
             // SAFETY: single-threaded init, state already initialized
             unsafe {
-                let t = &mut (*crabefi::state::drivers_mut_ptr()).timing;
+                let t = &mut (*crabefi::state::drivers_ptr()).timing;
                 t.counter_freq_hz = freq;
                 t.counter_cycles_per_us = (freq / 1_000_000).max(1);
             }
@@ -689,7 +689,9 @@ fn riscv_fdt_only_boot(fdt_ptr: u64, fdt_size: u32) -> ! {
     let region_count = build_memory_map_from_fdt(fdt_ptr, fdt_size, &mut memory_regions);
 
     let timer = CorebootTimer {
-        freq_hz: crabefi::state::drivers().timing.counter_freq_hz,
+        freq_hz: unsafe { &*crabefi::state::drivers_ptr() }
+            .timing
+            .counter_freq_hz,
     };
     let reset = CorebootReset;
     let hooks = CorebootHooks;
@@ -938,7 +940,9 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
 
     // Create timer backed by the calibrated arch counter.
     let timer = CorebootTimer {
-        freq_hz: crabefi::state::drivers().timing.counter_freq_hz,
+        freq_hz: unsafe { &*crabefi::state::drivers_ptr() }
+            .timing
+            .counter_freq_hz,
     };
 
     let reset = CorebootReset;
@@ -1098,7 +1102,10 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
     // for ECAM base and add_platform_mmio_regions() reads for MMIO.
     // RISC-V platforms use FDT rather than ACPI, so skip this.
     #[cfg(not(target_arch = "riscv64"))]
-    if let Some(rsdp) = crabefi::state::drivers().platform.acpi_rsdp {
+    if let Some(rsdp) = unsafe { &*crabefi::state::drivers_ptr() }
+        .platform
+        .acpi_rsdp
+    {
         let acpi_info = unsafe { acpi::discover_platform(rsdp) };
         crabefi::state::with_drivers_mut(|d| d.acpi_info = acpi_info.clone());
 


### PR DESCRIPTION
`FirmwareState` exposed shared subsystem references alongside closures that borrowed the entire state mutably. Re-entrant access could therefore create aliased Rust references, while the guard intended to catch this was absent from release firmware.

Store independently accessed subsystems in separate `UnsafeCell`s and expose raw-pointer projections rather than static references. Mutable accessors now borrow one subsystem at a time with always-on guards.
