### PR TITLE
Fix USB HID polling and native 4K GPT detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ nix develop
 ./crabefi build --arch aarch64
 ```
 
+## USB and pointing devices
+
+Connect USB boot drives and input devices **before starting CrabEFI**. USB
+hotplug/rescanning is not currently supported; restart after attaching a device.
+Native 4K logical sectors are supported, including GPT-partitioned USB storage.
+Hybrid ISO partitions must start and end on native logical-block boundaries;
+unaligned or out-of-device GPT ranges are rejected instead of rounded.
+
+USB configuration descriptors are bounded to 4 KiB, eight active interfaces,
+and four endpoints per interface. Alternate setting zero is used; CrabEFI does
+not activate other settings. SuperSpeed HID bursts and extended service payloads
+are explicitly unsupported rather than configured as single-packet endpoints.
+
+USB input uses HID boot-protocol keyboards and mice. The built-in PS/2 driver
+supports standard relative mice and Synaptics touchpads with PS/2 compatibility;
+SMBus/I²C-only touchpads and replacement trackpads using other protocols are not
+supported. `--features ui` enables the graphical menu, not additional touchpad
+protocols. When reporting a non-working replacement trackpad, include its model,
+Linux input-device identification, and CrabEFI's PS/2/USB initialization logs.
+
 ## Workspace Structure
 
 | Crate | Description |

--- a/crabefi-core/src/boot.rs
+++ b/crabefi-core/src/boot.rs
@@ -90,43 +90,30 @@ pub fn install_block_io_protocols(
 
     // Read GPT partitions, falling back to MBR for removable media. If a GPT is
     // present, measure its header and non-empty partition entries into PCR 5 per
-    // the TCG PC Client PFP EFI_GPT_DATA event format.
-    let partitions = match fs::gpt::read_gpt_header(disk) {
-        Ok(header) => match fs::gpt::read_partitions(disk, &header) {
-            Ok(p) => {
-                if let Ok(event_data) = fs::gpt::build_gpt_measurement_event(disk, &header)
-                    && !GPT_MEASURED.swap(true, Ordering::Relaxed)
-                {
-                    // EDK2 measures EV_EFI_GPT_EVENT once per boot, not once per boot attempt.
-                    efi::tcg::measured_boot::measure_event_all(
-                        5,
-                        efi::tcg::types::EV_EFI_GPT_EVENT,
-                        &event_data,
-                        &event_data,
-                        "GPT partition table",
-                    );
-                }
-                p
+    // the TCG PC Client PFP EFI_GPT_DATA event format. The layout is detected
+    // once and reused for the partition scan and the measurement payload.
+    let gpt_scan = fs::gpt::read_gpt_layout(disk).and_then(|(header, is_hybrid)| {
+        fs::gpt::read_partitions_with(disk, &header, is_hybrid).map(|p| (header, is_hybrid, p))
+    });
+    let partitions = match gpt_scan {
+        Ok((header, is_hybrid, partitions)) => {
+            if let Ok(event_data) =
+                fs::gpt::build_gpt_measurement_event_with(disk, &header, is_hybrid)
+                && !GPT_MEASURED.swap(true, Ordering::Relaxed)
+            {
+                // EDK2 measures EV_EFI_GPT_EVENT once per boot, not once per boot attempt.
+                efi::tcg::measured_boot::measure_event_all(
+                    5,
+                    efi::tcg::types::EV_EFI_GPT_EVENT,
+                    &event_data,
+                    &event_data,
+                    "GPT partition table",
+                );
             }
-            Err(e) => {
-                log::debug!("Failed to read GPT partitions: {:?}; trying MBR", e);
-                match fs::gpt::read_mbr_partitions(disk) {
-                    Ok(p) => {
-                        let mut partitions = heapless::Vec::new();
-                        for partition in p {
-                            let _ = partitions.push(partition);
-                        }
-                        partitions
-                    }
-                    Err(e) => {
-                        log::debug!("Failed to read partition table: {:?}", e);
-                        return None;
-                    }
-                }
-            }
-        },
-        Err(gpt_error) => {
-            log::debug!("GPT partition scan failed: {:?}; trying MBR", gpt_error);
+            partitions
+        }
+        Err(error) => {
+            log::debug!("GPT partition scan failed: {:?}; trying MBR", error);
             match fs::gpt::read_mbr_partitions(disk) {
                 Ok(p) => {
                     let mut partitions = heapless::Vec::new();

--- a/crabefi-core/src/drivers/usb/configuration_tests.rs
+++ b/crabefi-core/src/drivers/usb/configuration_tests.rs
@@ -102,6 +102,26 @@ fn superspeed_hid_bursts_and_nonstandard_payloads_are_explicitly_unsupported() {
 }
 
 #[test]
+fn interface_count_mismatch_is_tolerated() {
+    let mut descriptors = hid_interface(3, 0, 1).to_vec();
+    descriptors.extend_from_slice(&INTERRUPT_IN);
+    // bNumInterfaces claims two interfaces but only one is present.
+    let bytes = configuration(2, &descriptors);
+    let parsed = parse_configuration_checked(&bytes).unwrap();
+    assert_eq!(parsed.num_interfaces, 1);
+    assert_eq!(parsed.interfaces[0].interface_number, 3);
+    assert!(parsed.interfaces[0].is_hid_keyboard());
+
+    // bConfigurationValue == 0 would leave the device unconfigured.
+    let mut zero_configuration = bytes;
+    zero_configuration[5] = 0;
+    assert!(matches!(
+        parse_configuration_checked(&zero_configuration),
+        Err(UsbError::InvalidParameter)
+    ));
+}
+
+#[test]
 fn truncated_and_malformed_configurations_are_rejected() {
     let mut descriptors = hid_interface(0, 0, 1).to_vec();
     descriptors.extend_from_slice(&INTERRUPT_IN);

--- a/crabefi-core/src/drivers/usb/configuration_tests.rs
+++ b/crabefi-core/src/drivers/usb/configuration_tests.rs
@@ -1,0 +1,132 @@
+use super::*;
+use alloc::vec::Vec;
+
+fn configuration(interfaces: u8, descriptors: &[u8]) -> Vec<u8> {
+    let mut bytes = alloc::vec![9, 2, 0, 0, interfaces, 1, 0, 0x80, 50];
+    bytes.extend_from_slice(descriptors);
+    let length = bytes.len() as u16;
+    bytes[2..4].copy_from_slice(&length.to_le_bytes());
+    bytes
+}
+
+fn hid_interface(number: u8, alternate: u8, protocol: u8) -> [u8; 9] {
+    [9, 4, number, alternate, 1, 3, 1, protocol, 0]
+}
+
+const INTERRUPT_IN: [u8; 7] = [7, 5, 0x81, 3, 8, 0, 10];
+
+#[test]
+fn reads_complete_configuration_with_hid_after_byte_256() {
+    for protocol in [1, 2] {
+        let mut descriptors = alloc::vec![0; 255];
+        descriptors[0] = 255;
+        descriptors[1] = 0xff; // Opaque vendor descriptor before the HID interface.
+        descriptors.extend_from_slice(&hid_interface(3, 0, protocol));
+        descriptors.extend_from_slice(&INTERRUPT_IN);
+        let bytes = configuration(1, &descriptors);
+        let mut requests = Vec::new();
+        let parsed = read_configuration_with(|buffer| {
+            requests.push(buffer.len());
+            let length = buffer.len().min(bytes.len());
+            buffer[..length].copy_from_slice(&bytes[..length]);
+            Ok(length)
+        })
+        .unwrap();
+        assert_eq!(requests, [9, bytes.len()]);
+        assert_eq!(parsed.num_interfaces, 1);
+        assert_eq!(parsed.interfaces[0].interface_number, 3);
+        assert_eq!(parsed.interfaces[0].is_hid_keyboard(), protocol == 1);
+        assert_eq!(parsed.interfaces[0].is_hid_mouse(), protocol == 2);
+        assert_eq!(parsed.interfaces[0].find_interrupt_in().unwrap().number, 1);
+    }
+}
+
+#[test]
+fn inactive_alternate_settings_never_supply_boot_endpoints() {
+    let mut descriptors = alloc::vec![9, 4, 3, 0, 0, 0xff, 0, 0, 0];
+    for alternate in 1..=12 {
+        descriptors.extend_from_slice(&hid_interface(3, alternate, 1));
+        descriptors.extend_from_slice(&INTERRUPT_IN);
+    }
+    let parsed = parse_configuration_checked(&configuration(1, &descriptors)).unwrap();
+    assert_eq!(parsed.num_interfaces, 1);
+    assert!(!parsed.interfaces[0].is_hid_keyboard());
+    assert!(parsed.interfaces[0].find_interrupt_in().is_none());
+}
+
+#[test]
+fn parser_capacity_limits_reject_instead_of_returning_partial_devices() {
+    let mut descriptors = Vec::new();
+    for interface in 0..9 {
+        descriptors.extend_from_slice(&hid_interface(interface, 0, 1));
+        descriptors.extend_from_slice(&INTERRUPT_IN);
+    }
+    let bytes = configuration(9, &descriptors);
+    assert!(matches!(
+        parse_configuration_checked(&bytes),
+        Err(UsbError::NotSupported)
+    ));
+    assert_eq!(parse_configuration(&bytes).num_interfaces, 0);
+
+    let mut descriptors = hid_interface(0, 0, 1).to_vec();
+    descriptors[4] = 5;
+    for endpoint in 1..=5 {
+        let mut ep = INTERRUPT_IN;
+        ep[2] = 0x80 | endpoint;
+        descriptors.extend_from_slice(&ep);
+    }
+    assert!(matches!(
+        parse_configuration_checked(&configuration(1, &descriptors)),
+        Err(UsbError::NotSupported)
+    ));
+}
+
+#[test]
+fn superspeed_hid_bursts_and_nonstandard_payloads_are_explicitly_unsupported() {
+    for protocol in [1, 2] {
+        let mut descriptors = hid_interface(0, 0, protocol).to_vec();
+        descriptors.extend_from_slice(&INTERRUPT_IN);
+        descriptors.extend_from_slice(&[6, 48, 0, 0, 8, 0]);
+        let bytes = configuration(1, &descriptors);
+        assert!(parse_configuration_checked(&bytes).is_ok());
+        for (field, value) in [(2, 1), (3, 1), (4, 16)] {
+            let mut changed = bytes.clone();
+            let offset = changed.len() - 6 + field;
+            changed[offset] = value;
+            assert!(matches!(
+                parse_configuration_checked(&changed),
+                Err(UsbError::NotSupported)
+            ));
+        }
+    }
+}
+
+#[test]
+fn truncated_and_malformed_configurations_are_rejected() {
+    let mut descriptors = hid_interface(0, 0, 1).to_vec();
+    descriptors.extend_from_slice(&INTERRUPT_IN);
+    let bytes = configuration(1, &descriptors);
+    assert!(parse_configuration_checked(&bytes[..bytes.len() - 1]).is_err());
+    let mut short_descriptor = bytes.clone();
+    short_descriptor[18] = 1;
+    assert!(parse_configuration_checked(&short_descriptor).is_err());
+    let result = read_configuration_with(|buffer| {
+        let count = if buffer.len() == 9 {
+            9
+        } else {
+            buffer.len() - 1
+        };
+        buffer[..count].copy_from_slice(&bytes[..count]);
+        Ok(count)
+    });
+    assert!(matches!(result, Err(UsbError::InvalidParameter)));
+
+    let mut oversized_header = bytes[..9].to_vec();
+    oversized_header[2..4].copy_from_slice(&4097u16.to_le_bytes());
+    let result = read_configuration_with(|buffer| {
+        assert_eq!(buffer.len(), 9); // Reject before allocating/fetching the body.
+        buffer.copy_from_slice(&oversized_header);
+        Ok(9)
+    });
+    assert!(matches!(result, Err(UsbError::NotSupported)));
+}

--- a/crabefi-core/src/drivers/usb/controller.rs
+++ b/crabefi-core/src/drivers/usb/controller.rs
@@ -1237,11 +1237,17 @@ pub fn parse_configuration_checked(config_data: &[u8]) -> Result<ConfigurationIn
             _ => {}
         }
     }
-    if bytes != config_data.len()
-        || (active && endpoints != expected_endpoints)
-        || interfaces != config_data[4] as usize
-    {
+    if bytes != config_data.len() || (active && endpoints != expected_endpoints) {
         return Err(UsbError::InvalidParameter);
+    }
+    if interfaces != config_data[4] as usize {
+        // SET_CONFIGURATION uses bConfigurationValue, and the parsed interfaces
+        // are already bounded, so a stale interface count is not fatal.
+        log::warn!(
+            "USB: bNumInterfaces {} does not match {} active interfaces",
+            config_data[4],
+            interfaces
+        );
     }
     Ok(parse_configuration_inner(config_data))
 }

--- a/crabefi-core/src/drivers/usb/controller.rs
+++ b/crabefi-core/src/drivers/usb/controller.rs
@@ -15,6 +15,10 @@ use crate::time::Timeout;
 use core::ptr;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
+#[cfg(test)]
+#[path = "configuration_tests.rs"]
+mod configuration_tests;
+
 // ============================================================================
 // USB Speed
 // ============================================================================
@@ -681,7 +685,10 @@ pub trait UsbController {
         data: &mut [u8],
     ) -> Result<usize, UsbError>;
 
-    /// Perform a single synchronous interrupt IN transfer.
+    /// Poll an interrupt IN endpoint without waiting for input.
+    ///
+    /// Returns zero while a report is pending. Implementations must retain DMA
+    /// ownership between polls and must not keep a pointer into `data`.
     ///
     /// This is the correct way to poll HID devices (mice, keyboards) since
     /// many devices do not implement the GET_REPORT class request and will
@@ -696,6 +703,36 @@ pub trait UsbController {
         _data: &mut [u8],
     ) -> Result<usize, UsbError> {
         Err(UsbError::NotSupported)
+    }
+
+    /// Fetch a complete, bounded configuration; never parse a truncated prefix.
+    fn read_configuration(&mut self, device: u8) -> Result<ConfigurationInfo, UsbError> {
+        read_configuration_with(|buffer| {
+            self.control_transfer(
+                device,
+                req_type::DIR_IN | req_type::TYPE_STANDARD | req_type::RCPT_DEVICE,
+                request::GET_DESCRIPTOR,
+                (desc_type::CONFIGURATION as u16) << 8,
+                0,
+                Some(buffer),
+            )
+        })
+    }
+
+    /// Resolve the interface owning a discovered HID interrupt endpoint.
+    /// Composite devices need this interface number in every HID class request.
+    fn hid_interface_number(&mut self, device: u8, endpoint: u8) -> Result<u8, UsbError> {
+        let config = self.read_configuration(device)?;
+        config.interfaces[..config.num_interfaces]
+            .iter()
+            .find(|iface| {
+                (iface.is_hid_keyboard() || iface.is_hid_mouse())
+                    && iface
+                        .find_interrupt_in()
+                        .is_some_and(|ep| ep.number == endpoint)
+            })
+            .map(|iface| iface.interface_number)
+            .ok_or(UsbError::DeviceNotFound)
     }
 
     /// Create an interrupt transfer queue
@@ -1094,8 +1131,131 @@ impl<'a> Iterator for DescriptorIterator<'a> {
     }
 }
 
-/// Parse configuration descriptor to find interfaces and endpoints
+/// Firmware resource limits. Descriptors beyond these limits are rejected,
+/// not partially interpreted as a different set of device functions.
+const MAX_CONFIGURATION_DESCRIPTOR_SIZE: usize = 4096;
+const MAX_CONFIGURATION_INTERFACES: usize = 8;
+const MAX_INTERFACE_ENDPOINTS: usize = 4;
+
+fn read_configuration_with(
+    mut read: impl FnMut(&mut [u8]) -> Result<usize, UsbError>,
+) -> Result<ConfigurationInfo, UsbError> {
+    let mut header = [0u8; 9];
+    if read(&mut header)? != header.len() || header[0] != 9 || header[1] != desc_type::CONFIGURATION
+    {
+        return Err(UsbError::InvalidParameter);
+    }
+    let length = u16::from_le_bytes([header[2], header[3]]) as usize;
+    if length < header.len() {
+        return Err(UsbError::InvalidParameter);
+    }
+    if length > MAX_CONFIGURATION_DESCRIPTOR_SIZE {
+        return Err(UsbError::NotSupported);
+    }
+    let mut buffer = alloc::vec![0; length];
+    if read(&mut buffer)? != length {
+        return Err(UsbError::InvalidParameter);
+    }
+    parse_configuration_checked(&buffer)
+}
+
+pub fn parse_configuration_checked(config_data: &[u8]) -> Result<ConfigurationInfo, UsbError> {
+    if config_data.len() < 9
+        || config_data[0] != 9
+        || config_data[1] != desc_type::CONFIGURATION
+        || u16::from_le_bytes([config_data[2], config_data[3]]) as usize != config_data.len()
+        || config_data[5] == 0
+    {
+        return Err(UsbError::InvalidParameter);
+    }
+    if config_data.len() > MAX_CONFIGURATION_DESCRIPTOR_SIZE {
+        return Err(UsbError::NotSupported);
+    }
+    let mut bytes = 0;
+    let mut interfaces = 0;
+    let mut seen = [false; 256];
+    let mut active = false;
+    let mut hid = false;
+    let mut endpoints = 0;
+    let mut expected_endpoints = 0;
+    let mut interrupt_packet = None;
+    for (kind, data) in DescriptorIterator::new(config_data) {
+        bytes += data.len();
+        match kind {
+            desc_type::INTERFACE => {
+                if (active && endpoints != expected_endpoints) || data.len() < 9 {
+                    return Err(UsbError::InvalidParameter);
+                }
+                // SET_CONFIGURATION activates alternate setting zero only.
+                active = data[3] == 0;
+                hid = data[5] == class::HID && data[6] == 1 && matches!(data[7], 1 | 2);
+                endpoints = 0;
+                expected_endpoints = data[4] as usize;
+                interrupt_packet = None;
+                if active {
+                    if seen[data[2] as usize] {
+                        return Err(UsbError::InvalidParameter);
+                    }
+                    seen[data[2] as usize] = true;
+                    interfaces += 1;
+                    if interfaces > MAX_CONFIGURATION_INTERFACES
+                        || expected_endpoints > MAX_INTERFACE_ENDPOINTS
+                    {
+                        return Err(UsbError::NotSupported);
+                    }
+                }
+            }
+            desc_type::ENDPOINT => {
+                if data.len() < 7 {
+                    return Err(UsbError::InvalidParameter);
+                }
+                interrupt_packet = None;
+                if active {
+                    endpoints += 1;
+                    if endpoints > expected_endpoints {
+                        return Err(UsbError::InvalidParameter);
+                    }
+                    if hid && data[2] & 0x80 != 0 && data[3] & 3 == 3 {
+                        interrupt_packet = Some(u16::from_le_bytes([data[4], data[5]]) & 0x7ff);
+                    }
+                }
+            }
+            48 if interrupt_packet.is_some() => {
+                // SuperSpeed Endpoint Companion. The current HID context
+                // supports one packet per interval, not bursts or SS extensions.
+                if data.len() < 6 {
+                    return Err(UsbError::InvalidParameter);
+                }
+                if data[2] != 0
+                    || data[3] != 0
+                    || Some(u16::from_le_bytes([data[4], data[5]])) != interrupt_packet
+                {
+                    return Err(UsbError::NotSupported);
+                }
+                interrupt_packet = None;
+            }
+            _ => {}
+        }
+    }
+    if bytes != config_data.len()
+        || (active && endpoints != expected_endpoints)
+        || interfaces != config_data[4] as usize
+    {
+        return Err(UsbError::InvalidParameter);
+    }
+    Ok(parse_configuration_inner(config_data))
+}
+
+/// Compatibility entry point for legacy enumeration. Invalid or unsupported
+/// descriptors must expose no partial interfaces/endpoints to those callers.
 pub fn parse_configuration(config_data: &[u8]) -> ConfigurationInfo {
+    parse_configuration_checked(config_data).unwrap_or_else(|error| {
+        log::warn!("USB: rejected configuration descriptor: {:?}", error);
+        ConfigurationInfo::default()
+    })
+}
+
+fn parse_configuration_inner(config_data: &[u8]) -> ConfigurationInfo {
     let mut info = ConfigurationInfo::default();
 
     if config_data.len() < 9 {
@@ -1123,7 +1283,9 @@ pub fn parse_configuration(config_data: &[u8]) -> ConfigurationInfo {
                 }
 
                 // Parse interface descriptor using zerocopy
-                if let Ok((iface, _)) = InterfaceDescriptor::read_from_prefix(desc_data) {
+                if let Ok((iface, _)) = InterfaceDescriptor::read_from_prefix(desc_data)
+                    && iface.alternate_setting == 0
+                {
                     current_interface = Some(InterfaceInfo {
                         interface_number: iface.interface_number,
                         alternate_setting: iface.alternate_setting,
@@ -1203,14 +1365,14 @@ impl InterfaceInfo {
 
     /// Check if this is a HID keyboard interface
     pub fn is_hid_keyboard(&self) -> bool {
-        self.interface_class == class::HID
+        self.alternate_setting == 0 && self.interface_class == class::HID
             && self.interface_subclass == 0x01 // Boot interface
             && self.interface_protocol == 0x01 // Keyboard
     }
 
     /// Check if this is a HID mouse interface (boot protocol mouse)
     pub fn is_hid_mouse(&self) -> bool {
-        self.interface_class == class::HID
+        self.alternate_setting == 0 && self.interface_class == class::HID
             && self.interface_subclass == 0x01 // Boot interface
             && self.interface_protocol == 0x02 // Mouse
     }
@@ -1319,32 +1481,16 @@ where
     log::info!("  Device {}: VID={:04x} PID={:04x}", address, vid, pid);
 
     // Step 4: Get configuration descriptor
-    let mut config_buf = [0u8; 256];
-    let mut header = [0u8; 9];
-
-    do_control(
-        &device,
-        req_type::DIR_IN | req_type::TYPE_STANDARD | req_type::RCPT_DEVICE,
-        request::GET_DESCRIPTOR,
-        (desc_type::CONFIGURATION as u16) << 8,
-        0,
-        Some(&mut header),
-    )?;
-
-    let total_len = u16::from_le_bytes([header[2], header[3]]) as usize;
-    let total_len = total_len.min(config_buf.len());
-
-    do_control(
-        &device,
-        req_type::DIR_IN | req_type::TYPE_STANDARD | req_type::RCPT_DEVICE,
-        request::GET_DESCRIPTOR,
-        (desc_type::CONFIGURATION as u16) << 8,
-        0,
-        Some(&mut config_buf[..total_len]),
-    )?;
-
-    // Step 5: Parse configuration
-    device.config_info = parse_configuration(&config_buf[..total_len]);
+    device.config_info = read_configuration_with(|buffer| {
+        do_control(
+            &device,
+            req_type::DIR_IN | req_type::TYPE_STANDARD | req_type::RCPT_DEVICE,
+            request::GET_DESCRIPTOR,
+            (desc_type::CONFIGURATION as u16) << 8,
+            0,
+            Some(buffer),
+        )
+    })?;
 
     // Check if this is a hub (device class)
     if device.device_desc.device_class == class::HUB {

--- a/crabefi-core/src/drivers/usb/hid_keyboard.rs
+++ b/crabefi-core/src/drivers/usb/hid_keyboard.rs
@@ -12,6 +12,10 @@ use super::controller::{UsbController, UsbError, hid_request, req_type};
 use crate::time::Timeout;
 use spin::Mutex;
 
+#[cfg(test)]
+#[path = "hid_keyboard_tests.rs"]
+mod tests;
+
 // ============================================================================
 // HID Boot Protocol Keyboard
 // ============================================================================
@@ -90,6 +94,8 @@ pub struct UsbHidKeyboard {
     controller_idx: usize,
     /// Device address
     device_address: u8,
+    /// Interface owning the boot-protocol interrupt endpoint.
+    interface_number: u8,
     /// Interrupt endpoint number (USB endpoint hardware property)
     #[allow(dead_code)] // Endpoint descriptor shadow; completeness for re-enumeration.
     endpoint: u8,
@@ -131,6 +137,7 @@ impl UsbHidKeyboard {
         Self {
             controller_idx,
             device_address,
+            interface_number: 0,
             endpoint,
             max_packet,
             interval,
@@ -151,13 +158,15 @@ impl UsbHidKeyboard {
         &mut self,
         controller: &mut C,
     ) -> Result<(), UsbError> {
+        self.interface_number =
+            controller.hid_interface_number(self.device_address, self.endpoint)?;
         // SET_PROTOCOL with protocol = 0 (boot protocol)
         controller.control_transfer(
             self.device_address,
             req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_INTERFACE,
             hid_request::SET_PROTOCOL,
             0, // Boot protocol
-            0, // Interface 0
+            self.interface_number as u16,
             None,
         )?;
         Ok(())
@@ -176,7 +185,7 @@ impl UsbHidKeyboard {
             req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_INTERFACE,
             hid_request::SET_IDLE,
             (duration as u16) << 8, // Duration in high byte
-            0,                      // Interface 0
+            self.interface_number as u16,
             None,
         )?;
         Ok(())
@@ -199,7 +208,7 @@ impl UsbHidKeyboard {
             req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_INTERFACE,
             hid_request::SET_REPORT,
             0x0200, // Report type = Output (2), Report ID = 0
-            0,      // Interface 0
+            self.interface_number as u16,
             Some(&mut data),
         )?;
         Ok(())
@@ -745,19 +754,31 @@ pub fn poll<C: UsbController>(controller: &mut C) {
         None => return,
     };
 
-    // Try to get a report via control transfer (since interrupt queues aren't implemented)
+    poll_report(keyboard, controller);
+}
+
+fn poll_report<C: UsbController>(keyboard: &mut UsbHidKeyboard, controller: &mut C) {
+    // Most real keyboards require interrupt IN; GET_REPORT is only a legacy
+    // controller fallback. A pending interrupt TD is not an all-keys-up report.
     let mut report_buf = [0u8; 8];
-    let result = controller.control_transfer(
+    let result = match controller.interrupt_transfer(
         keyboard.device_address(),
-        req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_INTERFACE,
-        hid_request::GET_REPORT,
-        0x0100, // Report type = Input (1), Report ID = 0
-        0,      // Interface 0
-        Some(&mut report_buf),
-    );
+        keyboard.endpoint,
+        &mut report_buf,
+    ) {
+        Err(UsbError::NotSupported) => controller.control_transfer(
+            keyboard.device_address(),
+            req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_INTERFACE,
+            hid_request::GET_REPORT,
+            0x0100,
+            keyboard.interface_number as u16,
+            Some(&mut report_buf),
+        ),
+        result => result,
+    };
 
     match result {
-        Ok(_) => {
+        Ok(8) => {
             let report = KeyboardReport {
                 modifiers: report_buf[0],
                 reserved: report_buf[1],
@@ -772,8 +793,8 @@ pub fn poll<C: UsbController>(controller: &mut C) {
             };
             keyboard.process_report(&report);
         }
-        Err(_) => {
-            // Silently ignore errors - keyboard might not have anything new
+        _ => {
+            // No completion, short report, or error: retain the held-key state.
         }
     }
 

--- a/crabefi-core/src/drivers/usb/hid_keyboard_tests.rs
+++ b/crabefi-core/src/drivers/usb/hid_keyboard_tests.rs
@@ -1,0 +1,120 @@
+use super::*;
+use crate::drivers::usb::controller::{desc_type, request};
+
+struct Controller {
+    report: [u8; 8],
+    length: usize,
+    supported: bool,
+    get_reports: usize,
+    class_indices: alloc::vec::Vec<u16>,
+}
+
+impl Controller {
+    fn new() -> Self {
+        Self {
+            report: [0, 0, 4, 0, 0, 0, 0, 0],
+            length: 8,
+            supported: true,
+            get_reports: 0,
+            class_indices: alloc::vec::Vec::new(),
+        }
+    }
+}
+
+impl UsbController for Controller {
+    fn controller_type(&self) -> &'static str {
+        "test"
+    }
+    fn control_transfer(
+        &mut self,
+        _device: u8,
+        request_type: u8,
+        req: u8,
+        value: u16,
+        index: u16,
+        data: Option<&mut [u8]>,
+    ) -> Result<usize, UsbError> {
+        if request_type & req_type::TYPE_CLASS == 0 {
+            assert_eq!(req, request::GET_DESCRIPTOR);
+            assert_eq!(value, (desc_type::CONFIGURATION as u16) << 8);
+            let config = [
+                9, 2, 25, 0, 1, 1, 0, 0x80, 50, 9, 4, 3, 0, 1, 3, 1, 1, 0, 7, 5, 0x81, 3, 8, 0, 10,
+            ];
+            let data = data.unwrap();
+            let length = data.len().min(config.len());
+            data[..length].copy_from_slice(&config[..length]);
+            return Ok(length);
+        }
+        self.class_indices.push(index);
+        if req == hid_request::GET_REPORT {
+            self.get_reports += 1;
+            data.unwrap()[..8].copy_from_slice(&self.report);
+            return Ok(8);
+        }
+        Ok(0)
+    }
+    fn interrupt_transfer(
+        &mut self,
+        _device: u8,
+        endpoint: u8,
+        data: &mut [u8],
+    ) -> Result<usize, UsbError> {
+        assert_eq!(endpoint, 1);
+        if !self.supported {
+            return Err(UsbError::NotSupported);
+        }
+        data[..self.length].copy_from_slice(&self.report[..self.length]);
+        Ok(self.length)
+    }
+    fn bulk_transfer(&mut self, _: u8, _: u8, _: bool, _: &mut [u8]) -> Result<usize, UsbError> {
+        unreachable!()
+    }
+    fn create_interrupt_queue(
+        &mut self,
+        _: u8,
+        _: u8,
+        _: bool,
+        _: u16,
+        _: u8,
+    ) -> Result<u32, UsbError> {
+        unreachable!()
+    }
+    fn poll_interrupt_queue(&mut self, _: u32, _: &mut [u8]) -> Option<usize> {
+        unreachable!()
+    }
+    fn destroy_interrupt_queue(&mut self, _: u32) {
+        unreachable!()
+    }
+}
+
+#[test]
+fn interrupt_reports_preserve_keys_when_pending_or_short() {
+    let mut controller = Controller::new();
+    let mut keyboard = UsbHidKeyboard::new(0, 1, 1, 8, 10);
+    poll_report(&mut keyboard, &mut controller);
+    assert_eq!(keyboard.get_key(), Some(b'a' as u16));
+    assert_eq!(keyboard.prev_report.keys[0], 4);
+    controller.report.fill(0);
+    for length in [0, 2, 7] {
+        controller.length = length;
+        poll_report(&mut keyboard, &mut controller);
+        assert_eq!(keyboard.prev_report.keys[0], 4);
+    }
+    controller.length = 8;
+    poll_report(&mut keyboard, &mut controller);
+    assert_eq!(keyboard.prev_report.keys[0], 0);
+    assert_eq!(controller.get_reports, 0);
+}
+
+#[test]
+fn composite_interface_is_used_for_all_class_requests() {
+    let mut controller = Controller::new();
+    let mut keyboard = UsbHidKeyboard::new(0, 1, 1, 8, 10);
+    keyboard.set_boot_protocol(&mut controller).unwrap();
+    keyboard.set_idle(&mut controller, 0).unwrap();
+    keyboard.set_leds(&mut controller).unwrap();
+    controller.supported = false;
+    poll_report(&mut keyboard, &mut controller);
+    assert_eq!(controller.class_indices, [3, 3, 3, 3]);
+    assert_eq!(controller.get_reports, 1);
+}

--- a/crabefi-core/src/drivers/usb/hid_mouse.rs
+++ b/crabefi-core/src/drivers/usb/hid_mouse.rs
@@ -53,6 +53,8 @@ pub struct UsbHidMouse {
     controller_idx: usize,
     /// Device address
     device_address: u8,
+    /// Interface owning the boot-protocol interrupt endpoint.
+    interface_number: u8,
     /// Interrupt endpoint number
     endpoint: u8,
     /// Max packet size
@@ -85,6 +87,7 @@ impl UsbHidMouse {
         Self {
             controller_idx,
             device_address,
+            interface_number: 0,
             endpoint,
             max_packet,
             interval,
@@ -97,13 +100,15 @@ impl UsbHidMouse {
     }
 
     /// Set boot protocol mode
-    fn set_boot_protocol<C: UsbController>(&self, controller: &mut C) -> Result<(), UsbError> {
+    fn set_boot_protocol<C: UsbController>(&mut self, controller: &mut C) -> Result<(), UsbError> {
+        self.interface_number =
+            controller.hid_interface_number(self.device_address, self.endpoint)?;
         controller.control_transfer(
             self.device_address,
             req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_INTERFACE,
             hid_request::SET_PROTOCOL,
             0, // Boot protocol
-            0, // Interface 0
+            self.interface_number as u16,
             None,
         )?;
         Ok(())
@@ -117,7 +122,7 @@ impl UsbHidMouse {
             req_type::DIR_OUT | req_type::TYPE_CLASS | req_type::RCPT_INTERFACE,
             hid_request::SET_IDLE,
             (duration as u16) << 8,
-            0,
+            self.interface_number as u16,
             None,
         )?;
         Ok(())
@@ -187,7 +192,7 @@ pub fn init_mouse<C: UsbController>(
         ep_info.interval
     );
 
-    let mouse = UsbHidMouse::new(
+    let mut mouse = UsbHidMouse::new(
         controller_idx,
         device_addr,
         ep_info.number,
@@ -280,7 +285,7 @@ pub fn poll<C: UsbController>(controller: &mut C) {
         req_type::DIR_IN | req_type::TYPE_CLASS | req_type::RCPT_INTERFACE,
         hid_request::GET_REPORT,
         0x0100, // Report type = Input (1), Report ID = 0
-        0,      // Interface 0
+        mouse.interface_number as u16,
         Some(&mut ctrl_buf),
     );
 

--- a/crabefi-core/src/drivers/usb/mod.rs
+++ b/crabefi-core/src/drivers/usb/mod.rs
@@ -538,20 +538,11 @@ impl UsbController for XhciController {
     }
 
     fn find_hid_keyboard(&self) -> Option<u8> {
-        // Check all slots for HID keyboard devices
-        (0..xhci::MAX_SLOTS as u8).find(|&slot_id| {
-            self.get_slot(slot_id)
-                .map(|slot| slot.is_hid_keyboard)
-                .unwrap_or(false)
-        })
+        self.find_slot(|slot| slot.is_hid_keyboard)
     }
 
     fn find_hid_mouse(&self) -> Option<u8> {
-        (0..xhci::MAX_SLOTS as u8).find(|&slot_id| {
-            self.get_slot(slot_id)
-                .map(|slot| slot.is_hid_mouse)
-                .unwrap_or(false)
-        })
+        self.find_slot(|slot| slot.is_hid_mouse)
     }
 
     fn get_mouse_interrupt_endpoint(&self, device: u8) -> Option<self::controller::EndpointInfo> {

--- a/crabefi-core/src/drivers/usb/xhci/bulk.rs
+++ b/crabefi-core/src/drivers/usb/xhci/bulk.rs
@@ -16,12 +16,50 @@ fn bulk_dma_offset(address: u64) -> usize {
     (address.wrapping_neg() & (TD_MAX_TRANSFER_SIZE as u64 - 1)) as usize
 }
 
+/// Owns the DMA buffer for one endpoint across nonblocking polls.
+pub(super) struct InterruptPoll {
+    slot: u8,
+    dci: u8,
+    td: u64,
+    bounce: Option<DmaBuffer>,
+    offset: usize,
+    len: usize,
+    completion: Option<super::RawTrb>,
+}
+
+impl InterruptPoll {
+    fn capture(&mut self, raw: super::RawTrb) -> bool {
+        let pointer = u64::from(raw[0]) | (u64::from(raw[1]) << 32);
+        let slot = (raw[3] >> 24) as u8;
+        let dci = ((raw[3] >> 16) & 0x1f) as u8;
+        if super::raw_trb_type(&raw) == 32
+            && self.slot == slot
+            && self.dci == dci
+            && self.td == pointer
+        {
+            self.completion = Some(raw);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl Drop for InterruptPoll {
+    fn drop(&mut self) {
+        if self.td != 0 && self.completion.is_none() {
+            // No completion proves that DMA stopped. Preserve the mapping if
+            // the controller is dropped without first quiescing this endpoint.
+            if let Some(bounce) = self.bounce.take() {
+                core::mem::forget(bounce);
+            }
+        }
+    }
+}
+
 impl super::XhciController {
-    /// Perform a single synchronous interrupt IN transfer.
-    ///
-    /// Queues one Normal TRB on the interrupt endpoint's transfer ring,
-    /// uses a DMA-domain bounce buffer, and waits for its completion event.
-    /// Failed polls cancel the old TD before releasing that buffer.
+    /// Poll a persistent interrupt IN TD without waiting for a NAKing device.
+    /// Zero means no report yet, not a completed zero-filled HID report.
     pub(super) fn interrupt_transfer_impl(
         &mut self,
         slot_id: u8,
@@ -34,73 +72,122 @@ impl super::XhciController {
         if data.is_empty() {
             return Ok(0);
         }
+        self.poll_interrupt_events()?;
         let in_dci = (endpoint as usize * 2) + 1;
-        let domain = pci::dma_domain(self.pci_address).ok_or(XhciError::NotReady)?;
-        let mask = if self
-            .registers
-            .capability
-            .hccparams1
-            .read_volatile()
-            .addressing_capability()
-        {
-            DmaMask::bits64()
+        let index = self
+            .interrupt_polls
+            .iter()
+            .position(|poll| poll.slot == slot_id && poll.dci == in_dci as u8);
+        let mut transferred = 0;
+        let mut poll = if let Some(index) = index {
+            let poll = &self.interrupt_polls[index];
+            if poll.len != data.len() {
+                return Err(XhciError::InvalidParameter);
+            }
+            let Some(raw) = poll.completion else {
+                return Ok(0);
+            };
+            // Leave failed endpoints quarantined. Never reset an idle endpoint
+            // or repeatedly allocate buffers when a device is unplugged.
+            let event =
+                event::TransferEvent::try_from(raw).map_err(|_| XhciError::InvalidParameter)?;
+            if !matches!(
+                event.completion_code(),
+                Ok(event::CompletionCode::Success | event::CompletionCode::ShortPacket)
+            ) {
+                return Err(XhciError::TransferFailed(event.completion_code()));
+            }
+            let poll = self.interrupt_polls.swap_remove(index);
+            let bounce = poll.bounce.as_ref().ok_or(XhciError::NotReady)?;
+            bounce
+                .sync_for_cpu(0..bounce.len(), DmaDirection::FromDevice)
+                .map_err(|_| XhciError::NotReady)?;
+            transferred = poll
+                .len
+                .saturating_sub(event.trb_transfer_length() as usize);
+            data[..transferred]
+                .copy_from_slice(&bounce.as_slice()[poll.offset..poll.offset + transferred]);
+            poll
         } else {
-            DmaMask::bits32()
+            let domain = pci::dma_domain(self.pci_address).ok_or(XhciError::NotReady)?;
+            let mask = if self
+                .registers
+                .capability
+                .hccparams1
+                .read_volatile()
+                .addressing_capability()
+            {
+                DmaMask::bits64()
+            } else {
+                DmaMask::bits32()
+            };
+            let bounce =
+                DmaBuffer::allocate_in_domain(data.len() + TD_MAX_TRANSFER_SIZE - 1, mask, domain)
+                    .map_err(|_| XhciError::AllocationFailed)?;
+            let offset = bulk_dma_offset(bounce.dma_address());
+            InterruptPoll {
+                slot: slot_id,
+                dci: in_dci as u8,
+                td: 0,
+                bounce: Some(bounce),
+                offset,
+                len: data.len(),
+                completion: None,
+            }
         };
-        let bounce =
-            DmaBuffer::allocate_in_domain(data.len() + TD_MAX_TRANSFER_SIZE - 1, mask, domain)
-                .map_err(|_| XhciError::AllocationFailed)?;
-        let offset = bulk_dma_offset(bounce.dma_address());
+        let bounce = poll.bounce.as_ref().ok_or(XhciError::NotReady)?;
         bounce
             .sync_for_device(0..bounce.len(), DmaDirection::FromDevice)
             .map_err(|_| XhciError::NotReady)?;
-        let td = self.queue_bulk_trb(
+        poll.td = self.queue_bulk_trb(
             slot_id,
             in_dci,
             true,
-            bounce.dma_address() + offset as u64,
-            data.len(),
+            bounce.dma_address() + poll.offset as u64,
+            poll.len,
         )?;
+        poll.completion = None;
+        self.interrupt_polls.push(poll);
         barrier::mmio_write();
         self.ring_doorbell(slot_id, in_dci as u8);
+        Ok(transferred)
+    }
 
-        match self.wait_transfer_td(slot_id, endpoint, td) {
-            Ok(residual) => {
-                bounce
-                    .sync_for_cpu(0..bounce.len(), DmaDirection::FromDevice)
-                    .map_err(|_| XhciError::NotReady)?;
-                let transferred = data.len().saturating_sub(residual as usize);
-                data[..transferred]
-                    .copy_from_slice(&bounce.as_slice()[offset..offset + transferred]);
-                Ok(transferred)
-            }
-            Err(error) => {
-                // A timeout does not cancel DMA. Stop and skip the old TD before
-                // allowing another poll; Reset Endpoint is only for halted EPs.
-                let cancelled = if matches!(error, XhciError::StallError) {
-                    self.reset_endpoint(slot_id, in_dci as u8)
-                } else {
-                    self.stop_endpoint(slot_id, in_dci as u8)
-                };
-                if cancelled.is_err() {
-                    // Quarantine the endpoint and retain its DMA mapping if we
-                    // cannot prove the old TD is no longer controller-owned.
-                    core::mem::forget(bounce);
-                    if let Some(slot) = self
-                        .slots
-                        .get_mut(slot_id as usize)
-                        .and_then(Option::as_mut)
-                    {
-                        slot.transfer_rings[in_dci - 1] = None;
+    /// Route completions even when command or bulk-transfer code owns the ring.
+    pub(super) fn capture_interrupt_event(&mut self, raw: super::RawTrb) -> bool {
+        self.interrupt_polls
+            .iter_mut()
+            .any(|poll| poll.capture(raw))
+    }
+
+    fn poll_interrupt_events(&mut self) -> Result<(), XhciError> {
+        // Bounded even if hardware keeps publishing events while we poll.
+        // Command/bulk operations are synchronous and never overlap this poll.
+        for _ in 0..self.event_ring.size {
+            let address = self.event_ring.base + (self.event_ring.dequeue_idx * 16) as u64;
+            let Some(raw) = super::read_event_trb(address, self.event_ring.cycle) else {
+                break;
+            };
+            if !self.capture_interrupt_event(raw) {
+                match event::Allowed::try_from(raw) {
+                    // USB hotplug is not implemented, as in the synchronous waiters.
+                    Ok(event::Allowed::PortStatusChange(_)) => {}
+                    Ok(event::Allowed::HostController(host)) => {
+                        return Err(XhciError::TransferFailed(host.completion_code()));
                     }
-                } else {
-                    bounce
-                        .sync_for_cpu(0..bounce.len(), DmaDirection::FromDevice)
-                        .map_err(|_| XhciError::NotReady)?;
+                    // Preserve any unrelated completion for its synchronous
+                    // waiter rather than silently stealing it from the ring.
+                    _ => break,
                 }
-                Err(error)
             }
+            self.event_ring.dequeue_idx += 1;
+            if self.event_ring.dequeue_idx == self.event_ring.size {
+                self.event_ring.dequeue_idx = 0;
+                self.event_ring.cycle = !self.event_ring.cycle;
+            }
+            self.update_erdp();
         }
+        Ok(())
     }
 
     /// Configure bulk endpoints
@@ -377,7 +464,34 @@ impl super::XhciController {
 
 #[cfg(test)]
 mod tests {
-    use super::{TD_MAX_TRANSFER_SIZE, bulk_dma_offset};
+    use super::{InterruptPoll, TD_MAX_TRANSFER_SIZE, bulk_dma_offset};
+
+    #[test]
+    fn interrupt_completion_matches_slot_direction_and_td() {
+        let mut poll = InterruptPoll {
+            slot: 2,
+            dci: 3,
+            td: 0x1000,
+            bounce: None,
+            offset: 0,
+            len: 8,
+            completion: None,
+        };
+        let completed = [
+            0x1000,
+            0,
+            (13 << 24) | 5,
+            (2 << 24) | (3 << 16) | (32 << 10) | 1,
+        ];
+        for (word, bit) in [(0, 4), (3, 1 << 24), (3, 1 << 16), (3, 1 << 10)] {
+            let mut unrelated = completed;
+            unrelated[word] ^= bit;
+            assert!(!poll.capture(unrelated));
+            assert!(poll.completion.is_none());
+        }
+        assert!(poll.capture(completed));
+        assert_eq!(poll.completion, Some(completed));
+    }
 
     #[test]
     fn bounce_window_fits_all_device_address_alignments() {

--- a/crabefi-core/src/drivers/usb/xhci/commands.rs
+++ b/crabefi-core/src/drivers/usb/xhci/commands.rs
@@ -44,6 +44,9 @@ impl super::XhciController {
                 }
                 self.update_erdp();
 
+                if self.capture_interrupt_event(raw) {
+                    continue;
+                }
                 match event::Allowed::try_from(raw) {
                     Ok(event::Allowed::CommandCompletion(completion)) => {
                         if (u64::from(raw[0]) | (u64::from(raw[1]) << 32)) != expected {
@@ -126,6 +129,9 @@ impl super::XhciController {
                 }
                 self.update_erdp();
 
+                if self.capture_interrupt_event(raw) {
+                    continue;
+                }
                 match event::Allowed::try_from(raw) {
                     Ok(event::Allowed::TransferEvent(transfer_event)) => {
                         let event_slot = (raw[3] >> 24) as u8;
@@ -223,7 +229,8 @@ impl super::XhciController {
                 }
                 consumed += 1;
 
-                if event::TransferEvent::try_from(raw).is_ok() {
+                if !self.capture_interrupt_event(raw) && event::TransferEvent::try_from(raw).is_ok()
+                {
                     drained += 1;
                 }
             } else {

--- a/crabefi-core/src/drivers/usb/xhci/configure.rs
+++ b/crabefi-core/src/drivers/usb/xhci/configure.rs
@@ -1,13 +1,36 @@
 //! xHCI endpoint configuration by device class.
 
-use super::super::controller::{
-    ConfigurationInfo, desc_type, parse_configuration, req_type, request,
-};
+use super::super::controller::{ConfigurationInfo, UsbController};
 use super::{TrbRing, XhciError};
 use crate::barrier;
 use crate::efi;
 use xhci::context::EndpointType;
 use xhci::ring::trb::command;
+
+/// xHCI schedules in powers of two microframes. Never poll less frequently
+/// than the LS/FS descriptor requests; HS/SS bInterval is already exponent + 1.
+fn hid_interval(speed: u8, interval: u8) -> u8 {
+    if speed >= 3 {
+        interval.clamp(1, 16) - 1
+    } else {
+        ((interval.max(1) as u32 * 8).ilog2() as u8).max(3)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hid_interval;
+
+    #[test]
+    fn interrupt_intervals_respect_usb_periods() {
+        assert_eq!(hid_interval(1, 1), 3);
+        assert_eq!(hid_interval(2, 10), 6); // 8 ms, not 16 ms
+        assert_eq!(hid_interval(1, 255), 10);
+        assert_eq!(hid_interval(3, 1), 0);
+        assert_eq!(hid_interval(3, 4), 3);
+        assert_eq!(hid_interval(4, 16), 15);
+    }
+}
 
 impl super::XhciController {
     /// Fetch and parse the full configuration descriptor for a device
@@ -15,37 +38,14 @@ impl super::XhciController {
         &mut self,
         slot_id: u8,
     ) -> Result<ConfigurationInfo, XhciError> {
-        let mut config_buf = [0u8; 256];
-
-        // First get just the header to learn total length
-        let mut header = [0u8; 9];
-        self.control_transfer(
-            slot_id,
-            req_type::DIR_IN | req_type::TYPE_STANDARD | req_type::RCPT_DEVICE,
-            request::GET_DESCRIPTOR,
-            (desc_type::CONFIGURATION as u16) << 8,
-            0,
-            Some(&mut header),
-        )?;
-
-        let total_len = u16::from_le_bytes([header[2], header[3]]) as usize;
-        if total_len < header.len() {
-            log::debug!("xHCI: invalid wTotalLength {}", total_len);
-            return Err(XhciError::InvalidParameter);
-        }
-        let total_len = total_len.min(config_buf.len());
-
-        // Get full configuration
-        self.control_transfer(
-            slot_id,
-            req_type::DIR_IN | req_type::TYPE_STANDARD | req_type::RCPT_DEVICE,
-            request::GET_DESCRIPTOR,
-            (desc_type::CONFIGURATION as u16) << 8,
-            0,
-            Some(&mut config_buf[..total_len]),
-        )?;
-
-        Ok(parse_configuration(&config_buf[..total_len]))
+        self.read_configuration(slot_id).map_err(|error| {
+            log::warn!(
+                "xHCI: configuration descriptor for slot {}: {:?}",
+                slot_id,
+                error
+            );
+            XhciError::UsbError
+        })
     }
 
     /// Configure a mass storage device
@@ -166,10 +166,24 @@ impl super::XhciController {
             return Err(XhciError::DeviceNotFound);
         }
 
-        // Set configuration
-        self.set_configuration(slot_id, config_info.configuration_value)?;
+        // Do not reset another function's already-configured endpoints.
+        let already_configured = self
+            .slots
+            .get(slot_id as usize)
+            .and_then(Option::as_ref)
+            .is_some_and(|slot| slot.is_mass_storage || slot.is_hid_mouse);
+        if !already_configured {
+            self.set_configuration(slot_id, config_info.configuration_value)?;
+        }
 
-        // Update slot info (but don't configure endpoint - we use control transfers for HID)
+        self.configure_hid_interrupt_endpoint(
+            slot_id,
+            interrupt_in,
+            interrupt_max_packet,
+            interrupt_interval,
+        )?;
+
+        // Update slot info after configuring the interrupt pipe.
         if let Some(slot) = self
             .slots
             .get_mut(slot_id as usize)
@@ -187,10 +201,7 @@ impl super::XhciController {
 
     /// Configure a HID mouse device.
     ///
-    /// Unlike the keyboard (which may get away with GET_REPORT on some
-    /// hardware), USB mice almost universally require interrupt IN transfers.
-    /// We configure the interrupt endpoint with a transfer ring here so that
-    /// `interrupt_transfer()` can queue Normal TRBs on it later.
+    /// Configure the interrupt pipe, shared with HID keyboards.
     pub(super) fn configure_hid_mouse(&mut self, slot_id: u8) -> Result<(), XhciError> {
         let config_info = self.get_config_descriptor(slot_id)?;
 
@@ -229,6 +240,35 @@ impl super::XhciController {
             self.set_configuration(slot_id, config_info.configuration_value)?;
         }
 
+        self.configure_hid_interrupt_endpoint(
+            slot_id,
+            interrupt_in,
+            interrupt_max_packet,
+            interrupt_interval,
+        )?;
+        if let Some(slot) = self
+            .slots
+            .get_mut(slot_id as usize)
+            .and_then(Option::as_mut)
+        {
+            slot.is_hid_mouse = true;
+            slot.mouse_interrupt_in_ep = interrupt_in;
+            slot.mouse_interrupt_max_packet = interrupt_max_packet;
+            slot.mouse_interrupt_interval = interrupt_interval;
+        }
+        Ok(())
+    }
+
+    fn configure_hid_interrupt_endpoint(
+        &mut self,
+        slot_id: u8,
+        interrupt_in: u8,
+        interrupt_max_packet: u16,
+        interrupt_interval: u8,
+    ) -> Result<(), XhciError> {
+        if interrupt_in == 0 || interrupt_in > 15 || interrupt_max_packet == 0 {
+            return Err(XhciError::InvalidParameter);
+        }
         // ── Configure the interrupt IN endpoint on the xHC ──
         //
         // Allocate a transfer ring and tell the controller about the endpoint
@@ -248,10 +288,6 @@ impl super::XhciController {
                 .and_then(|s| s.as_mut())
                 .ok_or(XhciError::DeviceNotFound)?;
 
-            slot.is_hid_mouse = true;
-            slot.mouse_interrupt_in_ep = interrupt_in;
-            slot.mouse_interrupt_max_packet = interrupt_max_packet;
-            slot.mouse_interrupt_interval = interrupt_interval;
             slot.transfer_rings[in_dci - 1] = Some(ring);
 
             // Set up input context for Configure Endpoint
@@ -261,7 +297,8 @@ impl super::XhciController {
             }
             Self::copy_device_slot_context(input, slot.device_context, context_size);
             let slot_ctx = Self::input_slot_context(input, context_size);
-            slot_ctx.set_context_entries(in_dci as u8);
+            // Adding a second HID function must not hide a higher existing DCI.
+            slot_ctx.set_context_entries(slot_ctx.context_entries().max(in_dci as u8));
             let control = Self::input_control_context(input, context_size);
             control.set_add_context_flag(0);
             control.set_add_context_flag(in_dci);
@@ -271,31 +308,27 @@ impl super::XhciController {
             //   For LS/FS: period = 2^(Interval) * 125µs, bInterval is in ms
             //   Use Interval such that 2^Interval ≈ bInterval * 8
             //   For HS: bInterval already is exponent+1
-            let speed = slot.speed;
-            let xhci_interval = if speed >= 3 {
-                // High/Super speed: bInterval is already exponent form
-                interrupt_interval.max(1)
+            let xhci_interval = hid_interval(slot.speed, interrupt_interval);
+            let max_packet = interrupt_max_packet & 0x7ff;
+            let max_burst = if slot.speed == 3 {
+                ((interrupt_max_packet >> 11) & 3) as u8
             } else {
-                // Low/Full speed: bInterval in ms, convert to 125µs exponent
-                // 2^N * 125µs ≈ bInterval * 1000µs → N ≈ log2(bInterval*8)
-                let frames = (interrupt_interval as u32).max(1) * 8;
-                let mut n = 0u8;
-                let mut v = 1u32;
-                while v < frames && n < 15 {
-                    n += 1;
-                    v <<= 1;
-                }
-                n.max(3) // At least 1ms (2^3 * 125µs)
+                0
             };
+            if max_packet == 0 || max_burst == 3 {
+                return Err(XhciError::InvalidParameter);
+            }
+            let payload = max_packet * (max_burst as u16 + 1);
 
             let ep_ctx = Self::input_ep_context(input, context_size, in_dci - 1);
             ep_ctx.set_endpoint_type(EndpointType::InterruptIn);
-            ep_ctx.set_max_packet_size(interrupt_max_packet);
-            ep_ctx.set_max_burst_size(0);
+            ep_ctx.set_max_packet_size(max_packet);
+            ep_ctx.set_max_burst_size(max_burst);
             ep_ctx.set_error_count(3);
             ep_ctx.set_tr_dequeue_pointer(ring_addr);
             ep_ctx.set_dequeue_cycle_state();
-            ep_ctx.set_average_trb_length(interrupt_max_packet);
+            ep_ctx.set_average_trb_length(max_packet);
+            ep_ctx.set_max_endpoint_service_time_interval_payload_low(payload);
             ep_ctx.set_interval(xhci_interval);
         }
 
@@ -318,7 +351,7 @@ impl super::XhciController {
         self.wait_command_completion()?;
 
         log::info!(
-            "USB HID Mouse configured on slot {}, interrupt EP {} (DCI {})",
+            "USB HID interrupt pipe configured on slot {}, EP {} (DCI {})",
             slot_id,
             interrupt_in,
             in_dci

--- a/crabefi-core/src/drivers/usb/xhci/init.rs
+++ b/crabefi-core/src/drivers/usb/xhci/init.rs
@@ -123,10 +123,9 @@ impl super::XhciController {
             num_scratchpad_bufs
         );
 
-        // Pre-fill slot Vec to max_slots entries (all None) so slot IDs
-        // from the controller map directly to Vec indices.
+        // Slot IDs are one-based; include the highest advertised slot.
         let mut slots = heapless::Vec::new();
-        for _ in 0..max_slots {
+        for _ in 0..=max_slots {
             let _ = slots.push(None);
         }
 
@@ -143,6 +142,7 @@ impl super::XhciController {
             erst: 0,
             event_ring: TrbRing::empty(), // Will be initialized in init()
             slots,
+            interrupt_polls: alloc::vec::Vec::new(),
         };
 
         controller.init()?;

--- a/crabefi-core/src/drivers/usb/xhci/mod.rs
+++ b/crabefi-core/src/drivers/usb/xhci/mod.rs
@@ -122,10 +122,12 @@ pub struct XhciController {
     /// Active device slots, indexed by slot ID.
     ///
     /// Slot IDs are assigned by the controller (1-based). We pre-fill the Vec
-    /// to `MAX_SLOTS` entries (all `None`) so slot IDs map directly to indices.
+    /// to `max_slots + 1` entries (all `None`), reserving index zero.
     /// All accesses use `.get()` / `.get_mut()` to safely handle out-of-range
     /// slot IDs without panicking.
-    slots: heapless::Vec<Option<UsbSlot>, MAX_SLOTS>,
+    slots: heapless::Vec<Option<UsbSlot>, { MAX_SLOTS + 1 }>,
+    /// Persistent interrupt TDs; their DMA buffers remain alive between polls.
+    interrupt_polls: alloc::vec::Vec<bulk::InterruptPoll>,
 }
 
 /// xHCI error type
@@ -166,14 +168,23 @@ unsafe impl Send for XhciController {}
 // through the parent XhciController. Single-threaded firmware ensures no races.
 unsafe impl Send for UsbSlot {}
 
+fn find_device_slot<T>(slots: &[Option<T>], mut matches: impl FnMut(&T) -> bool) -> Option<u8> {
+    slots.iter().enumerate().skip(1).find_map(|(id, slot)| {
+        slot.as_ref()
+            .filter(|slot| matches(slot))
+            .and_then(|_| u8::try_from(id).ok())
+    })
+}
+
 impl XhciController {
     /// Find a mass storage device
     pub fn find_mass_storage(&self) -> Option<u8> {
-        self.slots.iter().enumerate().find_map(|(slot_id, slot)| {
-            slot.as_ref()
-                .filter(|s| s.is_mass_storage)
-                .map(|_| slot_id as u8)
-        })
+        self.find_slot(|slot| slot.is_mass_storage)
+    }
+
+    /// Search the actual slot table, including its highest one-based slot ID.
+    pub(super) fn find_slot(&self, matches: impl FnMut(&UsbSlot) -> bool) -> Option<u8> {
+        find_device_slot(&self.slots, matches)
     }
 
     /// Get slot info
@@ -287,6 +298,23 @@ mod tests {
     use core::mem::size_of;
     use xhci::context::{self, InputHandler};
     use xhci::ring::trb::{self, command, event, transfer};
+
+    #[test]
+    fn discovery_includes_highest_slot_and_ignores_reserved_zero() {
+        let mut slots = [None; MAX_SLOTS + 1];
+        slots[0] = Some("keyboard");
+        assert_eq!(find_device_slot(&slots, |class| *class == "keyboard"), None);
+        for class in ["keyboard", "mouse", "storage"] {
+            slots[MAX_SLOTS] = Some(class);
+            assert_eq!(
+                find_device_slot(&slots, |value| *value == class),
+                Some(MAX_SLOTS as u8)
+            );
+        }
+        assert_eq!(find_device_slot(&slots[..MAX_SLOTS], |_| true), None);
+        slots[2] = Some("mouse");
+        assert_eq!(find_device_slot(&slots, |class| *class == "mouse"), Some(2));
+    }
 
     #[test]
     fn event_trb_read_requires_expected_cycle_and_returns_coherent_raw() {

--- a/crabefi-core/src/drivers/usb/xhci/slots.rs
+++ b/crabefi-core/src/drivers/usb/xhci/slots.rs
@@ -121,17 +121,6 @@ impl super::XhciController {
         self.discard_endpoint_transfers(slot_id, dci)
     }
 
-    /// Stop an active endpoint before releasing a timed-out transfer buffer.
-    pub(super) fn stop_endpoint(&mut self, slot_id: u8, dci: u8) -> Result<(), XhciError> {
-        let mut command = command::StopEndpoint::new();
-        command.set_slot_id(slot_id).set_endpoint_id(dci);
-        self.cmd_ring.enqueue(command, false);
-        barrier::mmio_write();
-        self.ring_doorbell(0, 0);
-        self.wait_command_completion()?;
-        self.discard_endpoint_transfers(slot_id, dci)
-    }
-
     /// Skip pending TDs while the endpoint is stopped or halted.
     fn discard_endpoint_transfers(&mut self, slot_id: u8, dci: u8) -> Result<(), XhciError> {
         // Step 2: Send Set TR Dequeue Pointer command

--- a/crabefi-core/src/fs/gpt.rs
+++ b/crabefi-core/src/fs/gpt.rs
@@ -310,8 +310,10 @@ pub fn read_gpt_header(device: &mut dyn BlockDevice) -> Result<GptHeader, GptErr
 
 /// Prefer native GPT at device LBA 1. Only use 512-byte ISO addressing when
 /// a header is actually found at byte 512; block size alone cannot identify it.
-/// Keep this decision shared by discovery and measured boot.
-fn read_gpt_layout(device: &mut dyn BlockDevice) -> Result<(GptHeader, bool), GptError> {
+/// Keep this decision shared by discovery and measured boot. Callers that read
+/// partitions and the measurement event pass the result to the `_with` helpers
+/// so one probe covers the whole boot scan.
+pub(crate) fn read_gpt_layout(device: &mut dyn BlockDevice) -> Result<(GptHeader, bool), GptError> {
     let block_size = device.info().block_size as usize;
     if !(MIN_BLOCK_SIZE..=MAX_BLOCK_SIZE).contains(&block_size) || !block_size.is_power_of_two() {
         return Err(GptError::InvalidHeader);
@@ -382,9 +384,18 @@ pub fn build_gpt_measurement_event(
     device: &mut dyn BlockDevice,
     header: &GptHeader,
 ) -> Result<Vec<u8>, GptError> {
+    let (_, is_hybrid) = read_gpt_layout(device)?;
+    build_gpt_measurement_event_with(device, header, is_hybrid)
+}
+
+/// Build the `EFI_GPT_DATA` payload for an already-detected layout.
+pub(crate) fn build_gpt_measurement_event_with(
+    device: &mut dyn BlockDevice,
+    header: &GptHeader,
+    is_hybrid: bool,
+) -> Result<Vec<u8>, GptError> {
     let info = device.info();
     let block_size = (info.block_size as usize).clamp(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE);
-    let (_, is_hybrid) = read_gpt_layout(device)?;
 
     let entry_size = header.partition_entry_size as usize;
     let (entries_byte_offset, total_entries, total_bytes_needed) =
@@ -452,14 +463,22 @@ pub fn read_partitions(
     device: &mut dyn BlockDevice,
     header: &GptHeader,
 ) -> Result<heapless::Vec<Partition, 16>, GptError> {
+    // Detect the on-disk layout rather than treating all large sectors as ISO media.
+    let (_, is_hybrid) = read_gpt_layout(device)?;
+    read_partitions_with(device, header, is_hybrid)
+}
+
+/// Read partition entries for an already-detected layout.
+pub(crate) fn read_partitions_with(
+    device: &mut dyn BlockDevice,
+    header: &GptHeader,
+    is_hybrid: bool,
+) -> Result<heapless::Vec<Partition, 16>, GptError> {
     let mut partitions = heapless::Vec::new();
 
     // Use device's actual block size, capped at MAX_BLOCK_SIZE
     let info = device.info();
     let block_size = (info.block_size as usize).clamp(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE);
-
-    // Detect the on-disk layout rather than treating all large sectors as ISO media.
-    let (_, is_hybrid) = read_gpt_layout(device)?;
 
     let entry_size = header.partition_entry_size as usize;
     if entry_size < core::mem::size_of::<GptPartitionEntry>() || entry_size > MAX_BLOCK_SIZE {
@@ -642,7 +661,9 @@ pub fn read_mbr_partitions(
 pub fn read_partitions_auto(
     device: &mut dyn BlockDevice,
 ) -> Result<heapless::Vec<Partition, 16>, GptError> {
-    match read_gpt_header(device).and_then(|header| read_partitions(device, &header)) {
+    match read_gpt_layout(device)
+        .and_then(|(header, is_hybrid)| read_partitions_with(device, &header, is_hybrid))
+    {
         Ok(partitions) => Ok(partitions),
         Err(gpt_error) => {
             log::debug!("GPT partition scan failed: {:?}; trying MBR", gpt_error);

--- a/crabefi-core/src/fs/gpt.rs
+++ b/crabefi-core/src/fs/gpt.rs
@@ -7,6 +7,10 @@ use crate::drivers::block::{BlockDevice, BlockError};
 use alloc::vec::Vec;
 use zerocopy::{FromBytes, Immutable, KnownLayout, Unaligned};
 
+#[cfg(test)]
+#[path = "gpt_tests.rs"]
+mod tests;
+
 /// Maximum supported block size (4KB - handles most devices including CD-ROMs)
 const MAX_BLOCK_SIZE: usize = 4096;
 
@@ -299,60 +303,73 @@ impl From<BlockError> for GptError {
 
 /// Read and parse the GPT header
 ///
-/// Handles both standard disks (512-byte sectors) and hybrid ISOs on CD-ROMs
-/// (2048-byte sectors with GPT embedded at byte offset 512).
+/// Handles native logical sectors (including 4Kn) and hybrid ISO images.
 pub fn read_gpt_header(device: &mut dyn BlockDevice) -> Result<GptHeader, GptError> {
-    // Use device's actual block size, capped at MAX_BLOCK_SIZE
-    let info = device.info();
-    let block_size = (info.block_size as usize).min(MAX_BLOCK_SIZE);
+    read_gpt_layout(device).map(|(header, _)| header)
+}
 
-    // Allocate buffer large enough for any supported block size
-    let mut buffer = [0u8; MAX_BLOCK_SIZE];
-
-    // For devices with block sizes > 512 bytes (like CD-ROMs), the GPT on hybrid
-    // ISOs is at byte offset 512, which is inside the first block (LBA 0).
-    // For standard 512-byte sector devices, GPT is at LBA 1.
-    let (lba, gpt_offset) = if block_size > MIN_BLOCK_SIZE {
-        // Hybrid ISO: GPT header at byte 512 (inside LBA 0)
-        (0, MIN_BLOCK_SIZE)
-    } else {
-        // Standard disk: GPT header at LBA 1
-        (1, 0)
-    };
-
-    log::debug!(
-        "Reading GPT header from LBA {} offset {} (block_size={})...",
-        lba,
-        gpt_offset,
-        block_size
-    );
-
-    device.read_block(lba, &mut buffer[..block_size])?;
-
-    // Parse header from the appropriate offset using zerocopy
-    let header = GptHeader::read_from_prefix(&buffer[gpt_offset..])
-        .map_err(|_| GptError::InvalidHeader)?
-        .0;
-
-    // Copy fields for logging to avoid reference to packed struct
-    let signature = header.signature;
-    let revision = header.revision;
-    let num_partition_entries = header.num_partition_entries;
-    let partition_entry_size = header.partition_entry_size;
-
-    if !header.is_valid() {
-        log::debug!("Invalid GPT signature: {:#018x}", signature);
+/// Prefer native GPT at device LBA 1. Only use 512-byte ISO addressing when
+/// a header is actually found at byte 512; block size alone cannot identify it.
+/// Keep this decision shared by discovery and measured boot.
+fn read_gpt_layout(device: &mut dyn BlockDevice) -> Result<(GptHeader, bool), GptError> {
+    let block_size = device.info().block_size as usize;
+    if !(MIN_BLOCK_SIZE..=MAX_BLOCK_SIZE).contains(&block_size) || !block_size.is_power_of_two() {
         return Err(GptError::InvalidHeader);
     }
+    let mut buffer = [0u8; MAX_BLOCK_SIZE];
+    device.read_block(1, &mut buffer[..block_size])?;
+    let header = GptHeader::read_from_prefix(&buffer[..block_size])
+        .map_err(|_| GptError::InvalidHeader)?
+        .0;
+    if header.is_valid() {
+        return Ok((header, false));
+    }
+    if block_size > MIN_BLOCK_SIZE {
+        device.read_block(0, &mut buffer[..block_size])?;
+        let header = GptHeader::read_from_prefix(&buffer[MIN_BLOCK_SIZE..block_size])
+            .map_err(|_| GptError::InvalidHeader)?
+            .0;
+        if header.is_valid() {
+            return Ok((header, true));
+        }
+    }
+    Err(GptError::InvalidHeader)
+}
 
-    log::debug!(
-        "GPT Header: revision={:#x}, entries={}, entry_size={}",
-        revision,
-        num_partition_entries,
-        partition_entry_size
-    );
-
-    Ok(header)
+/// Validate and translate a partition without rounding away a byte offset.
+/// The block-device partition abstraction can expose only whole native blocks.
+fn partition_lba_range(
+    info: crate::drivers::block::BlockDeviceInfo,
+    entry: &GptPartitionEntry,
+    is_hybrid: bool,
+) -> Result<(u64, u64), GptError> {
+    let block_size = u64::from(info.block_size);
+    let unit = if is_hybrid {
+        MIN_BLOCK_SIZE as u64
+    } else {
+        block_size
+    };
+    if block_size == 0 || entry.first_lba > entry.last_lba {
+        return Err(GptError::InvalidHeader);
+    }
+    let start = entry
+        .first_lba
+        .checked_mul(unit)
+        .ok_or(GptError::InvalidHeader)?;
+    let end = entry
+        .last_lba
+        .checked_add(1)
+        .and_then(|end| end.checked_mul(unit))
+        .ok_or(GptError::InvalidHeader)?;
+    if !start.is_multiple_of(block_size) || !end.is_multiple_of(block_size) {
+        return Err(GptError::InvalidHeader);
+    }
+    let first_lba = start / block_size;
+    let last_lba = end / block_size - 1;
+    if last_lba >= info.num_blocks {
+        return Err(GptError::InvalidHeader);
+    }
+    Ok((first_lba, last_lba))
 }
 
 /// Build an `EFI_GPT_DATA` event payload for TCG measured boot.
@@ -367,7 +384,7 @@ pub fn build_gpt_measurement_event(
 ) -> Result<Vec<u8>, GptError> {
     let info = device.info();
     let block_size = (info.block_size as usize).clamp(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE);
-    let is_hybrid = block_size > MIN_BLOCK_SIZE;
+    let (_, is_hybrid) = read_gpt_layout(device)?;
 
     let entry_size = header.partition_entry_size as usize;
     let (entries_byte_offset, total_entries, total_bytes_needed) =
@@ -407,6 +424,7 @@ pub fn build_gpt_measurement_event(
             .map_err(|_| GptError::InvalidHeader)?
             .0;
         if !entry.is_empty() {
+            partition_lba_range(info, &entry, is_hybrid)?;
             raw_entries.extend_from_slice(&entry_buf);
         }
     }
@@ -440,9 +458,8 @@ pub fn read_partitions(
     let info = device.info();
     let block_size = (info.block_size as usize).clamp(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE);
 
-    // For hybrid ISOs on large-block devices, the GPT's LBA values are in 512-byte terms.
-    // We need to translate to actual device blocks.
-    let is_hybrid = block_size > MIN_BLOCK_SIZE;
+    // Detect the on-disk layout rather than treating all large sectors as ISO media.
+    let (_, is_hybrid) = read_gpt_layout(device)?;
 
     let entry_size = header.partition_entry_size as usize;
     if entry_size < core::mem::size_of::<GptPartitionEntry>() || entry_size > MAX_BLOCK_SIZE {
@@ -503,14 +520,7 @@ pub fn read_partitions(
             .0;
 
         if !entry.is_empty() {
-            // For hybrid ISOs, translate GPT LBAs (512-byte terms) to device LBAs.
-            let (first_lba, last_lba) = if is_hybrid {
-                let first = entry.first_lba * MIN_BLOCK_SIZE as u64 / block_size as u64;
-                let last = entry.last_lba * MIN_BLOCK_SIZE as u64 / block_size as u64;
-                (first, last)
-            } else {
-                (entry.first_lba, entry.last_lba)
-            };
+            let (first_lba, last_lba) = partition_lba_range(info, &entry, is_hybrid)?;
 
             let partition = Partition {
                 type_guid: entry.type_guid,

--- a/crabefi-core/src/fs/gpt_tests.rs
+++ b/crabefi-core/src/fs/gpt_tests.rs
@@ -1,0 +1,164 @@
+use super::*;
+use crate::drivers::block::BlockDeviceInfo;
+
+/// Sparse fixture: a 4 TB disk must not require a 4 TB test allocation.
+struct Disk {
+    info: BlockDeviceInfo,
+    prefix: Vec<u8>,
+}
+
+impl BlockDevice for Disk {
+    fn info(&self) -> BlockDeviceInfo {
+        self.info
+    }
+
+    fn read_blocks(&mut self, lba: u64, count: u32, buffer: &mut [u8]) -> Result<(), BlockError> {
+        self.validate_read(lba, count, buffer)?;
+        let start = lba as usize * self.info.block_size as usize;
+        let size = count as usize * self.info.block_size as usize;
+        buffer[..size].fill(0);
+        if start < self.prefix.len() {
+            let copied = size.min(self.prefix.len() - start);
+            buffer[..copied].copy_from_slice(&self.prefix[start..start + copied]);
+        }
+        Ok(())
+    }
+}
+
+fn disk(block_size: u32, hybrid: bool) -> Disk {
+    let unit = if hybrid { 512 } else { block_size as usize };
+    let mut prefix = alloc::vec![0; 4 * block_size as usize];
+    let header = &mut prefix[unit..unit + 92];
+    header[..8].copy_from_slice(b"EFI PART");
+    header[8..12].copy_from_slice(&0x10000u32.to_le_bytes());
+    header[12..16].copy_from_slice(&92u32.to_le_bytes());
+    header[24..32].copy_from_slice(&1u64.to_le_bytes());
+    header[72..80].copy_from_slice(&2u64.to_le_bytes());
+    header[80..84].copy_from_slice(&4u32.to_le_bytes());
+    header[84..88].copy_from_slice(&128u32.to_le_bytes());
+    let entry = &mut prefix[2 * unit..2 * unit + 128];
+    entry[..16].copy_from_slice(&ESP_TYPE_GUID);
+    entry[16..32].fill(0x42);
+    entry[32..40].copy_from_slice(&2048u64.to_le_bytes());
+    entry[40..48].copy_from_slice(&4095u64.to_le_bytes());
+    Disk {
+        info: BlockDeviceInfo {
+            num_blocks: 4_000_000_000_000 / block_size as u64,
+            block_size,
+            media_id: 0,
+            removable: true,
+            read_only: false,
+        },
+        prefix,
+    }
+}
+
+#[test]
+fn native_gpt_preserves_logical_lbas_and_measurement() {
+    for block_size in [512, 1024, 2048, 4096] {
+        let mut disk = disk(block_size, false);
+        let header = read_gpt_header(&mut disk).unwrap();
+        let partitions = read_partitions(&mut disk, &header).unwrap();
+        assert_eq!(partitions.len(), 1);
+        assert_eq!(partitions[0].first_lba, 2048);
+        assert_eq!(partitions[0].last_lba, 4095);
+        assert_eq!(partitions[0].size_bytes(), 2048 * block_size as u64);
+        let event = build_gpt_measurement_event(&mut disk, &header).unwrap();
+        assert_eq!(event.len(), 92 + 8 + 128);
+        assert_eq!(&event[92..100], &1u64.to_le_bytes());
+        assert_eq!(&event[100..116], &ESP_TYPE_GUID);
+        assert_eq!(&event[132..140], &2048u64.to_le_bytes());
+    }
+}
+
+#[test]
+fn hybrid_iso_fallback_translates_only_partition_lbas() {
+    let mut disk = disk(2048, true);
+    let header = read_gpt_header(&mut disk).unwrap();
+    let partitions = read_partitions(&mut disk, &header).unwrap();
+    assert_eq!(partitions[0].first_lba, 512);
+    assert_eq!(partitions[0].last_lba, 1023);
+    let event = build_gpt_measurement_event(&mut disk, &header).unwrap();
+    assert_eq!(&event[132..140], &2048u64.to_le_bytes());
+}
+
+#[test]
+fn native_header_takes_precedence_over_embedded_signature() {
+    let mut disk = disk(4096, false);
+    disk.prefix[512..520].copy_from_slice(b"EFI PART");
+    assert_eq!(find_esp(&mut disk).unwrap().first_lba, 2048);
+}
+
+#[test]
+fn missing_header_and_unsupported_block_sizes_are_rejected() {
+    let mut disk = disk(4096, false);
+    disk.prefix.fill(0);
+    assert!(read_gpt_header(&mut disk).is_err());
+    for block_size in [0, 256, 513, 8192] {
+        disk.info.block_size = block_size;
+        assert!(read_gpt_header(&mut disk).is_err());
+    }
+}
+
+fn set_partition_range(disk: &mut Disk, hybrid: bool, first: u64, last: u64) {
+    let unit = if hybrid {
+        512
+    } else {
+        disk.info.block_size as usize
+    };
+    disk.prefix[2 * unit + 32..2 * unit + 40].copy_from_slice(&first.to_le_bytes());
+    disk.prefix[2 * unit + 40..2 * unit + 48].copy_from_slice(&last.to_le_bytes());
+}
+
+#[test]
+fn hybrid_partitions_must_cover_whole_native_blocks() {
+    for (first, last) in [(33, 63), (32, 62), (33, 62)] {
+        let mut disk = disk(2048, true);
+        set_partition_range(&mut disk, true, first, last);
+        let header = read_gpt_header(&mut disk).unwrap();
+        assert!(matches!(
+            read_partitions(&mut disk, &header),
+            Err(GptError::InvalidHeader)
+        ));
+        assert!(matches!(
+            build_gpt_measurement_event(&mut disk, &header),
+            Err(GptError::InvalidHeader)
+        ));
+    }
+    let mut disk = disk(2048, true);
+    set_partition_range(&mut disk, true, 32, 63);
+    let header = read_gpt_header(&mut disk).unwrap();
+    let partitions = read_partitions(&mut disk, &header).unwrap();
+    assert_eq!((partitions[0].first_lba, partitions[0].last_lba), (8, 15));
+}
+
+#[test]
+fn invalid_partition_ranges_are_rejected_for_discovery_and_measurement() {
+    for (block_size, hybrid) in [(512, false), (4096, false), (2048, true)] {
+        let mut disk = disk(block_size, hybrid);
+        let header = read_gpt_header(&mut disk).unwrap();
+        let unit = if hybrid { 512 } else { block_size as u64 };
+        let end = disk.info.num_blocks * block_size as u64 / unit;
+        for (first, last) in [
+            (4096, 2048),                               // Reversed range.
+            (2048, u64::MAX),                           // Inclusive end overflows.
+            (u64::MAX / unit + 1, u64::MAX / unit + 2), // Byte offset overflows.
+            (2048, end + block_size as u64 / unit - 1), // One block beyond media.
+        ] {
+            set_partition_range(&mut disk, hybrid, first, last);
+            assert!(matches!(
+                read_partitions(&mut disk, &header),
+                Err(GptError::InvalidHeader)
+            ));
+            assert!(matches!(
+                build_gpt_measurement_event(&mut disk, &header),
+                Err(GptError::InvalidHeader)
+            ));
+        }
+        // The inclusive last block of the disk is valid.
+        set_partition_range(&mut disk, hybrid, 2048, end - 1);
+        let partitions = read_partitions(&mut disk, &header).unwrap();
+        assert_eq!(partitions[0].last_lba, disk.info.num_blocks - 1);
+        assert!(build_gpt_measurement_event(&mut disk, &header).is_ok());
+    }
+}

--- a/crabefi-core/src/ui/mod.rs
+++ b/crabefi-core/src/ui/mod.rs
@@ -520,7 +520,7 @@ fn run_no_media(fb: &FramebufferInfo) -> ScreenNav {
         cx,
         mid_y + 28,
         cw,
-        "Connect a USB drive to continue",
+        "Connect a USB drive, then press R to restart",
         FontSize::Small,
         theme::TEXT_DIM,
         None,


### PR DESCRIPTION
## Summary

Addresses #109 in three separate commits:

1. **GPT / 4Kn storage** — probe native logical LBA 1 before the hybrid-ISO header at byte 512; use the same layout and checked partition-range validation for discovery and measured boot. Reject unaligned hybrid ranges, arithmetic overflow, reversed ranges, and partitions extending beyond the device.
2. **USB HID input** — configure keyboard and mouse interrupt IN endpoints and retain DMA-backed TDs across nonblocking polls. Route HID completions through synchronous command/transfer consumers, use the discovered composite interface number for HID requests, correct endpoint scheduling/context fields, and include the highest advertised slot in device discovery. Fetch complete configuration descriptors within explicit resource limits, ignore inactive alternate settings, and reject unsupported SuperSpeed HID service payloads rather than silently misconfiguring them.
3. **Documentation / UI** — replace the misleading hotplug prompt with instructions to attach the drive and restart, and document input-device and descriptor limitations.

Includes regression tests for native 512/1K/2K/4K GPT layouts (using a sparse simulated 4 TB disk), hybrid ISO translation, malformed partition ranges, slot-16 discovery, HID pending/short reports, composite-interface requests, long/truncated USB descriptors, alternate settings, and unsupported SuperSpeed companions.

## Validation

- `cargo +nightly test -p crabefi-core --lib --target x86_64-unknown-linux-gnu` — 165 tests passed.
- `cargo +nightly build -p crabefi-coreboot --target x86_64-unknown-none --features ui` — passed.
- Rust LSP diagnostics — no errors.

## Remaining limitations

- Physical T580/replacement-trackpad validation is still needed. SMBus/I²C-only and other unsupported trackpad protocols are not implemented by this PR.
- USB hotplug/rescanning remains unsupported; devices must be connected before startup.
- A QEMU smoke test enumerated both USB HID devices, but interactive input validation was blocked by the test firmware not providing a framebuffer. No end-to-end 4Kn USB boot test was performed.
- USB descriptor support is explicitly bounded to 4 KiB, eight active interfaces, and four endpoints per interface; only alternate setting zero and single-packet SuperSpeed HID service payloads are supported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for native 4K-sector and GPT-partitioned USB storage.
  * Improved compatibility with composite USB keyboards and mice, including HID interfaces beyond the first interface.
  * Added support for relative PS/2 mice and Synaptics touchpads.

* **Bug Fixes**
  * Improved handling of malformed, unsupported, and oversized USB configurations.
  * Improved interrupt-input polling to preserve keyboard and mouse state.
  * Updated the no-bootable-media message with restart guidance.

* **Documentation**
  * Documented USB device requirements, configuration limits, supported input devices, and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->