### PR TITLE
Reject overflowing Block I/O ranges

### DIFF
--- a/ci/run-coreboot-feature-tests.sh
+++ b/ci/run-coreboot-feature-tests.sh
@@ -29,6 +29,7 @@ rustc --edition=2024 --test \
 "$TMPDIR/pool_free_list_tests"
 
 for test_source in \
+    "$ROOT/crabefi-core/src/efi/block_range.rs" \
     "$ROOT/crabefi-core/src/efi/dma_range.rs" \
     "$ROOT/crabefi-core/src/drivers/mmio_bounds.rs" \
     "$ROOT/crabefi-core/src/drivers/nvme/logic.rs" \

--- a/crabefi-core/src/efi/block_range.rs
+++ b/crabefi-core/src/efi/block_range.rs
@@ -1,0 +1,50 @@
+//! Checked block-address arithmetic shared by storage protocols.
+
+/// Validate a relative block range and translate it to an absolute LBA.
+///
+/// # Arguments
+/// * `start_lba` - Absolute start of the exposed device or partition.
+/// * `lba` - Caller-provided LBA relative to `start_lba`.
+/// * `num_blocks` - Number of blocks requested.
+/// * `total_blocks` - Number of blocks exposed by the protocol instance.
+///
+/// # Returns
+/// The absolute starting LBA, or `None` when either addition overflows or the
+/// requested range extends beyond the exposed device.
+pub fn checked_absolute_lba(
+    start_lba: u64,
+    lba: u64,
+    num_blocks: u64,
+    total_blocks: u64,
+) -> Option<u64> {
+    let end_lba = lba.checked_add(num_blocks)?;
+    if end_lba > total_blocks {
+        return None;
+    }
+    start_lba.checked_add(lba)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::checked_absolute_lba;
+
+    #[test]
+    fn accepts_range_ending_at_device_boundary() {
+        assert_eq!(checked_absolute_lba(100, 8, 2, 10), Some(108));
+    }
+
+    #[test]
+    fn rejects_relative_range_overflow() {
+        assert_eq!(checked_absolute_lba(0, u64::MAX - 1, 4, u64::MAX), None);
+    }
+
+    #[test]
+    fn rejects_absolute_lba_overflow() {
+        assert_eq!(checked_absolute_lba(u64::MAX - 4, 8, 1, 16), None);
+    }
+
+    #[test]
+    fn rejects_range_past_device_boundary() {
+        assert_eq!(checked_absolute_lba(100, 9, 2, 10), None);
+    }
+}

--- a/crabefi-core/src/efi/mod.rs
+++ b/crabefi-core/src/efi/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod allocator;
 pub mod auth;
+pub(crate) mod block_range;
 pub mod boot_services;
 pub mod capsule;
 pub mod dma;

--- a/crabefi-core/src/efi/protocols/block_io.rs
+++ b/crabefi-core/src/efi/protocols/block_io.rs
@@ -99,16 +99,20 @@ extern "efiapi" fn block_io_read_blocks(
 
     let num_blocks = buffer_size / block_size;
 
-    // Check bounds
-    if lba + num_blocks as u64 > ctx.num_blocks {
+    let Some(absolute_lba) = crate::efi::block_range::checked_absolute_lba(
+        ctx.start_lba,
+        lba,
+        num_blocks as u64,
+        ctx.num_blocks,
+    ) else {
         log::debug!(
-            "BlockIO.ReadBlocks: LBA {} + {} blocks exceeds device size {}",
+            "BlockIO.ReadBlocks: invalid LBA {} + {} blocks for device size {}",
             lba,
             num_blocks,
             ctx.num_blocks
         );
         return Status::INVALID_PARAMETER;
-    }
+    };
 
     log::trace!(
         "BlockIO.ReadBlocks(media={}, lba={}, blocks={}, size={})",
@@ -123,7 +127,6 @@ extern "efiapi" fn block_io_read_blocks(
     // (e.g., 128 sectors / 64KB per SCSI command for USB). This avoids the massive
     // overhead of issuing one BOT transaction (CBW + data + CSW) per 512-byte sector.
     let buffer_slice = unsafe { core::slice::from_raw_parts_mut(buffer as *mut u8, buffer_size) };
-    let absolute_lba = ctx.start_lba + lba;
 
     if storage::read_sectors(ctx.storage_device_id, absolute_lba, buffer_slice).is_err() {
         log::error!(


### PR DESCRIPTION
BlockIo.ReadBlocks added the requested LBA and block count before checking the device boundary. Near `u64::MAX`, release builds could wrap the calculation and accept an invalid request.

Perform the range validation and absolute-LBA translation with checked arithmetic, with focused host tests for both overflow paths and boundary handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved block read range validation to correctly account for device offsets and total capacity.
  - Requests that overflow or extend beyond the available device blocks are now rejected safely.

- **Tests**
  - Added coverage for valid boundary requests, range overflow, out-of-bounds access, and absolute address overflow.
  - Included the new block-range tests in host-side regression testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->