### PR TITLE
Harden firmware device error recovery

### DIFF
--- a/crabefi-core/src/boot.rs
+++ b/crabefi-core/src/boot.rs
@@ -467,6 +467,7 @@ fn load_and_execute_bootloader(
 ) -> Result<(), Status> {
     use core::ptr;
     use efi::allocator::{MemoryType, allocate_pool, free_pool};
+    use efi::protocols::loaded_image::LOADED_IMAGE_PROTOCOL_GUID;
 
     log::info!("Loading bootloader: {} ({} bytes)", path, file_size);
     let buffer_ptr = allocate_pool(MemoryType::LoaderData, file_size as usize)?;
@@ -502,6 +503,21 @@ fn load_and_execute_bootloader(
     let _ = free_pool(full_path.cast());
     if status != Status::SUCCESS {
         return Err(status);
+    }
+
+    // LoadImage derives LoadedImage.DeviceHandle by resolving the device path it
+    // was given. A platform-provided block device has no device path protocol,
+    // so that resolution fails and DeviceHandle is left NULL. Restore the handle
+    // this bootloader was read from: shim and GRUB use it to locate their own
+    // config and modules.
+    let loaded_image =
+        boot_services::get_protocol_on_handle(image_handle, &LOADED_IMAGE_PROTOCOL_GUID)
+            as *mut r_efi::protocols::loaded_image::Protocol;
+    if !loaded_image.is_null() && unsafe { (*loaded_image).device_handle.is_null() } {
+        // SAFETY: the protocol is installed on the image handle we just created
+        // and remains live until UnloadImage/StartImage teardown.
+        unsafe { (*loaded_image).device_handle = device_handle };
+        log::info!("LoadedImage.DeviceHandle restored to {device_handle:?}");
     }
 
     log::info!("Executing bootloader...");

--- a/crabefi-core/src/drivers/usb/mass_storage.rs
+++ b/crabefi-core/src/drivers/usb/mass_storage.rs
@@ -661,7 +661,7 @@ impl UsbMassStorage {
         if block_size == 0 || buffer.len() < required_len {
             return Err(MassStorageError::InvalidParameter);
         }
-        let sectors_per_cmd =
+        let mut sectors_per_cmd =
             (controller.max_bulk_transfer_size() / block_size).clamp(1, u16::MAX as usize) as u32;
         let mut lba = start_lba;
         let mut remaining = num_sectors;
@@ -669,12 +669,28 @@ impl UsbMassStorage {
 
         while remaining > 0 {
             let chunk = remaining.min(sectors_per_cmd);
-            self.read_sectors_with_retry(
+            match self.read_sectors_with_retry(
                 controller,
                 lba,
                 chunk,
                 &mut buffer[offset..offset + chunk as usize * block_size],
-            )?;
+            ) {
+                Ok(()) => {}
+                // Some bridges cap the data phase below what we asked for. Halve
+                // the request and retry instead of failing the whole read; a
+                // single sector that still comes up short is a real error.
+                Err(MassStorageError::ShortTransfer) if chunk > 1 => {
+                    sectors_per_cmd = (chunk / 2).max(1);
+                    log::debug!(
+                        "USB mass storage: short {} sector read at LBA {}, retrying with {}",
+                        chunk,
+                        lba,
+                        sectors_per_cmd
+                    );
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
 
             lba += chunk as u64;
             remaining -= chunk;

--- a/crabefi-core/src/drivers/usb/xhci/bulk.rs
+++ b/crabefi-core/src/drivers/usb/xhci/bulk.rs
@@ -355,8 +355,10 @@ impl super::XhciController {
             barrier::mmio_write();
             self.ring_doorbell(slot_id, dci as u8);
 
-            // Error paths retain the allocation: a timeout or failed recovery
-            // does not prove that the controller has stopped referencing it.
+            // A timeout does not prove the controller has stopped referencing
+            // the buffer, so it is retained below. Error completions (stall,
+            // babble) do: the event means the controller finished with the TD,
+            // so those arms release the bounce window.
             match self.wait_transfer_td(slot_id, ep, td) {
                 Ok(residual) => {
                     bounce
@@ -378,7 +380,9 @@ impl super::XhciController {
                     }
                 }
                 Err(XhciError::StallError) => {
-                    core::mem::forget(bounce);
+                    // The transfer event proves the controller finished with this
+                    // TD, so the bounce window is safe to release even if the
+                    // endpoint reset below fails.
                     log::debug!(
                         "xHCI: Bulk transfer stalled on slot={} dci={}, resetting endpoint",
                         slot_id,
@@ -393,7 +397,7 @@ impl super::XhciController {
                     cc @ (event::CompletionCode::BabbleDetectedError
                     | event::CompletionCode::UsbTransactionError),
                 ))) => {
-                    core::mem::forget(bounce);
+                    // Same as the stall arm: the error completion retires the TD.
                     log::debug!(
                         "xHCI: Bulk transfer failed with {:?} on slot={} dci={}, resetting endpoint",
                         cc,
@@ -410,6 +414,8 @@ impl super::XhciController {
                     return Err(XhciError::TransferFailed(Ok(cc)));
                 }
                 Err(e) => {
+                    // Timeout or an unrecovered error: the controller may still
+                    // own the TD, so retain the DMA mapping rather than free it.
                     core::mem::forget(bounce);
                     return Err(e);
                 }

--- a/crabefi-core/src/efi/protocols/loaded_image.rs
+++ b/crabefi-core/src/efi/protocols/loaded_image.rs
@@ -11,9 +11,14 @@ use r_efi::protocols::loaded_image;
 /// Re-export the GUID for external use
 pub const LOADED_IMAGE_PROTOCOL_GUID: Guid = loaded_image::PROTOCOL_GUID;
 
-/// Unload callback - not supported
+/// Unload callback for images the firmware loaded itself.
+///
+/// It deliberately does no work: the image owns no resources the firmware did
+/// not allocate for it, and `UnloadImage` frees the image pages itself once
+/// this callback reports success. Returning `EFI_UNSUPPORTED` here made
+/// `UnloadImage` fail for every image the firmware had loaded.
 extern "efiapi" fn unload_image(_image_handle: Handle) -> Status {
-    Status::UNSUPPORTED
+    Status::SUCCESS
 }
 
 /// Create a new Loaded Image Protocol instance for a loaded EFI application
@@ -106,5 +111,17 @@ pub unsafe fn set_file_path(
         unsafe {
             (*protocol).file_path = device_path;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_unload_reports_success_so_unload_image_can_free_the_pages() {
+        // UnloadImage only releases the image when its callback reports
+        // success; the firmware's own no-op callback must not veto that.
+        assert_eq!(unload_image(core::ptr::null_mut()), Status::SUCCESS);
     }
 }

--- a/crabefi-core/src/efi/protocols/simple_file_system.rs
+++ b/crabefi-core/src/efi/protocols/simple_file_system.rs
@@ -461,7 +461,8 @@ extern "efiapi" fn file_read(
                 .map_err(|_| Status::DEVICE_ERROR);
         }
         let mut fat =
-            FatFilesystem::from_geometry(device, filesystem.partition_start, filesystem.geometry);
+            FatFilesystem::from_geometry(device, filesystem.partition_start, filesystem.geometry)
+                .map_err(|_| Status::DEVICE_ERROR)?;
         let entry = create_file_entry(first_cluster, file_size as u32);
         let mut next_hint = cluster_hint;
         fat.read_file_with_hint(&entry, position as u32, buf_slice, &mut next_hint)
@@ -928,7 +929,8 @@ fn read_directory(buffer_size: *mut usize, buffer: *mut c_void, handle_idx: usiz
                 .map_err(|_| Status::DEVICE_ERROR);
         }
         let mut fat =
-            FatFilesystem::from_geometry(device, filesystem.partition_start, filesystem.geometry);
+            FatFilesystem::from_geometry(device, filesystem.partition_start, filesystem.geometry)
+                .map_err(|_| Status::DEVICE_ERROR)?;
 
         fat.get_directory_entry_at_position(cluster, position)
             .map_err(|_| Status::DEVICE_ERROR)

--- a/crabefi-core/src/fs/fat.rs
+++ b/crabefi-core/src/fs/fat.rs
@@ -370,6 +370,8 @@ pub enum FatError {
     InvalidCluster,
     /// Buffer too small
     BufferTooSmall,
+    /// Device block size exceeds the internal read buffer
+    UnsupportedBlockSize,
 }
 
 impl core::fmt::Display for FatError {
@@ -384,6 +386,9 @@ impl core::fmt::Display for FatError {
             FatError::EndOfFile => write!(f, "end of file"),
             FatError::InvalidCluster => write!(f, "invalid cluster"),
             FatError::BufferTooSmall => write!(f, "buffer too small"),
+            FatError::UnsupportedBlockSize => {
+                write!(f, "device block size exceeds the FAT read buffer")
+            }
         }
     }
 }
@@ -458,9 +463,14 @@ pub struct FatFilesystem<'a> {
 impl<'a> FatFilesystem<'a> {
     /// Create a new FAT filesystem instance
     pub fn new(device: &'a mut dyn BlockDevice, partition_start: u64) -> Result<Self, FatError> {
-        // Use device's actual block size for reading
+        // Use device's actual block size for reading. The FAT read buffer holds
+        // one device block, so a larger block cannot be read correctly.
         let info = device.info();
-        let block_size = (info.block_size as usize).min(MAX_BLOCK_SIZE);
+        let block_size = info.block_size as usize;
+        if !(1..=MAX_BLOCK_SIZE).contains(&block_size) {
+            log::debug!("Unsupported device block size: {block_size}");
+            return Err(FatError::UnsupportedBlockSize);
+        }
         let mut buffer = [0u8; MAX_BLOCK_SIZE];
 
         // Read the boot sector
@@ -615,13 +625,24 @@ impl<'a> FatFilesystem<'a> {
     ///
     /// The host block size is always taken from the live device, never from
     /// the cache, so a controller quirk cannot silently change the access path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FatError::UnsupportedBlockSize`] when the live device reports
+    /// a block size the internal read buffer cannot hold. [`Self::new`]
+    /// enforces the same bound, so this only fails if the device changed
+    /// between mounting and this call.
     pub fn from_geometry(
         device: &'a mut dyn BlockDevice,
         partition_start: u64,
         geometry: FatGeometry,
-    ) -> Self {
+    ) -> Result<Self, FatError> {
         let device_block_size = device.info().block_size;
-        Self {
+        if !(1..=MAX_BLOCK_SIZE as u32).contains(&device_block_size) {
+            log::debug!("Unsupported device block size: {device_block_size}");
+            return Err(FatError::UnsupportedBlockSize);
+        }
+        Ok(Self {
             device,
             partition_start,
             fat_type: geometry.fat_type,
@@ -636,7 +657,7 @@ impl<'a> FatFilesystem<'a> {
             data_clusters: geometry.data_clusters,
             fat_block_cache: [0u8; MAX_BLOCK_SIZE],
             fat_block_cached: u64::MAX,
-        }
+        })
     }
 
     /// Return the validated geometry needed to reopen this filesystem.

--- a/crabefi-coreboot/src/main.rs
+++ b/crabefi-coreboot/src/main.rs
@@ -955,26 +955,33 @@ pub extern "C" fn rust_main(coreboot_table_ptr: u64) -> ! {
     let region_count = convert_memory_map(&cb_info.memory_map, &mut memory_regions);
     let region_count = match framebuffer {
         Some(framebuffer) => {
-            let count = memory_map::overlay_framebuffer_region(
+            match memory_map::overlay_framebuffer_region(
                 &mut memory_regions,
                 region_count,
                 framebuffer.physical_address,
                 framebuffer.size(),
                 crabefi::MemoryType::Mmio,
-            )
-            .unwrap_or_else(|error| {
+            ) {
+                Ok(count) => {
+                    log::info!(
+                        "Reported framebuffer MMIO region at {:#x} ({} bytes)",
+                        framebuffer.physical_address,
+                        framebuffer.size()
+                    );
+                    count
+                }
                 // EmptyFramebuffer is unreachable: malformed descriptors are
-                // filtered into `None` above. Overlay failures here mean the
-                // map cannot safely describe the display aperture, so stop
-                // rather than hand the OS a corrupt memory map.
-                panic!("Cannot safely report framebuffer MMIO: {:?}", error)
-            });
-            log::info!(
-                "Reported framebuffer MMIO region at {:#x} ({} bytes)",
-                framebuffer.physical_address,
-                framebuffer.size()
-            );
-            count
+                // filtered into `None` above. A rejected or overlapping map is
+                // coreboot's, not ours; keep booting with the un-overlaid map
+                // rather than halting a payload that cannot report the fault.
+                Err(error) => {
+                    log::error!(
+                        "Framebuffer MMIO overlay rejected ({error:?}); \
+                         using the platform memory map unchanged"
+                    );
+                    region_count
+                }
+            }
         }
         None => region_count,
     };


### PR DESCRIPTION
Several firmware error paths can leave stale device state, lose the boot device association, or reject otherwise recoverable hardware configurations.

Harden the FAT, image lifecycle, framebuffer, and xHCI paths so failures remain recoverable and DMA buffers are only released after the controller can no longer reference them. Also reduce repeated USB mass-storage transfer sizes after recurring short reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot compatibility for platforms that provide block devices without device paths.
  * USB storage reads now retry smaller chunks when short transfers occur.
  * USB transfer recovery now more reliably resets affected endpoints and prevents stale transfers.
  * Filesystem operations now report device errors instead of continuing with invalid filesystem state.
  * Devices with unsupported block sizes are rejected clearly rather than processed incorrectly.
  * Framebuffer setup now provides clearer failure handling when memory mapping is rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->